### PR TITLE
cmake: preserve spaces in clang-cl linker paths

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -321,7 +321,12 @@ set(KYTY_EMULATOR_MAP_LINK_PATH "${CMAKE_CURRENT_BINARY_DIR}/${KYTY_EMULATOR_MAP
 set(KYTY_EMULATOR_PDB_LINK_PATH "${CMAKE_CURRENT_BINARY_DIR}/kyty_emulator.pdb")
 
 if(KYTY_CLANG_CL)
-	set_target_properties(kyty_emulator PROPERTIES LINK_FLAGS "/DYNAMICBASE:NO /DEBUG:FULL /PDB:${KYTY_EMULATOR_PDB_LINK_PATH} /lldmap:${KYTY_EMULATOR_MAP_LINK_PATH}")
+	target_link_options(kyty_emulator PRIVATE
+		"/DYNAMICBASE:NO"
+		"/DEBUG:FULL"
+		"/PDB:${KYTY_EMULATOR_PDB_LINK_PATH}"
+		"/lldmap:${KYTY_EMULATOR_MAP_LINK_PATH}"
+	)
 	add_custom_command(TARGET kyty_emulator POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different "${KYTY_THIRD_PARTY_DIR}/winpthread/bin/libwinpthread-1.dll" $<TARGET_FILE_DIR:kyty_emulator>/libwinpthread-1.dll)
 elseif(WIN32 OR LINUX)
 	set_target_properties(kyty_emulator PROPERTIES LINK_FLAGS "${KYTY_LD_OPTIONS} -Wl,-Map=${KYTY_EMULATOR_MAP_LINK_PATH}")


### PR DESCRIPTION
## Summary

Pass linker flags as individual CMake options so PDB and linker map paths remain intact when the build directory contains spaces.

The existing `LINK_FLAGS` string splits these paths before the final link. This change uses `target_link_options` so CMake passes each option correctly.

## Testing

The failure reproduced in two clean Release configurations. The fixed branch completed a Release build in a path containing spaces, installation succeeded, the launcher started correctly, and all ten existing test executables passed.

## AI disclosure

I used AI to help investigate the failure, prepare the change, and run the verification commands. I reviewed the change, reproduction evidence, test results, and this pull request text before submission.