### PR TITLE
Refactor resource alias ownership and transactional unmap

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,6 +323,17 @@ add_executable(image_page_table_tests EXCLUDE_FROM_ALL
 )
 target_include_directories(image_page_table_tests PRIVATE ${inc_headers})
 
+add_executable(resource_range_tests EXCLUDE_FROM_ALL
+	../tests/ResourceRangeTests.cpp
+)
+target_include_directories(resource_range_tests PRIVATE ${inc_headers})
+
+add_custom_target(host_gpu_aliasing_tests
+	COMMAND $<TARGET_FILE:resource_range_tests>
+	COMMAND $<TARGET_FILE:image_page_table_tests>
+	DEPENDS resource_range_tests image_page_table_tests
+)
+
 add_kyty_full_emulator_test(shader_recompiler_compute_tests ../tests/ShaderRecompilerComputeTests.cpp)
 
 add_kyty_full_emulator_test(virtual_memory_allocation_tests ../tests/VirtualMemoryAllocationTests.cpp)

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -1909,6 +1909,10 @@ bool GraphicsRunIsCommandProcessorThread() noexcept {
 	return g_current_run_cp != nullptr;
 }
 
+bool GraphicsRunIsInitialized() noexcept {
+	return g_gpu != nullptr;
+}
+
 CommandProcessor* GraphicsRunCurrentCommandProcessor() noexcept {
 	return g_current_run_cp;
 }

--- a/src/graphics/guest_gpu/graphicsRun.h
+++ b/src/graphics/guest_gpu/graphicsRun.h
@@ -26,6 +26,7 @@ void GraphicsRunWait();
 void GraphicsRunDone();
 int  GraphicsRunGetFrameNum();
 [[nodiscard]] bool              GraphicsRunIsCommandProcessorThread() noexcept;
+[[nodiscard]] bool              GraphicsRunIsInitialized() noexcept;
 [[nodiscard]] CommandProcessor* GraphicsRunCurrentCommandProcessor() noexcept;
 void                            GraphicsRunFinishCommandProcessors();
 [[nodiscard]] bool              GraphicsRunSubmissionLockHeld() noexcept;

--- a/src/graphics/host_gpu/renderer/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/bufferCache.cpp
@@ -584,9 +584,12 @@ bool BufferCache::InvalidateMemory(PageFaultAccess access, uint64_t vaddr, uint6
 	return true;
 }
 
-void BufferCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
-	GraphicsRunSubmissionLock submissions;
-	FaultSafeCacheLock        lock(this, m_mutex);
+void BufferCache::ValidateUnmapMemoryLocked(uint64_t vaddr, uint64_t size) {
+	if (vaddr == 0 || size == 0 || vaddr >= TRACKER_ADDRESS_SIZE ||
+	    size > TRACKER_ADDRESS_SIZE - vaddr) {
+		EXIT("BufferCache: invalid unmap range, addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
+		     vaddr, size);
+	}
 	for (const auto& [begin, cached]: m_buffers) {
 		if (vaddr < begin + cached->size && begin < vaddr + size &&
 		    (vaddr > begin || size < cached->size || vaddr + size < begin + cached->size)) {
@@ -595,6 +598,34 @@ void BufferCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 			     vaddr, size, begin, cached->size);
 		}
 	}
