### PR TITLE
Improve Windows memory and Intel Vulkan compatibility

### DIFF
--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -247,7 +247,15 @@ static VulkanQueues VulkanFindQueues(VkPhysicalDevice device, VkSurfaceKHR surfa
 	}
 
 	select_queues(transfer_num, [](const auto& q) { return q.transfer; }, qs.transfer);
+	if (transfer_num != 0 && qs.transfer.empty() && !qs.graphics.empty() &&
+	    qs.graphics.front().transfer) {
+		qs.transfer.push_back(qs.graphics.front());
+	}
 	select_queues(present_num, [](const auto& q) { return q.present; }, qs.present);
+	if (present_num != 0 && qs.present.empty() && !qs.graphics.empty() &&
+	    qs.graphics.front().present) {
+		qs.present.push_back(qs.graphics.front());
+	}
 
 	return qs;
 }
@@ -370,11 +378,6 @@ static void VulkanFindPhysicalDevice(VkInstance instance, VkSurfaceKHR surface,
 			LOGF("shaderStorageImageWriteWithoutFormat is not supported\n");
 			skip_device = true;
 		}
-		if (device_features2.features.shaderStorageImageReadWithoutFormat != VK_TRUE) {
-			LOGF("shaderStorageImageReadWithoutFormat is not supported\n");
-			skip_device = true;
-		}
-
 		if (device_features2.features.shaderImageGatherExtended != VK_TRUE) {
 			LOGF("shaderImageGatherExtended is not supported\n");
 			skip_device = true;
@@ -640,7 +643,6 @@ static VkDevice VulkanCreateDevice(VkPhysicalDevice physical_device, VkSurfaceKH
 	device_features.robustBufferAccess                   = VK_TRUE;
 	device_features.depthBounds                          = VK_TRUE;
 	device_features.shaderStorageImageWriteWithoutFormat = VK_TRUE;
-	device_features.shaderStorageImageReadWithoutFormat  = VK_TRUE;
 	device_features.shaderImageGatherExtended            = VK_TRUE;
 	device_features.independentBlend                     = VK_TRUE;
 	device_features.tessellationShader                   = VK_TRUE;
@@ -909,7 +911,19 @@ static void VulkanCreateQueues(GraphicContext* ctx, const VulkanQueues& queues) 
 	ctx->queues[GraphicContext::QUEUE_UTIL].mutex = ctx->queues[GraphicContext::QUEUE_GFX].mutex;
 	LOGF("Vulkan queue: using graphics queue for utility submissions to preserve resource "
 	     "ordering\n");
-	get_queue(GraphicContext::QUEUE_PRESENT, queues.present[0], true);
+	if (queues.present[0].family == queues.graphics[0].family &&
+	    queues.present[0].index == queues.graphics[0].index) {
+		ctx->queues[GraphicContext::QUEUE_PRESENT].family =
+		    ctx->queues[GraphicContext::QUEUE_GFX].family;
+		ctx->queues[GraphicContext::QUEUE_PRESENT].index =
+		    ctx->queues[GraphicContext::QUEUE_GFX].index;
+		ctx->queues[GraphicContext::QUEUE_PRESENT].vk_queue =
+		    ctx->queues[GraphicContext::QUEUE_GFX].vk_queue;
+		ctx->queues[GraphicContext::QUEUE_PRESENT].mutex =
+		    ctx->queues[GraphicContext::QUEUE_GFX].mutex;
+	} else {
+		get_queue(GraphicContext::QUEUE_PRESENT, queues.present[0], true);
+	}
 
 	for (int id = 0; id < GraphicContext::QUEUE_COMPUTE_NUM; id++) {
 		bool with_mutex = (GraphicContext::QUEUE_COMPUTE_NUM == queues.compute.size());

--- a/src/graphics/shader/recompiler/spirvEmitter/spirvEmitterModule.cpp
+++ b/src/graphics/shader/recompiler/spirvEmitter/spirvEmitterModule.cpp
@@ -497,7 +497,6 @@ void EmitHeaderAndTypes(EmitterState* state) {
 	}
 	if (state->storage_image_variable != 0 || state->storage_image_2d_array_variable != 0 ||
 	    state->storage_image_3d_variable != 0) {
-		state->builder.AddCapability({CapabilityStorageImageReadWithoutFormat});
 		state->builder.AddCapability({CapabilityStorageImageWriteWithoutFormat});
 	}
 	if (state->needs_subgroup_ballot || state->needs_subgroup_shuffle ||

--- a/src/kernel/memoryAddressSpace.inc
+++ b/src/kernel/memoryAddressSpace.inc
@@ -13,6 +13,7 @@ public:
 	enum class FailureReason {
 		None,
 		BackingUnavailable,
+		BackingCommitFailed,
 		PhysicalRangeOutOfBounds,
 		HostAddressNotGranularityAligned,
 		SizeNotGranularityAligned,
@@ -35,9 +36,9 @@ public:
 		GetSystemInfo(&info);
 		m_granularity = info.dwAllocationGranularity;
 
-		m_handle = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, PAGE_EXECUTE_READWRITE,
-		                              static_cast<DWORD>(m_size >> 32u),
-		                              static_cast<DWORD>(m_size & 0xffffffffu), nullptr);
+		m_handle = CreateFileMappingA(
+		    INVALID_HANDLE_VALUE, nullptr, PAGE_EXECUTE_READWRITE | SEC_RESERVE,
+		    static_cast<DWORD>(m_size >> 32u), static_cast<DWORD>(m_size & 0xffffffffu), nullptr);
 		if (m_handle == nullptr) {
 			LOGF_COLOR(Log::Color::Red,
 			           "\t direct-memory backing: CreateFileMapping failed: 0x%08" PRIx32 "\n",
@@ -102,6 +103,7 @@ public:
 		switch (reason) {
 			case FailureReason::None: return "n/a";
 			case FailureReason::BackingUnavailable: return "backing-unavailable";
+			case FailureReason::BackingCommitFailed: return "backing-commit-failed";
 			case FailureReason::PhysicalRangeOutOfBounds: return "physical-range-out-of-bounds";
 			case FailureReason::HostAddressNotGranularityAligned:
 				return "host-address-not-64k-aligned";
@@ -165,6 +167,10 @@ public:
 			                                          : FailureReason::PhysicalRangeOutOfBounds);
 			return 0;
 		}
+		if (!EnsureBackingCommitted(backing_offset, size)) {
+			SetFailure(failure_reason, FailureReason::BackingCommitFailed);
+			return 0;
+		}
 
 		if (alignment == 0) {
 			alignment = 0x4000;
@@ -202,6 +208,10 @@ public:
 		if (!IsAvailable() || !RangeOk(backing_offset, size)) {
 			SetFailure(failure_reason, !IsAvailable() ? FailureReason::BackingUnavailable
 			                                          : FailureReason::PhysicalRangeOutOfBounds);
+			return false;
+		}
+		if (!EnsureBackingCommitted(backing_offset, size)) {
+			SetFailure(failure_reason, FailureReason::BackingCommitFailed);
 			return false;
 		}
 
@@ -274,6 +284,10 @@ public:
 		if (!IsAvailable() || !RangeOk(backing_offset, size)) {
 			SetFailure(failure_reason, !IsAvailable() ? FailureReason::BackingUnavailable
 			                                          : FailureReason::PhysicalRangeOutOfBounds);
+			return false;
+		}
+		if (!EnsureBackingCommitted(backing_offset, size)) {
+			SetFailure(failure_reason, FailureReason::BackingCommitFailed);
 			return false;
 		}
 
@@ -529,6 +543,9 @@ private:
 			if (!RangeOk(entry.backing_offset + current - entry.vaddr, bytes)) {
 				return false;
 			}
+			if (!EnsureBackingCommitted(entry.backing_offset + current - entry.vaddr, bytes)) {
+				return false;
+			}
 			current += bytes;
 		}
 
@@ -594,6 +611,18 @@ private:
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	[[nodiscard]] uint64_t    GetMappableTestSize() const { return m_granularity; }
 	static constexpr uint64_t PageSize() { return 0x4000; }
+
+	bool EnsureBackingCommitted(uint64_t backing_offset, uint64_t size) const {
+		if (!RangeOk(backing_offset, size)) {
+			return false;
+		}
+
+		const auto commit_start = backing_offset & ~(PageSize() - 1u);
+		const auto commit_end   = (backing_offset + size + PageSize() - 1u) & ~(PageSize() - 1u);
+		auto* committed = VirtualAlloc(m_backing_base + commit_start, commit_end - commit_start,
+		                               MEM_COMMIT, PAGE_READWRITE);
+		return committed == m_backing_base + commit_start;
+	}
 
 	[[nodiscard]] static bool IsPageAligned(uint64_t value) {
 		return (value & (PageSize() - 1u)) == 0;
@@ -1022,6 +1051,10 @@ private:
 	HANDLE   m_handle      = nullptr;
 	uint64_t m_granularity = 0x10000;
 #elif KYTY_PLATFORM == KYTY_PLATFORM_LINUX
+	bool EnsureBackingCommitted(uint64_t /*backing_offset*/, uint64_t /*size*/) const {
+		return true;
+	}
+
 	[[nodiscard]] static uint64_t GetMappableTestSize() { return 0x4000; }
 
 	static int GetProtect(VirtualMemory::Mode mode) {

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -2455,9 +2455,6 @@ private:
     Require("VulkanHarness", "dispatch",
             available_features.shaderStorageImageWriteWithoutFormat == VK_TRUE,
             "shaderStorageImageWriteWithoutFormat is not supported");
-    Require("VulkanHarness", "dispatch",
-            available_features.shaderStorageImageReadWithoutFormat == VK_TRUE,
-            "shaderStorageImageReadWithoutFormat is not supported");
 
     float priority = 1.0f;
     VkDeviceQueueCreateInfo queue_info{};
@@ -2472,7 +2469,6 @@ private:
     device_info.pQueueCreateInfos = &queue_info;
     VkPhysicalDeviceFeatures device_features{};
     device_features.shaderStorageImageWriteWithoutFormat = VK_TRUE;
-    device_features.shaderStorageImageReadWithoutFormat = VK_TRUE;
     device_info.pEnabledFeatures = &device_features;
     RequireVk(
         "VulkanHarness", "dispatch",
@@ -8320,9 +8316,8 @@ TestCase ImageStoreR32FloatUsesFormatlessStorageImage() {
   test.storage_image_dwords_per_pixel = 1;
   test.storage_image_rgba = std::vector<u32>(16, 0);
   test.expected_storage_image_rgba = expected_image;
-  test.required_spirv = {"OpCapability StorageImageReadWithoutFormat",
-                         "OpCapability StorageImageWriteWithoutFormat"};
-  test.forbidden_spirv = {"Rgba32f"};
+  test.required_spirv = {"OpCapability StorageImageWriteWithoutFormat"};
+  test.forbidden_spirv = {"OpCapability StorageImageReadWithoutFormat", "Rgba32f"};
   return test;
 }
 


### PR DESCRIPTION
This PR fixes a couple of issues that prevented some games from starting on Windows, especially on systems using Intel integrated graphics.
Direct memory is now committed only when needed instead of reserving everything at startup, vulkan can also reuse a single universal queue when the GPU does not expose separate queues.
I also removed a storage image feature requirement that the emulator wasn’t actually using.
With these changes, Dreaming Sarah now boots and renders correctly on Intel Iris Xe graphics.