### PR TITLE
Install glslang for Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@v5
 
+      - name: Install glslang
+        shell: pwsh
+        run: |
+          vcpkg install glslang:x64-windows
+          "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\tools\glslang" |
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Install Qt 6.10.3
         uses: jurplel/install-qt-action@v4
         with:
@@ -38,6 +45,7 @@ jobs:
           cmake --version
           ninja --version
           clang-cl --version
+          glslangValidator --version
           echo Qt6_DIR=%Qt6_DIR%
 
       - name: Configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Install glslang
         shell: pwsh
         run: |
+          $vcpkgRoot = Split-Path (Get-Command vcpkg).Source
           vcpkg install glslang:x64-windows
-          "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\tools\glslang" |
+          "$vcpkgRoot\installed\x64-windows\tools\glslang" |
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Qt 6.10.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         shell: pwsh
         run: |
           $vcpkgRoot = Split-Path (Get-Command vcpkg).Source
-          vcpkg install glslang[tools]:x64-windows
+          vcpkg install glslang[tools,opt]:x64-windows
           "$vcpkgRoot\installed\x64-windows\tools\glslang" |
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         shell: pwsh
         run: |
           $vcpkgRoot = Split-Path (Get-Command vcpkg).Source
-          vcpkg install glslang:x64-windows
+          vcpkg install glslang[tools]:x64-windows
           "$vcpkgRoot\installed\x64-windows\tools\glslang" |
             Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 


### PR DESCRIPTION
## What changed

- Install `glslang` through the runner's vcpkg installation.
- Add the glslang tools directory to `PATH`.
- Verify `glslangValidator` before configuring the project.

## Why

The Windows workflow failed during CMake configuration because `glslangValidator` was not installed or available on `PATH`.

## Validation

- Workflow YAML parses successfully.
- `git diff --check` passes.
- The pull-request workflow will validate the Windows installation and build.