+	for (const auto& [begin, cached]: m_buffers) {
+		const auto offset = begin >= vaddr ? begin - vaddr : UINT64_MAX;
+		if (offset > size || cached->size > size - offset ||
+		    !m_memory_tracker.IsRegionGpuModified(begin, cached->size)) {
+			continue;
+		}
+		if (m_gpu_modified_ranges.Intersections(begin, cached->size).empty()) {
+			EXIT("BufferCache: GPU-modified buffer has no dirty ranges, addr=0x%016" PRIx64
+			     " size=0x%016" PRIx64 "\n",
+			     begin, cached->size);
+		}
+	}
+}
+
+void BufferCache::ValidateUnmapMemory(uint64_t vaddr, uint64_t size) {
+	if (!m_resource_mutex.IsOwnedByCurrentThread()) {
+		EXIT("BufferCache: unmap validation requires the shared resource transaction\n");
+	}
+	FaultSafeCacheLock lock(this, m_mutex);
+	ValidateUnmapMemoryLocked(vaddr, size);
+}
+
+void BufferCache::CommitUnmapMemory(uint64_t vaddr, uint64_t size) {
+	if (!m_resource_mutex.IsOwnedByCurrentThread()) {
+		EXIT("BufferCache: unmap commit requires the shared resource transaction\n");
+	}
+	FaultSafeCacheLock lock(this, m_mutex);
+	ValidateUnmapMemoryLocked(vaddr, size);
 	for (const auto& [begin, cached]: m_buffers) {
 		const auto offset = begin >= vaddr ? begin - vaddr : UINT64_MAX;
 		if (offset > size || cached->size > size - offset ||

--- a/src/graphics/host_gpu/renderer/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/bufferCache.cpp
@@ -8,6 +8,7 @@
 #include "graphics/host_gpu/objects/label.h"
 #include "graphics/host_gpu/renderer/render.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
+#include "graphics/host_gpu/renderer/resourceRange.h"
 #include "graphics/host_gpu/renderer/resourceMutex.h"
 #include "graphics/host_gpu/renderer/textureCache.h"
 #include "graphics/host_gpu/transfer.h"
@@ -140,11 +141,12 @@ uint64_t AlignUp(uint64_t value) {
 }
 
 bool PageOverlaps(uint64_t left, uint64_t left_size, uint64_t right, uint64_t right_size) {
-	const auto left_begin  = left & ~(TRACKER_PAGE_SIZE - 1);
-	const auto left_end    = (left + left_size + TRACKER_PAGE_SIZE - 1) & ~(TRACKER_PAGE_SIZE - 1);
-	const auto right_begin = right & ~(TRACKER_PAGE_SIZE - 1);
-	const auto right_end = (right + right_size + TRACKER_PAGE_SIZE - 1) & ~(TRACKER_PAGE_SIZE - 1);
-	return left_begin < right_end && right_begin < left_end;
+	const auto relation =
+	    ClassifyRangeRelation({left, left_size}, {right, right_size}, TRACKER_PAGE_SIZE);
+	if (!relation.has_value()) {
+		EXIT("BufferCache: invalid page-overlap range\n");
+	}
+	return HasPageOverlap(*relation);
 }
 } // namespace
 

--- a/src/graphics/host_gpu/renderer/bufferCache.h
+++ b/src/graphics/host_gpu/renderer/bufferCache.h
@@ -16,6 +16,7 @@ namespace Libs::Graphics {
 struct GraphicContext;
 struct VulkanBuffer;
 class CommandBuffer;
+class GpuResourceManager;
 class TextureCache;
 class ResourceMutex;
 
@@ -57,7 +58,6 @@ public:
 
 	[[nodiscard]] bool InvalidateMemory(PageFaultAccess access, uint64_t vaddr, uint64_t size,
 	                                    PageFaultPhase phase) noexcept;
-	void               UnmapMemory(uint64_t vaddr, uint64_t size);
 	[[nodiscard]] BufferBinding ObtainBuffer(CommandBuffer& command, uint64_t vaddr, uint64_t size,
 	                                         bool is_written = false, bool is_read = true,
 	                                         bool is_formatted = false);
@@ -80,6 +80,10 @@ public:
 	void ResetNullBuffer();
 
 private:
+	friend class GpuResourceManager;
+	void ValidateUnmapMemory(uint64_t vaddr, uint64_t size);
+	void CommitUnmapMemory(uint64_t vaddr, uint64_t size);
+	void ValidateUnmapMemoryLocked(uint64_t vaddr, uint64_t size);
 	struct CachedBuffer;
 	struct ReadbackWorker;
 

--- a/src/graphics/host_gpu/renderer/cachedImageRecord.cpp
+++ b/src/graphics/host_gpu/renderer/cachedImageRecord.cpp
@@ -1,0 +1,158 @@
+#include "graphics/host_gpu/renderer/cachedImageRecord.h"
+
+#include "common/assert.h"
+
+namespace Libs::Graphics {
+
+CachedImageRecord::CachedImageRecord(Kind kind, const ImageInfo& info)
+    : kind(kind), m_descriptor(MakeImage(info)) {
+	if (kind != Kind::Texture && kind != Kind::StorageTexture) {
+		EXIT("TextureCache: image descriptor has incompatible kind %u\n",
+		     static_cast<uint32_t>(kind));
+	}
+}
+
+CachedImageRecord::CachedImageRecord(const RenderTargetInfo& info)
+    : kind(Kind::RenderTarget), m_descriptor(info) {}
+
+CachedImageRecord::CachedImageRecord(const DepthTargetInfo& info)
+    : kind(Kind::DepthTarget), m_descriptor(info) {}
+
+CachedImageRecord::CachedImageRecord(const VideoOutInfo& info)
+    : kind(Kind::VideoOut), m_descriptor(info) {}
+
+CachedImageRecord::~CachedImageRecord() {
+	if (image == nullptr || registered || !DescriptorMatchesKind()) {
+		EXIT("TextureCache: cached image destroyed with invalid resources, image=%p "
+		     "kind=%u registered=%d\n",
+		     static_cast<const void*>(image), static_cast<uint32_t>(kind), registered);
+	}
+	ImageOps::Destroy(*image);
+	image = nullptr;
+}
+
+Image& CachedImageRecord::ImageDesc() {
+	return std::get<Image>(m_descriptor);
+}
+
+const Image& CachedImageRecord::ImageDesc() const {
+	return std::get<Image>(m_descriptor);
+}
+
+RenderTargetInfo& CachedImageRecord::RenderTargetDesc() {
+	return std::get<RenderTargetInfo>(m_descriptor);
+}
+
+const RenderTargetInfo& CachedImageRecord::RenderTargetDesc() const {
+	return std::get<RenderTargetInfo>(m_descriptor);
+}
+
+DepthTargetInfo& CachedImageRecord::DepthTargetDesc() {
+	return std::get<DepthTargetInfo>(m_descriptor);
+}
+
+const DepthTargetInfo& CachedImageRecord::DepthTargetDesc() const {
+	return std::get<DepthTargetInfo>(m_descriptor);
+}
+
+VideoOutInfo& CachedImageRecord::VideoOutDesc() {
+	return std::get<VideoOutInfo>(m_descriptor);
+}
+
+const VideoOutInfo& CachedImageRecord::VideoOutDesc() const {
+	return std::get<VideoOutInfo>(m_descriptor);
+}
+
+uint32_t CachedImageRecord::RangeCount() const {
+	return kind == Kind::DepthTarget && DepthTargetDesc().stencil_address != 0 ? 2u : 1u;
+}
+
+BufferImageBinding CachedImageRecord::BufferBinding() const {
+	switch (kind) {
+		case Kind::Texture: return BufferImageBinding::Texture;
+		case Kind::VideoOut: return BufferImageBinding::VideoOut;
+		case Kind::RenderTarget: return BufferImageBinding::RenderTarget;
+		case Kind::StorageTexture: return BufferImageBinding::StorageTexture;
+		case Kind::DepthTarget: return BufferImageBinding::DepthTarget;
+	}
+	return BufferImageBinding::Unsupported;
+}
+
+uint64_t CachedImageRecord::Address(uint32_t index) const {
+	if (index >= RangeCount()) {
+		EXIT("TextureCache: image address range index out of bounds, index=%u count=%u\n", index,
+		     RangeCount());
+	}
+	if (index == 1) {
+		return DepthTargetDesc().stencil_address;
+	}
+	switch (kind) {
+		case Kind::Texture:
+		case Kind::StorageTexture: return ImageDesc().address;
+		case Kind::RenderTarget: return RenderTargetDesc().address;
+		case Kind::DepthTarget: return DepthTargetDesc().address;
+		case Kind::VideoOut: return VideoOutDesc().address;
+	}
+	EXIT("TextureCache: unsupported cached image kind %u for address\n",
+	     static_cast<uint32_t>(kind));
+}
+
+uint64_t CachedImageRecord::Size(uint32_t index) const {
+	if (index >= RangeCount()) {
+		EXIT("TextureCache: image size range index out of bounds, index=%u count=%u\n", index,
+		     RangeCount());
+	}
+	if (index == 1) {
+		return DepthTargetDesc().stencil_size;
+	}
+	switch (kind) {
+		case Kind::Texture:
+		case Kind::StorageTexture: return ImageDesc().size;
+		case Kind::RenderTarget: return RenderTargetDesc().size;
+		case Kind::DepthTarget: return DepthTargetDesc().size;
+		case Kind::VideoOut: return VideoOutDesc().size;
+	}
+	EXIT("TextureCache: unsupported cached image kind %u for size\n", static_cast<uint32_t>(kind));
+}
+
+bool CachedImageRecord::OverlapsRange(uint64_t address, uint64_t size, bool page) const {
+	for (uint32_t i = 0; i < RangeCount(); i++) {
+		if (page ? ImagePageRangesOverlap(address, size, Address(i), Size(i))
+		         : ImageRangeOverlaps(address, size, Address(i), Size(i))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool CachedImageRecord::IsGpuReadbackPageCandidate(uint64_t address, uint64_t size) const {
+	return gpu_modified && OverlapsRange(address, size, true);
+}
+
+bool CachedImageRecord::HasExactRange(uint64_t address, uint64_t size) const {
+	for (uint32_t i = 0; i < RangeCount(); i++) {
+		if (address == Address(i) && size == Size(i)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+Image CachedImageRecord::MakeImage(const ImageInfo& info) {
+	Image image;
+	image = info;
+	return image;
+}
+
+bool CachedImageRecord::DescriptorMatchesKind() const {
+	switch (kind) {
+		case Kind::Texture:
+		case Kind::StorageTexture: return std::holds_alternative<Image>(m_descriptor);
+		case Kind::RenderTarget: return std::holds_alternative<RenderTargetInfo>(m_descriptor);
+		case Kind::DepthTarget: return std::holds_alternative<DepthTargetInfo>(m_descriptor);
+		case Kind::VideoOut: return std::holds_alternative<VideoOutInfo>(m_descriptor);
+	}
+	return false;
+}
+
+} // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/cachedImageRecord.h
+++ b/src/graphics/host_gpu/renderer/cachedImageRecord.h
@@ -1,0 +1,58 @@
+#ifndef EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_CACHEDIMAGERECORD_H_
+#define EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_CACHEDIMAGERECORD_H_
+
+#include "common/abi.h"
+#include "common/common.h"
+#include "graphics/host_gpu/renderer/image.h"
+
+#include <variant>
+
+namespace Libs::Graphics {
+
+struct VulkanImage;
+
+class CachedImageRecord final {
+public:
+	enum class Kind : uint8_t { Texture, StorageTexture, RenderTarget, DepthTarget, VideoOut };
+
+	CachedImageRecord(Kind kind, const ImageInfo& info);
+	explicit CachedImageRecord(const RenderTargetInfo& info);
+	explicit CachedImageRecord(const DepthTargetInfo& info);
+	explicit CachedImageRecord(const VideoOutInfo& info);
+	~CachedImageRecord();
+	KYTY_CLASS_NO_COPY(CachedImageRecord);
+
+	[[nodiscard]] Image&                 ImageDesc();
+	[[nodiscard]] const Image&           ImageDesc() const;
+	[[nodiscard]] RenderTargetInfo&      RenderTargetDesc();
+	[[nodiscard]] const RenderTargetInfo& RenderTargetDesc() const;
+	[[nodiscard]] DepthTargetInfo&       DepthTargetDesc();
+	[[nodiscard]] const DepthTargetInfo& DepthTargetDesc() const;
+	[[nodiscard]] VideoOutInfo&          VideoOutDesc();
+	[[nodiscard]] const VideoOutInfo&    VideoOutDesc() const;
+
+	[[nodiscard]] uint32_t           RangeCount() const;
+	[[nodiscard]] BufferImageBinding BufferBinding() const;
+	[[nodiscard]] uint64_t           Address(uint32_t index = 0) const;
+	[[nodiscard]] uint64_t           Size(uint32_t index = 0) const;
+	[[nodiscard]] bool               OverlapsRange(uint64_t address, uint64_t size, bool page) const;
+	[[nodiscard]] bool IsGpuReadbackPageCandidate(uint64_t address, uint64_t size) const;
+	[[nodiscard]] bool HasExactRange(uint64_t address, uint64_t size) const;
+
+	const Kind   kind;
+	VulkanImage* image               = nullptr;
+	bool         gpu_modified        = false;
+	bool         buffer_modified     = false;
+	bool         stencil_initialized = false;
+	bool         registered          = false;
+
+private:
+	[[nodiscard]] static Image MakeImage(const ImageInfo& info);
+	[[nodiscard]] bool         DescriptorMatchesKind() const;
+
+	std::variant<Image, RenderTargetInfo, DepthTargetInfo, VideoOutInfo> m_descriptor;
+};
+
+} // namespace Libs::Graphics
+
+#endif // EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_CACHEDIMAGERECORD_H_

--- a/src/graphics/host_gpu/renderer/cachedImageRegistry.cpp
+++ b/src/graphics/host_gpu/renderer/cachedImageRegistry.cpp
@@ -1,0 +1,102 @@
+#include "graphics/host_gpu/renderer/cachedImageRegistry.h"
+
+#include "common/assert.h"
+
+#include <algorithm>
+
+namespace Libs::Graphics {
+
+void CachedImageRegistry::Add(Owner owner) {
+	if (owner == nullptr || owner->image == nullptr || owner->registered ||
+	    m_records_by_image.contains(owner->image)) {
+		EXIT("TextureCache: invalid or duplicate image registration\n");
+	}
+	std::vector<OwnerIndex::ByteRange> ranges;
+	ranges.reserve(owner->RangeCount());
+	for (uint32_t range = 0; range < owner->RangeCount(); range++) {
+		ranges.push_back({owner->Address(range), owner->Size(range)});
+	}
+
+	m_owners.push_back(std::move(owner));
+	auto& registered = m_owners.back();
+	m_records_by_image.emplace(registered->image, registered);
+	if (!m_owner_index.Register(registered.get(), ranges)) {
+		EXIT("TextureCache: invalid or duplicate image range registration\n");
+	}
+	registered->registered = true;
+}
+
+CachedImageRegistry::Removal CachedImageRegistry::Remove(CachedImageRecord& record) {
+	if (!record.registered) {
+		EXIT("TextureCache: unregistering an unregistered image\n");
+	}
+	const auto handle = m_records_by_image.find(record.image);
+	if (handle == m_records_by_image.end() || handle->second.lock().get() != &record) {
+		EXIT("TextureCache: image missing from handle index\n");
+	}
+	const auto owner = std::find_if(m_owners.begin(), m_owners.end(),
+	                                [&](const auto& item) { return item.get() == &record; });
+	if (owner == m_owners.end()) {
+		EXIT("TextureCache: indexed image is missing its strong owner\n");
+	}
+
+	std::vector<OwnerIndex::ByteRange> final_page_releases;
+	if (!m_owner_index.Unregister(&record, final_page_releases)) {
+		EXIT("TextureCache: image missing from owner index\n");
+	}
+	Removal removal;
+	removal.final_page_releases.reserve(final_page_releases.size());
+	for (const auto& range: final_page_releases) {
+		removal.final_page_releases.push_back({range.address, range.size});
+	}
+	m_records_by_image.erase(handle);
+	record.registered = false;
+	removal.owner     = std::move(*owner);
+	m_owners.erase(owner);
+	return removal;
+}
+
+void CachedImageRegistry::ReserveAdditional(size_t count) {
+	if (count > m_owners.max_size() - m_owners.size()) {
+		EXIT("TextureCache: cached image registry capacity overflow\n");
+	}
+	m_owners.reserve(m_owners.size() + count);
+}
+
+CachedImageRegistry::Owner CachedImageRegistry::Find(const CachedImageRecord& record) const {
+	const auto handle = m_records_by_image.find(record.image);
+	const auto owner = std::find_if(m_owners.begin(), m_owners.end(),
+	                                [&](const auto& item) { return item.get() == &record; });
+	if (record.image == nullptr || !record.registered || handle == m_records_by_image.end() ||
+	    handle->second.lock().get() != &record || owner == m_owners.end()) {
+		EXIT("TextureCache: cached image owner is missing\n");
+	}
+	return *owner;
+}
+
+CachedImageRegistry::Owner CachedImageRegistry::Find(VulkanImage& image) const {
+	const auto record = m_records_by_image.find(&image);
+	if (record == m_records_by_image.end()) {
+		EXIT("TextureCache: Vulkan image has no cached owner, image=%p\n",
+		     static_cast<void*>(&image));
+	}
+	auto owner = record->second.lock();
+	if (owner == nullptr || owner->image != &image || !owner->registered || !Contains(*owner)) {
+		EXIT("TextureCache: Vulkan image owner expired while registered, image=%p\n",
+		     static_cast<void*>(&image));
+	}
+	return owner;
+}
+
+std::vector<CachedImageRecord*> CachedImageRegistry::Query(uint64_t address, uint64_t size,
+                                                          QueryMode mode) const {
+	return mode == QueryMode::PageCandidates ? m_owner_index.QueryCandidates(address, size)
+	                                         : m_owner_index.Query(address, size);
+}
+
+bool CachedImageRegistry::Contains(const CachedImageRecord& record) const {
+	return std::any_of(m_owners.begin(), m_owners.end(),
+	                   [&](const auto& owner) { return owner.get() == &record; });
+}
+
+} // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/cachedImageRegistry.h
+++ b/src/graphics/host_gpu/renderer/cachedImageRegistry.h
@@ -1,0 +1,52 @@
+#ifndef EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_CACHEDIMAGEREGISTRY_H_
+#define EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_CACHEDIMAGEREGISTRY_H_
+
+#include "common/abi.h"
+#include "common/common.h"
+#include "graphics/host_gpu/renderer/cachedImageRecord.h"
+#include "graphics/host_gpu/renderer/multiLevelPageTable.h"
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace Libs::Graphics {
+
+class CachedImageRegistry final {
+public:
+	using Owner = std::shared_ptr<CachedImageRecord>;
+	using Owners = std::vector<Owner>;
+	enum class QueryMode : uint8_t { Bytes, PageCandidates };
+	struct Removal {
+		Owner                   owner;
+		std::vector<GuestRange> final_page_releases;
+	};
+
+	CachedImageRegistry() = default;
+	~CachedImageRegistry() = default;
+	KYTY_CLASS_NO_COPY(CachedImageRegistry);
+
+	void Add(Owner owner);
+	[[nodiscard]] Removal Remove(CachedImageRecord& record);
+	void                  ReserveAdditional(size_t count);
+
+	[[nodiscard]] Owner Find(const CachedImageRecord& record) const;
+	[[nodiscard]] Owner Find(VulkanImage& image) const;
+	[[nodiscard]] std::vector<CachedImageRecord*> Query(uint64_t address, uint64_t size,
+	                                                    QueryMode mode) const;
+	[[nodiscard]] bool         Contains(const CachedImageRecord& record) const;
+	[[nodiscard]] bool         Empty() const { return m_owners.empty(); }
+	[[nodiscard]] size_t       Size() const { return m_owners.size(); }
+	[[nodiscard]] const Owners& All() const { return m_owners; }
+
+private:
+	using OwnerIndex = MultiRangePageOwnerIndex<CachedImageRecord*>;
+
+	Owners                                                    m_owners;
+	OwnerIndex                                                m_owner_index;
+	std::unordered_map<VulkanImage*, std::weak_ptr<CachedImageRecord>> m_records_by_image;
+};
+
+} // namespace Libs::Graphics
+
+#endif // EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_CACHEDIMAGEREGISTRY_H_

--- a/src/graphics/host_gpu/renderer/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/gpuResourceManager.cpp
@@ -13,7 +13,7 @@ namespace Libs::Graphics {
 
 GpuResourceManager::GpuResourceManager(GraphicContext& graphics)
     : m_page_manager(FaultThunk, this), m_buffer_cache(graphics, m_page_manager, m_resource_mutex),
-      m_texture_cache(graphics, m_page_manager, m_buffer_cache, m_resource_mutex) {
+      m_texture_cache(m_page_manager, m_buffer_cache, m_resource_mutex) {
 	m_buffer_cache.SetTextureCache(m_texture_cache);
 }
 

--- a/src/graphics/host_gpu/renderer/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/gpuResourceManager.cpp
@@ -7,6 +7,8 @@
 #include "graphics/host_gpu/renderer/render.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
 
+#include <optional>
+
 namespace Libs::Graphics {
 
 GpuResourceManager::GpuResourceManager(GraphicContext& graphics)
@@ -56,7 +58,10 @@ bool GpuResourceManager::HandleFault(PageFaultAccess access, uint64_t fault_vadd
 	// Stop command-processor jobs before taking the shared cache transaction. External readback
 	// workers inherit this paused state and therefore never form resource -> submission lock
 	// inversion.
-	GraphicsRunSubmissionLock submissions;
+	std::optional<GraphicsRunSubmissionLock> submissions;
+	if (GraphicsRunIsInitialized()) {
+		submissions.emplace();
+	}
 	ResourceMutex::FaultScope fault(m_resource_mutex);
 	return m_page_manager.HandleFault(access, fault_vaddr);
 }
@@ -90,7 +95,10 @@ void GpuResourceManager::PrepareHostWrite(uint64_t vaddr, uint64_t size) {
 		     " size=0x%016" PRIx64 "\n",
 		     vaddr, size);
 	}
-	GraphicsRunSubmissionLock submissions;
+	std::optional<GraphicsRunSubmissionLock> submissions;
+	if (GraphicsRunIsInitialized()) {
+		submissions.emplace();
+	}
 	ResourceMutex::FaultScope fault(m_resource_mutex);
 	handle_range();
 }
@@ -107,8 +115,18 @@ void GpuResourceManager::UnmapMemory(uint64_t vaddr, uint64_t size, GpuAccess ac
 	if (!IsMapped(vaddr, size)) {
 		EXIT("cannot unmap an unmapped GPU resource range\n");
 	}
-	m_texture_cache.UnmapMemory(vaddr, size);
-	m_buffer_cache.UnmapMemory(vaddr, size);
+	if (m_resource_mutex.IsOwnedByCurrentThread()) {
+		EXIT("cannot unmap from a pre-owned resource transaction\n");
+	}
+	std::optional<GraphicsRunSubmissionLock> submissions;
+	if (GraphicsRunIsInitialized()) {
+		submissions.emplace();
+	}
+	std::lock_guard          transaction(m_resource_mutex);
+	m_texture_cache.ValidateUnmapMemory(vaddr, size);
+	m_buffer_cache.ValidateUnmapMemory(vaddr, size);
+	m_texture_cache.CommitUnmapMemory(vaddr, size);
+	m_buffer_cache.CommitUnmapMemory(vaddr, size);
 	m_page_manager.OnGpuUnmap(vaddr, size, access);
 }
 

--- a/src/graphics/host_gpu/renderer/imageAliasPlan.cpp
+++ b/src/graphics/host_gpu/renderer/imageAliasPlan.cpp
@@ -1,0 +1,52 @@
+#include "graphics/host_gpu/renderer/imageAliasPlan.h"
+
+#include "common/assert.h"
+#include "graphics/host_gpu/renderer/cachedImageRecord.h"
+
+#include <algorithm>
+
+namespace Libs::Graphics {
+
+ImageAliasPlan::ImageAliasPlan(const char* operation, GuestRange request,
+                               PageIsolation isolation)
+    : m_operation(operation), m_request(request), m_isolation(isolation) {}
+
+void ImageAliasPlan::Add(const std::shared_ptr<CachedImageRecord>& image, Action action) {
+	if (image == nullptr) {
+		EXIT("TextureCache: alias plan has an empty image owner\n");
+	}
+	if (Contains(*image)) {
+		EXIT("TextureCache: alias plan contains a duplicate retirement\n");
+	}
+	if (action == Action::PreserveNative && NativeSource() != nullptr) {
+		EXIT("TextureCache: alias plan contains multiple native sources\n");
+	}
+	m_entries.push_back({image, action});
+}
+
+void ImageAliasPlan::PreserveMetadata(uint64_t address) {
+	if (address != 0 && m_preserved_metadata_address != 0 &&
+	    m_preserved_metadata_address != address) {
+		EXIT("TextureCache: alias plan preserves multiple metadata allocations\n");
+	}
+	m_preserved_metadata_address = address;
+}
+
+bool ImageAliasPlan::Contains(const CachedImageRecord& image) const {
+	return std::any_of(m_entries.begin(), m_entries.end(),
+	                   [&](const auto& entry) { return entry.image.get() == &image; });
+}
+
+bool ImageAliasPlan::HasAction(Action action) const {
+	return std::any_of(m_entries.begin(), m_entries.end(),
+	                   [action](const auto& entry) { return entry.action == action; });
+}
+
+std::shared_ptr<CachedImageRecord> ImageAliasPlan::NativeOwner() const {
+	const auto entry = std::find_if(m_entries.begin(), m_entries.end(), [](const auto& item) {
+		return item.action == Action::PreserveNative;
+	});
+	return entry != m_entries.end() ? entry->image : nullptr;
+}
+
+} // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/imageAliasPlan.h
+++ b/src/graphics/host_gpu/renderer/imageAliasPlan.h
@@ -1,0 +1,58 @@
+#ifndef EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_IMAGEALIASPLAN_H_
+#define EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_IMAGEALIASPLAN_H_
+
+#include "common/abi.h"
+#include "common/common.h"
+#include "graphics/host_gpu/renderer/resourceRange.h"
+
+#include <memory>
+#include <vector>
+
+namespace Libs::Graphics {
+
+class CachedImageRecord;
+
+class ImageAliasPlan final {
+public:
+	enum class Action : uint8_t {
+		RetireGuestCurrent,
+		MaterializeGuest,
+		PreserveNative,
+		ReleaseGpuOwnership
+	};
+	enum class PageIsolation : uint8_t { Required, SharedPagesAllowed };
+	struct Entry {
+		std::shared_ptr<CachedImageRecord> image;
+		Action                             action;
+	};
+
+	ImageAliasPlan(const char* operation, GuestRange request, PageIsolation isolation);
+
+	void Add(const std::shared_ptr<CachedImageRecord>& image, Action action);
+	void PreserveMetadata(uint64_t address);
+
+	[[nodiscard]] bool Empty() const { return m_entries.empty(); }
+	[[nodiscard]] size_t RetirementCount() const { return m_entries.size(); }
+	[[nodiscard]] bool Contains(const CachedImageRecord& image) const;
+	[[nodiscard]] bool HasAction(Action action) const;
+	[[nodiscard]] std::shared_ptr<CachedImageRecord> NativeOwner() const;
+	[[nodiscard]] CachedImageRecord* NativeSource() const { return NativeOwner().get(); }
+	[[nodiscard]] const std::vector<Entry>& Entries() const { return m_entries; }
+	[[nodiscard]] const char* Operation() const { return m_operation; }
+	[[nodiscard]] GuestRange Request() const { return m_request; }
+	[[nodiscard]] PageIsolation Isolation() const { return m_isolation; }
+	[[nodiscard]] uint64_t PreservedMetadataAddress() const {
+		return m_preserved_metadata_address;
+	}
+
+private:
+	const char* const          m_operation;
+	const GuestRange           m_request;
+	const PageIsolation        m_isolation;
+	uint64_t                   m_preserved_metadata_address = 0;
+	std::vector<Entry>         m_entries;
+};
+
+} // namespace Libs::Graphics
+
+#endif // EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_IMAGEALIASPLAN_H_

--- a/src/graphics/host_gpu/renderer/imageInfo.h
+++ b/src/graphics/host_gpu/renderer/imageInfo.h
@@ -4,6 +4,7 @@
 #include "common/assert.h"
 #include "graphics/guest_gpu/gpu_defs.h"
 #include "graphics/host_gpu/regionDefinitions.h"
+#include "graphics/host_gpu/renderer/resourceRange.h"
 #include "graphics/host_gpu/vulkanCommon.h"
 
 #include <array>
@@ -610,24 +611,21 @@ SelectDepthTransitionSource(bool depth_load_clear, bool sampled_native_available
 
 [[nodiscard]] inline bool ImageRangeOverlaps(uint64_t left, uint64_t left_size, uint64_t right,
                                              uint64_t right_size) {
-	if (left_size == 0 || right_size == 0 || left > UINT64_MAX - left_size ||
-	    right > UINT64_MAX - right_size) {
+	const auto relation = ClassifyRangeRelation({left, left_size}, {right, right_size}, 1);
+	if (!relation.has_value()) {
 		EXIT("invalid image overlap range\n");
 	}
-	return left < right + right_size && right < left + left_size;
+	return HasByteOverlap(*relation);
 }
 
 [[nodiscard]] inline bool ImagePageRangesOverlap(uint64_t left, uint64_t left_size, uint64_t right,
                                                  uint64_t right_size) {
-	if (left_size == 0 || right_size == 0 || left > UINT64_MAX - left_size ||
-	    right > UINT64_MAX - right_size) {
+	const auto relation =
+	    ClassifyRangeRelation({left, left_size}, {right, right_size}, TRACKER_PAGE_SIZE);
+	if (!relation.has_value()) {
 		EXIT("invalid image page-overlap range\n");
 	}
-	const auto left_first  = left / TRACKER_PAGE_SIZE;
-	const auto left_last   = (left + left_size - 1) / TRACKER_PAGE_SIZE;
-	const auto right_first = right / TRACKER_PAGE_SIZE;
-	const auto right_last  = (right + right_size - 1) / TRACKER_PAGE_SIZE;
-	return left_first <= right_last && right_first <= left_last;
+	return HasPageOverlap(*relation);
 }
 
 [[nodiscard]] inline SampledOverlap ClassifySampledOverlap(const ImageInfo& requested,

--- a/src/graphics/host_gpu/renderer/resourceRange.h
+++ b/src/graphics/host_gpu/renderer/resourceRange.h
@@ -1,0 +1,84 @@
+#ifndef EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_RESOURCERANGE_H_
+#define EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_RESOURCERANGE_H_
+
+#include <cstdint>
+#include <optional>
+
+namespace Libs::Graphics {
+
+struct GuestRange final {
+	uint64_t address = 0;
+	uint64_t size    = 0;
+
+	[[nodiscard]] constexpr bool IsValid() const noexcept {
+		return size != 0 && size <= UINT64_MAX - address;
+	}
+
+	[[nodiscard]] constexpr std::optional<uint64_t> EndExclusive() const noexcept {
+		return IsValid() ? std::optional<uint64_t> {address + size} : std::nullopt;
+	}
+};
+
+// Describes the first range relative to the second range. SharedPageOnly means that the byte
+// ranges are disjoint but share at least one page at the requested granularity.
+enum class RangeRelation : uint8_t {
+	Disjoint,
+	SharedPageOnly,
+	Exact,
+	Contains,
+	ContainedBy,
+	PartialOverlap
+};
+
+[[nodiscard]] constexpr bool IsPowerOfTwo(uint64_t value) noexcept {
+	return value != 0 && (value & (value - 1)) == 0;
+}
+
+[[nodiscard]] constexpr std::optional<RangeRelation>
+ClassifyRangeRelation(GuestRange left, GuestRange right, uint64_t page_size) noexcept {
+	if (!left.IsValid() || !right.IsValid() || !IsPowerOfTwo(page_size)) {
+		return std::nullopt;
+	}
+
+	const auto left_end  = *left.EndExclusive();
+	const auto right_end = *right.EndExclusive();
+	if (left.address >= right_end || right.address >= left_end) {
+		const auto left_first  = left.address / page_size;
+		const auto left_last   = (left_end - 1) / page_size;
+		const auto right_first = right.address / page_size;
+		const auto right_last  = (right_end - 1) / page_size;
+		return left_first <= right_last && right_first <= left_last
+		           ? RangeRelation::SharedPageOnly
+		           : RangeRelation::Disjoint;
+	}
+	if (left.address == right.address && left.size == right.size) {
+		return RangeRelation::Exact;
+	}
+	if (left.address <= right.address && left_end >= right_end) {
+		return RangeRelation::Contains;
+	}
+	if (right.address <= left.address && right_end >= left_end) {
+		return RangeRelation::ContainedBy;
+	}
+	return RangeRelation::PartialOverlap;
+}
+
+[[nodiscard]] constexpr bool HasByteOverlap(RangeRelation relation) noexcept {
+	switch (relation) {
+		case RangeRelation::Exact:
+		case RangeRelation::Contains:
+		case RangeRelation::ContainedBy:
+		case RangeRelation::PartialOverlap: return true;
+		case RangeRelation::Disjoint:
+		case RangeRelation::SharedPageOnly: return false;
+	}
+	return false;
+}
+
+[[nodiscard]] constexpr bool HasPageOverlap(RangeRelation relation) noexcept {
+	return relation == RangeRelation::SharedPageOnly || HasByteOverlap(relation);
+}
+
+} // namespace Libs::Graphics
+
+#endif // EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_RESOURCERANGE_H_

--- a/src/graphics/host_gpu/renderer/resourceRange.h
+++ b/src/graphics/host_gpu/renderer/resourceRange.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <span>
 
 namespace Libs::Graphics {
 
@@ -29,6 +30,8 @@ enum class RangeRelation : uint8_t {
 	ContainedBy,
 	PartialOverlap
 };
+
+enum class RangeSetCoverage : uint8_t { Disjoint, ContainsAll, Partial };
 
 [[nodiscard]] constexpr bool IsPowerOfTwo(uint64_t value) noexcept {
 	return value != 0 && (value & (value - 1)) == 0;
@@ -77,6 +80,30 @@ ClassifyRangeRelation(GuestRange left, GuestRange right, uint64_t page_size) noe
 
 [[nodiscard]] constexpr bool HasPageOverlap(RangeRelation relation) noexcept {
 	return relation == RangeRelation::SharedPageOnly || HasByteOverlap(relation);
+}
+
+// Classifies one range against an atomic set of owner ranges. A byte hit may retire the owner only
+// when every range is contained; page-only neighbors remain disjoint at this layer.
+[[nodiscard]] constexpr std::optional<RangeSetCoverage>
+ClassifyRangeSetCoverage(GuestRange range, std::span<const GuestRange> owner_ranges) noexcept {
+	if (!range.IsValid() || owner_ranges.empty()) {
+		return std::nullopt;
+	}
+	bool overlaps = false;
+	bool contains_all = true;
+	for (const auto owner_range: owner_ranges) {
+		const auto relation = ClassifyRangeRelation(range, owner_range, 1);
+		if (!relation.has_value()) {
+			return std::nullopt;
+		}
+		overlaps |= HasByteOverlap(*relation);
+		contains_all &=
+		    *relation == RangeRelation::Exact || *relation == RangeRelation::Contains;
+	}
+	if (!overlaps) {
+		return RangeSetCoverage::Disjoint;
+	}
+	return contains_all ? RangeSetCoverage::ContainsAll : RangeSetCoverage::Partial;
 }
 
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/textureCache.cpp
@@ -12,6 +12,7 @@
 #include "graphics/host_gpu/objects/label.h"
 #include "graphics/host_gpu/objects/textureCommon.h"
 #include "graphics/host_gpu/renderer/bufferCache.h"
+#include "graphics/host_gpu/renderer/cachedImageRecord.h"
 #include "graphics/host_gpu/renderer/dummyTextureCache.h"
 #include "graphics/host_gpu/renderer/image.h"
 #include "graphics/host_gpu/renderer/imageView.h"
@@ -188,164 +189,6 @@ bool IsExactRenderTargetMipStorage(const ImageInfo& sampled, const ImageInfo& st
 	}
 	return false;
 }
-
-struct TextureCache::CachedImage {
-	enum class Kind {
-		Texture,
-		StorageTexture,
-		RenderTarget,
-		DepthTarget,
-		VideoOut
-	};
-
-	CachedImage(GraphicContext& graphics, Kind kind, const ImageInfo& info)
-	    : kind(kind), descriptor(MakeImage(info)), graphics(graphics) {
-		if (kind != Kind::Texture && kind != Kind::StorageTexture) {
-			EXIT("TextureCache: image descriptor has incompatible kind %u\n",
-			     static_cast<uint32_t>(kind));
-		}
-	}
-	CachedImage(GraphicContext& graphics, const RenderTargetInfo& info)
-	    : kind(Kind::RenderTarget), descriptor(info), graphics(graphics) {}
-	CachedImage(GraphicContext& graphics, const DepthTargetInfo& info)
-	    : kind(Kind::DepthTarget), descriptor(info), graphics(graphics) {}
-	CachedImage(GraphicContext& graphics, const VideoOutInfo& info)
-	    : kind(Kind::VideoOut), descriptor(info), graphics(graphics) {}
-
-	[[nodiscard]] Image& ImageDesc() { return std::get<Image>(descriptor); }
-	[[nodiscard]] const Image& ImageDesc() const { return std::get<Image>(descriptor); }
-	[[nodiscard]] RenderTargetInfo& RenderTargetDesc() {
-		return std::get<RenderTargetInfo>(descriptor);
-	}
-	[[nodiscard]] const RenderTargetInfo& RenderTargetDesc() const {
-		return std::get<RenderTargetInfo>(descriptor);
-	}
-	[[nodiscard]] DepthTargetInfo& DepthTargetDesc() {
-		return std::get<DepthTargetInfo>(descriptor);
-	}
-	[[nodiscard]] const DepthTargetInfo& DepthTargetDesc() const {
-		return std::get<DepthTargetInfo>(descriptor);
-	}
-	[[nodiscard]] VideoOutInfo& VideoOutDesc() { return std::get<VideoOutInfo>(descriptor); }
-	[[nodiscard]] const VideoOutInfo& VideoOutDesc() const {
-		return std::get<VideoOutInfo>(descriptor);
-	}
-
-	const Kind kind;
-
-private:
-	std::variant<Image, RenderTargetInfo, DepthTargetInfo, VideoOutInfo> descriptor;
-
-public:
-	GraphicContext&                                                     graphics;
-	VulkanImage*     image               = nullptr;
-	bool             gpu_modified        = false;
-	bool             buffer_modified     = false;
-	bool             stencil_initialized = false;
-	bool             registered          = false;
-
-	~CachedImage() {
-		if (image == nullptr || registered || !DescriptorMatchesKind()) {
-			EXIT("TextureCache: cached image destroyed with invalid resources, image=%p "
-			     "kind=%u registered=%d\n",
-			     static_cast<const void*>(image), static_cast<uint32_t>(kind), registered);
-		}
-		ImageOps::Destroy(*image);
-		image = nullptr;
-	}
-
-	[[nodiscard]] uint32_t RangeCount() const {
-		return kind == Kind::DepthTarget && DepthTargetDesc().stencil_address != 0 ? 2u : 1u;
-	}
-	[[nodiscard]] BufferImageBinding BufferBinding() const {
-		switch (kind) {
-			case Kind::Texture: return BufferImageBinding::Texture;
-			case Kind::RenderTarget: return BufferImageBinding::RenderTarget;
-			case Kind::VideoOut: return BufferImageBinding::VideoOut;
-			case Kind::StorageTexture: return BufferImageBinding::StorageTexture;
-			case Kind::DepthTarget: return BufferImageBinding::DepthTarget;
-		}
-		return BufferImageBinding::Unsupported;
-	}
-	[[nodiscard]] uint64_t Address(uint32_t index = 0) const {
-		if (index >= RangeCount()) {
-			EXIT("TextureCache: image address range index out of bounds, index=%u count=%u\n",
-			     index, RangeCount());
-		}
-		if (index == 1) {
-			return DepthTargetDesc().stencil_address;
-		}
-		switch (kind) {
-			case Kind::Texture:
-			case Kind::StorageTexture: return ImageDesc().address;
-			case Kind::RenderTarget: return RenderTargetDesc().address;
-			case Kind::DepthTarget: return DepthTargetDesc().address;
-			case Kind::VideoOut: return VideoOutDesc().address;
-		}
-		EXIT("TextureCache: unsupported cached image kind %u for address\n",
-		     static_cast<uint32_t>(kind));
-	}
-	[[nodiscard]] uint64_t Size(uint32_t index = 0) const {
-		if (index >= RangeCount()) {
-			EXIT("TextureCache: image size range index out of bounds, index=%u count=%u\n", index,
-			     RangeCount());
-		}
-		if (index == 1) {
-			return DepthTargetDesc().stencil_size;
-		}
-		switch (kind) {
-			case Kind::Texture:
-			case Kind::StorageTexture: return ImageDesc().size;
-			case Kind::RenderTarget: return RenderTargetDesc().size;
-			case Kind::DepthTarget: return DepthTargetDesc().size;
-			case Kind::VideoOut: return VideoOutDesc().size;
-		}
-		EXIT("TextureCache: unsupported cached image kind %u for size\n",
-		     static_cast<uint32_t>(kind));
-	}
-	[[nodiscard]] bool OverlapsRange(uint64_t address, uint64_t size, bool page) const {
-		for (uint32_t i = 0; i < RangeCount(); i++) {
-			if (page ? ImagePageRangesOverlap(address, size, Address(i), Size(i))
-			         : ImageRangeOverlaps(address, size, Address(i), Size(i))) {
-				return true;
-			}
-		}
-		return false;
-	}
-	// A page-expanded region lookup identifies candidates before exact byte classification. Kyty's
-	// tracker retains GPU ownership per 4 KiB page, so an edge-page
-	// candidate must remain coherent even when the triggering byte lies just outside the image.
-	[[nodiscard]] bool IsGpuReadbackPageCandidate(uint64_t address, uint64_t size) const {
-		return gpu_modified && OverlapsRange(address, size, true);
-	}
-	[[nodiscard]] bool HasExactRange(uint64_t address, uint64_t size) const {
-		for (uint32_t i = 0; i < RangeCount(); i++) {
-			if (address == Address(i) && size == Size(i)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-private:
-	[[nodiscard]] static Image MakeImage(const ImageInfo& info) {
-		Image image;
-		image = info;
-		return image;
-	}
-
-	[[nodiscard]] bool DescriptorMatchesKind() const {
-		switch (kind) {
-			case Kind::Texture:
-			case Kind::StorageTexture: return std::holds_alternative<Image>(descriptor);
-			case Kind::RenderTarget:
-				return std::holds_alternative<RenderTargetInfo>(descriptor);
-			case Kind::DepthTarget: return std::holds_alternative<DepthTargetInfo>(descriptor);
-			case Kind::VideoOut: return std::holds_alternative<VideoOutInfo>(descriptor);
-		}
-		return false;
-	}
-};
 
 struct TextureCache::AliasRetirementPlan {
 	enum class Action : uint8_t {
@@ -1462,11 +1305,10 @@ void AppendLayerCopies(std::vector<ImageImageCopy>& regions, VulkanImage& source
 
 } // namespace
 
-TextureCache::TextureCache(GraphicContext& graphics, PageManager& page_manager,
-                           BufferCache& buffer_cache, ResourceMutex& resource_mutex)
-    : m_graphics(graphics), m_memory_tracker(page_manager),
-      m_metadata_tracker(page_manager, PageWatchMode::Write), m_buffer_cache(buffer_cache),
-      m_resource_mutex(resource_mutex) {
+TextureCache::TextureCache(PageManager& page_manager, BufferCache& buffer_cache,
+                           ResourceMutex& resource_mutex)
+    : m_memory_tracker(page_manager), m_metadata_tracker(page_manager, PageWatchMode::Write),
+      m_buffer_cache(buffer_cache), m_resource_mutex(resource_mutex) {
 	if (!Common::Thread::IsMainThread()) {
 		EXIT("TextureCache: construction is restricted to the main thread\n");
 	}
@@ -1878,7 +1720,7 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 		}
 	}
 	m_images.reserve(m_images.size() + 1);
-	auto cached = std::make_shared<CachedImage>(m_graphics, CachedImage::Kind::Texture, info);
+	auto cached = std::make_shared<CachedImage>(CachedImage::Kind::Texture, info);
 	vk::ComponentMapping components {};
 	cached->image = ImageOps::CreateTexture(info, false, components);
 	m_memory_tracker.ForEachUploadRange(
@@ -2007,8 +1849,7 @@ StorageTextureVulkanImage& TextureCache::FindStorageTexture(CommandBuffer&   com
 
 	ResolveStorageImageOverlaps(info);
 	m_images.reserve(m_images.size() + 1);
-	auto cached =
-	    std::make_shared<CachedImage>(m_graphics, CachedImage::Kind::StorageTexture, info);
+	auto cached = std::make_shared<CachedImage>(CachedImage::Kind::StorageTexture, info);
 	vk::ComponentMapping components {};
 	cached->image = ImageOps::CreateTexture(info, true, components);
 	m_memory_tracker.ForEachUploadRange(
@@ -2244,7 +2085,7 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 	auto native_image_source = alias_plan.NativeOwner();
 	ExecuteAliasRetirementLocked(alias_plan);
 	ResolveImageMetadataOverlapsLocked(info.address, info.size);
-	auto cached                = std::make_shared<CachedImage>(m_graphics, info);
+	auto cached                = std::make_shared<CachedImage>(info);
 	cached->image              = ImageOps::CreateRenderTarget(info);
 	const bool preserve_native = native_image_source != nullptr;
 	if (preserve_native) {
@@ -2654,7 +2495,7 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 		     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 " samples=%u\n",
 		     info.stencil_address, info.stencil_size, info.samples);
 	}
-	auto cached                 = std::make_shared<CachedImage>(m_graphics, info);
+	auto cached                 = std::make_shared<CachedImage>(info);
 	cached->stencil_initialized = !has_stencil || info.stencil_load_clear || initial_stencil_clear;
 	cached->image               = ImageOps::CreateDepthTarget(info);
 	auto* depth_image           = static_cast<DepthStencilVulkanImage*>(cached->image);
@@ -2814,7 +2655,7 @@ TextureCache::RegisterVideoOutSurfaces(const std::vector<VideoOutInfo>& infos) {
 	std::vector<VideoOutVulkanImage*> result;
 	result.reserve(infos.size());
 	for (const auto& info: infos) {
-		auto cached = std::make_shared<CachedImage>(m_graphics, info);
+		auto cached = std::make_shared<CachedImage>(info);
 		cached->image     = ImageOps::CreateVideoOut(info);
 		if (info.compression == VideoOutCompression::Uncompressed) {
 			m_memory_tracker.ForEachUploadRange(

--- a/src/graphics/host_gpu/renderer/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/textureCache.cpp
@@ -31,6 +31,7 @@
 #include <mutex>
 #include <optional>
 #include <thread>
+#include <variant>
 #include <xxhash.h>
 
 namespace Libs::Graphics {
@@ -189,20 +190,54 @@ bool IsExactRenderTargetMipStorage(const ImageInfo& sampled, const ImageInfo& st
 }
 
 struct TextureCache::CachedImage {
-	explicit CachedImage(GraphicContext& graphics): graphics(graphics) {}
-
 	enum class Kind {
 		Texture,
 		StorageTexture,
 		RenderTarget,
 		DepthTarget,
 		VideoOut
-	} kind = Kind::Texture;
-	Image            info;
-	RenderTargetInfo target;
-	DepthTargetInfo  depth;
-	VideoOutInfo     video_out;
-	GraphicContext&  graphics;
+	};
+
+	CachedImage(GraphicContext& graphics, Kind kind, const ImageInfo& info)
+	    : kind(kind), descriptor(MakeImage(info)), graphics(graphics) {
+		if (kind != Kind::Texture && kind != Kind::StorageTexture) {
+			EXIT("TextureCache: image descriptor has incompatible kind %u\n",
+			     static_cast<uint32_t>(kind));
+		}
+	}
+	CachedImage(GraphicContext& graphics, const RenderTargetInfo& info)
+	    : kind(Kind::RenderTarget), descriptor(info), graphics(graphics) {}
+	CachedImage(GraphicContext& graphics, const DepthTargetInfo& info)
+	    : kind(Kind::DepthTarget), descriptor(info), graphics(graphics) {}
+	CachedImage(GraphicContext& graphics, const VideoOutInfo& info)
+	    : kind(Kind::VideoOut), descriptor(info), graphics(graphics) {}
+
+	[[nodiscard]] Image& ImageDesc() { return std::get<Image>(descriptor); }
+	[[nodiscard]] const Image& ImageDesc() const { return std::get<Image>(descriptor); }
+	[[nodiscard]] RenderTargetInfo& RenderTargetDesc() {
+		return std::get<RenderTargetInfo>(descriptor);
+	}
+	[[nodiscard]] const RenderTargetInfo& RenderTargetDesc() const {
+		return std::get<RenderTargetInfo>(descriptor);
+	}
+	[[nodiscard]] DepthTargetInfo& DepthTargetDesc() {
+		return std::get<DepthTargetInfo>(descriptor);
+	}
+	[[nodiscard]] const DepthTargetInfo& DepthTargetDesc() const {
+		return std::get<DepthTargetInfo>(descriptor);
+	}
+	[[nodiscard]] VideoOutInfo& VideoOutDesc() { return std::get<VideoOutInfo>(descriptor); }
+	[[nodiscard]] const VideoOutInfo& VideoOutDesc() const {
+		return std::get<VideoOutInfo>(descriptor);
+	}
+
+	const Kind kind;
+
+private:
+	std::variant<Image, RenderTargetInfo, DepthTargetInfo, VideoOutInfo> descriptor;
+
+public:
+	GraphicContext&                                                     graphics;
 	VulkanImage*     image               = nullptr;
 	bool             gpu_modified        = false;
 	bool             buffer_modified     = false;
@@ -210,7 +245,7 @@ struct TextureCache::CachedImage {
 	bool             registered          = false;
 
 	~CachedImage() {
-		if (image == nullptr || registered) {
+		if (image == nullptr || registered || !DescriptorMatchesKind()) {
 			EXIT("TextureCache: cached image destroyed with invalid resources, image=%p "
 			     "kind=%u registered=%d\n",
 			     static_cast<const void*>(image), static_cast<uint32_t>(kind), registered);
@@ -220,7 +255,7 @@ struct TextureCache::CachedImage {
 	}
 
 	[[nodiscard]] uint32_t RangeCount() const {
-		return kind == Kind::DepthTarget && depth.stencil_address != 0 ? 2u : 1u;
+		return kind == Kind::DepthTarget && DepthTargetDesc().stencil_address != 0 ? 2u : 1u;
 	}
 	[[nodiscard]] BufferImageBinding BufferBinding() const {
 		switch (kind) {
@@ -238,14 +273,14 @@ struct TextureCache::CachedImage {
 			     index, RangeCount());
 		}
 		if (index == 1) {
-			return depth.stencil_address;
+			return DepthTargetDesc().stencil_address;
 		}
 		switch (kind) {
-			case Kind::Texture: return info.address;
-			case Kind::StorageTexture: return info.address;
-			case Kind::RenderTarget: return target.address;
-			case Kind::DepthTarget: return depth.address;
-			case Kind::VideoOut: return video_out.address;
+			case Kind::Texture:
+			case Kind::StorageTexture: return ImageDesc().address;
+			case Kind::RenderTarget: return RenderTargetDesc().address;
+			case Kind::DepthTarget: return DepthTargetDesc().address;
+			case Kind::VideoOut: return VideoOutDesc().address;
 		}
 		EXIT("TextureCache: unsupported cached image kind %u for address\n",
 		     static_cast<uint32_t>(kind));
@@ -256,14 +291,14 @@ struct TextureCache::CachedImage {
 			     RangeCount());
 		}
 		if (index == 1) {
-			return depth.stencil_size;
+			return DepthTargetDesc().stencil_size;
 		}
 		switch (kind) {
-			case Kind::Texture: return info.size;
-			case Kind::StorageTexture: return info.size;
-			case Kind::RenderTarget: return target.size;
-			case Kind::DepthTarget: return depth.size;
-			case Kind::VideoOut: return video_out.size;
+			case Kind::Texture:
+			case Kind::StorageTexture: return ImageDesc().size;
+			case Kind::RenderTarget: return RenderTargetDesc().size;
+			case Kind::DepthTarget: return DepthTargetDesc().size;
+			case Kind::VideoOut: return VideoOutDesc().size;
 		}
 		EXIT("TextureCache: unsupported cached image kind %u for size\n",
 		     static_cast<uint32_t>(kind));
@@ -291,37 +326,158 @@ struct TextureCache::CachedImage {
 		}
 		return false;
 	}
+
+private:
+	[[nodiscard]] static Image MakeImage(const ImageInfo& info) {
+		Image image;
+		image = info;
+		return image;
+	}
+
+	[[nodiscard]] bool DescriptorMatchesKind() const {
+		switch (kind) {
+			case Kind::Texture:
+			case Kind::StorageTexture: return std::holds_alternative<Image>(descriptor);
+			case Kind::RenderTarget:
+				return std::holds_alternative<RenderTargetInfo>(descriptor);
+			case Kind::DepthTarget: return std::holds_alternative<DepthTargetInfo>(descriptor);
+			case Kind::VideoOut: return std::holds_alternative<VideoOutInfo>(descriptor);
+		}
+		return false;
+	}
 };
 
-void TextureCache::RegisterImageLocked(CachedImage& image) {
-	if (image.registered) {
+struct TextureCache::AliasRetirementPlan {
+	enum class Action : uint8_t {
+		RetireGuestCurrent,
+		MaterializeGuest,
+		PreserveNative,
+		ReleaseGpuOwnership
+	};
+	enum class PageIsolation : uint8_t { Required, SharedPagesAllowed };
+	struct Entry {
+		std::shared_ptr<CachedImage> image;
+		Action                       action;
+	};
+
+	AliasRetirementPlan(const char* operation, GuestRange request, PageIsolation isolation)
+	    : operation(operation), request(request), isolation(isolation) {}
+
+	void Add(const std::shared_ptr<CachedImage>& image, Action action) {
+		if (image == nullptr) {
+			EXIT("TextureCache: alias plan has an empty image owner\n");
+		}
+		if (std::any_of(entries.begin(), entries.end(), [&](const auto& entry) {
+			    return entry.image.get() == image.get();
+		    })) {
+			EXIT("TextureCache: alias plan contains a duplicate retirement\n");
+		}
+		if (action == Action::PreserveNative && NativeSource() != nullptr) {
+			EXIT("TextureCache: alias plan contains multiple native sources\n");
+		}
+		entries.push_back({image, action});
+	}
+
+	void PreserveMetadata(uint64_t address) {
+		if (address != 0 && preserve_metadata_address != 0 &&
+		    preserve_metadata_address != address) {
+			EXIT("TextureCache: alias plan preserves multiple metadata allocations\n");
+		}
+		preserve_metadata_address = address;
+	}
+
+	[[nodiscard]] bool Empty() const { return entries.empty(); }
+	[[nodiscard]] size_t RetirementCount() const { return entries.size(); }
+	[[nodiscard]] bool Contains(const CachedImage& image) const {
+		return std::any_of(entries.begin(), entries.end(),
+		                   [&](const auto& entry) { return entry.image.get() == &image; });
+	}
+	[[nodiscard]] bool HasAction(Action action) const {
+		return std::any_of(entries.begin(), entries.end(),
+		                   [action](const auto& entry) { return entry.action == action; });
+	}
+	[[nodiscard]] std::shared_ptr<CachedImage> NativeOwner() const {
+		const auto entry = std::find_if(entries.begin(), entries.end(), [](const auto& item) {
+			return item.action == Action::PreserveNative;
+		});
+		return entry != entries.end() ? entry->image : nullptr;
+	}
+	[[nodiscard]] CachedImage* NativeSource() const { return NativeOwner().get(); }
+	[[nodiscard]] const std::vector<Entry>& Entries() const { return entries; }
+
+private:
+	friend class TextureCache;
+	const char* const        operation;
+	const GuestRange         request;
+	const PageIsolation isolation;
+	uint64_t                 preserve_metadata_address = 0;
+	std::vector<Entry>       entries;
+};
+
+void TextureCache::RegisterImageLocked(const std::shared_ptr<CachedImage>& image) {
+	if (image == nullptr || image->image == nullptr || image->registered) {
 		EXIT("TextureCache: registering an already registered image\n");
 	}
-	std::vector<ImageOwnerIndex::ByteRange> ranges;
-	ranges.reserve(image.RangeCount());
-	for (uint32_t range = 0; range < image.RangeCount(); range++) {
-		ranges.push_back({image.Address(range), image.Size(range)});
+	if (m_records_by_image.contains(image->image)) {
+		EXIT("TextureCache: duplicate Vulkan image registration, image=%p\n",
+		     static_cast<const void*>(image->image));
 	}
-	if (!m_image_owner_index.Register(&image, ranges)) {
+	std::vector<ImageOwnerIndex::ByteRange> ranges;
+	ranges.reserve(image->RangeCount());
+	for (uint32_t range = 0; range < image->RangeCount(); range++) {
+		ranges.push_back({image->Address(range), image->Size(range)});
+	}
+	m_records_by_image.emplace(image->image, image);
+	if (!m_image_owner_index.Register(image.get(), ranges)) {
+		m_records_by_image.erase(image->image);
 		EXIT("TextureCache: invalid or duplicate image registration\n");
 	}
-	image.registered = true;
+	image->registered = true;
 }
 
 void TextureCache::UnregisterImageLocked(CachedImage& image, bool release_tracking) {
 	if (!image.registered) {
 		EXIT("TextureCache: unregistering an unregistered image\n");
 	}
+	const auto handle = m_records_by_image.find(image.image);
+	if (handle == m_records_by_image.end() || handle->second.lock().get() != &image) {
+		EXIT("TextureCache: image missing from handle index\n");
+	}
 	std::vector<ImageOwnerIndex::ByteRange> final_releases;
 	if (!m_image_owner_index.Unregister(&image, final_releases)) {
 		EXIT("TextureCache: image missing from owner index\n");
 	}
+	m_records_by_image.erase(handle);
 	if (release_tracking) {
 		for (const auto& release: final_releases) {
 			m_memory_tracker.UntrackMemory(release.address, release.size);
 		}
 	}
 	image.registered = false;
+}
+
+std::shared_ptr<TextureCache::CachedImage>
+TextureCache::FindImageOwnerLocked(const CachedImage& image) const {
+	auto owner = FindImageOwnerLocked(*image.image);
+	if (owner.get() != &image) {
+		EXIT("TextureCache: native image record is inconsistent\n");
+	}
+	return owner;
+}
+
+std::shared_ptr<TextureCache::CachedImage>
+TextureCache::FindImageOwnerLocked(VulkanImage& image) const {
+	const auto record = m_records_by_image.find(&image);
+	if (record == m_records_by_image.end()) {
+		EXIT("TextureCache: native image is not registered, image=%p\n",
+		     static_cast<const void*>(&image));
+	}
+	auto owner = record->second.lock();
+	if (owner == nullptr || owner->image != &image) {
+		EXIT("TextureCache: native image record is inconsistent, image=%p\n",
+		     static_cast<const void*>(&image));
+	}
+	return owner;
 }
 
 VulkanImage& TextureCache::PublishImage(CommandBuffer&               command,
@@ -336,7 +492,7 @@ VulkanImage& TextureCache::PublishImage(CommandBuffer&               command,
 	auto& result = *image->image;
 	command.RetainResourceUntilFence(image);
 	m_images.push_back(std::move(image));
-	RegisterImageLocked(*m_images.back());
+	RegisterImageLocked(m_images.back());
 	return result;
 }
 
@@ -344,6 +500,19 @@ std::vector<TextureCache::CachedImage*>
 TextureCache::FindImagesInRegionLocked(uint64_t vaddr, uint64_t size, bool page_overlap) {
 	return page_overlap ? m_image_owner_index.QueryCandidates(vaddr, size)
 	                    : m_image_owner_index.Query(vaddr, size);
+}
+
+std::vector<TextureCache::CachedImage*> TextureCache::FindImagesInRegionsLocked(
+    std::span<const GuestRange> ranges, bool page_overlap) {
+	std::vector<CachedImage*> result;
+	for (const auto& range: ranges) {
+		for (auto* image: FindImagesInRegionLocked(range.address, range.size, page_overlap)) {
+			if (std::find(result.begin(), result.end(), image) == result.end()) {
+				result.push_back(image);
+			}
+		}
+	}
+	return result;
 }
 
 struct TextureCache::ReadbackWorker {
@@ -486,7 +655,7 @@ struct TextureCache::ReadbackWorker {
 
 	[[nodiscard]] ReadbackTransfer DownloadDepthTarget(CachedImage& cached,
 	                                                   bool         require_fault_range = true) {
-		const auto& info = cached.depth;
+		const auto& info = cached.DepthTargetDesc();
 		if (info.samples != 1 || cached.image->samples != 1) {
 			EXIT("TextureCache: multisampled depth-image readback is unsupported, samples=%u/%u\n",
 			     info.samples, cached.image->samples);
@@ -660,28 +829,28 @@ struct TextureCache::ReadbackWorker {
 		const bool storage = cached.kind == CachedImage::Kind::StorageTexture;
 		const bool target  = cached.kind == CachedImage::Kind::RenderTarget;
 		const auto info =
-		    storage ? MakeColorImageTransferInfo(cached.info, VulkanFormat(cached.info.format),
-		                                         Prospero::NumBytesPerElement(cached.info.format))
-		            : MakeColorImageTransferInfo(cached.target);
+		    storage ? MakeColorImageTransferInfo(cached.ImageDesc(), VulkanFormat(cached.ImageDesc().format),
+		                                         Prospero::NumBytesPerElement(cached.ImageDesc().format))
+		            : MakeColorImageTransferInfo(cached.RenderTargetDesc());
 		const bool linear = info.tile_mode == Prospero::GpuEnumValue(Prospero::TileMode::kLinear);
-		const bool tiled_target = target && IsTiledRenderTarget(cached.target);
+		const bool tiled_target = target && IsTiledRenderTarget(cached.RenderTargetDesc());
 		const bool tiled_storage =
 		    storage && info.tile_mode == Prospero::GpuEnumValue(Prospero::TileMode::kRenderTarget);
 		bool single_layer_storage = false;
 		if (storage) {
-			switch (static_cast<Prospero::ImageType>(cached.info.type)) {
+			switch (static_cast<Prospero::ImageType>(cached.ImageDesc().type)) {
 				case Prospero::ImageType::kColor2D:
 				case Prospero::ImageType::kColor2DArray:
-					single_layer_storage = cached.info.depth == 1;
+					single_layer_storage = cached.ImageDesc().depth == 1;
 					break;
 				default: break;
 			}
 		}
 		const bool basic_storage =
 		    !storage ||
-		    (single_layer_storage && cached.info.base_level == 0 && cached.info.levels == 1 &&
-		     cached.info.base_array == 0 && (linear || tiled_storage));
-		const auto    layers = target ? cached.target.layers : 1u;
+		    (single_layer_storage && cached.ImageDesc().base_level == 0 && cached.ImageDesc().levels == 1 &&
+		     cached.ImageDesc().base_array == 0 && (linear || tiled_storage));
+		const auto    layers = target ? cached.RenderTargetDesc().layers : 1u;
 		TileSizeAlign target_mip_layout {};
 		const bool    target_mip_chain =
 		    target && info.levels > 1 && layers == 1 && tiled_target &&
@@ -717,7 +886,7 @@ struct TextureCache::ReadbackWorker {
 		const bool                   gpu_tiled = tiled_target || tiled_storage;
 		if (gpu_tiled) {
 			const auto format = storage
-			                        ? cached.info.format
+			                        ? cached.ImageDesc().format
 			                        : ImageOps::RenderTargetTransferFormat(info.bytes_per_element);
 			tiled_layout = TextureCalcUploadLayout(format, info.width, info.height, info.levels,
 			                                       layers, info.pitch, info.tile_mode, info.size,
@@ -740,7 +909,7 @@ struct TextureCache::ReadbackWorker {
 		if (gpu_tiled) {
 			std::vector<GpuTileInfo> infos;
 			const auto format = storage
-			                        ? cached.info.format
+			                        ? cached.ImageDesc().format
 			                        : ImageOps::RenderTargetTransferFormat(info.bytes_per_element);
 			guest.resize(info.size);
 			EXIT_NOT_IMPLEMENTED(!TextureBuildGpuTileInfos(info.size, tiled_regions, tiled_layout,
@@ -912,7 +1081,7 @@ void TextureCache::RetireImages(const std::vector<CachedImage*>& retire,
 			bool source_valid = (*it)->gpu_modified && !(*it)->buffer_modified;
 			switch ((*it)->kind) {
 				case CachedImage::Kind::StorageTexture:
-					source_valid = source_valid && !(*it)->info.IsCpuDirty();
+					source_valid = source_valid && !(*it)->ImageDesc().IsCpuDirty();
 					break;
 				case CachedImage::Kind::RenderTarget:
 				case CachedImage::Kind::DepthTarget: break;
@@ -928,13 +1097,13 @@ void TextureCache::RetireImages(const std::vector<CachedImage*>& retire,
 				     "buffer_modified=%d cpu_dirty=%d\n",
 				     static_cast<uint32_t>((*it)->kind), (*it)->gpu_modified,
 				     (*it)->buffer_modified,
-				     (*it)->kind == CachedImage::Kind::StorageTexture && (*it)->info.IsCpuDirty());
+				     (*it)->kind == CachedImage::Kind::StorageTexture && (*it)->ImageDesc().IsCpuDirty());
 			}
 			(*it)->gpu_modified  = false;
 			native_image_retired = true;
 		}
 		if ((!sampled && !storage && !target && !native_image) || (*it)->gpu_modified ||
-		    (storage && ((*it)->buffer_modified || (*it)->info.IsCpuDirty())) ||
+		    (storage && ((*it)->buffer_modified || (*it)->ImageDesc().IsCpuDirty())) ||
 		    (target && (*it)->buffer_modified)) {
 			EXIT("TextureCache: invalid image retirement, kind=%u gpu_modified=%d "
 			     "buffer_modified=%d\n",
@@ -967,33 +1136,33 @@ void TextureCache::RetireDepthMetadataLocked(const std::vector<CachedImage*>& re
                                              uint64_t                         preserve_address) {
 	std::vector<uint64_t> addresses;
 	for (auto* cached: retire) {
-		if (cached->kind != CachedImage::Kind::DepthTarget || cached->depth.htile_address == 0) {
+		if (cached->kind != CachedImage::Kind::DepthTarget || cached->DepthTargetDesc().htile_address == 0) {
 			continue;
 		}
 		const bool retained_owner =
 		    std::any_of(m_images.begin(), m_images.end(), [&](const auto& other) {
 			    return std::find(retire.begin(), retire.end(), other.get()) == retire.end() &&
 			           other->kind == CachedImage::Kind::DepthTarget &&
-			           other->depth.htile_address == cached->depth.htile_address &&
-			           other->depth.htile_size == cached->depth.htile_size;
+			           other->DepthTargetDesc().htile_address == cached->DepthTargetDesc().htile_address &&
+			           other->DepthTargetDesc().htile_size == cached->DepthTargetDesc().htile_size;
 		    });
-		if (!retained_owner && cached->depth.htile_address != preserve_address &&
-		    std::find(addresses.begin(), addresses.end(), cached->depth.htile_address) ==
+		if (!retained_owner && cached->DepthTargetDesc().htile_address != preserve_address &&
+		    std::find(addresses.begin(), addresses.end(), cached->DepthTargetDesc().htile_address) ==
 		        addresses.end()) {
-			addresses.push_back(cached->depth.htile_address);
+			addresses.push_back(cached->DepthTargetDesc().htile_address);
 		}
 	}
 	for (const auto address: addresses) {
 		auto metadata = m_surface_metas.find(address);
 		auto owner    = std::find_if(retire.begin(), retire.end(), [&](const auto* cached) {
 			return cached->kind == CachedImage::Kind::DepthTarget &&
-			       cached->depth.htile_address == address;
+			       cached->DepthTargetDesc().htile_address == address;
 		});
 		if (metadata == m_surface_metas.end() || owner == retire.end() ||
-		    metadata->second.size != (*owner)->depth.htile_size) {
+		    metadata->second.size != (*owner)->DepthTargetDesc().htile_size) {
 			EXIT("TextureCache: retiring depth target has invalid HTile metadata, "
 			     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
-			     address, owner != retire.end() ? (*owner)->depth.htile_size : 0);
+			     address, owner != retire.end() ? (*owner)->DepthTargetDesc().htile_size : 0);
 		}
 		if (metadata->second.gpu_modified) {
 			m_metadata_tracker.ForEachDownloadRange<true>(metadata->first, metadata->second.size,
@@ -1034,6 +1203,103 @@ void TextureCache::MaterializeImagesToGuestLocked(
 		}
 		cached->gpu_modified = false;
 	}
+}
+
+void TextureCache::ExecuteAliasRetirementLocked(const AliasRetirementPlan& plan) {
+	if (plan.operation == nullptr || !plan.request.IsValid() ||
+	    (plan.isolation != AliasRetirementPlan::PageIsolation::Required &&
+	     plan.isolation != AliasRetirementPlan::PageIsolation::SharedPagesAllowed)) {
+		EXIT("TextureCache: invalid alias retirement plan\n");
+	}
+	std::vector<CachedImage*>                 retirements;
+	std::vector<std::shared_ptr<CachedImage>> materializations;
+	std::vector<std::shared_ptr<CachedImage>> discarded_owners;
+	retirements.reserve(plan.entries.size());
+	for (const auto& entry: plan.entries) {
+		if (entry.image == nullptr || !entry.image->registered ||
+		    FindImageOwnerLocked(*entry.image).get() != entry.image.get()) {
+			EXIT("TextureCache: alias plan references an unregistered image\n");
+		}
+		const bool storage = entry.image->kind == CachedImage::Kind::StorageTexture;
+		const bool target  = entry.image->kind == CachedImage::Kind::RenderTarget ||
+		                    entry.image->kind == CachedImage::Kind::DepthTarget;
+		const bool cpu_dirty = storage && entry.image->ImageDesc().IsCpuDirty();
+		retirements.push_back(entry.image.get());
+		switch (entry.action) {
+			case AliasRetirementPlan::Action::RetireGuestCurrent:
+				if ((!storage && !target && entry.image->kind != CachedImage::Kind::Texture) ||
+				    entry.image->gpu_modified || ((storage || target) && entry.image->buffer_modified) ||
+				    cpu_dirty) {
+					EXIT("TextureCache: invalid guest-current alias retirement\n");
+				}
+				for (uint32_t range = 0; target && range < entry.image->RangeCount(); range++) {
+					if (m_memory_tracker.IsRegionGpuModified(entry.image->Address(range),
+					                                         entry.image->Size(range))) {
+						EXIT("TextureCache: guest-current target retains GPU tracker ownership\n");
+					}
+				}
+				break;
+			case AliasRetirementPlan::Action::MaterializeGuest:
+				if ((!storage && !target) || entry.image->buffer_modified || cpu_dirty) {
+					EXIT("TextureCache: invalid alias materialization source\n");
+				}
+				for (uint32_t range = 0; !entry.image->gpu_modified && target &&
+				                         range < entry.image->RangeCount();
+				     range++) {
+					if (m_memory_tracker.IsRegionGpuModified(entry.image->Address(range),
+					                                         entry.image->Size(range))) {
+						EXIT("TextureCache: clean materialization source retains GPU ownership\n");
+					}
+				}
+				materializations.push_back(entry.image);
+				break;
+			case AliasRetirementPlan::Action::PreserveNative:
+				if ((!storage && !target) || !entry.image->gpu_modified ||
+				    entry.image->buffer_modified || cpu_dirty) {
+					EXIT("TextureCache: invalid native alias source\n");
+				}
+				for (uint32_t range = 0; range < entry.image->RangeCount(); range++) {
+					if (!m_memory_tracker.IsRegionGpuModified(entry.image->Address(range),
+					                                          entry.image->Size(range))) {
+						EXIT("TextureCache: native alias source lacks GPU tracker ownership\n");
+					}
+				}
+				break;
+			case AliasRetirementPlan::Action::ReleaseGpuOwnership:
+				if (!storage || entry.image->buffer_modified || cpu_dirty) {
+					EXIT("TextureCache: invalid GPU ownership release\n");
+				}
+				for (uint32_t range = 0; range < entry.image->RangeCount(); range++) {
+					const bool tracker_gpu = m_memory_tracker.IsRegionGpuModified(
+					    entry.image->Address(range), entry.image->Size(range));
+					if (tracker_gpu != entry.image->gpu_modified) {
+						EXIT("TextureCache: GPU ownership release has inconsistent tracking\n");
+					}
+				}
+				discarded_owners.push_back(entry.image);
+				break;
+			default: EXIT("TextureCache: alias plan contains an invalid action\n");
+		}
+	}
+	if (plan.Empty()) {
+		return;
+	}
+	if (plan.isolation == AliasRetirementPlan::PageIsolation::Required) {
+		RequireRetirementIsolation(retirements, plan.operation, plan.request.address,
+		                           plan.request.size);
+	}
+	MaterializeImagesToGuestLocked(materializations);
+	for (const auto& image: discarded_owners) {
+		if (!image->gpu_modified) {
+			continue;
+		}
+		for (uint32_t range = 0; range < image->RangeCount(); range++) {
+			m_memory_tracker.UnmarkRegionAsGpuModified(image->Address(range), image->Size(range));
+		}
+		image->gpu_modified = false;
+	}
+	RetireDepthMetadataLocked(retirements, plan.preserve_metadata_address);
+	RetireImages(retirements, plan.NativeSource());
 }
 
 namespace {
@@ -1169,32 +1435,32 @@ void TextureCache::MarkSampledAliasesCpuDirtyLocked(uint64_t vaddr, uint64_t siz
 			continue;
 		}
 		if (cached->gpu_modified &&
-		    ImageRangeOverlaps(cached->info.address, cached->info.size, vaddr, size)) {
+		    ImageRangeOverlaps(cached->ImageDesc().address, cached->ImageDesc().size, vaddr, size)) {
 			EXIT("TextureCache: CPU write overlaps a GPU-modified sampled texture, "
 			     "write=0x%016" PRIx64 "+0x%016" PRIx64 " image=0x%016" PRIx64 "+0x%016" PRIx64
 			     "\n",
-			     vaddr, size, cached->info.address, cached->info.size);
+			     vaddr, size, cached->ImageDesc().address, cached->ImageDesc().size);
 		}
-		cached->info.InvalidateCpuWrite(vaddr, size);
-		if (cached->info.NeedsMaybeCpuHash()) {
-			cached->info.SetMaybeCpuHash(HashSampledImageEdges(cached->info));
+		cached->ImageDesc().InvalidateCpuWrite(vaddr, size);
+		if (cached->ImageDesc().NeedsMaybeCpuHash()) {
+			cached->ImageDesc().SetMaybeCpuHash(HashSampledImageEdges(cached->ImageDesc()));
 		}
 	}
 }
 
 void TextureCache::RetireSampledTargetAliases(const ImageInfo& requested) {
-	std::vector<CachedImage*> retire;
-	bool                      wait_idle = false;
+	AliasRetirementPlan plan("sampled target", {requested.address, requested.size},
+	                         AliasRetirementPlan::PageIsolation::Required);
 	for (auto* cached: FindImagesInRegionLocked(requested.address, requested.size, true)) {
 		if (cached->kind != CachedImage::Kind::RenderTarget) {
 			continue;
 		}
-		switch (ClassifySampledRenderTargetOverlap(requested, cached->target,
+		switch (ClassifySampledRenderTargetOverlap(requested, cached->RenderTargetDesc(),
 		                                           cached->buffer_modified)) {
 			case RenderTargetOverlap::None: continue;
 			case RenderTargetOverlap::RetireTarget:
-				wait_idle |= cached->gpu_modified;
-				retire.push_back(cached);
+				plan.Add(FindImageOwnerLocked(*cached),
+				         AliasRetirementPlan::Action::MaterializeGuest);
 				break;
 			case RenderTargetOverlap::RetireSampled:
 			case RenderTargetOverlap::RetireStorage:
@@ -1204,7 +1470,8 @@ void TextureCache::RetireSampledTargetAliases(const ImageInfo& requested) {
 				EXIT("TextureCache: unsupported sampled/render-target alias, sampled=0x%016" PRIx64
 				     "+0x%016" PRIx64 " target=0x%016" PRIx64 "+0x%016" PRIx64
 				     " gpu=%d buffer=%d\n",
-				     requested.address, requested.size, cached->target.address, cached->target.size,
+				     requested.address, requested.size, cached->RenderTargetDesc().address,
+				     cached->RenderTargetDesc().size,
 				     cached->gpu_modified, cached->buffer_modified);
 		}
 	}
@@ -1212,35 +1479,37 @@ void TextureCache::RetireSampledTargetAliases(const ImageInfo& requested) {
 		if (cached->kind != CachedImage::Kind::DepthTarget) {
 			continue;
 		}
-		const bool overlaps_depth = ImageRangeOverlaps(requested.address, requested.size,
-		                                               cached->depth.address, cached->depth.size);
+		const bool overlaps_depth =
+		    ImageRangeOverlaps(requested.address, requested.size,
+		                       cached->DepthTargetDesc().address, cached->DepthTargetDesc().size);
 		const bool overlaps_stencil =
-		    cached->depth.stencil_address != 0 &&
-		    ImageRangeOverlaps(requested.address, requested.size, cached->depth.stencil_address,
-		                       cached->depth.stencil_size);
+		    cached->DepthTargetDesc().stencil_address != 0 &&
+		    ImageRangeOverlaps(requested.address, requested.size, cached->DepthTargetDesc().stencil_address,
+		                       cached->DepthTargetDesc().stencil_size);
 		if (!overlaps_depth && !overlaps_stencil) {
 			continue;
 		}
-		const auto delta = cached->depth.address >= requested.address
-		                       ? cached->depth.address - requested.address
+		const auto delta = cached->DepthTargetDesc().address >= requested.address
+		                       ? cached->DepthTargetDesc().address - requested.address
 		                       : UINT64_MAX;
 		const bool contained =
-		    delta <= requested.size && cached->depth.size <= requested.size - delta;
-		const bool sampled_expansion = IsSampledDepthExpansion(requested, cached->depth);
-		const bool exact_range =
-		    requested.address == cached->depth.address && requested.size == cached->depth.size;
-		const bool depth_tracker_gpu =
-		    m_memory_tracker.IsRegionGpuModified(cached->depth.address, cached->depth.size);
+		    delta <= requested.size && cached->DepthTargetDesc().size <= requested.size - delta;
+		const bool sampled_expansion = IsSampledDepthExpansion(requested, cached->DepthTargetDesc());
+		const bool exact_range = requested.address == cached->DepthTargetDesc().address &&
+		                         requested.size == cached->DepthTargetDesc().size;
+		const bool depth_tracker_gpu = m_memory_tracker.IsRegionGpuModified(
+		    cached->DepthTargetDesc().address, cached->DepthTargetDesc().size);
 		const bool stencil_tracker_gpu =
-		    cached->depth.stencil_address != 0 &&
-		    m_memory_tracker.IsRegionGpuModified(cached->depth.stencil_address,
-		                                         cached->depth.stencil_size);
+		    cached->DepthTargetDesc().stencil_address != 0 &&
+		    m_memory_tracker.IsRegionGpuModified(cached->DepthTargetDesc().stencil_address,
+		                                         cached->DepthTargetDesc().stencil_size);
 		const bool clean_pool_alias = CanRetireGuestCurrentDepthForSampled(
-		    requested, cached->depth, cached->gpu_modified, cached->buffer_modified,
+		    requested, cached->DepthTargetDesc(), cached->gpu_modified, cached->buffer_modified,
 		    depth_tracker_gpu, stencil_tracker_gpu);
 		const bool native_transition =
-		    !cached->buffer_modified && cached->depth.stencil_address == 0 &&
-		    cached->depth.stencil_size == 0 && cached->depth.layers == 1 && contained &&
+		    !cached->buffer_modified && cached->DepthTargetDesc().stencil_address == 0 &&
+		    cached->DepthTargetDesc().stencil_size == 0 &&
+		    cached->DepthTargetDesc().layers == 1 && contained &&
 		    (exact_range || sampled_expansion);
 		const bool supported = clean_pool_alias || native_transition;
 		if (!supported) {
@@ -1251,45 +1520,30 @@ void TextureCache::RetireSampledTargetAliases(const ImageInfo& requested) {
 			     " sampled_info={fmt=%u extent=%ux%u pitch=%u levels=%u/%u tile=%u type=%u}"
 			     " depth_info={fmt=%u host=%d extent=%ux%u pitch=%u tile=%u htile=0x%016" PRIx64
 			     "+0x%016" PRIx64 "}\n",
-			     requested.address, requested.size, cached->depth.address, cached->depth.size,
+			     requested.address, requested.size, cached->DepthTargetDesc().address,
+			     cached->DepthTargetDesc().size,
 			     overlaps_depth, overlaps_stencil, contained, cached->gpu_modified,
 			     depth_tracker_gpu, stencil_tracker_gpu, cached->buffer_modified,
-			     cached->depth.stencil_address, cached->depth.stencil_size, cached->depth.layers,
+			     cached->DepthTargetDesc().stencil_address,
+			     cached->DepthTargetDesc().stencil_size, cached->DepthTargetDesc().layers,
 			     sampled_expansion, requested.format, requested.width, requested.height,
 			     requested.pitch, requested.levels, requested.view_levels, requested.tile,
-			     requested.type, cached->depth.guest_format, static_cast<int>(cached->depth.format),
-			     cached->depth.width, cached->depth.height, cached->depth.pitch,
-			     cached->depth.tile_mode, cached->depth.htile_address, cached->depth.htile_size);
+			     requested.type, cached->DepthTargetDesc().guest_format,
+			     static_cast<int>(cached->DepthTargetDesc().format),
+			     cached->DepthTargetDesc().width, cached->DepthTargetDesc().height,
+			     cached->DepthTargetDesc().pitch,
+			     cached->DepthTargetDesc().tile_mode,
+			     cached->DepthTargetDesc().htile_address,
+			     cached->DepthTargetDesc().htile_size);
 		}
-		wait_idle |= cached->gpu_modified;
-		retire.push_back(cached);
+		plan.Add(FindImageOwnerLocked(*cached), AliasRetirementPlan::Action::MaterializeGuest);
 	}
-	if (retire.empty()) {
-		return;
-	}
-	RequireRetirementIsolation(retire, "sampled target", requested.address, requested.size);
-	if (wait_idle) {
-		Transfer::WaitForGraphicsIdle();
-	}
-	for (auto* cached: retire) {
-		if (!cached->gpu_modified) {
-			continue;
-		}
-		const auto transfer = cached->kind == CachedImage::Kind::DepthTarget
-		                          ? m_readback->DownloadDepthTarget(*cached, false)
-		                          : m_readback->DownloadColorImage(*cached);
-		for (const auto& range: transfer.Ranges()) {
-			m_memory_tracker.ForEachDownloadRange<true>(range.address, range.size,
-			                                            [](uint64_t, uint64_t) noexcept {});
-		}
-		cached->gpu_modified = false;
-	}
-	RetireDepthMetadataLocked(retire);
-	RetireImages(retire);
+	ExecuteAliasRetirementLocked(plan);
 }
 
 void TextureCache::ResolveStorageImageOverlaps(const ImageInfo& requested) {
-	std::vector<CachedImage*> retire;
+	AliasRetirementPlan plan("storage image", {requested.address, requested.size},
+	                         AliasRetirementPlan::PageIsolation::SharedPagesAllowed);
 	for (auto* cached: FindImagesInRegionLocked(requested.address, requested.size, true)) {
 		const bool tracker_gpu =
 		    m_memory_tracker.IsRegionGpuModified(cached->Address(), cached->Size());
@@ -1298,7 +1552,9 @@ void TextureCache::ResolveStorageImageOverlaps(const ImageInfo& requested) {
 		    cached->kind == CachedImage::Kind::Texture, cached->gpu_modified,
 		    cached->buffer_modified, tracker_gpu)) {
 			case StorageImageOverlap::None: continue;
-			case StorageImageOverlap::RetireSampled: retire.push_back(cached); continue;
+			case StorageImageOverlap::RetireSampled:
+				plan.Add(FindImageOwnerLocked(*cached), AliasRetirementPlan::Action::RetireGuestCurrent);
+				continue;
 			case StorageImageOverlap::PageNeighbor: continue;
 			case StorageImageOverlap::Unsupported:
 				EXIT("TextureCache: unsupported storage-image byte alias, requested=0x%016" PRIx64
@@ -1309,22 +1565,9 @@ void TextureCache::ResolveStorageImageOverlaps(const ImageInfo& requested) {
 				     cached->buffer_modified);
 		}
 	}
-	// Every exact byte overlap was classified above: only clean sampled images are retired and all
-	// retained byte aliases remain fatal. A retired full mip chain can still contain a cached,
-	// byte-disjoint subresource outside this storage request. The multi-owner index keeps those
-	// retained pages tracked and UnregisterImageLocked releases only pages whose final owner left.
-	for (auto* cached: retire) {
-		if (!cached->gpu_modified) {
-			continue;
-		}
-		const auto transfer = m_readback->DownloadColorImage(*cached);
-		for (const auto& range: transfer.Ranges()) {
-			m_memory_tracker.ForEachDownloadRange<true>(range.address, range.size,
-			                                            [](uint64_t, uint64_t) noexcept {});
-		}
-		cached->gpu_modified = false;
-	}
-	RetireImages(retire);
+	// Only clean sampled images reach the plan; retained byte aliases remain fatal. The owner index
+	// keeps byte-disjoint neighbors tracked when the sampled record is retired.
+	ExecuteAliasRetirementLocked(plan);
 }
 
 void TextureCache::RetireStorageDepthAliasLocked(const ImageInfo& requested) {
@@ -1335,7 +1578,7 @@ void TextureCache::RetireStorageDepthAliasLocked(const ImageInfo& requested) {
 		    !cached.OverlapsRange(requested.address, requested.size, true)) {
 			continue;
 		}
-		const auto& depth = cached.depth;
+		const auto& depth = cached.DepthTargetDesc();
 		const bool  exact_d32_uint =
 		    cached.gpu_modified && !cached.buffer_modified && depth.address == requested.address &&
 		    depth.size == requested.size && depth.stencil_address == 0 && depth.stencil_size == 0 &&
@@ -1360,14 +1603,10 @@ void TextureCache::RetireStorageDepthAliasLocked(const ImageInfo& requested) {
 	if (selected == nullptr) {
 		return;
 	}
-	Transfer::WaitForGraphicsIdle();
-	const auto transfer = m_readback->DownloadDepthTarget(*selected, false);
-	for (const auto& range: transfer.Ranges()) {
-		m_memory_tracker.ForEachDownloadRange<true>(range.address, range.size,
-		                                            [](uint64_t, uint64_t) noexcept {});
-	}
-	selected->gpu_modified = false;
-	RetireImages({selected});
+	AliasRetirementPlan plan("storage depth", {requested.address, requested.size},
+	                         AliasRetirementPlan::PageIsolation::SharedPagesAllowed);
+	plan.Add(FindImageOwnerLocked(*selected), AliasRetirementPlan::Action::MaterializeGuest);
+	ExecuteAliasRetirementLocked(plan);
 }
 
 TextureCache::~TextureCache() {
@@ -1417,21 +1656,22 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 		     info.address, info.size, metadata_read);
 	}
 	std::shared_ptr<CachedImage> storage_match;
-	std::vector<CachedImage*>    storage_retire;
+	AliasRetirementPlan storage_aliases("sampled mip storage", {info.address, info.size},
+	                                    AliasRetirementPlan::PageIsolation::SharedPagesAllowed);
 	const auto                   requested_view_format = TextureGetFormat(info.format);
-	for (auto& cached: m_images) {
+	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
 		if (cached->kind != CachedImage::Kind::StorageTexture) {
 			continue;
 		}
 		const bool tracker_gpu =
-		    m_memory_tracker.IsRegionGpuModified(cached->info.address, cached->info.size);
+		    m_memory_tracker.IsRegionGpuModified(cached->ImageDesc().address, cached->ImageDesc().size);
 		const bool cpu_dirty =
-		    cached->info.IsCpuDirty() ||
-		    m_memory_tracker.IsRegionCpuModified(cached->info.address, cached->info.size);
+		    cached->ImageDesc().IsCpuDirty() ||
+		    m_memory_tracker.IsRegionCpuModified(cached->ImageDesc().address, cached->ImageDesc().size);
 		const bool exact_mip = IsExactRenderTargetMipStorage(
-		    info, cached->info, requested_view_format, cached->image->format);
+		    info, cached->ImageDesc(), requested_view_format, cached->image->format);
 		switch (ClassifyStorageSampledOverlap(
-		    info, cached->info, requested_view_format, cached->image->format, cached->gpu_modified,
+		    info, cached->ImageDesc(), requested_view_format, cached->image->format, cached->gpu_modified,
 		    cpu_dirty, exact_mip, cached->buffer_modified, tracker_gpu)) {
 			case StorageSampledOverlap::None: break;
 			case StorageSampledOverlap::ExactImage:
@@ -1440,10 +1680,11 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 					     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
 					     info.address, info.size);
 				}
-				storage_match = cached;
+				storage_match = FindImageOwnerLocked(*cached);
 				break;
 			case StorageSampledOverlap::RetireStorage:
-				storage_retire.push_back(cached.get());
+				storage_aliases.Add(FindImageOwnerLocked(*cached),
+				                    AliasRetirementPlan::Action::MaterializeGuest);
 				break;
 			case StorageSampledOverlap::Unsupported:
 				EXIT("TextureCache: unsupported sampled/storage image alias, "
@@ -1455,21 +1696,21 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 				     " view_levels=%u tile=%u swizzle=0x%03x type=%u base_array=%u}"
 				     " storage_info={format=%u extent=%ux%ux%u pitch=%u base=%u levels=%u"
 				     " view_levels=%u tile=%u swizzle=0x%03x type=%u base_array=%u}\n",
-				     info.address, info.size, cached->info.address, cached->info.size,
+				     info.address, info.size, cached->ImageDesc().address, cached->ImageDesc().size,
 				     cached->gpu_modified, cached->buffer_modified, tracker_gpu, cpu_dirty,
 				     exact_mip, info.format, info.width, info.height, info.depth, info.pitch,
 				     info.base_level, info.levels, info.view_levels, info.tile, info.swizzle,
-				     info.type, info.base_array, cached->info.format, cached->info.width,
-				     cached->info.height, cached->info.depth, cached->info.pitch,
-				     cached->info.base_level, cached->info.levels, cached->info.view_levels,
-				     cached->info.tile, cached->info.swizzle, cached->info.type,
-				     cached->info.base_array);
+				     info.type, info.base_array, cached->ImageDesc().format, cached->ImageDesc().width,
+				     cached->ImageDesc().height, cached->ImageDesc().depth, cached->ImageDesc().pitch,
+				     cached->ImageDesc().base_level, cached->ImageDesc().levels, cached->ImageDesc().view_levels,
+				     cached->ImageDesc().tile, cached->ImageDesc().swizzle, cached->ImageDesc().type,
+				     cached->ImageDesc().base_array);
 		}
 	}
-	if (storage_match != nullptr && !storage_retire.empty()) {
+	if (storage_match != nullptr && !storage_aliases.Empty()) {
 		EXIT("TextureCache: sampled binding has both exact and mip storage owners, "
 		     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 " mip_owners=%zu\n",
-		     info.address, info.size, storage_retire.size());
+		     info.address, info.size, storage_aliases.RetirementCount());
 	}
 	if (storage_match != nullptr) {
 		if (m_memory_tracker.IsRegionCpuModified(info.address, info.size) ||
@@ -1483,36 +1724,30 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 		command.RetainResourceUntilFence(storage_match);
 		return *storage_match->image;
 	}
-	if (!storage_retire.empty()) {
-		// shadPS4 resolves a modified cached mip before replacing it with the containing image.
+	if (!storage_aliases.Empty()) {
+		// Resolve a modified cached mip before replacing it with the containing image.
 		// Kyty does not yet copy between those independently allocated Vulkan images, so use the
 		// existing synchronized tiled readback seam and rebuild the complete chain from coherent
 		// guest backing. This is an uncommon ownership transition, not a frame lookup fast path.
-		Transfer::WaitForGraphicsIdle();
-		for (auto* cached: storage_retire) {
-			if (!cached->gpu_modified || cached->buffer_modified || cached->info.IsCpuDirty() ||
-			    !m_memory_tracker.IsRegionGpuModified(cached->info.address, cached->info.size) ||
-			    m_memory_tracker.IsRegionCpuModified(cached->info.address, cached->info.size)) {
+		for (const auto& entry: storage_aliases.Entries()) {
+			auto* cached = entry.image.get();
+			if (!cached->gpu_modified || cached->buffer_modified || cached->ImageDesc().IsCpuDirty() ||
+			    !m_memory_tracker.IsRegionGpuModified(cached->ImageDesc().address, cached->ImageDesc().size) ||
+			    m_memory_tracker.IsRegionCpuModified(cached->ImageDesc().address, cached->ImageDesc().size)) {
 				EXIT("TextureCache: sampled mip-storage ownership changed during transition, "
 				     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 " gpu=%d buffer=%d dirty=%d\n",
-				     cached->info.address, cached->info.size, cached->gpu_modified,
-				     cached->buffer_modified, cached->info.IsCpuDirty());
+				     cached->ImageDesc().address, cached->ImageDesc().size, cached->gpu_modified,
+				     cached->buffer_modified, cached->ImageDesc().IsCpuDirty());
 			}
-			const auto transfer = m_readback->DownloadColorImage(*cached);
-			for (const auto& range: transfer.Ranges()) {
-				m_memory_tracker.ForEachDownloadRange<true>(range.address, range.size,
-				                                            [](uint64_t, uint64_t) noexcept {});
-			}
-			cached->gpu_modified = false;
 		}
-		RetireImages(storage_retire);
+		ExecuteAliasRetirementLocked(storage_aliases);
 	}
 	if (m_memory_tracker.IsRegionCpuModified(info.address, info.size)) {
 		MarkSampledAliasesCpuDirtyLocked(info.address, info.size);
 	}
 	std::shared_ptr<CachedImage> match;
-	for (auto& cached: m_images) {
-		if (cached->kind != CachedImage::Kind::Texture || !Equal(info, cached->info)) {
+	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
+		if (cached->kind != CachedImage::Kind::Texture || !Equal(info, cached->ImageDesc())) {
 			continue;
 		}
 		if (match != nullptr || cached->gpu_modified) {
@@ -1520,12 +1755,12 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 			     " size=0x%016" PRIx64 " duplicate=%d gpu_modified=%d\n",
 			     info.address, info.size, match != nullptr, cached->gpu_modified);
 		}
-		match = cached;
+		match = FindImageOwnerLocked(*cached);
 	}
 	if (match != nullptr) {
-		if (match->info.IsMaybeCpuDirty() && !match->info.IsDefinitelyCpuDirty()) {
+		if (match->ImageDesc().IsMaybeCpuDirty() && !match->ImageDesc().IsDefinitelyCpuDirty()) {
 			const bool changed =
-			    match->info.ResolveMaybeCpuHash(HashSampledImageEdges(match->info));
+			    match->ImageDesc().ResolveMaybeCpuHash(HashSampledImageEdges(match->ImageDesc()));
 			if (!changed) {
 				m_memory_tracker.ForEachUploadRange(
 				    info.address, info.size, false, [](uint64_t, uint64_t) noexcept {},
@@ -1544,22 +1779,22 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 			}
 			m_memory_tracker.MarkRegionAsCpuModified(info.address, info.size);
 		}
-		if (match->info.IsCpuDirty() || buffer_dirty) {
+		if (match->ImageDesc().IsCpuDirty() || buffer_dirty) {
 			m_memory_tracker.ForEachUploadRange(
 			    info.address, info.size, false, [](uint64_t, uint64_t) noexcept {},
 			    [&]() noexcept {
 				    m_tiler.DetileImage(*static_cast<GpuTextureVulkanImage*>(match->image),
-				                        match->info, source, true, false);
+				                        match->ImageDesc(), source, true, false);
 			    });
-			if (match->info.IsCpuDirty()) {
-				match->info.RefreshComplete();
+			if (match->ImageDesc().IsCpuDirty()) {
+				match->ImageDesc().RefreshComplete();
 			}
 			match->buffer_modified = false;
 		}
 		command.RetainResourceUntilFence(match);
 		return *match->image;
 	}
-	for (const auto& cached: m_images) {
+	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
 		if (cached->kind != CachedImage::Kind::Texture) {
 			if (!cached->OverlapsRange(info.address, info.size, true)) {
 				continue;
@@ -1572,24 +1807,22 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 			     static_cast<uint32_t>(cached->kind), info.format, info.width, info.height,
 			     info.depth, info.pitch, info.levels, info.tile, info.type);
 		}
-		const auto overlap = ClassifySampledOverlap(info, cached->info, cached->gpu_modified);
+		const auto overlap = ClassifySampledOverlap(info, cached->ImageDesc(), cached->gpu_modified);
 		if (overlap == SampledOverlap::Unsupported) {
 			EXIT("TextureCache: unsupported sampled-texture alias, requested=0x%016" PRIx64
 			     "+0x%016" PRIx64 " existing=0x%016" PRIx64 "+0x%016" PRIx64 " gpu_modified=%d\n",
-			     info.address, info.size, cached->info.address, cached->info.size,
+			     info.address, info.size, cached->ImageDesc().address, cached->ImageDesc().size,
 			     cached->gpu_modified);
 		}
 	}
 	m_images.reserve(m_images.size() + 1);
-	auto cached  = std::make_shared<CachedImage>(m_graphics);
-	cached->kind = CachedImage::Kind::Texture;
-	cached->info = info;
+	auto cached = std::make_shared<CachedImage>(m_graphics, CachedImage::Kind::Texture, info);
 	vk::ComponentMapping components {};
 	cached->image = ImageOps::CreateTexture(info, false, components);
 	m_memory_tracker.ForEachUploadRange(
 	    info.address, info.size, false, [](uint64_t, uint64_t) noexcept {},
 	    [&]() noexcept {
-		    m_tiler.DetileImage(*static_cast<GpuTextureVulkanImage*>(cached->image), cached->info,
+		    m_tiler.DetileImage(*static_cast<GpuTextureVulkanImage*>(cached->image), cached->ImageDesc(),
 		                        source, false, false);
 	    });
 	ImageOps::CreateTextureViews(*static_cast<GpuTextureVulkanImage*>(cached->image), info, false,
@@ -1651,17 +1884,17 @@ StorageTextureVulkanImage& TextureCache::FindStorageTexture(CommandBuffer&   com
 	}
 
 	std::shared_ptr<CachedImage> match;
-	for (auto& cached: m_images) {
+	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
 		if (cached->kind != CachedImage::Kind::StorageTexture ||
-		    !EqualStorageBacking(info, cached->info)) {
+		    !EqualStorageBacking(info, cached->ImageDesc())) {
 			continue;
 		}
-		if (match != nullptr || cached->info.IsCpuDirty()) {
+		if (match != nullptr || cached->ImageDesc().IsCpuDirty()) {
 			EXIT("TextureCache: invalid exact storage-image cache match, addr=0x%016" PRIx64
 			     " size=0x%016" PRIx64 " duplicate=%d cpu_dirty=%d\n",
-			     info.address, info.size, match != nullptr, cached->info.IsCpuDirty());
+			     info.address, info.size, match != nullptr, cached->ImageDesc().IsCpuDirty());
 		}
-		match = cached;
+		match = FindImageOwnerLocked(*cached);
 	}
 	if (match != nullptr) {
 		const bool cpu_modified = m_memory_tracker.IsRegionCpuModified(info.address, info.size);
@@ -1686,7 +1919,7 @@ StorageTextureVulkanImage& TextureCache::FindStorageTexture(CommandBuffer&   com
 			    info.address, info.size, true, [](uint64_t, uint64_t) noexcept {},
 			    [&]() noexcept {
 				    m_tiler.DetileImage(*static_cast<GpuTextureVulkanImage*>(match->image),
-				                        match->info, source, true, true);
+				                        match->ImageDesc(), source, true, true);
 			    });
 			match->buffer_modified = false;
 			match->gpu_modified    = true;
@@ -1696,8 +1929,8 @@ StorageTextureVulkanImage& TextureCache::FindStorageTexture(CommandBuffer&   com
 				    info.address, info.size, true, [](uint64_t, uint64_t) noexcept {},
 				    [&]() noexcept {
 					    m_tiler.DetileImage(
-					        *static_cast<GpuTextureVulkanImage*>(match->image), match->info,
-					        {nullptr, 0, match->info.address, match->info.size, true}, true, true);
+					        *static_cast<GpuTextureVulkanImage*>(match->image), match->ImageDesc(),
+					        {nullptr, 0, match->ImageDesc().address, match->ImageDesc().size, true}, true, true);
 				    });
 			} else {
 				// A readback leaves both copies current. Reclaim ownership without an unnecessary
@@ -1712,15 +1945,14 @@ StorageTextureVulkanImage& TextureCache::FindStorageTexture(CommandBuffer&   com
 
 	ResolveStorageImageOverlaps(info);
 	m_images.reserve(m_images.size() + 1);
-	auto cached  = std::make_shared<CachedImage>(m_graphics);
-	cached->kind = CachedImage::Kind::StorageTexture;
-	cached->info = info;
+	auto cached =
+	    std::make_shared<CachedImage>(m_graphics, CachedImage::Kind::StorageTexture, info);
 	vk::ComponentMapping components {};
 	cached->image = ImageOps::CreateTexture(info, true, components);
 	m_memory_tracker.ForEachUploadRange(
 	    info.address, info.size, true, [](uint64_t, uint64_t) noexcept {},
 	    [&]() noexcept {
-		    m_tiler.DetileImage(*static_cast<GpuTextureVulkanImage*>(cached->image), cached->info,
+		    m_tiler.DetileImage(*static_cast<GpuTextureVulkanImage*>(cached->image), cached->ImageDesc(),
 		                        source, false, true);
 	    });
 	cached->gpu_modified = true;
@@ -1815,13 +2047,19 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 	}
 	FaultSafeTextureLock         lock(this, m_lock);
 	std::shared_ptr<CachedImage> match;
-	for (auto& cached: m_images) {
+	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
 		if (cached->kind != CachedImage::Kind::RenderTarget ||
-		    (!Equal(info, cached->target) && !IsCompatibleRenderTargetView(cached->target, info) &&
-		     !IsCompatibleRenderTargetBacking(cached->target, info))) {
+		    (!Equal(info, cached->RenderTargetDesc()) &&
+		     !IsCompatibleRenderTargetView(cached->RenderTargetDesc(), info) &&
+		     !IsCompatibleRenderTargetBacking(cached->RenderTargetDesc(), info))) {
 			continue;
 		}
-		match = cached;
+		if (match != nullptr) {
+			EXIT("TextureCache: ambiguous render-target cache match, addr=0x%016" PRIx64
+			     " size=0x%016" PRIx64 "\n",
+			     info.address, info.size);
+		}
+		match = FindImageOwnerLocked(*cached);
 	}
 	if (match != nullptr) {
 		ResolveImageMetadataOverlapsLocked(info.address, info.size);
@@ -1854,10 +2092,9 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 		command.RetainResourceUntilFence(match);
 		return *static_cast<RenderTextureVulkanImage*>(match->image);
 	}
-	std::vector<CachedImage*>                 retire;
-	std::vector<std::shared_ptr<CachedImage>> recreated_depth_sources;
-	std::shared_ptr<CachedImage>              native_image_source;
-	for (const auto& entry: m_images) {
+	AliasRetirementPlan alias_plan("render target", {info.address, info.size},
+	                                   AliasRetirementPlan::PageIsolation::Required);
+	for (auto* entry: FindImagesInRegionLocked(info.address, info.size, true)) {
 		auto& cached = *entry;
 		if (!cached.OverlapsRange(info.address, info.size, true)) {
 			continue;
@@ -1865,20 +2102,21 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 		RenderTargetOverlap overlap = RenderTargetOverlap::Unsupported;
 		switch (cached.kind) {
 			case CachedImage::Kind::Texture:
-				overlap = ClassifyRenderTargetOverlap(cached.info, cached.gpu_modified, info);
+				overlap = ClassifyRenderTargetOverlap(cached.ImageDesc(), cached.gpu_modified, info);
 				break;
 			case CachedImage::Kind::StorageTexture:
 				overlap = ClassifyStorageRenderTargetOverlap(
-				    cached.info, cached.image->format, cached.gpu_modified, cached.buffer_modified,
-				    cached.info.IsCpuDirty() ||
-				        m_memory_tracker.IsRegionCpuModified(cached.info.address, cached.info.size),
-				    m_memory_tracker.IsRegionGpuModified(cached.info.address, cached.info.size),
+				    cached.ImageDesc(), cached.image->format, cached.gpu_modified, cached.buffer_modified,
+				    cached.ImageDesc().IsCpuDirty() ||
+				        m_memory_tracker.IsRegionCpuModified(cached.ImageDesc().address, cached.ImageDesc().size),
+				    m_memory_tracker.IsRegionGpuModified(cached.ImageDesc().address, cached.ImageDesc().size),
 				    info);
 				break;
 			case CachedImage::Kind::RenderTarget:
 				overlap = ClassifyRenderTargetOverlap(
-				    cached.target, cached.gpu_modified, cached.buffer_modified,
-				    m_memory_tracker.IsRegionGpuModified(cached.target.address, cached.target.size),
+				    cached.RenderTargetDesc(), cached.gpu_modified, cached.buffer_modified,
+				    m_memory_tracker.IsRegionGpuModified(cached.RenderTargetDesc().address,
+				                                         cached.RenderTargetDesc().size),
 				    IsCoherentGuestImageSource(target_source, info.address, info.size), info);
 				break;
 			case CachedImage::Kind::DepthTarget: {
@@ -1888,7 +2126,7 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 					    cached.Address(range), cached.Size(range));
 				}
 				if (CanRecreateDepthForRenderTarget(
-				        cached.depth, cached.gpu_modified, cached.buffer_modified,
+				        cached.DepthTargetDesc(), cached.gpu_modified, cached.buffer_modified,
 				        tracker_gpu_modified,
 				        IsCoherentGuestImageSource(target_source, info.address, info.size), info)) {
 					overlap = RenderTargetOverlap::RetireTarget;
@@ -1899,7 +2137,8 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 		if (overlap == RenderTargetOverlap::None) {
 			continue;
 		}
-		bool supported = false;
+		bool                        supported = false;
+		AliasRetirementPlan::Action action    = AliasRetirementPlan::Action::RetireGuestCurrent;
 		switch (overlap) {
 			case RenderTargetOverlap::RetireSampled:
 				supported = cached.kind == CachedImage::Kind::Texture;
@@ -1909,23 +2148,23 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 				break;
 			case RenderTargetOverlap::PreserveStorage:
 				supported = cached.kind == CachedImage::Kind::StorageTexture &&
-				            native_image_source == nullptr;
+				            alias_plan.NativeSource() == nullptr;
 				if (supported) {
-					native_image_source = entry;
+					action = AliasRetirementPlan::Action::PreserveNative;
 				}
 				break;
 			case RenderTargetOverlap::ExpandTarget:
 				supported = cached.kind == CachedImage::Kind::RenderTarget &&
-				            native_image_source == nullptr;
+				            alias_plan.NativeSource() == nullptr;
 				if (supported) {
-					native_image_source = entry;
+					action = AliasRetirementPlan::Action::PreserveNative;
 				}
 				break;
 			case RenderTargetOverlap::RetireTarget:
 				supported = cached.kind == CachedImage::Kind::RenderTarget ||
 				            cached.kind == CachedImage::Kind::DepthTarget;
 				if (supported && cached.kind == CachedImage::Kind::DepthTarget) {
-					recreated_depth_sources.push_back(entry);
+					action = AliasRetirementPlan::Action::MaterializeGuest;
 				}
 				break;
 			case RenderTargetOverlap::None:
@@ -1934,36 +2173,22 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 		if (!supported) {
 			EXIT("TextureCache: unsupported render-target alias, requested=0x%016" PRIx64
 			     "+0x%016" PRIx64 " existing_kind=%u existing=0x%016" PRIx64 "+0x%016" PRIx64
-			     " gpu_modified=%d"
-			     " sampled_format=%u extent=%ux%ux%u pitch=%u levels=%u base_level=%u"
-			     " tile=%u type=%u base_array=%u\n",
+			     " gpu_modified=%d buffer_modified=%d\n",
 			     info.address, info.size, static_cast<uint32_t>(cached.kind), cached.Address(),
-			     cached.Size(), cached.gpu_modified, cached.info.format, cached.info.width,
-			     cached.info.height, cached.info.depth, cached.info.pitch, cached.info.levels,
-			     cached.info.base_level, cached.info.tile, cached.info.type,
-			     cached.info.base_array);
+			     cached.Size(), cached.gpu_modified, cached.buffer_modified);
 		}
-		retire.push_back(&cached);
+		alias_plan.Add(FindImageOwnerLocked(cached), action);
 	}
-	RequireRetirementIsolation(retire, "render target", info.address, info.size);
-	MaterializeImagesToGuestLocked(recreated_depth_sources);
-	for (const auto& cached: recreated_depth_sources) {
-		// The exact guest range owns the current bytes. Clear a stale buffer marker only after
-		// source-coherence validation so retirement can replace the obsolete Vulkan shape.
-		cached->buffer_modified = false;
-	}
-	RetireDepthMetadataLocked(retire);
-	RetireImages(retire, native_image_source.get());
+	auto native_image_source = alias_plan.NativeOwner();
+	ExecuteAliasRetirementLocked(alias_plan);
 	ResolveImageMetadataOverlapsLocked(info.address, info.size);
-	auto cached                = std::make_shared<CachedImage>(m_graphics);
-	cached->kind               = CachedImage::Kind::RenderTarget;
-	cached->target             = info;
+	auto cached                = std::make_shared<CachedImage>(m_graphics, info);
 	cached->image              = ImageOps::CreateRenderTarget(info);
 	const bool preserve_native = native_image_source != nullptr;
 	if (preserve_native) {
 		command.RetainResourceUntilFence(native_image_source);
 		if (native_image_source->kind == CachedImage::Kind::RenderTarget) {
-			const auto& old          = native_image_source->target;
+			const auto& old          = native_image_source->RenderTargetDesc();
 			const auto  tail_address = info.address + old.size;
 			const auto  tail_size    = info.size - old.size;
 			if (old.layers >= info.layers || tail_size == 0 ||
@@ -2115,13 +2340,23 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 	if (has_stencil) {
 		ResolveImageMetadataOverlapsLocked(info.stencil_address, info.stencil_size);
 	}
+	const std::array<GuestRange, 2> requested_ranges {{
+	    {info.address, info.size}, {info.stencil_address, info.stencil_size}}};
+	const auto candidates = FindImagesInRegionsLocked(
+	    {requested_ranges.data(), has_stencil ? requested_ranges.size() : 1}, true);
 	std::shared_ptr<CachedImage> match;
-	for (auto& cached: m_images) {
+	for (auto* cached: candidates) {
 		if (cached->kind != CachedImage::Kind::DepthTarget ||
-		    (!Equal(info, cached->depth) && !IsCompatibleDepthTargetBacking(cached->depth, info))) {
+		    (!Equal(info, cached->DepthTargetDesc()) &&
+		     !IsCompatibleDepthTargetBacking(cached->DepthTargetDesc(), info))) {
 			continue;
 		}
-		match = cached;
+		if (match != nullptr) {
+			EXIT("TextureCache: ambiguous depth-target cache match, addr=0x%016" PRIx64
+			     " size=0x%016" PRIx64 "\n",
+			     info.address, info.size);
+		}
+		match = FindImageOwnerLocked(*cached);
 	}
 	if (match != nullptr) {
 		const bool depth_cpu_modified =
@@ -2186,13 +2421,14 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 		command.RetainResourceUntilFence(match);
 		return *static_cast<DepthStencilVulkanImage*>(match->image);
 	}
-	std::vector<CachedImage*>                 retire;
+	AliasRetirementPlan alias_plan("depth target", {info.address, info.size},
+	                                   AliasRetirementPlan::PageIsolation::Required);
+	alias_plan.PreserveMetadata(info.htile_address);
 	std::shared_ptr<CachedImage>              sampled_depth_source;
 	std::shared_ptr<CachedImage>              native_depth_source;
 	std::shared_ptr<CachedImage>              discarded_depth_source;
 	std::shared_ptr<CachedImage>              retired_storage_source;
-	std::vector<std::shared_ptr<CachedImage>> recreated_target_sources;
-	for (const auto& entry: m_images) {
+	for (auto* entry: candidates) {
 		auto&      cached = *entry;
 		const bool overlaps =
 		    cached.OverlapsRange(info.address, info.size, true) ||
@@ -2204,11 +2440,11 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 		switch (cached.kind) {
 			case CachedImage::Kind::Texture: {
 				const auto native_overlap =
-				    ClassifyDepthOverlap(cached.info, cached.gpu_modified, info);
+				    ClassifyDepthOverlap(cached.ImageDesc(), cached.gpu_modified, info);
 				const bool overlaps_depth = ImageRangeOverlaps(
-				    cached.info.address, cached.info.size, info.address, info.size);
+				    cached.ImageDesc().address, cached.ImageDesc().size, info.address, info.size);
 				const bool overlaps_stencil =
-				    has_stencil && ImageRangeOverlaps(cached.info.address, cached.info.size,
+				    has_stencil && ImageRangeOverlaps(cached.ImageDesc().address, cached.ImageDesc().size,
 				                                      info.stencil_address, info.stencil_size);
 				const bool guest_source_current =
 				    (!overlaps_depth || info.depth_load_clear ||
@@ -2219,36 +2455,38 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 				overlap = native_overlap;
 				if (overlap == DepthOverlap::Unsupported &&
 				    CanRetireGuestCurrentSampledForDepth(
-				        cached.info, info, cached.gpu_modified, cached.buffer_modified,
-				        cached.info.IsCpuDirty(),
-				        m_memory_tracker.IsRegionGpuModified(cached.info.address, cached.info.size),
+				        cached.ImageDesc(), info, cached.gpu_modified, cached.buffer_modified,
+				        cached.ImageDesc().IsCpuDirty(),
+				        m_memory_tracker.IsRegionGpuModified(cached.ImageDesc().address, cached.ImageDesc().size),
 				        guest_source_current)) {
 					overlap = DepthOverlap::RetireSampled;
 				}
 				if (overlap == DepthOverlap::RetireSampled && !info.depth_load_clear &&
 				    native_overlap == DepthOverlap::RetireSampled &&
 				    sampled_depth_source == nullptr) {
-					sampled_depth_source = entry;
+					sampled_depth_source = FindImageOwnerLocked(cached);
 				}
 			} break;
 			case CachedImage::Kind::DepthTarget:
-				overlap = ClassifyDepthTargetOverlap(cached.depth, cached.gpu_modified,
+				overlap = ClassifyDepthTargetOverlap(cached.DepthTargetDesc(), cached.gpu_modified,
 				                                     cached.buffer_modified, info);
 				break;
 			case CachedImage::Kind::StorageTexture:
 				overlap = ClassifyStorageDepthOverlap(
-				    cached.info, cached.gpu_modified, cached.buffer_modified,
-				    cached.info.IsCpuDirty() ||
-				        m_memory_tracker.IsRegionCpuModified(cached.info.address, cached.info.size),
-				    m_memory_tracker.IsRegionGpuModified(cached.info.address, cached.info.size),
+				    cached.ImageDesc(), cached.gpu_modified, cached.buffer_modified,
+				    cached.ImageDesc().IsCpuDirty() ||
+				        m_memory_tracker.IsRegionCpuModified(cached.ImageDesc().address, cached.ImageDesc().size),
+				    m_memory_tracker.IsRegionGpuModified(cached.ImageDesc().address, cached.ImageDesc().size),
 				    info);
 				break;
 			case CachedImage::Kind::RenderTarget: {
 				const bool overlaps_depth = ImageRangeOverlaps(
-				    cached.target.address, cached.target.size, info.address, info.size);
+				    cached.RenderTargetDesc().address, cached.RenderTargetDesc().size, info.address, info.size);
 				const bool overlaps_stencil =
-				    has_stencil && ImageRangeOverlaps(cached.target.address, cached.target.size,
-				                                      info.stencil_address, info.stencil_size);
+				    has_stencil &&
+				    ImageRangeOverlaps(cached.RenderTargetDesc().address,
+				                       cached.RenderTargetDesc().size, info.stencil_address,
+				                       info.stencil_size);
 				const bool guest_source_current =
 				    (!overlaps_depth || info.depth_load_clear ||
 				     IsCoherentGuestImageSource(depth_source, info.address, info.size)) &&
@@ -2256,16 +2494,17 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 				     IsCoherentGuestImageSource(stencil_source, info.stencil_address,
 				                                info.stencil_size));
 				overlap = CanRecreateRenderTargetForDepth(
-				              cached.target, cached.gpu_modified, cached.buffer_modified,
-				              m_memory_tracker.IsRegionGpuModified(cached.target.address,
-				                                                   cached.target.size),
+				              cached.RenderTargetDesc(), cached.gpu_modified, cached.buffer_modified,
+				              m_memory_tracker.IsRegionGpuModified(cached.RenderTargetDesc().address,
+				                                                   cached.RenderTargetDesc().size),
 				              guest_source_current, info)
 				              ? DepthOverlap::RecreateTarget
 				              : DepthOverlap::Unsupported;
 			} break;
 			case CachedImage::Kind::VideoOut: break;
 		}
-		bool supported = false;
+		bool                        supported = false;
+		AliasRetirementPlan::Action action    = AliasRetirementPlan::Action::RetireGuestCurrent;
 		switch (overlap) {
 			case DepthOverlap::RetireSampled:
 				supported = cached.kind == CachedImage::Kind::Texture;
@@ -2273,26 +2512,30 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 			case DepthOverlap::RetireStorage:
 				supported = cached.kind == CachedImage::Kind::StorageTexture &&
 				            retired_storage_source == nullptr && native_depth_source == nullptr &&
-				            discarded_depth_source == nullptr && recreated_target_sources.empty();
+				            discarded_depth_source == nullptr &&
+				            !alias_plan.HasAction(AliasRetirementPlan::Action::MaterializeGuest);
 				if (supported) {
-					retired_storage_source = entry;
+					retired_storage_source = FindImageOwnerLocked(cached);
+					action = AliasRetirementPlan::Action::ReleaseGpuOwnership;
 				}
 				break;
 			case DepthOverlap::ExpandTarget:
 				supported = cached.kind == CachedImage::Kind::DepthTarget &&
 				            native_depth_source == nullptr && retired_storage_source == nullptr &&
-				            recreated_target_sources.empty();
+				            !alias_plan.HasAction(AliasRetirementPlan::Action::MaterializeGuest);
 				if (supported) {
-					native_depth_source = entry;
+					native_depth_source = FindImageOwnerLocked(cached);
+					action = AliasRetirementPlan::Action::PreserveNative;
 				}
 				break;
 			case DepthOverlap::DiscardTarget:
 				supported = cached.kind == CachedImage::Kind::DepthTarget &&
 				            discarded_depth_source == nullptr && native_depth_source == nullptr;
 				supported = supported && retired_storage_source == nullptr &&
-				            recreated_target_sources.empty();
+				            !alias_plan.HasAction(AliasRetirementPlan::Action::MaterializeGuest);
 				if (supported) {
-					discarded_depth_source = entry;
+					discarded_depth_source = FindImageOwnerLocked(cached);
+					action = AliasRetirementPlan::Action::PreserveNative;
 				}
 				break;
 			case DepthOverlap::RecreateTarget:
@@ -2301,7 +2544,7 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 				            native_depth_source == nullptr && discarded_depth_source == nullptr &&
 				            retired_storage_source == nullptr;
 				if (supported) {
-					recreated_target_sources.push_back(entry);
+					action = AliasRetirementPlan::Action::MaterializeGuest;
 				}
 				break;
 			case DepthOverlap::None:
@@ -2313,23 +2556,9 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 			     info.address, info.size, static_cast<uint32_t>(cached.kind), cached.Address(),
 			     cached.Size());
 		}
-		retire.push_back(&cached);
+		alias_plan.Add(FindImageOwnerLocked(cached), action);
 	}
-	RequireRetirementIsolation(retire, "depth target", info.address, info.size);
-	MaterializeImagesToGuestLocked(recreated_target_sources);
-	if (retired_storage_source != nullptr) {
-		if (retired_storage_source->gpu_modified) {
-			m_memory_tracker.UnmarkRegionAsGpuModified(retired_storage_source->info.address,
-			                                           retired_storage_source->info.size);
-			retired_storage_source->gpu_modified = false;
-		}
-	}
-	const auto* transition_source =
-	    native_depth_source != nullptr
-	        ? native_depth_source.get()
-	        : (discarded_depth_source != nullptr ? discarded_depth_source.get() : nullptr);
-	RetireDepthMetadataLocked(retire, info.htile_address);
-	RetireImages(retire, transition_source);
+	ExecuteAliasRetirementLocked(alias_plan);
 	const bool coherent_guest_stencil =
 	    has_stencil &&
 	    IsCoherentGuestImageSource(stencil_source, info.stencil_address, info.stencil_size);
@@ -2363,9 +2592,7 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 		     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 " samples=%u\n",
 		     info.stencil_address, info.stencil_size, info.samples);
 	}
-	auto cached                 = std::make_shared<CachedImage>(m_graphics);
-	cached->kind                = CachedImage::Kind::DepthTarget;
-	cached->depth               = info;
+	auto cached                 = std::make_shared<CachedImage>(m_graphics, info);
 	cached->stencil_initialized = !has_stencil || info.stencil_load_clear || initial_stencil_clear;
 	cached->image               = ImageOps::CreateDepthTarget(info);
 	auto* depth_image           = static_cast<DepthStencilVulkanImage*>(cached->image);
@@ -2378,7 +2605,7 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 		command.RetainResourceUntilFence(retired_storage_source);
 	}
 	if (native_depth_source != nullptr) {
-		const auto& old = native_depth_source->depth;
+		const auto& old = native_depth_source->DepthTargetDesc();
 		if (old.layers >= info.layers || native_depth_source->image->layers != old.layers) {
 			EXIT("TextureCache: invalid depth expansion source, old_layers=%u new_layers=%u\n",
 			     old.layers, info.layers);
@@ -2449,7 +2676,7 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 		}
 		const auto transition_source = SelectDepthTransitionSource(
 		    info.depth_load_clear, sampled_depth_source != nullptr,
-		    sampled_depth_source != nullptr && sampled_depth_source->info.IsCpuDirty(),
+		    sampled_depth_source != nullptr && sampled_depth_source->ImageDesc().IsCpuDirty(),
 		    sampled_depth_source != nullptr && sampled_depth_source->buffer_modified,
 		    depth_buffer_overlap, depth_source.cpu_dirty);
 		m_memory_tracker.ForEachUploadRange(
@@ -2512,7 +2739,7 @@ TextureCache::RegisterVideoOutSurfaces(const std::vector<VideoOutInfo>& infos) {
 	FaultSafeTextureLock lock(this, m_lock);
 	for (const auto& info: infos) {
 		ResolveImageMetadataOverlapsLocked(info.address, info.size);
-		for (const auto& cached: m_images) {
+		for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
 			if (cached->OverlapsRange(info.address, info.size, true)) {
 				EXIT(
 				    "TextureCache: video-out surface aliases cached image pages, addr=0x%016" PRIx64
@@ -2525,9 +2752,7 @@ TextureCache::RegisterVideoOutSurfaces(const std::vector<VideoOutInfo>& infos) {
 	std::vector<VideoOutVulkanImage*> result;
 	result.reserve(infos.size());
 	for (const auto& info: infos) {
-		auto cached       = std::make_shared<CachedImage>(m_graphics);
-		cached->kind      = CachedImage::Kind::VideoOut;
-		cached->video_out = info;
+		auto cached = std::make_shared<CachedImage>(m_graphics, info);
 		cached->image     = ImageOps::CreateVideoOut(info);
 		if (info.compression == VideoOutCompression::Uncompressed) {
 			m_memory_tracker.ForEachUploadRange(
@@ -2546,7 +2771,7 @@ TextureCache::RegisterVideoOutSurfaces(const std::vector<VideoOutInfo>& infos) {
 		}
 		result.push_back(static_cast<VideoOutVulkanImage*>(cached->image));
 		m_images.push_back(std::move(cached));
-		RegisterImageLocked(*m_images.back());
+		RegisterImageLocked(m_images.back());
 	}
 	return result;
 }
@@ -2554,17 +2779,16 @@ TextureCache::RegisterVideoOutSurfaces(const std::vector<VideoOutInfo>& infos) {
 void TextureCache::RefreshVideoOut(VideoOutVulkanImage& image, bool render_target) {
 	std::lock_guard      transaction(m_resource_mutex);
 	FaultSafeTextureLock lock(this, m_lock);
-	const auto it = std::find_if(m_images.begin(), m_images.end(),
-	                             [&image](const auto& cached) { return cached->image == &image; });
-	if (it == m_images.end() || (*it)->kind != CachedImage::Kind::VideoOut) {
-		EXIT("TextureCache: video-out image is not registered, image=%p\n",
-		     static_cast<const void*>(&image));
+	auto owner = FindImageOwnerLocked(image);
+	if (owner->kind != CachedImage::Kind::VideoOut) {
+		EXIT("TextureCache: registered image is not a video-out surface, image=%p kind=%u\n",
+		     static_cast<const void*>(&image), static_cast<uint32_t>(owner->kind));
 	}
-	auto& cached = **it;
+	auto& cached = *owner;
 	if (cached.gpu_modified) {
 		return;
 	}
-	const auto& info           = cached.video_out;
+	const auto& info           = cached.VideoOutDesc();
 	const bool  image_dirty    = m_memory_tracker.IsRegionCpuModified(info.address, info.size);
 	const bool  buffer_overlap = m_buffer_cache.HasPageOverlap(info.address, info.size);
 	const bool  buffer_dirty =
@@ -2608,7 +2832,7 @@ void TextureCache::UnregisterVideoOutSurfaces(const std::vector<VideoOutVulkanIm
 	}
 	std::lock_guard           transaction(m_resource_mutex);
 	FaultSafeTextureLock      lock(this, m_lock);
-	std::vector<CachedImage*> selected;
+	std::vector<std::shared_ptr<CachedImage>> selected;
 	selected.reserve(images.size());
 	for (size_t i = 0; i < images.size(); i++) {
 		auto* image = images[i];
@@ -2617,15 +2841,15 @@ void TextureCache::UnregisterVideoOutSurfaces(const std::vector<VideoOutVulkanIm
 			EXIT("TextureCache: invalid or duplicate video-out image at index %zu, image=%p\n", i,
 			     static_cast<const void*>(image));
 		}
-		auto it = std::find_if(m_images.begin(), m_images.end(),
-		                       [image](const auto& cached) { return cached->image == image; });
-		if (it == m_images.end() || (*it)->kind != CachedImage::Kind::VideoOut) {
-			EXIT("TextureCache: video-out image is not registered, index=%zu image=%p\n", i,
-			     static_cast<const void*>(image));
+		auto owner = FindImageOwnerLocked(*image);
+		if (owner->kind != CachedImage::Kind::VideoOut) {
+			EXIT("TextureCache: registered image is not a video-out surface, index=%zu image=%p "
+			     "kind=%u\n",
+			     i, static_cast<const void*>(image), static_cast<uint32_t>(owner->kind));
 		}
-		selected.push_back(it->get());
+		selected.push_back(std::move(owner));
 	}
-	for (auto* cached: selected) {
+	for (const auto& cached: selected) {
 		if (cached->buffer_modified) {
 			EXIT("TextureCache: cannot unregister a buffer-dirty video-out surface, "
 			     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
@@ -2633,16 +2857,18 @@ void TextureCache::UnregisterVideoOutSurfaces(const std::vector<VideoOutVulkanIm
 		}
 	}
 	Transfer::WaitForGraphicsIdle();
-	for (auto* cached: selected) {
+	for (const auto& cached: selected) {
 		if (cached->gpu_modified) {
 			m_memory_tracker.UnmarkRegionAsGpuModified(cached->Address(), cached->Size());
 			cached->gpu_modified = false;
 		}
 		UnregisterImageLocked(*cached, true);
 	}
-	for (auto* image: images) {
-		auto it = std::find_if(m_images.begin(), m_images.end(),
-		                       [image](const auto& cached) { return cached->image == image; });
+	for (const auto& cached: selected) {
+		auto it = std::find(m_images.begin(), m_images.end(), cached);
+		if (it == m_images.end()) {
+			EXIT("TextureCache: video-out owner disappeared during unregistration\n");
+		}
 		m_images.erase(it);
 	}
 }
@@ -2668,7 +2894,7 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t vaddr, 
 		if (cached.kind != CachedImage::Kind::DepthTarget) {
 			return ClearAspect::None;
 		}
-		if (CanNativeClearDepthFromBuffer(cached.depth, vaddr, size)) {
+		if (CanNativeClearDepthFromBuffer(cached.DepthTargetDesc(), vaddr, size)) {
 			return ClearAspect::Depth;
 		}
 		if (cached.RangeCount() == 2 && cached.Address(1) == vaddr && cached.Size(1) == size) {
@@ -2681,7 +2907,7 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t vaddr, 
 	ClearAspect                  aspect       = ClearAspect::None;
 	bool                         incompatible = false;
 	uint32_t                     matches      = 0;
-	for (const auto& cached: m_images) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, true)) {
 		if (!cached->OverlapsRange(vaddr, size, true)) {
 			continue;
 		}
@@ -2692,7 +2918,7 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t vaddr, 
 		}
 		if (aspect == ClearAspect::None) {
 			aspect = candidate;
-			match  = cached;
+			match  = FindImageOwnerLocked(*cached);
 		} else if (candidate != aspect) {
 			incompatible = true;
 			continue;
@@ -2801,67 +3027,62 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t vaddr, 
 void TextureCache::MarkGpuWritten(VulkanImage& image) {
 	std::lock_guard      transaction(m_resource_mutex);
 	FaultSafeTextureLock lock(this, m_lock);
-	for (auto& cached: m_images) {
-		if (cached->image != &image) {
-			continue;
-		}
-		if (cached->kind != CachedImage::Kind::RenderTarget &&
-		    cached->kind != CachedImage::Kind::DepthTarget &&
-		    cached->kind != CachedImage::Kind::VideoOut) {
-			EXIT("TextureCache: sampled texture cannot be marked GPU-written, image=%p kind=%u\n",
-			     static_cast<const void*>(&image), static_cast<uint32_t>(cached->kind));
-		}
-		for (uint32_t i = 0; i < cached->RangeCount(); i++) {
-			if (m_buffer_cache.HasPageOverlap(cached->Address(i), cached->Size(i))) {
-				const bool cpu_modified =
-				    m_buffer_cache.IsRegionCpuModified(cached->Address(i), cached->Size(i));
-				const bool gpu_modified =
-				    m_buffer_cache.IsRegionGpuModified(cached->Address(i), cached->Size(i));
-				if (cpu_modified || gpu_modified) {
-					EXIT(
-					    "TextureCache: GPU-written image aliases a dirty buffer, addr=0x%016" PRIx64
-					    " size=0x%016" PRIx64 " cpu_modified=%d gpu_modified=%d\n",
-					    cached->Address(i), cached->Size(i), cpu_modified, gpu_modified);
-				}
-			}
-			if (m_memory_tracker.IsRegionCpuModified(cached->Address(i), cached->Size(i))) {
-				EXIT("TextureCache: GPU-write begins while image range is CPU-modified, "
-				     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
-				     cached->Address(i), cached->Size(i));
-			}
-		}
-		if (cached->kind == CachedImage::Kind::DepthTarget) {
-			if ((cached->depth.htile_address == 0) != (cached->depth.htile_size == 0)) {
-				EXIT("TextureCache: depth target has incomplete HTile range, addr=0x%016" PRIx64
-				     " size=0x%016" PRIx64 "\n",
-				     cached->depth.htile_address, cached->depth.htile_size);
-			}
-			if (cached->depth.htile_address != 0) {
-				auto meta = m_surface_metas.find(cached->depth.htile_address);
-				if (meta == m_surface_metas.end() ||
-				    meta->second.size != cached->depth.htile_size) {
-					EXIT("TextureCache: depth target HTile metadata is missing or mismatched, "
-					     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
-					     cached->depth.htile_address, cached->depth.htile_size);
-				}
-				m_buffer_cache.ValidateGpuAccess(cached->depth.htile_address,
-				                                 cached->depth.htile_size, false, true);
-				m_metadata_tracker.ForEachUploadRange(
-				    cached->depth.htile_address, cached->depth.htile_size, true,
-				    [](uint64_t, uint64_t) noexcept {}, []() noexcept {});
-				meta->second.gpu_modified = true;
-			}
-		}
-		if (!cached->gpu_modified) {
-			for (uint32_t i = 0; i < cached->RangeCount(); i++) {
-				m_memory_tracker.MarkRegionAsGpuModified(cached->Address(i), cached->Size(i));
-			}
-			cached->gpu_modified = true;
-		}
-		return;
+	auto cached = FindImageOwnerLocked(image);
+	if (cached->kind != CachedImage::Kind::RenderTarget &&
+	    cached->kind != CachedImage::Kind::DepthTarget &&
+	    cached->kind != CachedImage::Kind::VideoOut) {
+		EXIT("TextureCache: sampled texture cannot be marked GPU-written, image=%p kind=%u\n",
+		     static_cast<const void*>(&image), static_cast<uint32_t>(cached->kind));
 	}
-	EXIT("TextureCache: GPU-written image is not registered, image=%p\n",
-	     static_cast<const void*>(&image));
+	for (uint32_t i = 0; i < cached->RangeCount(); i++) {
+		if (m_buffer_cache.HasPageOverlap(cached->Address(i), cached->Size(i))) {
+			const bool cpu_modified =
+			    m_buffer_cache.IsRegionCpuModified(cached->Address(i), cached->Size(i));
+			const bool gpu_modified =
+			    m_buffer_cache.IsRegionGpuModified(cached->Address(i), cached->Size(i));
+			if (cpu_modified || gpu_modified) {
+				EXIT(
+				    "TextureCache: GPU-written image aliases a dirty buffer, addr=0x%016" PRIx64
+				    " size=0x%016" PRIx64 " cpu_modified=%d gpu_modified=%d\n",
+				    cached->Address(i), cached->Size(i), cpu_modified, gpu_modified);
+			}
+		}
+		if (m_memory_tracker.IsRegionCpuModified(cached->Address(i), cached->Size(i))) {
+			EXIT("TextureCache: GPU-write begins while image range is CPU-modified, "
+			     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
+			     cached->Address(i), cached->Size(i));
+		}
+	}
+	if (cached->kind == CachedImage::Kind::DepthTarget) {
+		if ((cached->DepthTargetDesc().htile_address == 0) !=
+		    (cached->DepthTargetDesc().htile_size == 0)) {
+			EXIT("TextureCache: depth target has incomplete HTile range, addr=0x%016" PRIx64
+			     " size=0x%016" PRIx64 "\n",
+			     cached->DepthTargetDesc().htile_address, cached->DepthTargetDesc().htile_size);
+		}
+		if (cached->DepthTargetDesc().htile_address != 0) {
+			auto meta = m_surface_metas.find(cached->DepthTargetDesc().htile_address);
+			if (meta == m_surface_metas.end() ||
+			    meta->second.size != cached->DepthTargetDesc().htile_size) {
+				EXIT("TextureCache: depth target HTile metadata is missing or mismatched, "
+				     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
+				     cached->DepthTargetDesc().htile_address, cached->DepthTargetDesc().htile_size);
+			}
+			m_buffer_cache.ValidateGpuAccess(cached->DepthTargetDesc().htile_address,
+			                                 cached->DepthTargetDesc().htile_size, false, true);
+			m_metadata_tracker.ForEachUploadRange(
+			    cached->DepthTargetDesc().htile_address,
+			    cached->DepthTargetDesc().htile_size, true,
+			    [](uint64_t, uint64_t) noexcept {}, []() noexcept {});
+			meta->second.gpu_modified = true;
+		}
+	}
+	if (!cached->gpu_modified) {
+		for (uint32_t i = 0; i < cached->RangeCount(); i++) {
+			m_memory_tracker.MarkRegionAsGpuModified(cached->Address(i), cached->Size(i));
+		}
+		cached->gpu_modified = true;
+	}
 }
 
 void TextureCache::PrepareHostWrite(uint64_t vaddr, uint64_t size) {
@@ -2874,7 +3095,7 @@ void TextureCache::PrepareHostWrite(uint64_t vaddr, uint64_t size) {
 	FaultSafeTextureLock lock(this, m_lock);
 	const bool           metadata_overlap = HasMetaOverlapLocked(vaddr, size);
 	bool                 found            = false;
-	for (const auto& cached: m_images) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, true)) {
 		for (uint32_t range = 0; range < cached->RangeCount(); range++) {
 			// CPU-current depth targets use the same tracked guest refresh path as sampled and
 			// color images. GPU-owned targets and metadata aliases remain unsupported below.
@@ -2914,9 +3135,12 @@ void TextureCache::SynchronizeColorImageToBufferLocked(CachedImage& cached, uint
 	const bool       render_target = cached.kind == CachedImage::Kind::RenderTarget;
 	const bool       video_out     = cached.kind == CachedImage::Kind::VideoOut;
 	const bool       storage       = cached.kind == CachedImage::Kind::StorageTexture;
-	RenderTargetInfo target        = cached.target;
+	RenderTargetInfo target {};
+	if (render_target) {
+		target = cached.RenderTargetDesc();
+	}
 	if (storage) {
-		const auto& info         = cached.info;
+		const auto& info         = cached.ImageDesc();
 		target.address           = info.address;
 		target.size              = info.size;
 		target.format            = VulkanFormat(info.format);
@@ -2928,7 +3152,7 @@ void TextureCache::SynchronizeColorImageToBufferLocked(CachedImage& cached, uint
 		target.levels            = info.levels;
 	}
 	if (video_out) {
-		const auto& info         = cached.video_out;
+		const auto& info         = cached.VideoOutDesc();
 		target.address           = info.address;
 		target.size              = info.size;
 		target.format            = info.format;
@@ -2940,7 +3164,7 @@ void TextureCache::SynchronizeColorImageToBufferLocked(CachedImage& cached, uint
 	}
 	const bool    linear = target.tile_mode == Prospero::GpuEnumValue(Prospero::TileMode::kLinear);
 	const bool    tiled  = IsTiledRenderTarget(target);
-	const bool    bgra16 = video_out && cached.video_out.bgra16;
+	const bool    bgra16 = video_out && cached.VideoOutDesc().bgra16;
 	TileSizeAlign exact {};
 	bool          single_slice = false;
 	if (IsSupportedStandard64RenderTarget(target)) {
@@ -2961,7 +3185,7 @@ void TextureCache::SynchronizeColorImageToBufferLocked(CachedImage& cached, uint
 	                         (storage ? single_slice && exact.size == target.size : layered_size);
 	const bool valid_kind =
 	    render_target || storage ||
-	    (video_out && cached.video_out.compression == VideoOutCompression::Uncompressed);
+	    (video_out && cached.VideoOutDesc().compression == VideoOutCompression::Uncompressed);
 	if (!valid_kind || !cached.gpu_modified || cached.buffer_modified ||
 	    (!storage && target.levels != 1) || target.size > UINT32_MAX || (!linear && !exact_tiled) ||
 	    HasMetaOverlapLocked(target.address, target.size)) {
@@ -2972,7 +3196,7 @@ void TextureCache::SynchronizeColorImageToBufferLocked(CachedImage& cached, uint
 		     target.address, target.size, target.width, target.height, target.pitch,
 		     target.bytes_per_element, target.levels, target.layers, target.tile_mode,
 		     static_cast<uint32_t>(cached.kind),
-		     video_out ? static_cast<uint32_t>(cached.video_out.compression) : 0,
+		     video_out ? static_cast<uint32_t>(cached.VideoOutDesc().compression) : 0,
 		     cached.gpu_modified, cached.buffer_modified);
 	}
 	if (write_address < target.address || write_size == 0 ||
@@ -2998,16 +3222,17 @@ void TextureCache::SynchronizeColorImageToBufferLocked(CachedImage& cached, uint
 	TextureUploadLayout          tiled_layout {};
 	uint32_t                     tiled_format = 0;
 	if (storage) {
-		const bool array_texture  = TextureIsLayeredTexture(cached.info.type);
-		const bool volume_texture = TextureIs3DTexture(cached.info.type);
-		tiled_format              = cached.info.format;
+		const bool array_texture  = TextureIsLayeredTexture(cached.ImageDesc().type);
+		const bool volume_texture = TextureIs3DTexture(cached.ImageDesc().type);
+		tiled_format              = cached.ImageDesc().format;
 		tiled_layout              = TextureCalcUploadLayout(
-		    cached.info.format, cached.info.width, cached.info.height, cached.info.levels,
-		    cached.info.depth, cached.info.pitch, cached.info.tile, cached.info.size, true,
+		    cached.ImageDesc().format, cached.ImageDesc().width, cached.ImageDesc().height,
+		    cached.ImageDesc().levels, cached.ImageDesc().depth, cached.ImageDesc().pitch,
+		    cached.ImageDesc().tile, cached.ImageDesc().size, true,
 		    volume_texture, "StorageTextureReadback");
 		tiled_regions = TextureBuildUploadRegions(
-		    tiled_layout, cached.image->format, cached.info.width, cached.info.height,
-		    cached.info.depth, cached.info.levels, array_texture, volume_texture,
+		    tiled_layout, cached.image->format, cached.ImageDesc().width, cached.ImageDesc().height,
+		    cached.ImageDesc().depth, cached.ImageDesc().levels, array_texture, volume_texture,
 		    TextureUploadDestination::MipLevels);
 		regions = TextureBuildDownloadRegions(tiled_regions);
 	} else if (tiled && !bgra16) {
@@ -3025,7 +3250,7 @@ void TextureCache::SynchronizeColorImageToBufferLocked(CachedImage& cached, uint
 	}
 	if (tiled && !bgra16) {
 		std::vector<GpuTileInfo> infos;
-		const uint32_t           depth = storage ? cached.info.depth : target.layers;
+		const uint32_t           depth = storage ? cached.ImageDesc().depth : target.layers;
 		EXIT_NOT_IMPLEMENTED(!TextureBuildGpuTileInfos(target.size, tiled_regions, tiled_layout,
 		                                               tiled_format, depth, target.levels, infos));
 		m_buffer_transition_guest.resize(target.size);
@@ -3068,7 +3293,7 @@ void TextureCache::SynchronizeColorImageToBufferLocked(CachedImage& cached, uint
 
 void TextureCache::SynchronizeDepthImageToBufferLocked(CachedImage& cached, uint64_t write_address,
                                                        uint64_t write_size) {
-	const auto&   info        = cached.depth;
+	const auto&   info        = cached.DepthTargetDesc();
 	const bool    has_stencil = info.stencil_address != 0 || info.stencil_size != 0;
 	const bool    has_htile   = info.htile_address != 0 || info.htile_size != 0;
 	TileSizeAlign expected_stencil {};
@@ -3155,32 +3380,32 @@ bool TextureCache::InvalidateMemoryFromGPU(uint64_t vaddr, uint64_t size,
 		m_metadata_tracker.UntrackMemory(it->first, it->second.size);
 		it = m_surface_metas.erase(it);
 	}
-	auto             match  = m_images.end();
+	CachedImage*     match  = nullptr;
 	BufferImageWrite action = BufferImageWrite::None;
-	for (auto it = m_images.begin(); it != m_images.end(); ++it) {
-		auto& cached = **it;
+	for (auto* candidate: FindImagesInRegionLocked(vaddr, size, false)) {
+		auto& cached = *candidate;
 		if (!cached.OverlapsRange(vaddr, size, false)) {
 			continue;
 		}
 		const auto next = ClassifyBufferImageWrite(vaddr, size, cached.Address(), cached.Size(),
 		                                           cached.BufferBinding(), cached.gpu_modified,
 		                                           formatted_buffer_write, cached.buffer_modified);
-		if (match != m_images.end() || next == BufferImageWrite::None ||
+		if (match != nullptr || next == BufferImageWrite::None ||
 		    next == BufferImageWrite::Unsupported) {
 			EXIT("TextureCache: unsupported GPU invalidation alias, addr=0x%016" PRIx64
 			     " size=0x%016" PRIx64 " cached_kind=%u cached=0x%016" PRIx64 "+0x%016" PRIx64
 			     " gpu_modified=%d buffer_modified=%d formatted=%d ambiguous=%d\n",
 			     vaddr, size, static_cast<uint32_t>(cached.kind), cached.Address(), cached.Size(),
 			     cached.gpu_modified, cached.buffer_modified, formatted_buffer_write,
-			     match != m_images.end());
+			     match != nullptr);
 		}
-		match  = it;
+		match  = candidate;
 		action = next;
 	}
-	if (match == m_images.end()) {
+	if (match == nullptr) {
 		return false;
 	}
-	auto& cached = **match;
+	auto& cached = *match;
 	switch (action) {
 		case BufferImageWrite::InvalidateTexture:
 		case BufferImageWrite::InvalidateVideoOut:
@@ -3221,20 +3446,21 @@ DepthStencilVulkanImage* TextureCache::FindDepthTargetByRange(CommandBuffer& com
 		    !cached->OverlapsRange(vaddr, size, false)) {
 			continue;
 		}
-		const bool containing_sampled =
-		    allow_containing_sampled && vaddr == cached->depth.address && size > cached->depth.size;
-		if ((!IsDepthTargetRangeCompatible(cached->depth, vaddr, size) && !containing_sampled) ||
+		const bool containing_sampled = allow_containing_sampled &&
+		                                vaddr == cached->DepthTargetDesc().address &&
+		                                size > cached->DepthTargetDesc().size;
+		if ((!IsDepthTargetRangeCompatible(cached->DepthTargetDesc(), vaddr, size) && !containing_sampled) ||
 		    found != nullptr) {
 			EXIT("TextureCache: incompatible or ambiguous depth-target range, addr=0x%016" PRIx64
 			     " size=0x%016" PRIx64 " cached=0x%016" PRIx64 "+0x%016" PRIx64 " previous=%p\n",
-			     vaddr, size, cached->depth.address, cached->depth.size,
+			     vaddr, size, cached->DepthTargetDesc().address, cached->DepthTargetDesc().size,
 			     static_cast<const void*>(found));
 		}
 		if (containing_sampled) {
 			return nullptr;
 		}
-		const bool stencil_range =
-		    vaddr == cached->depth.stencil_address && size == cached->depth.stencil_size;
+		const bool stencil_range = vaddr == cached->DepthTargetDesc().stencil_address &&
+		                           size == cached->DepthTargetDesc().stencil_size;
 		if (stencil_range && !cached->stencil_initialized) {
 			EXIT("TextureCache: sampled stencil range is uninitialized, addr=0x%016" PRIx64
 			     " size=0x%016" PRIx64 "\n",
@@ -3245,12 +3471,7 @@ DepthStencilVulkanImage* TextureCache::FindDepthTargetByRange(CommandBuffer& com
 	if (found == nullptr) {
 		return nullptr;
 	}
-	const auto owner = std::find_if(m_images.begin(), m_images.end(),
-	                                [found](const auto& image) { return image.get() == found; });
-	if (owner == m_images.end()) {
-		EXIT("TextureCache: page-table depth target has no cache owner\n");
-	}
-	command.RetainResourceUntilFence(*owner);
+	command.RetainResourceUntilFence(FindImageOwnerLocked(*found));
 	return static_cast<DepthStencilVulkanImage*>(found->image);
 }
 
@@ -3269,11 +3490,13 @@ RenderTextureVulkanImage* TextureCache::FindRenderTargetByRange(CommandBuffer& c
 		    !ImageRangeOverlaps(vaddr, size, cached->Address(), cached->Size())) {
 			continue;
 		}
-		const auto slice_size =
-		    cached->target.layers != 0 ? cached->target.size / cached->target.layers : 0;
-		const bool contained = vaddr == cached->target.address && slice_size != 0 &&
-		                       cached->target.size % cached->target.layers == 0 &&
-		                       size <= cached->target.size && size % slice_size == 0;
+		const auto slice_size = cached->RenderTargetDesc().layers != 0
+		                            ? cached->RenderTargetDesc().size /
+		                                  cached->RenderTargetDesc().layers
+		                            : 0;
+		const bool contained = vaddr == cached->RenderTargetDesc().address && slice_size != 0 &&
+		                       cached->RenderTargetDesc().size % cached->RenderTargetDesc().layers == 0 &&
+		                       size <= cached->RenderTargetDesc().size && size % slice_size == 0;
 		if (!contained) {
 			continue;
 		}
@@ -3287,12 +3510,7 @@ RenderTextureVulkanImage* TextureCache::FindRenderTargetByRange(CommandBuffer& c
 	if (found == nullptr) {
 		return nullptr;
 	}
-	const auto owner = std::find_if(m_images.begin(), m_images.end(),
-	                                [found](const auto& image) { return image.get() == found; });
-	if (owner == m_images.end()) {
-		EXIT("TextureCache: page-table render target has no cache owner\n");
-	}
-	command.RetainResourceUntilFence(*owner);
+	command.RetainResourceUntilFence(FindImageOwnerLocked(*found));
 	return static_cast<RenderTextureVulkanImage*>(found->image);
 }
 
@@ -3407,11 +3625,10 @@ void TextureCache::RegisterMeta(uint64_t vaddr, uint64_t size, uint32_t layers) 
 			     range_vaddr, range_size, address, meta.size);
 		}
 	}
-	std::vector<CachedImage*> retire;
-	for (const auto& cached: m_images) {
-		if (!cached->OverlapsRange(range_vaddr, range_size, true)) {
-			continue;
-		}
+	AliasRetirementPlan plan("metadata", {range_vaddr, range_size},
+	                         AliasRetirementPlan::PageIsolation::Required);
+	plan.PreserveMetadata(vaddr);
+	for (auto* cached: FindImagesInRegionLocked(range_vaddr, range_size, true)) {
 		const bool sampled        = cached->kind == CachedImage::Kind::Texture;
 		const bool writable_image = cached->kind == CachedImage::Kind::StorageTexture ||
 		                            cached->kind == CachedImage::Kind::RenderTarget ||
@@ -3420,8 +3637,8 @@ void TextureCache::RegisterMeta(uint64_t vaddr, uint64_t size, uint32_t layers) 
 		                                                        cached->Address(), cached->Size());
 		const bool cpu_dirty =
 		    cached->kind == CachedImage::Kind::StorageTexture &&
-		    (cached->info.IsCpuDirty() ||
-		     m_memory_tracker.IsRegionCpuModified(cached->info.address, cached->info.size));
+		    (cached->ImageDesc().IsCpuDirty() ||
+		     m_memory_tracker.IsRegionCpuModified(cached->ImageDesc().address, cached->ImageDesc().size));
 		const auto overlap = ClassifyMetaImageOverlap(sampled, writable_image, gpu_modified,
 		                                              cached->buffer_modified, cpu_dirty);
 		if (overlap == MetaImageOverlap::Unsupported) {
@@ -3432,24 +3649,24 @@ void TextureCache::RegisterMeta(uint64_t vaddr, uint64_t size, uint32_t layers) 
 			     cached->Size(), cached->gpu_modified, cached->buffer_modified);
 		}
 		if (overlap == MetaImageOverlap::RetireImage) {
-			retire.push_back(cached.get());
+			plan.Add(FindImageOwnerLocked(*cached),
+			         AliasRetirementPlan::Action::RetireGuestCurrent);
 			continue;
 		}
 		LOGF("TextureCache: metadata aliases a CPU-current sampled image, metadata=0x%016" PRIx64
 		     "+0x%016" PRIx64 " image=0x%016" PRIx64 "+0x%016" PRIx64 "\n",
 		     range_vaddr, range_size, cached->Address(), cached->Size());
 	}
-	if (!retire.empty()) {
-		RequireRetirementIsolation(retire, "metadata", range_vaddr, range_size);
-		for (const auto* cached: retire) {
+	if (!plan.Empty()) {
+		for (const auto& entry: plan.Entries()) {
+			const auto* cached = entry.image.get();
 			LOGF("TextureCache: retiring a guest-current image for metadata reuse, "
 			     "metadata=0x%016" PRIx64 "+0x%016" PRIx64 " image=0x%016" PRIx64 "+0x%016" PRIx64
 			     " kind=%u\n",
 			     range_vaddr, range_size, cached->Address(), cached->Size(),
 			     static_cast<uint32_t>(cached->kind));
 		}
-		RetireDepthMetadataLocked(retire, vaddr);
-		RetireImages(retire);
+		ExecuteAliasRetirementLocked(plan);
 	}
 	if (existing == m_surface_metas.end()) {
 		m_surface_metas.emplace(vaddr, MetaDataInfo {.size = size, .layers = layers});
@@ -3490,7 +3707,8 @@ void TextureCache::RequireNoMetaOverlapLocked(uint64_t vaddr, uint64_t size) con
 		}
 		const auto owner = std::find_if(m_images.begin(), m_images.end(), [&](const auto& cached) {
 			return cached->kind == CachedImage::Kind::DepthTarget &&
-			       cached->depth.htile_address == address && cached->depth.htile_size == meta.size;
+			       cached->DepthTargetDesc().htile_address == address &&
+			       cached->DepthTargetDesc().htile_size == meta.size;
 		});
 		EXIT("TextureCache: image range overlaps virtual metadata, image=0x%016" PRIx64
 		     "+0x%016" PRIx64 " metadata=0x%016" PRIx64 "+0x%016" PRIx64
@@ -3498,15 +3716,16 @@ void TextureCache::RequireNoMetaOverlapLocked(uint64_t vaddr, uint64_t size) con
 		     " owner_gpu=%d owner_buffer=%d\n",
 		     vaddr, size, address, meta.size, meta.layers, meta.gpu_modified, meta.clear_mask,
 		     owner != m_images.end() ? static_cast<const void*>(owner->get()) : nullptr,
-		     owner != m_images.end() ? (*owner)->depth.address : 0,
-		     owner != m_images.end() ? (*owner)->depth.size : 0,
+		     owner != m_images.end() ? (*owner)->DepthTargetDesc().address : 0,
+		     owner != m_images.end() ? (*owner)->DepthTargetDesc().size : 0,
 		     owner != m_images.end() && (*owner)->gpu_modified,
 		     owner != m_images.end() && (*owner)->buffer_modified);
 	}
 }
 
 void TextureCache::ResolveImageMetadataOverlapsLocked(uint64_t vaddr, uint64_t size) {
-	std::vector<CachedImage*> retire;
+	AliasRetirementPlan plan("image metadata", {vaddr, size},
+	                         AliasRetirementPlan::PageIsolation::Required);
 	for (const auto& [address, meta]: m_surface_metas) {
 		if (!ImagePageRangesOverlap(vaddr, size, address, meta.size)) {
 			continue;
@@ -3514,7 +3733,7 @@ void TextureCache::ResolveImageMetadataOverlapsLocked(uint64_t vaddr, uint64_t s
 		bool found_owner = false;
 		for (const auto& cached: m_images) {
 			if (cached->kind != CachedImage::Kind::DepthTarget ||
-			    cached->depth.htile_address != address) {
+			    cached->DepthTargetDesc().htile_address != address) {
 				continue;
 			}
 			found_owner               = true;
@@ -3525,7 +3744,7 @@ void TextureCache::ResolveImageMetadataOverlapsLocked(uint64_t vaddr, uint64_t s
 			}
 			const bool metadata_tracker_gpu_modified =
 			    m_metadata_tracker.IsRegionGpuModified(address, meta.size);
-			if (cached->depth.htile_size != meta.size ||
+			if (cached->DepthTargetDesc().htile_size != meta.size ||
 			    !CanRetireGuestCurrentDepthForMetadataReuse(
 			        cached->gpu_modified, cached->buffer_modified, tracker_gpu_modified,
 			        meta.gpu_modified, metadata_tracker_gpu_modified, meta.clear_mask)) {
@@ -3536,8 +3755,8 @@ void TextureCache::ResolveImageMetadataOverlapsLocked(uint64_t vaddr, uint64_t s
 				     cached->gpu_modified, tracker_gpu_modified, metadata_tracker_gpu_modified,
 				     cached->buffer_modified);
 			}
-			if (std::find(retire.begin(), retire.end(), cached.get()) == retire.end()) {
-				retire.push_back(cached.get());
+			if (!plan.Contains(*cached)) {
+				plan.Add(cached, AliasRetirementPlan::Action::RetireGuestCurrent);
 			}
 		}
 		if (!found_owner) {
@@ -3547,9 +3766,7 @@ void TextureCache::ResolveImageMetadataOverlapsLocked(uint64_t vaddr, uint64_t s
 			     vaddr, size, address, meta.size, meta.layers, meta.gpu_modified, meta.clear_mask);
 		}
 	}
-	RequireRetirementIsolation(retire, "image metadata", vaddr, size);
-	RetireDepthMetadataLocked(retire);
-	RetireImages(retire);
+	ExecuteAliasRetirementLocked(plan);
 	RequireNoMetaOverlapLocked(vaddr, size);
 }
 
@@ -3705,6 +3922,8 @@ void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 	std::lock_guard      transaction(m_resource_mutex);
 	FaultSafeTextureLock lock(this, m_lock);
 	const auto           end = vaddr + size;
+	const auto           image_candidates = FindImagesInRegionLocked(vaddr, size, true);
+	std::vector<std::shared_ptr<CachedImage>> unmapped_images;
 	for (const auto& [address, meta]: m_surface_metas) {
 		if (ImagePageRangesOverlap(vaddr, size, address, meta.size) &&
 		    (vaddr > address || end < address + meta.size)) {
@@ -3713,7 +3932,7 @@ void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 			     vaddr, size, address, meta.size);
 		}
 	}
-	for (const auto& cached: m_images) {
+	for (auto* cached: image_candidates) {
 		for (uint32_t i = 0; i < cached->RangeCount(); i++) {
 			if (ImagePageRangesOverlap(vaddr, size, cached->Address(i), cached->Size(i)) &&
 			    (vaddr > cached->Address(i) || end < cached->Address(i) + cached->Size(i))) {
@@ -3729,11 +3948,19 @@ void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 			     " buffer_modified=%d\n",
 			     vaddr, size, cached->Address(), cached->Size(), cached->buffer_modified);
 		}
+		if (cached->OverlapsRange(vaddr, size, false)) {
+			unmapped_images.push_back(FindImageOwnerLocked(*cached));
+		}
+	}
+	for (const auto& cached: unmapped_images) {
+		if (std::find(m_images.begin(), m_images.end(), cached) == m_images.end()) {
+			EXIT("TextureCache: indexed unmap owner is missing from the image cache\n");
+		}
 	}
 	std::vector<uint64_t> retire_depth_metadata;
-	for (const auto& cached: m_images) {
+	for (const auto& cached: unmapped_images) {
 		if (cached->kind != CachedImage::Kind::DepthTarget ||
-		    !cached->OverlapsRange(vaddr, size, false) || cached->depth.htile_address == 0) {
+		    cached->DepthTargetDesc().htile_address == 0) {
 			continue;
 		}
 		const bool retained_owner =
@@ -3741,29 +3968,29 @@ void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 			    return other.get() != cached.get() &&
 			           other->kind == CachedImage::Kind::DepthTarget &&
 			           !other->OverlapsRange(vaddr, size, false) &&
-			           other->depth.htile_address == cached->depth.htile_address &&
-			           other->depth.htile_size == cached->depth.htile_size;
+			           other->DepthTargetDesc().htile_address == cached->DepthTargetDesc().htile_address &&
+			           other->DepthTargetDesc().htile_size == cached->DepthTargetDesc().htile_size;
 		    });
 		if (!retained_owner &&
 		    std::find(retire_depth_metadata.begin(), retire_depth_metadata.end(),
-		              cached->depth.htile_address) == retire_depth_metadata.end()) {
-			retire_depth_metadata.push_back(cached->depth.htile_address);
+		              cached->DepthTargetDesc().htile_address) == retire_depth_metadata.end()) {
+			retire_depth_metadata.push_back(cached->DepthTargetDesc().htile_address);
 		}
 	}
 	for (const auto address: retire_depth_metadata) {
 		const auto meta  = m_surface_metas.find(address);
-		const auto owner = std::find_if(m_images.begin(), m_images.end(), [&](const auto& cached) {
+		const auto owner = std::find_if(unmapped_images.begin(), unmapped_images.end(),
+		                                [&](const auto& cached) {
 			return cached->kind == CachedImage::Kind::DepthTarget &&
-			       cached->OverlapsRange(vaddr, size, false) &&
-			       cached->depth.htile_address == address;
+			       cached->DepthTargetDesc().htile_address == address;
 		});
-		if (meta == m_surface_metas.end() || owner == m_images.end() ||
-		    meta->second.size != (*owner)->depth.htile_size) {
+		if (meta == m_surface_metas.end() || owner == unmapped_images.end() ||
+		    meta->second.size != (*owner)->DepthTargetDesc().htile_size) {
 			EXIT("TextureCache: retiring depth image has invalid HTile registration, "
 			     "unmap=0x%016" PRIx64 "+0x%016" PRIx64 " metadata=0x%016" PRIx64
 			     " registered=0x%016" PRIx64 " expected=0x%016" PRIx64 "\n",
 			     vaddr, size, address, meta != m_surface_metas.end() ? meta->second.size : 0,
-			     owner != m_images.end() ? (*owner)->depth.htile_size : 0);
+			     owner != unmapped_images.end() ? (*owner)->DepthTargetDesc().htile_size : 0);
 		}
 	}
 	std::vector<ImageRetirementRange> metadata_ranges;
@@ -3783,17 +4010,11 @@ void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 		     " retained=0x%016" PRIx64 "+0x%016" PRIx64 "\n",
 		     vaddr, size, retired.address, retired.size, retained.address, retained.size);
 	}
-	bool wait_idle = false;
-	for (auto& cached: m_images) {
-		if (cached->OverlapsRange(vaddr, size, false)) {
-			wait_idle = true;
-		}
-	}
-	if (wait_idle) {
+	if (!unmapped_images.empty()) {
 		Transfer::WaitForGraphicsIdle();
 	}
-	for (auto& cached: m_images) {
-		if (!cached->OverlapsRange(vaddr, size, false) || !cached->gpu_modified) {
+	for (const auto& cached: unmapped_images) {
+		if (!cached->gpu_modified) {
 			continue;
 		}
 		for (uint32_t i = 0; i < cached->RangeCount(); i++) {
@@ -3825,13 +4046,13 @@ void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 		it = m_surface_metas.erase(it);
 	}
 	m_memory_tracker.UntrackMemory(vaddr, size);
-	for (auto it = m_images.begin(); it != m_images.end();) {
-		if (!(**it).OverlapsRange(vaddr, size, false)) {
-			++it;
-			continue;
+	for (const auto& cached: unmapped_images) {
+		const auto owner = std::find(m_images.begin(), m_images.end(), cached);
+		if (owner == m_images.end()) {
+			EXIT("TextureCache: unmapped image owner disappeared\n");
 		}
-		UnregisterImageLocked(**it, false);
-		it = m_images.erase(it);
+		UnregisterImageLocked(*cached, false);
+		m_images.erase(owner);
 	}
 }
 

--- a/src/graphics/host_gpu/renderer/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/textureCache.cpp
@@ -104,6 +104,7 @@ private:
 };
 
 enum class ImageRangeOverlap : uint8_t { None, PageOnly, Bytes };
+using ImageQuery = CachedImageRegistry::QueryMode;
 
 ImageRangeOverlap ClassifyImageRangeOverlap(uint64_t left, uint64_t left_size, uint64_t right,
                                             uint64_t right_size) {
@@ -257,51 +258,18 @@ private:
 	std::vector<Entry>       entries;
 };
 
-void TextureCache::RegisterImageLocked(const std::shared_ptr<CachedImage>& image) {
-	if (image == nullptr || image->image == nullptr || image->registered) {
-		EXIT("TextureCache: registering an already registered image\n");
-	}
-	if (m_records_by_image.contains(image->image)) {
-		EXIT("TextureCache: duplicate Vulkan image registration, image=%p\n",
-		     static_cast<const void*>(image->image));
-	}
-	std::vector<ImageOwnerIndex::ByteRange> ranges;
-	ranges.reserve(image->RangeCount());
-	for (uint32_t range = 0; range < image->RangeCount(); range++) {
-		ranges.push_back({image->Address(range), image->Size(range)});
-	}
-	m_records_by_image.emplace(image->image, image);
-	if (!m_image_owner_index.Register(image.get(), ranges)) {
-		m_records_by_image.erase(image->image);
-		EXIT("TextureCache: invalid or duplicate image registration\n");
-	}
-	image->registered = true;
-}
-
-void TextureCache::UnregisterImageLocked(CachedImage& image, bool release_tracking) {
-	if (!image.registered) {
-		EXIT("TextureCache: unregistering an unregistered image\n");
-	}
-	const auto handle = m_records_by_image.find(image.image);
-	if (handle == m_records_by_image.end() || handle->second.lock().get() != &image) {
-		EXIT("TextureCache: image missing from handle index\n");
-	}
-	std::vector<ImageOwnerIndex::ByteRange> final_releases;
-	if (!m_image_owner_index.Unregister(&image, final_releases)) {
-		EXIT("TextureCache: image missing from owner index\n");
-	}
-	m_records_by_image.erase(handle);
+void TextureCache::RemoveImageLocked(CachedImage& image, bool release_tracking) {
+	auto removal = m_image_registry.Remove(image);
 	if (release_tracking) {
-		for (const auto& release: final_releases) {
+		for (const auto& release: removal.final_page_releases) {
 			m_memory_tracker.UntrackMemory(release.address, release.size);
 		}
 	}
-	image.registered = false;
 }
 
 std::shared_ptr<TextureCache::CachedImage>
 TextureCache::FindImageOwnerLocked(const CachedImage& image) const {
-	auto owner = FindImageOwnerLocked(*image.image);
+	auto owner = m_image_registry.Find(image);
 	if (owner.get() != &image) {
 		EXIT("TextureCache: native image record is inconsistent\n");
 	}
@@ -310,13 +278,8 @@ TextureCache::FindImageOwnerLocked(const CachedImage& image) const {
 
 std::shared_ptr<TextureCache::CachedImage>
 TextureCache::FindImageOwnerLocked(VulkanImage& image) const {
-	const auto record = m_records_by_image.find(&image);
-	if (record == m_records_by_image.end()) {
-		EXIT("TextureCache: native image is not registered, image=%p\n",
-		     static_cast<const void*>(&image));
-	}
-	auto owner = record->second.lock();
-	if (owner == nullptr || owner->image != &image) {
+	auto owner = m_image_registry.Find(image);
+	if (owner->image != &image) {
 		EXIT("TextureCache: native image record is inconsistent, image=%p\n",
 		     static_cast<const void*>(&image));
 	}
@@ -334,22 +297,21 @@ VulkanImage& TextureCache::PublishImage(CommandBuffer&               command,
 	}
 	auto& result = *image->image;
 	command.RetainResourceUntilFence(image);
-	m_images.push_back(std::move(image));
-	RegisterImageLocked(m_images.back());
+	m_image_registry.Add(std::move(image));
 	return result;
 }
 
 std::vector<TextureCache::CachedImage*>
-TextureCache::FindImagesInRegionLocked(uint64_t vaddr, uint64_t size, bool page_overlap) {
-	return page_overlap ? m_image_owner_index.QueryCandidates(vaddr, size)
-	                    : m_image_owner_index.Query(vaddr, size);
+TextureCache::FindImagesInRegionLocked(uint64_t vaddr, uint64_t size,
+                                       CachedImageRegistry::QueryMode mode) {
+	return m_image_registry.Query(vaddr, size, mode);
 }
 
 std::vector<TextureCache::CachedImage*> TextureCache::FindImagesInRegionsLocked(
-    std::span<const GuestRange> ranges, bool page_overlap) {
+    std::span<const GuestRange> ranges, CachedImageRegistry::QueryMode mode) {
 	std::vector<CachedImage*> result;
 	for (const auto& range: ranges) {
-		for (auto* image: FindImagesInRegionLocked(range.address, range.size, page_overlap)) {
+		for (auto* image: FindImagesInRegionLocked(range.address, range.size, mode)) {
 			if (std::find(result.begin(), result.end(), image) == result.end()) {
 				result.push_back(image);
 			}
@@ -940,8 +902,8 @@ void TextureCache::RequireRetirementIsolation(const std::vector<CachedImage*>& r
 		return;
 	}
 	std::vector<ImageRetirementRange> ranges;
-	ranges.reserve(m_images.size() * 2);
-	for (const auto& cached: m_images) {
+	ranges.reserve(m_image_registry.Size() * 2);
+	for (const auto& cached: m_image_registry.All()) {
 		const bool retiring = std::find(retire.begin(), retire.end(), cached.get()) != retire.end();
 		for (uint32_t range = 0; range < cached->RangeCount(); range++) {
 			ranges.push_back({cached->Address(range), cached->Size(range), retiring});
@@ -966,62 +928,80 @@ void TextureCache::RetireImages(const std::vector<CachedImage*>& retire,
 	}
 	// FindTexture and FindRenderTarget retain cache records on their recording commands. Erasing
 	// the lookup owner therefore defers Vulkan destruction until the last referencing fence.
+	std::vector<std::shared_ptr<CachedImage>> ordered;
+	ordered.reserve(retire.size());
+	for (const auto& owner: m_image_registry.All()) {
+		if (std::find(retire.begin(), retire.end(), owner.get()) != retire.end()) {
+			ordered.push_back(owner);
+		}
+	}
+	if (ordered.size() != retire.size()) {
+		EXIT("TextureCache: image retirement set mismatch, requested=%zu found=%zu\n",
+		     retire.size(), ordered.size());
+	}
+	if (native_image_source != nullptr) {
+		const auto native = std::find_if(ordered.begin(), ordered.end(), [&](const auto& owner) {
+			return owner.get() == native_image_source;
+		});
+		if (native == ordered.end()) {
+			EXIT("TextureCache: native image retirement source was not selected\n");
+		}
+		// Remove the native source last so its suppressed final-page releases keep tracker
+		// ownership continuous until the replacement image is published.
+		std::rotate(native, native + 1, ordered.end());
+	}
 	size_t removed              = 0;
 	bool   native_image_retired = false;
-	for (auto it = m_images.begin(); it != m_images.end();) {
-		if (std::find(retire.begin(), retire.end(), it->get()) == retire.end()) {
-			++it;
-			continue;
-		}
-		const bool sampled      = (*it)->kind == CachedImage::Kind::Texture;
-		const bool storage      = (*it)->kind == CachedImage::Kind::StorageTexture;
-		const bool target       = (*it)->kind == CachedImage::Kind::RenderTarget ||
-		                          (*it)->kind == CachedImage::Kind::DepthTarget;
-		const bool native_image = it->get() == native_image_source;
+	for (const auto& owner: ordered) {
+		auto&      cached       = *owner;
+		const bool sampled      = cached.kind == CachedImage::Kind::Texture;
+		const bool storage      = cached.kind == CachedImage::Kind::StorageTexture;
+		const bool target       = cached.kind == CachedImage::Kind::RenderTarget ||
+		                          cached.kind == CachedImage::Kind::DepthTarget;
+		const bool native_image = &cached == native_image_source;
 		if (native_image) {
-			bool source_valid = (*it)->gpu_modified && !(*it)->buffer_modified;
-			switch ((*it)->kind) {
+			bool source_valid = cached.gpu_modified && !cached.buffer_modified;
+			switch (cached.kind) {
 				case CachedImage::Kind::StorageTexture:
-					source_valid = source_valid && !(*it)->ImageDesc().IsCpuDirty();
+					source_valid = source_valid && !cached.ImageDesc().IsCpuDirty();
 					break;
 				case CachedImage::Kind::RenderTarget:
 				case CachedImage::Kind::DepthTarget: break;
 				case CachedImage::Kind::Texture:
 				case CachedImage::Kind::VideoOut: source_valid = false; break;
 			}
-			for (uint32_t range = 0; source_valid && range < (*it)->RangeCount(); range++) {
+			for (uint32_t range = 0; source_valid && range < cached.RangeCount(); range++) {
 				source_valid =
-				    m_memory_tracker.IsRegionGpuModified((*it)->Address(range), (*it)->Size(range));
+				    m_memory_tracker.IsRegionGpuModified(cached.Address(range), cached.Size(range));
 			}
 			if (!source_valid) {
 				EXIT("TextureCache: invalid native image retirement, kind=%u gpu_modified=%d "
 				     "buffer_modified=%d cpu_dirty=%d\n",
-				     static_cast<uint32_t>((*it)->kind), (*it)->gpu_modified,
-				     (*it)->buffer_modified,
-				     (*it)->kind == CachedImage::Kind::StorageTexture && (*it)->ImageDesc().IsCpuDirty());
+				     static_cast<uint32_t>(cached.kind), cached.gpu_modified,
+				     cached.buffer_modified,
+				     cached.kind == CachedImage::Kind::StorageTexture && cached.ImageDesc().IsCpuDirty());
 			}
-			(*it)->gpu_modified  = false;
+			cached.gpu_modified  = false;
 			native_image_retired = true;
 		}
-		if ((!sampled && !storage && !target && !native_image) || (*it)->gpu_modified ||
-		    (storage && ((*it)->buffer_modified || (*it)->ImageDesc().IsCpuDirty())) ||
-		    (target && (*it)->buffer_modified)) {
+		if ((!sampled && !storage && !target && !native_image) || cached.gpu_modified ||
+		    (storage && (cached.buffer_modified || cached.ImageDesc().IsCpuDirty())) ||
+		    (target && cached.buffer_modified)) {
 			EXIT("TextureCache: invalid image retirement, kind=%u gpu_modified=%d "
 			     "buffer_modified=%d\n",
-			     static_cast<uint32_t>((*it)->kind), (*it)->gpu_modified, (*it)->buffer_modified);
+			     static_cast<uint32_t>(cached.kind), cached.gpu_modified, cached.buffer_modified);
 		}
-		for (uint32_t range = 0; range < (*it)->RangeCount(); range++) {
+		for (uint32_t range = 0; range < cached.RangeCount(); range++) {
 			if (target && !native_image &&
-			    m_memory_tracker.IsRegionGpuModified((*it)->Address(range), (*it)->Size(range))) {
+			    m_memory_tracker.IsRegionGpuModified(cached.Address(range), cached.Size(range))) {
 				EXIT("TextureCache: clean target retirement retained tracker GPU ownership, "
 				     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
-				     (*it)->Address(range), (*it)->Size(range));
+				     cached.Address(range), cached.Size(range));
 			}
 		}
 		// A native transition keeps tracker ownership continuous until the replacement is
 		// published. Normal retirement only releases 4 KiB pages with no remaining image owner.
-		UnregisterImageLocked(**it, !native_image);
-		it = m_images.erase(it);
+		RemoveImageLocked(cached, !native_image);
 		removed++;
 	}
 	if (removed != retire.size()) {
@@ -1041,12 +1021,13 @@ void TextureCache::RetireDepthMetadataLocked(const std::vector<CachedImage*>& re
 			continue;
 		}
 		const bool retained_owner =
-		    std::any_of(m_images.begin(), m_images.end(), [&](const auto& other) {
+		    std::any_of(m_image_registry.All().begin(), m_image_registry.All().end(),
+		                [&](const auto& other) {
 			    return std::find(retire.begin(), retire.end(), other.get()) == retire.end() &&
 			           other->kind == CachedImage::Kind::DepthTarget &&
 			           other->DepthTargetDesc().htile_address == cached->DepthTargetDesc().htile_address &&
 			           other->DepthTargetDesc().htile_size == cached->DepthTargetDesc().htile_size;
-		    });
+		        });
 		if (!retained_owner && cached->DepthTargetDesc().htile_address != preserve_address &&
 		    std::find(addresses.begin(), addresses.end(), cached->DepthTargetDesc().htile_address) ==
 		        addresses.end()) {
@@ -1319,7 +1300,7 @@ TextureCache::TextureCache(PageManager& page_manager, BufferCache& buffer_cache,
 TextureCache::CachedImage* TextureCache::FindGpuReadbackPageCandidateLocked(uint64_t vaddr,
                                                                             uint64_t size) {
 	CachedImage* selected = nullptr;
-	for (auto* cached: FindImagesInRegionLocked(vaddr, size, true)) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, ImageQuery::PageCandidates)) {
 		if (!cached->IsGpuReadbackPageCandidate(vaddr, size)) {
 			continue;
 		}
@@ -1334,7 +1315,7 @@ TextureCache::CachedImage* TextureCache::FindGpuReadbackPageCandidateLocked(uint
 }
 
 void TextureCache::MarkSampledAliasesCpuDirtyLocked(uint64_t vaddr, uint64_t size) {
-	for (auto* cached: FindImagesInRegionLocked(vaddr, size, true)) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, ImageQuery::PageCandidates)) {
 		if (cached->kind != CachedImage::Kind::Texture) {
 			continue;
 		}
@@ -1355,7 +1336,8 @@ void TextureCache::MarkSampledAliasesCpuDirtyLocked(uint64_t vaddr, uint64_t siz
 void TextureCache::RetireSampledTargetAliases(const ImageInfo& requested) {
 	AliasRetirementPlan plan("sampled target", {requested.address, requested.size},
 	                         AliasRetirementPlan::PageIsolation::Required);
-	for (auto* cached: FindImagesInRegionLocked(requested.address, requested.size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(requested.address, requested.size, ImageQuery::PageCandidates)) {
 		if (cached->kind != CachedImage::Kind::RenderTarget) {
 			continue;
 		}
@@ -1379,7 +1361,8 @@ void TextureCache::RetireSampledTargetAliases(const ImageInfo& requested) {
 				     cached->gpu_modified, cached->buffer_modified);
 		}
 	}
-	for (auto* cached: FindImagesInRegionLocked(requested.address, requested.size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(requested.address, requested.size, ImageQuery::PageCandidates)) {
 		if (cached->kind != CachedImage::Kind::DepthTarget) {
 			continue;
 		}
@@ -1448,7 +1431,8 @@ void TextureCache::RetireSampledTargetAliases(const ImageInfo& requested) {
 void TextureCache::ResolveStorageImageOverlaps(const ImageInfo& requested) {
 	AliasRetirementPlan plan("storage image", {requested.address, requested.size},
 	                         AliasRetirementPlan::PageIsolation::SharedPagesAllowed);
-	for (auto* cached: FindImagesInRegionLocked(requested.address, requested.size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(requested.address, requested.size, ImageQuery::PageCandidates)) {
 		const bool tracker_gpu =
 		    m_memory_tracker.IsRegionGpuModified(cached->Address(), cached->Size());
 		switch (ClassifyStorageImageOverlap(
@@ -1476,7 +1460,8 @@ void TextureCache::ResolveStorageImageOverlaps(const ImageInfo& requested) {
 
 void TextureCache::RetireStorageDepthAliasLocked(const ImageInfo& requested) {
 	CachedImage* selected = nullptr;
-	for (auto* entry: FindImagesInRegionLocked(requested.address, requested.size, true)) {
+	for (auto* entry:
+	     FindImagesInRegionLocked(requested.address, requested.size, ImageQuery::PageCandidates)) {
 		auto& cached = *entry;
 		if (cached.kind != CachedImage::Kind::DepthTarget ||
 		    !cached.OverlapsRange(requested.address, requested.size, true)) {
@@ -1515,13 +1500,13 @@ void TextureCache::RetireStorageDepthAliasLocked(const ImageInfo& requested) {
 
 TextureCache::~TextureCache() {
 	m_readback.reset();
-	if (!m_images.empty()) {
+	if (!m_image_registry.Empty()) {
 		Transfer::WaitForGraphicsIdle();
 	}
-	for (const auto& image: m_images) {
-		UnregisterImageLocked(*image, false);
+	while (!m_image_registry.Empty()) {
+		auto image = m_image_registry.All().back();
+		RemoveImageLocked(*image, false);
 	}
-	m_images.clear();
 	m_dummy_textures.reset();
 }
 
@@ -1563,7 +1548,8 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 	AliasRetirementPlan storage_aliases("sampled mip storage", {info.address, info.size},
 	                                    AliasRetirementPlan::PageIsolation::SharedPagesAllowed);
 	const auto                   requested_view_format = TextureGetFormat(info.format);
-	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(info.address, info.size, ImageQuery::PageCandidates)) {
 		if (cached->kind != CachedImage::Kind::StorageTexture) {
 			continue;
 		}
@@ -1650,7 +1636,8 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 		MarkSampledAliasesCpuDirtyLocked(info.address, info.size);
 	}
 	std::shared_ptr<CachedImage> match;
-	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(info.address, info.size, ImageQuery::PageCandidates)) {
 		if (cached->kind != CachedImage::Kind::Texture || !Equal(info, cached->ImageDesc())) {
 			continue;
 		}
@@ -1698,7 +1685,8 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 		command.RetainResourceUntilFence(match);
 		return *match->image;
 	}
-	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(info.address, info.size, ImageQuery::PageCandidates)) {
 		if (cached->kind != CachedImage::Kind::Texture) {
 			if (!cached->OverlapsRange(info.address, info.size, true)) {
 				continue;
@@ -1719,7 +1707,7 @@ VulkanImage& TextureCache::FindTexture(CommandBuffer& command, const ImageInfo& 
 			     cached->gpu_modified);
 		}
 	}
-	m_images.reserve(m_images.size() + 1);
+	m_image_registry.ReserveAdditional(1);
 	auto cached = std::make_shared<CachedImage>(CachedImage::Kind::Texture, info);
 	vk::ComponentMapping components {};
 	cached->image = ImageOps::CreateTexture(info, false, components);
@@ -1788,7 +1776,8 @@ StorageTextureVulkanImage& TextureCache::FindStorageTexture(CommandBuffer&   com
 	}
 
 	std::shared_ptr<CachedImage> match;
-	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(info.address, info.size, ImageQuery::PageCandidates)) {
 		if (cached->kind != CachedImage::Kind::StorageTexture ||
 		    !EqualStorageBacking(info, cached->ImageDesc())) {
 			continue;
@@ -1848,7 +1837,7 @@ StorageTextureVulkanImage& TextureCache::FindStorageTexture(CommandBuffer&   com
 	}
 
 	ResolveStorageImageOverlaps(info);
-	m_images.reserve(m_images.size() + 1);
+	m_image_registry.ReserveAdditional(1);
 	auto cached = std::make_shared<CachedImage>(CachedImage::Kind::StorageTexture, info);
 	vk::ComponentMapping components {};
 	cached->image = ImageOps::CreateTexture(info, true, components);
@@ -1950,7 +1939,8 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 	}
 	FaultSafeTextureLock         lock(this, m_lock);
 	std::shared_ptr<CachedImage> match;
-	for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(info.address, info.size, ImageQuery::PageCandidates)) {
 		if (cached->kind != CachedImage::Kind::RenderTarget ||
 		    (!Equal(info, cached->RenderTargetDesc()) &&
 		     !IsCompatibleRenderTargetView(cached->RenderTargetDesc(), info) &&
@@ -1997,7 +1987,8 @@ RenderTextureVulkanImage& TextureCache::FindRenderTarget(CommandBuffer&         
 	}
 	AliasRetirementPlan alias_plan("render target", {info.address, info.size},
 	                                   AliasRetirementPlan::PageIsolation::Required);
-	for (auto* entry: FindImagesInRegionLocked(info.address, info.size, true)) {
+	for (auto* entry:
+	     FindImagesInRegionLocked(info.address, info.size, ImageQuery::PageCandidates)) {
 		auto& cached = *entry;
 		if (!cached.OverlapsRange(info.address, info.size, true)) {
 			continue;
@@ -2246,7 +2237,8 @@ DepthStencilVulkanImage& TextureCache::FindDepthTarget(CommandBuffer&         co
 	const std::array<GuestRange, 2> requested_ranges {{
 	    {info.address, info.size}, {info.stencil_address, info.stencil_size}}};
 	const auto candidates = FindImagesInRegionsLocked(
-	    {requested_ranges.data(), has_stencil ? requested_ranges.size() : 1}, true);
+	    {requested_ranges.data(), has_stencil ? requested_ranges.size() : 1},
+	    ImageQuery::PageCandidates);
 	std::shared_ptr<CachedImage> match;
 	for (auto* cached: candidates) {
 		if (cached->kind != CachedImage::Kind::DepthTarget ||
@@ -2642,7 +2634,8 @@ TextureCache::RegisterVideoOutSurfaces(const std::vector<VideoOutInfo>& infos) {
 	FaultSafeTextureLock lock(this, m_lock);
 	for (const auto& info: infos) {
 		ResolveImageMetadataOverlapsLocked(info.address, info.size);
-		for (auto* cached: FindImagesInRegionLocked(info.address, info.size, true)) {
+		for (auto* cached:
+		     FindImagesInRegionLocked(info.address, info.size, ImageQuery::PageCandidates)) {
 			if (cached->OverlapsRange(info.address, info.size, true)) {
 				EXIT(
 				    "TextureCache: video-out surface aliases cached image pages, addr=0x%016" PRIx64
@@ -2651,7 +2644,7 @@ TextureCache::RegisterVideoOutSurfaces(const std::vector<VideoOutInfo>& infos) {
 			}
 		}
 	}
-	m_images.reserve(m_images.size() + infos.size());
+	m_image_registry.ReserveAdditional(infos.size());
 	std::vector<VideoOutVulkanImage*> result;
 	result.reserve(infos.size());
 	for (const auto& info: infos) {
@@ -2673,8 +2666,7 @@ TextureCache::RegisterVideoOutSurfaces(const std::vector<VideoOutInfo>& infos) {
 			    []() noexcept {});
 		}
 		result.push_back(static_cast<VideoOutVulkanImage*>(cached->image));
-		m_images.push_back(std::move(cached));
-		RegisterImageLocked(m_images.back());
+		m_image_registry.Add(std::move(cached));
 	}
 	return result;
 }
@@ -2765,14 +2757,7 @@ void TextureCache::UnregisterVideoOutSurfaces(const std::vector<VideoOutVulkanIm
 			m_memory_tracker.UnmarkRegionAsGpuModified(cached->Address(), cached->Size());
 			cached->gpu_modified = false;
 		}
-		UnregisterImageLocked(*cached, true);
-	}
-	for (const auto& cached: selected) {
-		auto it = std::find(m_images.begin(), m_images.end(), cached);
-		if (it == m_images.end()) {
-			EXIT("TextureCache: video-out owner disappeared during unregistration\n");
-		}
-		m_images.erase(it);
+		RemoveImageLocked(*cached, true);
 	}
 }
 
@@ -2810,7 +2795,7 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t vaddr, 
 	ClearAspect                  aspect       = ClearAspect::None;
 	bool                         incompatible = false;
 	uint32_t                     matches      = 0;
-	for (auto* cached: FindImagesInRegionLocked(vaddr, size, true)) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, ImageQuery::PageCandidates)) {
 		if (!cached->OverlapsRange(vaddr, size, true)) {
 			continue;
 		}
@@ -2998,7 +2983,7 @@ void TextureCache::PrepareHostWrite(uint64_t vaddr, uint64_t size) {
 	FaultSafeTextureLock lock(this, m_lock);
 	const bool           metadata_overlap = HasMetaOverlapLocked(vaddr, size);
 	bool                 found            = false;
-	for (auto* cached: FindImagesInRegionLocked(vaddr, size, true)) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, ImageQuery::PageCandidates)) {
 		for (uint32_t range = 0; range < cached->RangeCount(); range++) {
 			// CPU-current depth targets use the same tracked guest refresh path as sampled and
 			// color images. GPU-owned targets and metadata aliases remain unsupported below.
@@ -3285,7 +3270,7 @@ bool TextureCache::InvalidateMemoryFromGPU(uint64_t vaddr, uint64_t size,
 	}
 	CachedImage*     match  = nullptr;
 	BufferImageWrite action = BufferImageWrite::None;
-	for (auto* candidate: FindImagesInRegionLocked(vaddr, size, false)) {
+	for (auto* candidate: FindImagesInRegionLocked(vaddr, size, ImageQuery::Bytes)) {
 		auto& cached = *candidate;
 		if (!cached.OverlapsRange(vaddr, size, false)) {
 			continue;
@@ -3344,7 +3329,7 @@ DepthStencilVulkanImage* TextureCache::FindDepthTargetByRange(CommandBuffer& com
 	}
 	FaultSafeTextureLock lock(this, m_lock);
 	CachedImage*         found = nullptr;
-	for (auto* cached: FindImagesInRegionLocked(vaddr, size, false)) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, ImageQuery::Bytes)) {
 		if (cached->kind != CachedImage::Kind::DepthTarget ||
 		    !cached->OverlapsRange(vaddr, size, false)) {
 			continue;
@@ -3388,7 +3373,7 @@ RenderTextureVulkanImage* TextureCache::FindRenderTargetByRange(CommandBuffer& c
 	}
 	FaultSafeTextureLock lock(this, m_lock);
 	CachedImage*         found = nullptr;
-	for (auto* cached: FindImagesInRegionLocked(vaddr, size, false)) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, ImageQuery::Bytes)) {
 		if (cached->kind != CachedImage::Kind::RenderTarget ||
 		    !ImageRangeOverlaps(vaddr, size, cached->Address(), cached->Size())) {
 			continue;
@@ -3425,7 +3410,7 @@ TextureCache::RegionInfo TextureCache::QueryRegion(uint64_t vaddr, uint64_t size
 	}
 	FaultSafeTextureLock lock(this, m_lock);
 	RegionInfo           result;
-	const auto           candidates = FindImagesInRegionLocked(vaddr, size, true);
+	const auto candidates = FindImagesInRegionLocked(vaddr, size, ImageQuery::PageCandidates);
 	result.image_pages              = !candidates.empty();
 	for (const auto* cached: candidates) {
 		const bool bytes = cached->OverlapsRange(vaddr, size, false);
@@ -3531,7 +3516,8 @@ void TextureCache::RegisterMeta(uint64_t vaddr, uint64_t size, uint32_t layers) 
 	AliasRetirementPlan plan("metadata", {range_vaddr, range_size},
 	                         AliasRetirementPlan::PageIsolation::Required);
 	plan.PreserveMetadata(vaddr);
-	for (auto* cached: FindImagesInRegionLocked(range_vaddr, range_size, true)) {
+	for (auto* cached:
+	     FindImagesInRegionLocked(range_vaddr, range_size, ImageQuery::PageCandidates)) {
 		const bool sampled        = cached->kind == CachedImage::Kind::Texture;
 		const bool writable_image = cached->kind == CachedImage::Kind::StorageTexture ||
 		                            cached->kind == CachedImage::Kind::RenderTarget ||
@@ -3608,7 +3594,8 @@ void TextureCache::RequireNoMetaOverlapLocked(uint64_t vaddr, uint64_t size) con
 		if (!ImagePageRangesOverlap(vaddr, size, address, meta.size)) {
 			continue;
 		}
-		const auto owner = std::find_if(m_images.begin(), m_images.end(), [&](const auto& cached) {
+		const auto& images = m_image_registry.All();
+		const auto owner = std::find_if(images.begin(), images.end(), [&](const auto& cached) {
 			return cached->kind == CachedImage::Kind::DepthTarget &&
 			       cached->DepthTargetDesc().htile_address == address &&
 			       cached->DepthTargetDesc().htile_size == meta.size;
@@ -3618,11 +3605,11 @@ void TextureCache::RequireNoMetaOverlapLocked(uint64_t vaddr, uint64_t size) con
 		     " layers=%u gpu=%d clear=0x%08x owner=%p owner_depth=0x%016" PRIx64 "+0x%016" PRIx64
 		     " owner_gpu=%d owner_buffer=%d\n",
 		     vaddr, size, address, meta.size, meta.layers, meta.gpu_modified, meta.clear_mask,
-		     owner != m_images.end() ? static_cast<const void*>(owner->get()) : nullptr,
-		     owner != m_images.end() ? (*owner)->DepthTargetDesc().address : 0,
-		     owner != m_images.end() ? (*owner)->DepthTargetDesc().size : 0,
-		     owner != m_images.end() && (*owner)->gpu_modified,
-		     owner != m_images.end() && (*owner)->buffer_modified);
+		     owner != images.end() ? static_cast<const void*>(owner->get()) : nullptr,
+		     owner != images.end() ? (*owner)->DepthTargetDesc().address : 0,
+		     owner != images.end() ? (*owner)->DepthTargetDesc().size : 0,
+		     owner != images.end() && (*owner)->gpu_modified,
+		     owner != images.end() && (*owner)->buffer_modified);
 	}
 }
 
@@ -3634,7 +3621,7 @@ void TextureCache::ResolveImageMetadataOverlapsLocked(uint64_t vaddr, uint64_t s
 			continue;
 		}
 		bool found_owner = false;
-		for (const auto& cached: m_images) {
+		for (const auto& cached: m_image_registry.All()) {
 			if (cached->kind != CachedImage::Kind::DepthTarget ||
 			    cached->DepthTargetDesc().htile_address != address) {
 				continue;
@@ -3838,7 +3825,7 @@ TextureCache::UnmapPlan TextureCache::BuildUnmapPlanLocked(uint64_t vaddr, uint6
 			plan.metadata_addresses.push_back(address);
 		}
 	}
-	for (auto* cached: FindImagesInRegionLocked(vaddr, size, true)) {
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, ImageQuery::PageCandidates)) {
 		std::array<GuestRange, 2> ranges {};
 		for (uint32_t i = 0; i < cached->RangeCount(); i++) {
 			ranges[i] = {cached->Address(i), cached->Size(i)};
@@ -3864,7 +3851,7 @@ TextureCache::UnmapPlan TextureCache::BuildUnmapPlanLocked(uint64_t vaddr, uint6
 			     vaddr, size, cached->Address(), cached->Size(), cached->buffer_modified);
 		}
 		auto owner = FindImageOwnerLocked(*cached);
-		if (std::find(m_images.begin(), m_images.end(), owner) == m_images.end()) {
+		if (!m_image_registry.Contains(*owner)) {
 			EXIT("TextureCache: indexed unmap owner is missing from the image cache\n");
 		}
 		if (cached->gpu_modified) {
@@ -3898,8 +3885,8 @@ TextureCache::UnmapPlan TextureCache::BuildUnmapPlanLocked(uint64_t vaddr, uint6
 		    cached->DepthTargetDesc().htile_address == 0) {
 			continue;
 		}
-		const bool retained_owner =
-		    std::any_of(m_images.begin(), m_images.end(), [&](const auto& other) {
+		const bool retained_owner = std::any_of(
+		    m_image_registry.All().begin(), m_image_registry.All().end(), [&](const auto& other) {
 			    return std::find(plan.images.begin(), plan.images.end(), other) == plan.images.end() &&
 			           other->kind == CachedImage::Kind::DepthTarget &&
 			           other->DepthTargetDesc().htile_address == cached->DepthTargetDesc().htile_address &&
@@ -4006,12 +3993,10 @@ void TextureCache::CommitUnmapMemory(uint64_t vaddr, uint64_t size) {
 		it = m_surface_metas.erase(it);
 	}
 	for (const auto& cached: plan.images) {
-		const auto owner = std::find(m_images.begin(), m_images.end(), cached);
-		if (owner == m_images.end()) {
+		if (!m_image_registry.Contains(*cached)) {
 			EXIT("TextureCache: unmapped image owner disappeared\n");
 		}
-		UnregisterImageLocked(*cached, true);
-		m_images.erase(owner);
+		RemoveImageLocked(*cached, true);
 	}
 }
 

--- a/src/graphics/host_gpu/renderer/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/textureCache.cpp
@@ -516,6 +516,7 @@ std::vector<TextureCache::CachedImage*> TextureCache::FindImagesInRegionsLocked(
 }
 
 struct TextureCache::ReadbackWorker {
+	enum class Purpose : uint8_t { Fault, AliasTransition, Unmap };
 	enum class State : uint32_t {
 		Idle,
 		Claimed,
@@ -544,6 +545,21 @@ struct TextureCache::ReadbackWorker {
 			return {ranges.data(), count};
 		}
 	};
+	struct PreparedDepthReadback {
+		CachedImage*                 image = nullptr;
+		std::vector<ImageBufferCopy> regions;
+		std::vector<GpuTileInfo>     gpu_infos;
+		uint64_t                     transfer_size = 0;
+		bool                         has_stencil   = false;
+	};
+	struct PreparedColorReadback {
+		CachedImage*                 image = nullptr;
+		ColorImageTransferInfo       info;
+		std::vector<ImageBufferCopy> regions;
+		std::vector<GpuTileInfo>     gpu_infos;
+		bool                         tiled = false;
+	};
+	using PreparedReadback = std::variant<PreparedDepthReadback, PreparedColorReadback>;
 	static_assert(std::atomic<State>::is_always_lock_free);
 
 	explicit ReadbackWorker(TextureCache& owner): cache(owner), thread([this] { Run(); }) {}
@@ -653,9 +669,11 @@ struct TextureCache::ReadbackWorker {
 		}
 	}
 
-	[[nodiscard]] ReadbackTransfer DownloadDepthTarget(CachedImage& cached,
-	                                                   bool         require_fault_range = true) {
+	[[nodiscard]] PreparedDepthReadback PrepareDepthTarget(CachedImage& cached,
+	                                                       Purpose purpose = Purpose::Fault) {
 		const auto& info = cached.DepthTargetDesc();
+		const bool require_fault_range = purpose == Purpose::Fault;
+		const bool allow_buffer_overlap = purpose == Purpose::Unmap;
 		if (info.samples != 1 || cached.image->samples != 1) {
 			EXIT("TextureCache: multisampled depth-image readback is unsupported, samples=%u/%u\n",
 			     info.samples, cached.image->samples);
@@ -741,9 +759,11 @@ struct TextureCache::ReadbackWorker {
 		const bool meta_overlap =
 		    cache.HasMetaOverlapLocked(info.address, info.size) ||
 		    (has_stencil && cache.HasMetaOverlapLocked(info.stencil_address, info.stencil_size));
-		const bool buffer_overlap = cache.m_buffer_cache.HasPageOverlap(info.address, info.size) ||
-		                            (has_stencil && cache.m_buffer_cache.HasPageOverlap(
-		                                                info.stencil_address, info.stencil_size));
+		const bool buffer_overlap =
+		    !allow_buffer_overlap &&
+		    (cache.m_buffer_cache.HasPageOverlap(info.address, info.size) ||
+		     (has_stencil && cache.m_buffer_cache.HasPageOverlap(info.stencil_address,
+		                                                         info.stencil_size)));
 		const auto transfer_size  = info.size + info.stencil_size;
 		if (depth_linear_size > depth_slice_size ||
 		    (has_stencil && stencil_linear_elements > stencil_slice_size) ||
@@ -811,13 +831,20 @@ struct TextureCache::ReadbackWorker {
 				gpu_infos.push_back(tile);
 			}
 		}
-		guest.resize(transfer_size);
-		Transfer::DownloadTiledImage(guest.data(), transfer_size, transfer_size, gpu_infos, regions,
-		                             *cached.image, cached.image->layout);
+		return {&cached, std::move(regions), std::move(gpu_infos), transfer_size, has_stencil};
+	}
+
+	[[nodiscard]] ReadbackTransfer Execute(PreparedDepthReadback& prepared) {
+		auto&       cached = *prepared.image;
+		const auto& info   = cached.DepthTargetDesc();
+		guest.resize(prepared.transfer_size);
+		Transfer::DownloadTiledImage(guest.data(), prepared.transfer_size, prepared.transfer_size,
+		                             prepared.gpu_infos, prepared.regions, *cached.image,
+		                             cached.image->layout);
 		Libs::LibKernel::Memory::WriteBacking(info.address, guest.data(), info.size);
 		ReadbackTransfer transfer;
 		transfer.Add(info.address, info.size);
-		if (has_stencil) {
+		if (prepared.has_stencil) {
 			Libs::LibKernel::Memory::WriteBacking(info.stencil_address, guest.data() + info.size,
 			                                      info.stencil_size);
 			transfer.Add(info.stencil_address, info.stencil_size);
@@ -825,7 +852,8 @@ struct TextureCache::ReadbackWorker {
 		return transfer;
 	}
 
-	[[nodiscard]] ReadbackTransfer DownloadColorImage(CachedImage& cached) {
+	[[nodiscard]] PreparedColorReadback PrepareColorImage(CachedImage& cached,
+	                                                     Purpose purpose = Purpose::Fault) {
 		const bool storage = cached.kind == CachedImage::Kind::StorageTexture;
 		const bool target  = cached.kind == CachedImage::Kind::RenderTarget;
 		const auto info =
@@ -873,7 +901,8 @@ struct TextureCache::ReadbackWorker {
 		}
 		const auto slice_size     = info.size / layers;
 		const bool meta_overlap   = cache.HasMetaOverlapLocked(info.address, info.size);
-		const bool buffer_overlap = cache.m_buffer_cache.HasPageOverlap(info.address, info.size);
+		const bool buffer_overlap = purpose != Purpose::Unmap &&
+		                            cache.m_buffer_cache.HasPageOverlap(info.address, info.size);
 		if (meta_overlap || buffer_overlap) {
 			EXIT("TextureCache: color-image readback storage is unsupported, addr=0x%016" PRIx64
 			     " size=0x%016" PRIx64 " meta=%d buffer=%d kind=%u\n",
@@ -906,27 +935,49 @@ struct TextureCache::ReadbackWorker {
 			regions = Transfer::MakeLayeredImageBufferCopies(layers, slice_size, info.pitch,
 			                                                 info.width, info.height);
 		}
+		std::vector<GpuTileInfo> gpu_infos;
 		if (gpu_tiled) {
-			std::vector<GpuTileInfo> infos;
 			const auto format = storage
 			                        ? cached.ImageDesc().format
 			                        : ImageOps::RenderTargetTransferFormat(info.bytes_per_element);
-			guest.resize(info.size);
 			EXIT_NOT_IMPLEMENTED(!TextureBuildGpuTileInfos(info.size, tiled_regions, tiled_layout,
-			                                               format, layers, info.levels, infos));
-			Transfer::DownloadTiledImage(guest.data(), info.size, info.size, infos, regions,
-			                             *cached.image, cached.image->layout);
+			                                               format, layers, info.levels, gpu_infos));
+		}
+		return {&cached, info, std::move(regions), std::move(gpu_infos), gpu_tiled};
+	}
+
+	[[nodiscard]] ReadbackTransfer Execute(PreparedColorReadback& prepared) {
+		auto&       cached = *prepared.image;
+		const auto& info   = prepared.info;
+		if (prepared.tiled) {
+			guest.resize(info.size);
+			Transfer::DownloadTiledImage(guest.data(), info.size, info.size, prepared.gpu_infos,
+			                             prepared.regions, *cached.image, cached.image->layout);
 			Libs::LibKernel::Memory::WriteBacking(info.address, guest.data(), info.size);
 		} else {
 			download.resize(info.size);
 			std::fill(download.begin(), download.end(), 0);
-			Transfer::DownloadImage(download.data(), info.size, regions, *cached.image,
+			Transfer::DownloadImage(download.data(), info.size, prepared.regions, *cached.image,
 			                        cached.image->layout);
 			Libs::LibKernel::Memory::WriteBacking(info.address, download.data(), info.size);
 		}
 		ReadbackTransfer transfer;
 		transfer.Add(info.address, info.size);
 		return transfer;
+	}
+
+	[[nodiscard]] PreparedReadback Prepare(CachedImage& cached, Purpose purpose) {
+		return cached.kind == CachedImage::Kind::DepthTarget
+		           ? PreparedReadback {PrepareDepthTarget(cached, purpose)}
+		           : PreparedReadback {PrepareColorImage(cached, purpose)};
+	}
+
+	[[nodiscard]] ReadbackTransfer Execute(PreparedReadback& prepared) {
+		return std::visit([this](auto& item) { return Execute(item); }, prepared);
+	}
+
+	[[nodiscard]] static CachedImage& Owner(PreparedReadback& prepared) {
+		return *std::visit([](auto& item) { return item.image; }, prepared);
 	}
 
 	void Run() noexcept {
@@ -970,8 +1021,8 @@ struct TextureCache::ReadbackWorker {
 				     selected != nullptr ? static_cast<const void*>(selected->image) : nullptr);
 			}
 
-			const auto transfer =
-			    depth_target ? DownloadDepthTarget(*selected) : DownloadColorImage(*selected);
+			auto       prepared = Prepare(*selected, Purpose::Fault);
+			const auto transfer = Execute(prepared);
 
 			if (!cache.m_memory_tracker.IsRegionGpuModified(vaddr, size)) {
 				EXIT("TextureCache: readback fault page is not GPU-modified, addr=0x%016" PRIx64
@@ -1030,6 +1081,13 @@ struct TextureCache::ReadbackWorker {
 	std::vector<uint8_t> download;
 	std::vector<uint8_t> guest;
 	std::thread          thread;
+};
+
+struct TextureCache::UnmapPlan {
+	GuestRange                                range;
+	std::vector<std::shared_ptr<CachedImage>> images;
+	std::vector<ReadbackWorker::PreparedReadback> materializations;
+	std::vector<uint64_t>                     metadata_addresses;
 };
 
 void TextureCache::RequireRetirementIsolation(const std::vector<CachedImage*>& retire,
@@ -1175,10 +1233,8 @@ void TextureCache::RetireDepthMetadataLocked(const std::vector<CachedImage*>& re
 
 void TextureCache::MaterializeImagesToGuestLocked(
     const std::vector<std::shared_ptr<CachedImage>>& images) {
-	if (std::any_of(images.begin(), images.end(),
-	                [](const auto& cached) { return cached->gpu_modified; })) {
-		Transfer::WaitForGraphicsIdle();
-	}
+	std::vector<ReadbackWorker::PreparedReadback> materializations;
+	materializations.reserve(images.size());
 	for (const auto& cached: images) {
 		if (!cached->gpu_modified) {
 			continue;
@@ -1194,14 +1250,20 @@ void TextureCache::MaterializeImagesToGuestLocked(
 			EXIT("TextureCache: unsupported image recreation source kind %u\n",
 			     static_cast<uint32_t>(cached->kind));
 		}
-		const auto transfer = cached->kind == CachedImage::Kind::DepthTarget
-		                          ? m_readback->DownloadDepthTarget(*cached, false)
-		                          : m_readback->DownloadColorImage(*cached);
+		materializations.push_back(
+		    m_readback->Prepare(*cached, ReadbackWorker::Purpose::AliasTransition));
+	}
+	if (!materializations.empty()) {
+		Transfer::WaitForGraphicsIdle();
+	}
+	for (auto& prepared: materializations) {
+		auto&      cached   = ReadbackWorker::Owner(prepared);
+		const auto transfer = m_readback->Execute(prepared);
 		for (const auto& range: transfer.Ranges()) {
 			m_memory_tracker.ForEachDownloadRange<true>(range.address, range.size,
 			                                            [](uint64_t, uint64_t) noexcept {});
 		}
-		cached->gpu_modified = false;
+		cached.gpu_modified = false;
 	}
 }
 
@@ -3913,92 +3975,124 @@ bool TextureCache::InvalidateMemory(PageFaultAccess access, uint64_t vaddr, uint
 	return true;
 }
 
-void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
+TextureCache::UnmapPlan TextureCache::BuildUnmapPlanLocked(uint64_t vaddr, uint64_t size) {
 	if (vaddr == 0 || size == 0 || vaddr >= TRACKER_ADDRESS_SIZE ||
 	    size > TRACKER_ADDRESS_SIZE - vaddr) {
 		EXIT("TextureCache: invalid unmap range, addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
 		     vaddr, size);
 	}
-	std::lock_guard      transaction(m_resource_mutex);
-	FaultSafeTextureLock lock(this, m_lock);
-	const auto           end = vaddr + size;
-	const auto           image_candidates = FindImagesInRegionLocked(vaddr, size, true);
-	std::vector<std::shared_ptr<CachedImage>> unmapped_images;
+	UnmapPlan plan {{vaddr, size}};
 	for (const auto& [address, meta]: m_surface_metas) {
-		if (ImagePageRangesOverlap(vaddr, size, address, meta.size) &&
-		    (vaddr > address || end < address + meta.size)) {
+		const auto relation = ClassifyRangeRelation(plan.range, {address, meta.size}, 1);
+		if (!relation.has_value()) {
+			EXIT("TextureCache: invalid metadata range during unmap\n");
+		}
+		if (HasByteOverlap(*relation) && *relation != RangeRelation::Exact &&
+		    *relation != RangeRelation::Contains) {
 			EXIT("TextureCache: partial metadata unmap is unsupported, unmap=0x%016" PRIx64
 			     "+0x%016" PRIx64 " metadata=0x%016" PRIx64 "+0x%016" PRIx64 "\n",
 			     vaddr, size, address, meta.size);
 		}
-	}
-	for (auto* cached: image_candidates) {
-		for (uint32_t i = 0; i < cached->RangeCount(); i++) {
-			if (ImagePageRangesOverlap(vaddr, size, cached->Address(i), cached->Size(i)) &&
-			    (vaddr > cached->Address(i) || end < cached->Address(i) + cached->Size(i))) {
-				EXIT("TextureCache: partial image unmap is unsupported, unmap=0x%016" PRIx64
-				     "+0x%016" PRIx64 " image=0x%016" PRIx64 "+0x%016" PRIx64 "\n",
-				     vaddr, size, cached->Address(i), cached->Size(i));
-			}
+		if (*relation == RangeRelation::Exact || *relation == RangeRelation::Contains) {
+			plan.metadata_addresses.push_back(address);
 		}
-		if (cached->OverlapsRange(vaddr, size, false) &&
-		    cached->kind == CachedImage::Kind::VideoOut) {
+	}
+	for (auto* cached: FindImagesInRegionLocked(vaddr, size, true)) {
+		std::array<GuestRange, 2> ranges {};
+		for (uint32_t i = 0; i < cached->RangeCount(); i++) {
+			ranges[i] = {cached->Address(i), cached->Size(i)};
+		}
+		const auto coverage = ClassifyRangeSetCoverage(
+		    plan.range, std::span<const GuestRange> {ranges.data(), cached->RangeCount()});
+		if (!coverage.has_value()) {
+			EXIT("TextureCache: invalid image range set during unmap\n");
+		}
+		if (*coverage == RangeSetCoverage::Disjoint) {
+			continue;
+		}
+		if (*coverage == RangeSetCoverage::Partial) {
+			EXIT("TextureCache: partial image unmap is unsupported, unmap=0x%016" PRIx64
+			     "+0x%016" PRIx64 " image=0x%016" PRIx64 "+0x%016" PRIx64
+			     " ranges=%u\n",
+			     vaddr, size, cached->Address(), cached->Size(), cached->RangeCount());
+		}
+		if (cached->kind == CachedImage::Kind::VideoOut) {
 			EXIT("TextureCache: registered video-out surface must be unregistered before unmap, "
 			     "unmap=0x%016" PRIx64 "+0x%016" PRIx64 " image=0x%016" PRIx64 "+0x%016" PRIx64
 			     " buffer_modified=%d\n",
 			     vaddr, size, cached->Address(), cached->Size(), cached->buffer_modified);
 		}
-		if (cached->OverlapsRange(vaddr, size, false)) {
-			unmapped_images.push_back(FindImageOwnerLocked(*cached));
-		}
-	}
-	for (const auto& cached: unmapped_images) {
-		if (std::find(m_images.begin(), m_images.end(), cached) == m_images.end()) {
+		auto owner = FindImageOwnerLocked(*cached);
+		if (std::find(m_images.begin(), m_images.end(), owner) == m_images.end()) {
 			EXIT("TextureCache: indexed unmap owner is missing from the image cache\n");
 		}
+		if (cached->gpu_modified) {
+			const bool materializable = cached->kind == CachedImage::Kind::StorageTexture ||
+			                            cached->kind == CachedImage::Kind::RenderTarget ||
+			                            cached->kind == CachedImage::Kind::DepthTarget;
+			const bool cpu_dirty = cached->kind == CachedImage::Kind::StorageTexture &&
+			                       cached->ImageDesc().IsCpuDirty();
+			if (!materializable || cached->buffer_modified || cpu_dirty) {
+				EXIT("TextureCache: GPU-owned image cannot be materialized for unmap, kind=%u "
+				     "buffer_modified=%d cpu_dirty=%d\n",
+				     static_cast<uint32_t>(cached->kind), cached->buffer_modified, cpu_dirty);
+			}
+			for (uint32_t i = 0; i < cached->RangeCount(); i++) {
+				if (!m_memory_tracker.IsRegionGpuModified(cached->Address(i), cached->Size(i))) {
+					EXIT("TextureCache: GPU-owned unmap image lacks tracker ownership, "
+					     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
+					     cached->Address(i), cached->Size(i));
+				}
+				if (m_buffer_cache.IsRegionGpuModified(cached->Address(i), cached->Size(i))) {
+					EXIT("TextureCache: unmap has competing GPU image and buffer ownership, "
+					     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
+					     cached->Address(i), cached->Size(i));
+				}
+			}
+		}
+		plan.images.push_back(std::move(owner));
 	}
-	std::vector<uint64_t> retire_depth_metadata;
-	for (const auto& cached: unmapped_images) {
+	for (const auto& cached: plan.images) {
 		if (cached->kind != CachedImage::Kind::DepthTarget ||
 		    cached->DepthTargetDesc().htile_address == 0) {
 			continue;
 		}
 		const bool retained_owner =
 		    std::any_of(m_images.begin(), m_images.end(), [&](const auto& other) {
-			    return other.get() != cached.get() &&
+			    return std::find(plan.images.begin(), plan.images.end(), other) == plan.images.end() &&
 			           other->kind == CachedImage::Kind::DepthTarget &&
-			           !other->OverlapsRange(vaddr, size, false) &&
 			           other->DepthTargetDesc().htile_address == cached->DepthTargetDesc().htile_address &&
 			           other->DepthTargetDesc().htile_size == cached->DepthTargetDesc().htile_size;
 		    });
 		if (!retained_owner &&
-		    std::find(retire_depth_metadata.begin(), retire_depth_metadata.end(),
-		              cached->DepthTargetDesc().htile_address) == retire_depth_metadata.end()) {
-			retire_depth_metadata.push_back(cached->DepthTargetDesc().htile_address);
+		    std::find(plan.metadata_addresses.begin(), plan.metadata_addresses.end(),
+		              cached->DepthTargetDesc().htile_address) == plan.metadata_addresses.end()) {
+			plan.metadata_addresses.push_back(cached->DepthTargetDesc().htile_address);
 		}
 	}
-	for (const auto address: retire_depth_metadata) {
+	for (const auto address: plan.metadata_addresses) {
 		const auto meta  = m_surface_metas.find(address);
-		const auto owner = std::find_if(unmapped_images.begin(), unmapped_images.end(),
+		const auto owner = std::find_if(plan.images.begin(), plan.images.end(),
 		                                [&](const auto& cached) {
 			return cached->kind == CachedImage::Kind::DepthTarget &&
 			       cached->DepthTargetDesc().htile_address == address;
 		});
-		if (meta == m_surface_metas.end() || owner == unmapped_images.end() ||
-		    meta->second.size != (*owner)->DepthTargetDesc().htile_size) {
+		const bool depth_metadata = owner != plan.images.end();
+		if (meta == m_surface_metas.end() ||
+		    (depth_metadata && meta->second.size != (*owner)->DepthTargetDesc().htile_size)) {
 			EXIT("TextureCache: retiring depth image has invalid HTile registration, "
 			     "unmap=0x%016" PRIx64 "+0x%016" PRIx64 " metadata=0x%016" PRIx64
 			     " registered=0x%016" PRIx64 " expected=0x%016" PRIx64 "\n",
 			     vaddr, size, address, meta != m_surface_metas.end() ? meta->second.size : 0,
-			     owner != unmapped_images.end() ? (*owner)->DepthTargetDesc().htile_size : 0);
+			     depth_metadata ? (*owner)->DepthTargetDesc().htile_size : 0);
 		}
 	}
 	std::vector<ImageRetirementRange> metadata_ranges;
 	metadata_ranges.reserve(m_surface_metas.size());
 	for (const auto& [address, meta]: m_surface_metas) {
-		const bool retiring = ImageRangeOverlaps(vaddr, size, address, meta.size) ||
-		                      std::find(retire_depth_metadata.begin(), retire_depth_metadata.end(),
-		                                address) != retire_depth_metadata.end();
+		const bool retiring = std::find(plan.metadata_addresses.begin(),
+		                                plan.metadata_addresses.end(), address) !=
+		                      plan.metadata_addresses.end();
 		metadata_ranges.push_back({address, meta.size, retiring});
 	}
 	const auto metadata_conflict = FindImageRetirementConflict(metadata_ranges);
@@ -4010,28 +4104,53 @@ void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 		     " retained=0x%016" PRIx64 "+0x%016" PRIx64 "\n",
 		     vaddr, size, retired.address, retired.size, retained.address, retained.size);
 	}
-	if (!unmapped_images.empty()) {
+	plan.materializations.reserve(plan.images.size());
+	for (const auto& cached: plan.images) {
+		if (cached->gpu_modified) {
+			plan.materializations.push_back(
+			    m_readback->Prepare(*cached, ReadbackWorker::Purpose::Unmap));
+		}
+	}
+	return plan;
+}
+
+void TextureCache::ValidateUnmapMemory(uint64_t vaddr, uint64_t size) {
+	if (!m_resource_mutex.IsOwnedByCurrentThread()) {
+		EXIT("TextureCache: unmap validation requires the shared resource transaction\n");
+	}
+	FaultSafeTextureLock lock(this, m_lock);
+	(void)BuildUnmapPlanLocked(vaddr, size);
+}
+
+void TextureCache::CommitUnmapMemory(uint64_t vaddr, uint64_t size) {
+	if (!m_resource_mutex.IsOwnedByCurrentThread()) {
+		EXIT("TextureCache: unmap commit requires the shared resource transaction\n");
+	}
+	FaultSafeTextureLock lock(this, m_lock);
+	auto                 plan = BuildUnmapPlanLocked(vaddr, size);
+	if (!plan.materializations.empty()) {
 		Transfer::WaitForGraphicsIdle();
 	}
-	for (const auto& cached: unmapped_images) {
-		if (!cached->gpu_modified) {
-			continue;
+	for (auto& prepared: plan.materializations) {
+		auto&      cached   = ReadbackWorker::Owner(prepared);
+		const auto transfer = m_readback->Execute(prepared);
+		for (const auto& range: transfer.Ranges()) {
+			m_memory_tracker.ForEachDownloadRange<true>(range.address, range.size,
+			                                            [](uint64_t, uint64_t) noexcept {});
 		}
-		for (uint32_t i = 0; i < cached->RangeCount(); i++) {
-			m_memory_tracker.UnmarkRegionAsGpuModified(cached->Address(i), cached->Size(i));
-		}
-		cached->gpu_modified = false;
+		cached.gpu_modified = false;
 	}
 	for (auto it = m_surface_metas.begin(); it != m_surface_metas.end();) {
-		const bool allocation_unmapped =
-		    ImageRangeOverlaps(vaddr, size, it->first, it->second.size);
-		const bool depth_owner_retired =
-		    std::find(retire_depth_metadata.begin(), retire_depth_metadata.end(), it->first) !=
-		    retire_depth_metadata.end();
-		if (!allocation_unmapped && !depth_owner_retired) {
+		if (std::find(plan.metadata_addresses.begin(), plan.metadata_addresses.end(), it->first) ==
+		    plan.metadata_addresses.end()) {
 			++it;
 			continue;
 		}
+		const bool depth_owner_retired =
+		    std::any_of(plan.images.begin(), plan.images.end(), [&](const auto& cached) {
+			    return cached->kind == CachedImage::Kind::DepthTarget &&
+			           cached->DepthTargetDesc().htile_address == it->first;
+		    });
 		if (depth_owner_retired) {
 			LOGF("TextureCache: retiring HTile metadata with depth image, "
 			     "unmap=0x%016" PRIx64 "+0x%016" PRIx64 " metadata=0x%016" PRIx64 "+0x%016" PRIx64
@@ -4045,13 +4164,12 @@ void TextureCache::UnmapMemory(uint64_t vaddr, uint64_t size) {
 		m_metadata_tracker.UntrackMemory(it->first, it->second.size);
 		it = m_surface_metas.erase(it);
 	}
-	m_memory_tracker.UntrackMemory(vaddr, size);
-	for (const auto& cached: unmapped_images) {
+	for (const auto& cached: plan.images) {
 		const auto owner = std::find(m_images.begin(), m_images.end(), cached);
 		if (owner == m_images.end()) {
 			EXIT("TextureCache: unmapped image owner disappeared\n");
 		}
-		UnregisterImageLocked(*cached, false);
+		UnregisterImageLocked(*cached, true);
 		m_images.erase(owner);
 	}
 }

--- a/src/graphics/host_gpu/renderer/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/textureCache.cpp
@@ -15,6 +15,7 @@
 #include "graphics/host_gpu/renderer/cachedImageRecord.h"
 #include "graphics/host_gpu/renderer/dummyTextureCache.h"
 #include "graphics/host_gpu/renderer/image.h"
+#include "graphics/host_gpu/renderer/imageAliasPlan.h"
 #include "graphics/host_gpu/renderer/imageView.h"
 #include "graphics/host_gpu/renderer/render.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
@@ -190,73 +191,6 @@ bool IsExactRenderTargetMipStorage(const ImageInfo& sampled, const ImageInfo& st
 	}
 	return false;
 }
-
-struct TextureCache::AliasRetirementPlan {
-	enum class Action : uint8_t {
-		RetireGuestCurrent,
-		MaterializeGuest,
-		PreserveNative,
-		ReleaseGpuOwnership
-	};
-	enum class PageIsolation : uint8_t { Required, SharedPagesAllowed };
-	struct Entry {
-		std::shared_ptr<CachedImage> image;
-		Action                       action;
-	};
-
-	AliasRetirementPlan(const char* operation, GuestRange request, PageIsolation isolation)
-	    : operation(operation), request(request), isolation(isolation) {}
-
-	void Add(const std::shared_ptr<CachedImage>& image, Action action) {
-		if (image == nullptr) {
-			EXIT("TextureCache: alias plan has an empty image owner\n");
-		}
-		if (std::any_of(entries.begin(), entries.end(), [&](const auto& entry) {
-			    return entry.image.get() == image.get();
-		    })) {
-			EXIT("TextureCache: alias plan contains a duplicate retirement\n");
-		}
-		if (action == Action::PreserveNative && NativeSource() != nullptr) {
-			EXIT("TextureCache: alias plan contains multiple native sources\n");
-		}
-		entries.push_back({image, action});
-	}
-
-	void PreserveMetadata(uint64_t address) {
-		if (address != 0 && preserve_metadata_address != 0 &&
-		    preserve_metadata_address != address) {
-			EXIT("TextureCache: alias plan preserves multiple metadata allocations\n");
-		}
-		preserve_metadata_address = address;
-	}
-
-	[[nodiscard]] bool Empty() const { return entries.empty(); }
-	[[nodiscard]] size_t RetirementCount() const { return entries.size(); }
-	[[nodiscard]] bool Contains(const CachedImage& image) const {
-		return std::any_of(entries.begin(), entries.end(),
-		                   [&](const auto& entry) { return entry.image.get() == &image; });
-	}
-	[[nodiscard]] bool HasAction(Action action) const {
-		return std::any_of(entries.begin(), entries.end(),
-		                   [action](const auto& entry) { return entry.action == action; });
-	}
-	[[nodiscard]] std::shared_ptr<CachedImage> NativeOwner() const {
-		const auto entry = std::find_if(entries.begin(), entries.end(), [](const auto& item) {
-			return item.action == Action::PreserveNative;
-		});
-		return entry != entries.end() ? entry->image : nullptr;
-	}
-	[[nodiscard]] CachedImage* NativeSource() const { return NativeOwner().get(); }
-	[[nodiscard]] const std::vector<Entry>& Entries() const { return entries; }
-
-private:
-	friend class TextureCache;
-	const char* const        operation;
-	const GuestRange         request;
-	const PageIsolation isolation;
-	uint64_t                 preserve_metadata_address = 0;
-	std::vector<Entry>       entries;
-};
 
 void TextureCache::RemoveImageLocked(CachedImage& image, bool release_tracking) {
 	auto removal = m_image_registry.Remove(image);
@@ -1092,16 +1026,18 @@ void TextureCache::MaterializeImagesToGuestLocked(
 }
 
 void TextureCache::ExecuteAliasRetirementLocked(const AliasRetirementPlan& plan) {
-	if (plan.operation == nullptr || !plan.request.IsValid() ||
-	    (plan.isolation != AliasRetirementPlan::PageIsolation::Required &&
-	     plan.isolation != AliasRetirementPlan::PageIsolation::SharedPagesAllowed)) {
+	const auto request   = plan.Request();
+	const auto isolation = plan.Isolation();
+	if (plan.Operation() == nullptr || !request.IsValid() ||
+	    (isolation != AliasRetirementPlan::PageIsolation::Required &&
+	     isolation != AliasRetirementPlan::PageIsolation::SharedPagesAllowed)) {
 		EXIT("TextureCache: invalid alias retirement plan\n");
 	}
 	std::vector<CachedImage*>                 retirements;
 	std::vector<std::shared_ptr<CachedImage>> materializations;
 	std::vector<std::shared_ptr<CachedImage>> discarded_owners;
-	retirements.reserve(plan.entries.size());
-	for (const auto& entry: plan.entries) {
+	retirements.reserve(plan.RetirementCount());
+	for (const auto& entry: plan.Entries()) {
 		if (entry.image == nullptr || !entry.image->registered ||
 		    FindImageOwnerLocked(*entry.image).get() != entry.image.get()) {
 			EXIT("TextureCache: alias plan references an unregistered image\n");
@@ -1170,9 +1106,8 @@ void TextureCache::ExecuteAliasRetirementLocked(const AliasRetirementPlan& plan)
 	if (plan.Empty()) {
 		return;
 	}
-	if (plan.isolation == AliasRetirementPlan::PageIsolation::Required) {
-		RequireRetirementIsolation(retirements, plan.operation, plan.request.address,
-		                           plan.request.size);
+	if (isolation == AliasRetirementPlan::PageIsolation::Required) {
+		RequireRetirementIsolation(retirements, plan.Operation(), request.address, request.size);
 	}
 	MaterializeImagesToGuestLocked(materializations);
 	for (const auto& image: discarded_owners) {
@@ -1184,7 +1119,7 @@ void TextureCache::ExecuteAliasRetirementLocked(const AliasRetirementPlan& plan)
 		}
 		image->gpu_modified = false;
 	}
-	RetireDepthMetadataLocked(retirements, plan.preserve_metadata_address);
+	RetireDepthMetadataLocked(retirements, plan.PreservedMetadataAddress());
 	RetireImages(retirements, plan.NativeSource());
 }
 

--- a/src/graphics/host_gpu/renderer/textureCache.h
+++ b/src/graphics/host_gpu/renderer/textureCache.h
@@ -21,7 +21,6 @@ namespace Libs::Graphics {
 
 struct DepthStencilVulkanImage;
 struct GpuTextureVulkanImage;
-struct GraphicContext;
 struct ImageViewInfo;
 struct RenderTextureVulkanImage;
 struct StorageTextureVulkanImage;
@@ -29,6 +28,7 @@ struct VideoOutVulkanImage;
 struct VulkanImage;
 struct VulkanMemory;
 class BufferCache;
+class CachedImageRecord;
 class CommandBuffer;
 class DummyTextureCache;
 class GpuResourceManager;
@@ -56,8 +56,7 @@ public:
 		bool     full             = false;
 	};
 
-	TextureCache(GraphicContext& graphics, PageManager& page_manager, BufferCache& buffer_cache,
-	             ResourceMutex& resource_mutex);
+	TextureCache(PageManager& page_manager, BufferCache& buffer_cache, ResourceMutex& resource_mutex);
 	~TextureCache();
 	KYTY_CLASS_NO_COPY(TextureCache);
 
@@ -122,7 +121,7 @@ public:
 
 private:
 	friend class GpuResourceManager;
-	struct CachedImage;
+	using CachedImage = CachedImageRecord;
 	struct AliasRetirementPlan;
 	struct UnmapPlan;
 	using ImageOwnerIndex = MultiRangePageOwnerIndex<CachedImage*>;
@@ -169,7 +168,6 @@ private:
 	void                    ValidateUnmapMemory(uint64_t vaddr, uint64_t size);
 	void                    CommitUnmapMemory(uint64_t vaddr, uint64_t size);
 
-	GraphicContext&                                             m_graphics;
 	std::unique_ptr<DummyTextureCache>                          m_dummy_textures;
 	TrackingSpinLock                                            m_lock;
 	std::mutex                                                  m_fault_mutex;

--- a/src/graphics/host_gpu/renderer/textureCache.h
+++ b/src/graphics/host_gpu/renderer/textureCache.h
@@ -30,6 +30,7 @@ class BufferCache;
 class CommandBuffer;
 class DummyTextureCache;
 class GpuResourceManager;
+class ImageAliasPlan;
 class ResourceMutex;
 
 [[nodiscard]] bool IsExactRenderTargetMipStorage(const ImageInfo& sampled, const ImageInfo& storage,
@@ -120,7 +121,7 @@ public:
 private:
 	friend class GpuResourceManager;
 	using CachedImage = CachedImageRecord;
-	struct AliasRetirementPlan;
+	using AliasRetirementPlan = ImageAliasPlan;
 	struct UnmapPlan;
 	struct ReadbackWorker;
 	struct MetaDataInfo {

--- a/src/graphics/host_gpu/renderer/textureCache.h
+++ b/src/graphics/host_gpu/renderer/textureCache.h
@@ -31,6 +31,7 @@ struct VulkanMemory;
 class BufferCache;
 class CommandBuffer;
 class DummyTextureCache;
+class GpuResourceManager;
 class ResourceMutex;
 
 [[nodiscard]] bool IsExactRenderTargetMipStorage(const ImageInfo& sampled, const ImageInfo& storage,
@@ -116,14 +117,14 @@ public:
 	[[nodiscard]] bool       TouchMeta(uint64_t vaddr, uint32_t slice, bool is_clear);
 	[[nodiscard]] bool       InvalidateMemory(PageFaultAccess access, uint64_t vaddr, uint64_t size,
 	                                          PageFaultPhase phase) noexcept;
-	void                     UnmapMemory(uint64_t vaddr, uint64_t size);
-
 	VulkanImage& GetDummySampledTexture(bool uint_format, bool image_3d);
 	VulkanImage& GetDummyStorageTexture(bool uint_format, bool image_3d);
 
 private:
+	friend class GpuResourceManager;
 	struct CachedImage;
 	struct AliasRetirementPlan;
+	struct UnmapPlan;
 	using ImageOwnerIndex = MultiRangePageOwnerIndex<CachedImage*>;
 	struct ReadbackWorker;
 	struct MetaDataInfo {
@@ -164,6 +165,9 @@ private:
 	                                         uint64_t write_size);
 	void SynchronizeDepthImageToBufferLocked(CachedImage& cached, uint64_t write_address,
 	                                         uint64_t write_size);
+	[[nodiscard]] UnmapPlan BuildUnmapPlanLocked(uint64_t vaddr, uint64_t size);
+	void                    ValidateUnmapMemory(uint64_t vaddr, uint64_t size);
+	void                    CommitUnmapMemory(uint64_t vaddr, uint64_t size);
 
 	GraphicContext&                                             m_graphics;
 	std::unique_ptr<DummyTextureCache>                          m_dummy_textures;

--- a/src/graphics/host_gpu/renderer/textureCache.h
+++ b/src/graphics/host_gpu/renderer/textureCache.h
@@ -5,8 +5,8 @@
 #include "common/common.h"
 #include "common/threads.h"
 #include "graphics/host_gpu/memoryTracker.h"
+#include "graphics/host_gpu/renderer/cachedImageRegistry.h"
 #include "graphics/host_gpu/renderer/imageInfo.h"
-#include "graphics/host_gpu/renderer/multiLevelPageTable.h"
 #include "graphics/host_gpu/renderer/tiler.h"
 #include "graphics/host_gpu/vulkanCommon.h"
 
@@ -14,7 +14,6 @@
 #include <memory>
 #include <mutex>
 #include <span>
-#include <unordered_map>
 #include <vector>
 
 namespace Libs::Graphics {
@@ -28,7 +27,6 @@ struct VideoOutVulkanImage;
 struct VulkanImage;
 struct VulkanMemory;
 class BufferCache;
-class CachedImageRecord;
 class CommandBuffer;
 class DummyTextureCache;
 class GpuResourceManager;
@@ -124,7 +122,6 @@ private:
 	using CachedImage = CachedImageRecord;
 	struct AliasRetirementPlan;
 	struct UnmapPlan;
-	using ImageOwnerIndex = MultiRangePageOwnerIndex<CachedImage*>;
 	struct ReadbackWorker;
 	struct MetaDataInfo {
 		uint64_t size         = 0;
@@ -141,17 +138,17 @@ private:
 	void                        RetireSampledTargetAliases(const ImageInfo& requested);
 	void                        ResolveStorageImageOverlaps(const ImageInfo& requested);
 	void                        RetireStorageDepthAliasLocked(const ImageInfo& requested);
-	void                        RegisterImageLocked(const std::shared_ptr<CachedImage>& image);
-	void                        UnregisterImageLocked(CachedImage& image, bool release_tracking);
+	void                        RemoveImageLocked(CachedImage& image, bool release_tracking);
 	[[nodiscard]] std::shared_ptr<CachedImage>
 	FindImageOwnerLocked(const CachedImage& image) const;
 	[[nodiscard]] std::shared_ptr<CachedImage> FindImageOwnerLocked(VulkanImage& image) const;
 	[[nodiscard]] VulkanImage&  PublishImage(CommandBuffer&               command,
 	                                         std::shared_ptr<CachedImage> image);
 	[[nodiscard]] std::vector<CachedImage*> FindImagesInRegionLocked(uint64_t vaddr, uint64_t size,
-	                                                                 bool page_overlap);
+	                                                                 CachedImageRegistry::QueryMode mode);
 	[[nodiscard]] std::vector<CachedImage*>
-	FindImagesInRegionsLocked(std::span<const GuestRange> ranges, bool page_overlap);
+	FindImagesInRegionsLocked(std::span<const GuestRange> ranges,
+	                          CachedImageRegistry::QueryMode mode);
 	void RequireRetirementIsolation(const std::vector<CachedImage*>& retire, const char* operation,
 	                                uint64_t address, uint64_t size) const;
 	void RetireImages(const std::vector<CachedImage*>& retire,
@@ -176,9 +173,7 @@ private:
 	Tiler                                                       m_tiler;
 	BufferCache&                                                m_buffer_cache;
 	ResourceMutex&                                              m_resource_mutex;
-	std::vector<std::shared_ptr<CachedImage>>                   m_images;
-	ImageOwnerIndex                                             m_image_owner_index;
-	std::unordered_map<VulkanImage*, std::weak_ptr<CachedImage>> m_records_by_image;
+	CachedImageRegistry                                        m_image_registry;
 	std::map<uint64_t, MetaDataInfo>                            m_surface_metas;
 	std::unique_ptr<ReadbackWorker>                             m_readback;
 	std::vector<uint8_t>                                        m_buffer_transition_guest;

--- a/src/graphics/host_gpu/renderer/textureCache.h
+++ b/src/graphics/host_gpu/renderer/textureCache.h
@@ -13,6 +13,8 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <span>
+#include <unordered_map>
 #include <vector>
 
 namespace Libs::Graphics {
@@ -121,6 +123,7 @@ public:
 
 private:
 	struct CachedImage;
+	struct AliasRetirementPlan;
 	using ImageOwnerIndex = MultiRangePageOwnerIndex<CachedImage*>;
 	struct ReadbackWorker;
 	struct MetaDataInfo {
@@ -138,38 +141,45 @@ private:
 	void                        RetireSampledTargetAliases(const ImageInfo& requested);
 	void                        ResolveStorageImageOverlaps(const ImageInfo& requested);
 	void                        RetireStorageDepthAliasLocked(const ImageInfo& requested);
-	void                        RegisterImageLocked(CachedImage& image);
+	void                        RegisterImageLocked(const std::shared_ptr<CachedImage>& image);
 	void                        UnregisterImageLocked(CachedImage& image, bool release_tracking);
+	[[nodiscard]] std::shared_ptr<CachedImage>
+	FindImageOwnerLocked(const CachedImage& image) const;
+	[[nodiscard]] std::shared_ptr<CachedImage> FindImageOwnerLocked(VulkanImage& image) const;
 	[[nodiscard]] VulkanImage&  PublishImage(CommandBuffer&               command,
 	                                         std::shared_ptr<CachedImage> image);
 	[[nodiscard]] std::vector<CachedImage*> FindImagesInRegionLocked(uint64_t vaddr, uint64_t size,
 	                                                                 bool page_overlap);
+	[[nodiscard]] std::vector<CachedImage*>
+	FindImagesInRegionsLocked(std::span<const GuestRange> ranges, bool page_overlap);
 	void RequireRetirementIsolation(const std::vector<CachedImage*>& retire, const char* operation,
 	                                uint64_t address, uint64_t size) const;
 	void RetireImages(const std::vector<CachedImage*>& retire,
 	                  const CachedImage*               native_image_source = nullptr);
 	void RetireDepthMetadataLocked(const std::vector<CachedImage*>& retire,
 	                               uint64_t                         preserve_address = 0);
+	void ExecuteAliasRetirementLocked(const AliasRetirementPlan& plan);
 	void MaterializeImagesToGuestLocked(const std::vector<std::shared_ptr<CachedImage>>& images);
 	void SynchronizeColorImageToBufferLocked(CachedImage& cached, uint64_t write_address,
 	                                         uint64_t write_size);
 	void SynchronizeDepthImageToBufferLocked(CachedImage& cached, uint64_t write_address,
 	                                         uint64_t write_size);
 
-	GraphicContext&                           m_graphics;
-	std::unique_ptr<DummyTextureCache>        m_dummy_textures;
-	TrackingSpinLock                          m_lock;
-	std::mutex                                m_fault_mutex;
-	MemoryTracker                             m_memory_tracker;
-	MemoryTracker                             m_metadata_tracker;
-	Tiler                                     m_tiler;
-	BufferCache&                              m_buffer_cache;
-	ResourceMutex&                            m_resource_mutex;
-	std::vector<std::shared_ptr<CachedImage>> m_images;
-	ImageOwnerIndex                           m_image_owner_index;
-	std::map<uint64_t, MetaDataInfo>          m_surface_metas;
-	std::unique_ptr<ReadbackWorker>           m_readback;
-	std::vector<uint8_t>                      m_buffer_transition_guest;
+	GraphicContext&                                             m_graphics;
+	std::unique_ptr<DummyTextureCache>                          m_dummy_textures;
+	TrackingSpinLock                                            m_lock;
+	std::mutex                                                  m_fault_mutex;
+	MemoryTracker                                               m_memory_tracker;
+	MemoryTracker                                               m_metadata_tracker;
+	Tiler                                                       m_tiler;
+	BufferCache&                                                m_buffer_cache;
+	ResourceMutex&                                              m_resource_mutex;
+	std::vector<std::shared_ptr<CachedImage>>                   m_images;
+	ImageOwnerIndex                                             m_image_owner_index;
+	std::unordered_map<VulkanImage*, std::weak_ptr<CachedImage>> m_records_by_image;
+	std::map<uint64_t, MetaDataInfo>                            m_surface_metas;
+	std::unique_ptr<ReadbackWorker>                             m_readback;
+	std::vector<uint8_t>                                        m_buffer_transition_guest;
 };
 
 } // namespace Libs::Graphics

--- a/tests/ImagePageTableTests.cpp
+++ b/tests/ImagePageTableTests.cpp
@@ -123,6 +123,34 @@ void TestStrictByteFilteringAndPredicate() {
 	Check(predicate_filtered.size() == 1 && predicate_filtered.front() == 32, "supplied predicate filters query owners");
 }
 
+void TestDisjointMultiRangeLifecycle() {
+	OwnerIndex index;
+	const std::vector<OwnerIndex::ByteRange> planes {{0x401100, 0x100},
+	                                                  {0x403100, 0x100}};
+	Check(index.Register(41, planes), "disjoint image planes register as one owner");
+	for (const auto& plane: planes) {
+		const auto owners = index.Query(plane.address, plane.size);
+		Check(owners.size() == 1 && owners.front() == 41,
+		      "either image plane finds the shared owner");
+	}
+	Check(index.Query(0x401800, 0x20).empty(),
+	      "strict lookup excludes a byte-disjoint plane neighbor");
+	const auto page_candidates = index.QueryCandidates(0x401800, 0x20);
+	Check(page_candidates.size() == 1 && page_candidates.front() == 41,
+	      "page lookup retains a byte-disjoint plane neighbor");
+	const auto union_query = index.Query(planes.front().address, 0x2100);
+	Check(union_query.size() == 1 && union_query.front() == 41,
+	      "a query spanning both planes deduplicates their owner");
+
+	std::vector<OwnerIndex::ByteRange> releases;
+	Check(index.Unregister(41, releases), "disjoint-plane owner unregisters");
+	Check(releases.size() == 2 && releases[0].address == 0x401000 &&
+	          releases[0].size == 0x1000 && releases[1].address == 0x403000 &&
+	          releases[1].size == 0x1000,
+	      "unregister releases both disjoint tracking pages");
+	Check(index.Register(41, planes), "an unregistered multi-range owner can register again");
+}
+
 } // namespace
 
 int main() {
@@ -133,6 +161,7 @@ int main() {
 	TestMultiRangeRegistrationDeduplicatesPages();
 	TestSharedPageUnregisterLifecycle();
 	TestStrictByteFilteringAndPredicate();
+	TestDisjointMultiRangeLifecycle();
 	std::printf("ImagePageTableTests: all cases passed\n");
 	return 0;
 }

--- a/tests/ResourceRangeTests.cpp
+++ b/tests/ResourceRangeTests.cpp
@@ -6,10 +6,12 @@
 namespace {
 
 using Libs::Graphics::ClassifyRangeRelation;
+using Libs::Graphics::ClassifyRangeSetCoverage;
 using Libs::Graphics::GuestRange;
 using Libs::Graphics::HasByteOverlap;
 using Libs::Graphics::HasPageOverlap;
 using Libs::Graphics::RangeRelation;
+using Libs::Graphics::RangeSetCoverage;
 
 void Check(bool condition, const char* message) {
 	if (!condition) {
@@ -74,6 +76,26 @@ void CheckPredicates() {
 	      "page neighbors overlap pages but not bytes");
 }
 
+void CheckRangeSetCoverage() {
+	constexpr GuestRange depth_stencil[] {{0x10000, 0x1000}, {0x14000, 0x1000}};
+	Check(ClassifyRangeSetCoverage({0x10000, 0x5000}, depth_stencil) ==
+	          RangeSetCoverage::ContainsAll,
+	      "one unmap containing both planes covers the owner");
+	Check(ClassifyRangeSetCoverage({0x10000, 0x1000}, depth_stencil) ==
+	          RangeSetCoverage::Partial,
+	      "an unmap containing only depth cannot retire depth and stencil");
+	Check(ClassifyRangeSetCoverage({0x10800, 0x4000}, depth_stencil) ==
+	          RangeSetCoverage::Partial,
+	      "partial intersections cannot retire a multi-range owner");
+	Check(ClassifyRangeSetCoverage({0x0ff00, 0x80}, depth_stencil) ==
+	          RangeSetCoverage::Disjoint,
+	      "a page-only neighbor is byte-disjoint from the owner");
+	Check(!ClassifyRangeSetCoverage({0x10000, 0}, depth_stencil).has_value(),
+	      "an empty unmap range is invalid");
+	Check(!ClassifyRangeSetCoverage({0x10000, 0x1000}, {}).has_value(),
+	      "an owner without ranges is invalid");
+}
+
 [[nodiscard]] constexpr RangeRelation Reverse(RangeRelation relation) {
 	switch (relation) {
 		case RangeRelation::Contains: return RangeRelation::ContainedBy;
@@ -121,6 +143,7 @@ int main() {
 	CheckRelations();
 	CheckBoundaries();
 	CheckPredicates();
+	CheckRangeSetCoverage();
 	CheckAlgebra();
 	std::puts("ResourceRangeTests: all cases passed");
 	return 0;

--- a/tests/ResourceRangeTests.cpp
+++ b/tests/ResourceRangeTests.cpp
@@ -1,0 +1,127 @@
+#include "graphics/host_gpu/renderer/resourceRange.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+using Libs::Graphics::ClassifyRangeRelation;
+using Libs::Graphics::GuestRange;
+using Libs::Graphics::HasByteOverlap;
+using Libs::Graphics::HasPageOverlap;
+using Libs::Graphics::RangeRelation;
+
+void Check(bool condition, const char* message) {
+	if (!condition) {
+		std::fprintf(stderr, "ResourceRangeTests: failed: %s\n", message);
+		std::abort();
+	}
+}
+
+void CheckRelations() {
+	constexpr uint64_t page = 4096;
+	Check(ClassifyRangeRelation({0x10020, 0x20}, {0x10020, 0x20}, page) ==
+	          RangeRelation::Exact,
+	      "equal ranges are exact");
+	Check(ClassifyRangeRelation({0x10000, 0x100}, {0x10020, 0x20}, page) ==
+	          RangeRelation::Contains,
+	      "larger left range contains right range");
+	Check(ClassifyRangeRelation({0x10020, 0x20}, {0x10000, 0x100}, page) ==
+	          RangeRelation::ContainedBy,
+	      "smaller left range is contained by right range");
+	Check(ClassifyRangeRelation({0x10080, 0x100}, {0x10100, 0x100}, page) ==
+	          RangeRelation::PartialOverlap,
+	      "intersecting ranges partially overlap");
+	Check(ClassifyRangeRelation({0x10000, 0x20}, {0x10800, 0x20}, page) ==
+	          RangeRelation::SharedPageOnly,
+	      "byte-disjoint ranges sharing a page are page neighbors");
+	Check(ClassifyRangeRelation({0x10000, 0x20}, {0x11000, 0x20}, page) ==
+	          RangeRelation::Disjoint,
+	      "ranges on distinct pages are disjoint");
+}
+
+void CheckBoundaries() {
+	constexpr uint64_t page = 4096;
+	Check(ClassifyRangeRelation({0, 1}, {0, 1}, page) == RangeRelation::Exact,
+	      "address zero is a valid generic byte range");
+	Check(!ClassifyRangeRelation({UINT64_MAX, 1}, {UINT64_MAX, 1}, page).has_value(),
+	      "overflowing ranges are invalid");
+	Check(!ClassifyRangeRelation({0x1000, 0}, {0x1000, 1}, page).has_value(),
+	      "empty ranges are invalid");
+	Check(!ClassifyRangeRelation({0x1000, 1}, {0x1000, 1}, 0).has_value(),
+	      "zero page size is invalid");
+	Check(!ClassifyRangeRelation({0x1000, 1}, {0x1000, 1}, 3).has_value(),
+	      "non-power-of-two page size is invalid");
+	Check(ClassifyRangeRelation({0x1fff, 1}, {0x2000, 1}, page) ==
+	          RangeRelation::Disjoint,
+	      "adjacent ranges on distinct pages are disjoint");
+	Check(ClassifyRangeRelation({0x1ffe, 1}, {0x1fff, 1}, page) ==
+	          RangeRelation::SharedPageOnly,
+	      "adjacent ranges within one page are page neighbors");
+	Check(ClassifyRangeRelation({UINT64_MAX - 1, 1}, {UINT64_MAX - 1, 1}, page) ==
+	          RangeRelation::Exact,
+	      "the highest non-overflowing byte range is valid");
+	Check(ClassifyRangeRelation({0, UINT64_MAX}, {UINT64_MAX - 1, 1}, page) ==
+	          RangeRelation::Contains,
+	      "a range ending exactly at UINT64_MAX is valid");
+}
+
+void CheckPredicates() {
+	constexpr auto exact = RangeRelation::Exact;
+	constexpr auto page  = RangeRelation::SharedPageOnly;
+	Check(HasByteOverlap(exact) && HasPageOverlap(exact), "exact ranges overlap bytes and pages");
+	Check(!HasByteOverlap(page) && HasPageOverlap(page),
+	      "page neighbors overlap pages but not bytes");
+}
+
+[[nodiscard]] constexpr RangeRelation Reverse(RangeRelation relation) {
+	switch (relation) {
+		case RangeRelation::Contains: return RangeRelation::ContainedBy;
+		case RangeRelation::ContainedBy: return RangeRelation::Contains;
+		default: return relation;
+	}
+}
+
+void CheckAlgebra() {
+	constexpr GuestRange ranges[] {{0, 1},       {1, 1},       {0xfff, 2},
+	                               {0x1000, 1},  {0x1000, 32}, {0x1010, 4},
+	                               {0x1800, 64}, {0x2000, 8},  {0x2800, 0x1800}};
+	constexpr uint64_t page_sizes[] {1, 2, 4, 4096};
+	for (const auto page_size: page_sizes) {
+		for (const auto left: ranges) {
+			for (const auto right: ranges) {
+				const auto forward = ClassifyRangeRelation(left, right, page_size);
+				const auto reverse = ClassifyRangeRelation(right, left, page_size);
+				Check(forward.has_value() && reverse.has_value(),
+				      "valid ranges always produce a relation");
+				Check(*reverse == Reverse(*forward), "range relation reverses consistently");
+				Check(HasByteOverlap(*forward) == HasByteOverlap(*reverse),
+				      "byte overlap is symmetric");
+				Check(HasPageOverlap(*forward) == HasPageOverlap(*reverse),
+				      "page overlap is symmetric");
+				const auto expected_bytes =
+				    left.address < *right.EndExclusive() && right.address < *left.EndExclusive();
+				Check(HasByteOverlap(*forward) == expected_bytes,
+				      "relation agrees with half-open byte intersection");
+			}
+		}
+	}
+}
+
+static_assert(ClassifyRangeRelation({0x1000, 4}, {0x1000, 4}, 4096) ==
+	              RangeRelation::Exact);
+static_assert(ClassifyRangeRelation({0x1000, 4}, {0x1001, 1}, 4096) ==
+	              RangeRelation::Contains);
+static_assert(ClassifyRangeRelation({0x1001, 1}, {0x1000, 4}, 4096) ==
+	              RangeRelation::ContainedBy);
+
+} // namespace
+
+int main() {
+	CheckRelations();
+	CheckBoundaries();
+	CheckPredicates();
+	CheckAlgebra();
+	std::puts("ResourceRangeTests: all cases passed");
+	return 0;
+}

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -16,6 +16,7 @@
 #include "graphics/host_gpu/renderer/colorRenderTarget.h"
 #include "graphics/host_gpu/renderer/depthRenderTarget.h"
 #include "graphics/host_gpu/renderer/descriptors.h"
+#include "graphics/host_gpu/renderer/gpuResourceManager.h"
 #include "graphics/host_gpu/renderer/image.h"
 #include "graphics/host_gpu/renderer/imageView.h"
 #include "graphics/host_gpu/renderer/render.h"
@@ -1308,13 +1309,9 @@ public:
     std::memset(memory, 0, allocation_size);
 
     EnsureRuntimeContext();
-    ResourceMutex resource_mutex;
-    PageManager page_manager(RejectUnexpectedPageFault, nullptr);
-    BufferCache buffer_cache(m_runtime_context, page_manager, resource_mutex);
-    TextureCache texture_cache(m_runtime_context, page_manager, buffer_cache,
-                               resource_mutex);
-    buffer_cache.SetTextureCache(texture_cache);
-    page_manager.OnGpuMap(base, allocation_size);
+    GpuResourceManager resources(m_runtime_context);
+    auto& texture_cache = resources.GetTextureCache();
+    resources.MapMemory(base, allocation_size, GpuAccess::ReadWrite);
 
     constexpr auto format =
         Prospero::GpuEnumValue(Prospero::BufferFormat::k8_8_8_8UNorm);
@@ -1390,8 +1387,7 @@ public:
                   !gpu_page.gpu_image_bytes && gpu_page.non_sampled_pages,
               "GPU ownership escaped the target's exact byte range");
 
-      texture_cache.UnmapMemory(base, allocation_size);
-      page_manager.OnGpuUnmap(base, allocation_size);
+      resources.UnmapMemory(base, allocation_size, GpuAccess::ReadWrite);
     }
     Require(name, "free", VirtualFree(memory, 0, MEM_RELEASE) != 0,
             "VirtualFree failed");
@@ -9812,17 +9808,6 @@ void CheckEmbeddedFetchVertexOffset() {
 }
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
-struct CacheFaultContext {
-  TextureCache *texture = nullptr;
-};
-
-bool CacheFault(void *opaque, PageFaultAccess access, uint64_t vaddr,
-                uint64_t size, PageFaultPhase phase) noexcept {
-  auto *context = static_cast<CacheFaultContext *>(opaque);
-  return context != nullptr && context->texture != nullptr &&
-         context->texture->InvalidateMemory(access, vaddr, size, phase);
-}
-
 [[noreturn]] void RunReverseRenderTargetDeathCase() {
   (void)TextureGetRenderTargetFormat(12u, 7u, 3u);
   std::_Exit(0x7f);
@@ -11861,15 +11846,9 @@ void CheckOverlappingMetadataViews() {
           memory == reinterpret_cast<void *>(base),
           "fixed VirtualAlloc failed");
 
-  ResourceMutex resource_mutex;
-  CacheFaultContext fault_context;
-  PageManager page_manager(CacheFault, &fault_context);
-  BufferCache buffer_cache(context, page_manager, resource_mutex);
-  TextureCache texture_cache(context, page_manager, buffer_cache,
-                             resource_mutex);
-  fault_context.texture = &texture_cache;
-  buffer_cache.SetTextureCache(texture_cache);
-  page_manager.OnGpuMap(base, allocation_size);
+  GpuResourceManager resources(context);
+  auto& texture_cache = resources.GetTextureCache();
+  resources.MapMemory(base, allocation_size, GpuAccess::ReadWrite);
 
   texture_cache.RegisterMeta(base, metadata_size);
   texture_cache.RegisterMeta(second, metadata_size);
@@ -11886,14 +11865,13 @@ void CheckOverlappingMetadataViews() {
               texture_cache.IsMetaCleared(second, 0),
           "overlapping metadata clears were not retained independently");
   Require("OverlappingMetadataViews", "fault",
-          page_manager.HandleFault(PageFaultAccess::Write, second),
+          resources.HandleFault(PageFaultAccess::Write, second),
           "shared metadata page did not transfer to CPU ownership");
   Require("OverlappingMetadataViews", "ownership",
           !texture_cache.QueryRegion(second, 0x1000).gpu_metadata_bytes,
           "shared metadata page retained GPU ownership after a CPU fault");
 
-  texture_cache.UnmapMemory(base, allocation_size);
-  page_manager.OnGpuUnmap(base, allocation_size);
+  resources.UnmapMemory(base, allocation_size, GpuAccess::ReadWrite);
   Require("OverlappingMetadataViews", "free",
           VirtualFree(memory, 0, MEM_RELEASE) != 0, "VirtualFree failed");
   std::printf("[host]    %-32s ok\n", "OverlappingMetadataViews");
@@ -11911,15 +11889,9 @@ void CheckQueryRegionAggregation() {
           memory == reinterpret_cast<void *>(base),
           "fixed VirtualAlloc failed");
 
-  ResourceMutex resource_mutex;
-  CacheFaultContext fault_context;
-  PageManager page_manager(CacheFault, &fault_context);
-  BufferCache buffer_cache(context, page_manager, resource_mutex);
-  TextureCache texture_cache(context, page_manager, buffer_cache,
-                             resource_mutex);
-  fault_context.texture = &texture_cache;
-  buffer_cache.SetTextureCache(texture_cache);
-  page_manager.OnGpuMap(base, allocation_size);
+  GpuResourceManager resources(context);
+  auto& texture_cache = resources.GetTextureCache();
+  resources.MapMemory(base, allocation_size, GpuAccess::ReadWrite);
 
   const auto empty = texture_cache.QueryRegion(base + 0x20, 0x40);
   Require("QueryRegionAggregation", "empty",
@@ -11953,8 +11925,7 @@ void CheckQueryRegionAggregation() {
               !gpu_page_only.gpu_metadata_bytes,
           "GPU metadata ownership escaped its exact registered byte range");
 
-  texture_cache.UnmapMemory(base, allocation_size);
-  page_manager.OnGpuUnmap(base, allocation_size);
+  resources.UnmapMemory(base, allocation_size, GpuAccess::ReadWrite);
   Require("QueryRegionAggregation", "free",
           VirtualFree(memory, 0, MEM_RELEASE) != 0, "VirtualFree failed");
   std::printf("[host]    %-32s ok\n", "QueryRegionAggregation");
@@ -11973,15 +11944,9 @@ void CheckGpuMetadataReuse() {
           memory == reinterpret_cast<void *>(base),
           "fixed VirtualAlloc failed");
 
-  ResourceMutex resource_mutex;
-  CacheFaultContext fault_context;
-  PageManager page_manager(CacheFault, &fault_context);
-  BufferCache buffer_cache(context, page_manager, resource_mutex);
-  TextureCache texture_cache(context, page_manager, buffer_cache,
-                             resource_mutex);
-  fault_context.texture = &texture_cache;
-  buffer_cache.SetTextureCache(texture_cache);
-  page_manager.OnGpuMap(base, allocation_size);
+  GpuResourceManager resources(context);
+  auto& texture_cache = resources.GetTextureCache();
+  resources.MapMemory(base, allocation_size, GpuAccess::ReadWrite);
 
   texture_cache.RegisterMeta(base, metadata_size, layers);
   TextureCache::MetaRangeInfo full_meta{};
@@ -12033,8 +11998,7 @@ void CheckGpuMetadataReuse() {
           "partial metadata overwrite retained identity or claimed an image "
           "transition");
 
-  texture_cache.UnmapMemory(base, allocation_size);
-  page_manager.OnGpuUnmap(base, allocation_size);
+  resources.UnmapMemory(base, allocation_size, GpuAccess::ReadWrite);
   Require("GpuMetadataReuse", "free", VirtualFree(memory, 0, MEM_RELEASE) != 0,
           "VirtualFree failed");
   std::printf("[host]    %-32s ok\n", "GpuMetadataReuse");
@@ -13942,15 +13906,10 @@ void CheckHostDmaMetadataReuse() {
           "fixed VirtualAlloc failed");
   std::memset(memory + metadata_size, 0x5a, 0x1000);
 
-  ResourceMutex resource_mutex;
-  CacheFaultContext fault_context;
-  PageManager page_manager(CacheFault, &fault_context);
-  BufferCache buffer_cache(context, page_manager, resource_mutex);
-  TextureCache texture_cache(context, page_manager, buffer_cache,
-                             resource_mutex);
-  fault_context.texture = &texture_cache;
-  buffer_cache.SetTextureCache(texture_cache);
-  page_manager.OnGpuMap(base, allocation_size);
+  GpuResourceManager resources(context);
+  auto& buffer_cache = resources.GetBufferCache();
+  auto& texture_cache = resources.GetTextureCache();
+  resources.MapMemory(base, allocation_size, GpuAccess::ReadWrite);
   texture_cache.RegisterMeta(base, metadata_size);
 
   Require("HostDmaMetadataReuse", "clear", texture_cache.ClearMeta(base),
@@ -13961,14 +13920,14 @@ void CheckHostDmaMetadataReuse() {
               protection.Protect == PAGE_READONLY,
           "virtual metadata was not write-watched");
   Require("HostDmaMetadataReuse", "copy fault",
-          page_manager.HandleFault(PageFaultAccess::Write, base),
+          resources.HandleFault(PageFaultAccess::Write, base),
           "copy destination did not transfer to CPU ownership");
   buffer_cache.CopyBuffer(nullptr, base, base + metadata_size, 0x1000);
   Require("HostDmaMetadataReuse", "copy",
           std::memcmp(memory, memory + metadata_size, 0x1000) == 0,
           "post-clear CPU DMA copy did not publish backing");
   Require("HostDmaMetadataReuse", "fill fault",
-          page_manager.HandleFault(PageFaultAccess::Write, base + 0x1000),
+          resources.HandleFault(PageFaultAccess::Write, base + 0x1000),
           "fill destination did not transfer to CPU ownership");
   buffer_cache.FillBuffer(nullptr, base + 0x1000, 0x1000, 0x11223344);
   Require("HostDmaMetadataReuse", "fill",
@@ -13982,8 +13941,7 @@ void CheckHostDmaMetadataReuse() {
               protection.Protect == PAGE_READWRITE,
           "CPU writes erased metadata identity or retained virtual ownership");
 
-  texture_cache.UnmapMemory(base, allocation_size);
-  page_manager.OnGpuUnmap(base, allocation_size);
+  resources.UnmapMemory(base, allocation_size, GpuAccess::ReadWrite);
   Require("HostDmaMetadataReuse", "free",
           VirtualFree(memory, 0, MEM_RELEASE) != 0, "VirtualFree failed");
   std::printf("[host]    %-32s ok\n", "HostDmaMetadataReuse");

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -1073,8 +1073,7 @@ public:
     ResourceMutex resource_mutex;
     PageManager page_manager(RejectUnexpectedPageFault, nullptr);
     BufferCache buffer_cache(m_runtime_context, page_manager, resource_mutex);
-    TextureCache texture_cache(m_runtime_context, page_manager, buffer_cache,
-                               resource_mutex);
+    TextureCache texture_cache(page_manager, buffer_cache, resource_mutex);
     buffer_cache.SetTextureCache(texture_cache);
     RenderTextureVulkanImage image;
     image.image = image_handle;
@@ -1185,8 +1184,7 @@ public:
     ResourceMutex resource_mutex;
     PageManager page_manager(RejectUnexpectedPageFault, nullptr);
     BufferCache buffer_cache(m_runtime_context, page_manager, resource_mutex);
-    TextureCache texture_cache(m_runtime_context, page_manager, buffer_cache,
-                               resource_mutex);
+    TextureCache texture_cache(page_manager, buffer_cache, resource_mutex);
     buffer_cache.SetTextureCache(texture_cache);
     DepthStencilVulkanImage image;
     image.image = image_handle;
@@ -1254,8 +1252,7 @@ public:
     ResourceMutex resource_mutex;
     PageManager page_manager(RejectUnexpectedPageFault, nullptr);
     BufferCache buffer_cache(m_runtime_context, page_manager, resource_mutex);
-    TextureCache texture_cache(m_runtime_context, page_manager, buffer_cache,
-                               resource_mutex);
+    TextureCache texture_cache(page_manager, buffer_cache, resource_mutex);
     buffer_cache.SetTextureCache(texture_cache);
     VideoOutVulkanImage image;
     image.image = backing.image;
@@ -11699,8 +11696,7 @@ void CheckStorageTextureAccessPermissions() {
   ResourceMutex resource_mutex;
   PageManager page_manager(CacheFault, nullptr);
   BufferCache buffer_cache(context, page_manager, resource_mutex);
-  TextureCache texture_cache(context, page_manager, buffer_cache,
-                             resource_mutex);
+  TextureCache texture_cache(page_manager, buffer_cache, resource_mutex);
   buffer_cache.SetTextureCache(texture_cache);
   page_manager.OnGpuMap(address, allocation_size);
   texture_cache.RegisterMeta(address, 0x8000);

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -11285,7 +11285,7 @@ void CheckStorageTextureGpuOwnedRebindState() {
   Require("StorageTextureGpuOwnedRebind", "allocation",
           memory == reinterpret_cast<void *>(base),
           "fixed VirtualAlloc failed");
-  PageManager page_manager(CacheFault, nullptr);
+  PageManager page_manager(RejectUnexpectedPageFault, nullptr);
   MemoryTracker tracker(page_manager);
   page_manager.OnGpuMap(base, size);
   tracker.ForEachUploadRange(
@@ -11622,7 +11622,7 @@ void CheckStorageTextureDepthAlias() {
     EXIT("storage access child could not reserve its fixed test address\n");
   }
   ResourceMutex resource_mutex;
-  PageManager page_manager(CacheFault, nullptr);
+  PageManager page_manager(RejectUnexpectedPageFault, nullptr);
   BufferCache buffer_cache(context, page_manager, resource_mutex);
   if (std::strcmp(kind, "read") == 0) {
     page_manager.OnGpuMap(base, size, GpuAccess::Write);
@@ -11646,7 +11646,7 @@ void CheckStorageTextureAccessPermissions() {
           memory == reinterpret_cast<void *>(base),
           "fixed VirtualAlloc failed");
   ResourceMutex resource_mutex;
-  PageManager page_manager(CacheFault, nullptr);
+  PageManager page_manager(RejectUnexpectedPageFault, nullptr);
   BufferCache buffer_cache(context, page_manager, resource_mutex);
   page_manager.OnGpuMap(base, size, GpuAccess::ReadWrite);
   buffer_cache.ValidateGpuAccess(base, size, true, true);
@@ -11694,7 +11694,7 @@ void CheckStorageTextureAccessPermissions() {
     EXIT("metadata-overlap child could not reserve its fixed test address\n");
   }
   ResourceMutex resource_mutex;
-  PageManager page_manager(CacheFault, nullptr);
+  PageManager page_manager(RejectUnexpectedPageFault, nullptr);
   BufferCache buffer_cache(context, page_manager, resource_mutex);
   TextureCache texture_cache(page_manager, buffer_cache, resource_mutex);
   buffer_cache.SetTextureCache(texture_cache);


### PR DESCRIPTION
## Summary

- introduce overflow-safe guest byte/page range classification for resource overlap checks
- make cached-image roles explicit and centralize strong ownership and Vulkan-handle/range indexes
- represent alias retirement as a typed plan that TextureCache revalidates and executes under the resource lock
- make guest-memory unmap a cross-cache validate/commit transaction coordinated by GpuResourceManager
- prepare image readbacks before mutating guest backing, ownership, metadata, or tracking state
- preserve depth/stencil atomicity, native handoff, HTile cleanup, and fence-retained image lifetime
- route focused resource fixtures through the same coordinator used by production

## Why

The previous aliasing paths duplicated range arithmetic, mixed byte overlap with page-candidate semantics, and performed ownership transitions through loosely ordered call sites. That made containment, partial overlap, multi-plane depth images, unsupported readback layouts, and unmap behavior difficult to reason about.

This refactor makes the transaction fail before effects begin and separates stable domain mechanics from PS5-specific acquisition and execution logic.

## Architecture

A renderer-wide resource graph is not needed. Texture and metadata alias rules remain local to TextureCache, while GpuResourceManager is the sole boundary for coordination between image, buffer, and page-manager state.

The extracted modules have narrow responsibilities:

- CachedImageRecord owns role-tagged descriptors and native-image lifetime
- CachedImageRegistry owns strong records, native-handle lookup, and multi-range page lookup
- ImageAliasPlan represents typed retirement intent without locks or mutation
- TextureCache validates current state and executes the plan

## Validation

- ResourceRangeTests with strict warnings
- ImagePageTableTests with strict warnings
- focused tests under AddressSanitizer and UndefinedBehaviorSanitizer
- standalone C++20 syntax checks for the new modules, TextureCache, and GpuResourceManager
- repeated correctness, architecture, and regression review passes
- git diff whitespace validation

A full emulator build and Windows runtime suite were not available locally; repository checks remain the integration gate.