### PR TITLE
Register remaining regression tests with CTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,17 @@ codesign --force --sign - _Build/macos/install/libMoltenVK.dylib
 
 Release archives already include a signed `libMoltenVK.dylib`.
 
+### Regression tests
+
+Build every regression executable and run the registered tests with:
+
+```powershell
+cmake --build _Build/windows --target kyty_tests
+ctest --test-dir _Build/windows --output-on-failure
+```
+
+Use `_Build/linux` instead of `_Build/windows` for a Linux build.
+
 ### Visual Studio Code
 
 A ready-made Visual Studio Code setup is included in [`.vscode`](.vscode). It configures CMake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -444,10 +444,14 @@ if(NOT KYTY_CLANG_CL)
 endif()
 
 if(BUILD_TESTING)
+	add_test(NAME shader_cfg COMMAND $<TARGET_FILE:shader_cfg_tests>)
 	add_test(NAME scalar_provenance COMMAND $<TARGET_FILE:scalar_provenance_tests>)
 	add_test(NAME image_page_table COMMAND $<TARGET_FILE:image_page_table_tests>)
 	add_test(NAME memory_tracker COMMAND $<TARGET_FILE:memory_tracker_tests>)
 	add_test(NAME page_manager COMMAND $<TARGET_FILE:page_manager_tests>)
+	add_test(NAME shader_vertex_metadata COMMAND $<TARGET_FILE:shader_vertex_metadata_tests>)
+	add_test(NAME shader_stage_runtime COMMAND $<TARGET_FILE:shader_stage_runtime_tests>)
+	add_test(NAME resource_tracking COMMAND $<TARGET_FILE:resource_tracking_tests>)
 	add_test(NAME resource_mutex COMMAND $<TARGET_FILE:resource_mutex_tests>)
 	add_test(NAME event_queue_lifetime COMMAND $<TARGET_FILE:event_queue_lifetime_tests>)
 	add_test(NAME shader_recompiler_compute COMMAND $<TARGET_FILE:shader_recompiler_compute_tests>)
@@ -482,6 +486,21 @@ if(BUILD_TESTING)
 		add_test(NAME buffer_cache_ranges
 			COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --buffer-cache-range-only)
 	endif()
+
+	add_custom_target(kyty_tests DEPENDS
+		shader_cfg_tests
+		scalar_provenance_tests
+		image_page_table_tests
+		memory_tracker_tests
+		page_manager_tests
+		shader_vertex_metadata_tests
+		shader_stage_runtime_tests
+		resource_tracking_tests
+		resource_mutex_tests
+		event_queue_lifetime_tests
+		shader_recompiler_compute_tests
+		virtual_memory_allocation_tests
+	)
 endif()
 
 


### PR DESCRIPTION
## What changed

- Register the four regression executables that the current CTest configuration does not yet expose.
- Add a `kyty_tests` target that builds all twelve regression executables before running CTest.
- Document the aggregate build and test commands for Windows and Linux.

## Why

`main` includes CTest and several focused test entries, but four existing regression executables still have to be discovered and run manually. This completes the registration without replacing the newer per-area tests that landed after this PR was opened.

## Rebase resolution

The branch is rebased onto `e63f5b7`. I kept the current `main` registrations for `scalar_provenance` and `virtual_memory_allocation`, retained the newer specialized CTest entries and macOS documentation, and added only the four missing executables to avoid duplicate test names.

## Validation

- Confirmed all 24 registered CTest names are unique.
- Confirmed every dependency of `kyty_tests` names an executable target defined in `src/CMakeLists.txt`.
- Ran `git diff --check` after the rebase.
- A full current-tree configure and build was not available in the isolated worktree because Ninja and `Qt6_DIR` were not configured.

## AI assistance disclosure

AI assistance was used to inspect the updated CMake configuration and resolve the rebase. The resulting two-file diff and validation results were reviewed before submission.