### PR TITLE
Add graphics regression testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,12 @@ jobs:
         run: |
           _Build\windows\frame_regression_tests.exe
 
-      - name: Validate game regression runner
+      - name: Test game regression runner
         shell: cmd
         run: |
+          python tests\GraphicsRegressionRunnerTests.py
           python tools\run_graphics_regression.py --help
+          python tools\run_graphics_regression_suite.py --help
 
       - name: Install
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,22 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          cmake --build _Build/windows --target launcher --parallel
+          cmake --build _Build/windows --target kyty_emulator launcher gpu_trace_tests frame_regression_tests --parallel
+
+      - name: Run GPU trace tests
+        shell: cmd
+        run: |
+          _Build\windows\gpu_trace_tests.exe
+
+      - name: Run frame regression tests
+        shell: cmd
+        run: |
+          _Build\windows\frame_regression_tests.exe
+
+      - name: Validate game regression runner
+        shell: cmd
+        run: |
+          python tools\run_graphics_regression.py --help
 
       - name: Install
         shell: cmd

--- a/.github/workflows/graphics-regression.yml
+++ b/.github/workflows/graphics-regression.yml
@@ -1,0 +1,87 @@
+name: Graphics Regression Suite
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite_path:
+        description: Absolute path to the private suite file on the runner
+        required: true
+        type: string
+      emulator_path:
+        description: Absolute path to kyty_emulator.exe on the runner
+        required: true
+        type: string
+      artifact_name:
+        description: Uploaded result artifact name
+        required: true
+        default: graphics-regression-results
+        type: string
+      allow_environment_mismatch:
+        description: Deliberately override baseline environment checks
+        required: true
+        default: false
+        type: boolean
+      upload_frame_evidence:
+        description: Upload raw, preview, and difference frames (may contain game imagery)
+        required: true
+        default: false
+        type: boolean
+
+jobs:
+  regression:
+    runs-on: [self-hosted, Windows, X64, gpu]
+    environment: graphics-regression
+    timeout-minutes: 360
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run serialized suite
+        shell: pwsh
+        env:
+          KYTY_SUITE: ${{ inputs.suite_path }}
+          KYTY_EMULATOR: ${{ inputs.emulator_path }}
+          KYTY_OUTPUT: ${{ runner.temp }}\kyty-graphics-regression-${{ github.run_id }}-${{ github.run_attempt }}
+          KYTY_ALLOW_ENVIRONMENT_MISMATCH: ${{ inputs.allow_environment_mismatch }}
+        run: |
+          New-Item -ItemType Directory -Force -Path $env:KYTY_OUTPUT | Out-Null
+          $arguments = @(
+            "tools\run_graphics_regression_suite.py",
+            "--suite", $env:KYTY_SUITE,
+            "--emulator", $env:KYTY_EMULATOR,
+            "--output", $env:KYTY_OUTPUT
+          )
+          if ($env:KYTY_ALLOW_ENVIRONMENT_MISMATCH -eq "true") {
+            $arguments += "--allow-environment-mismatch"
+          }
+          python @arguments
+          exit $LASTEXITCODE
+
+      - name: Upload reports and logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: |
+            ${{ runner.temp }}\kyty-graphics-regression-${{ github.run_id }}-${{ github.run_attempt }}\summary.json
+            ${{ runner.temp }}\kyty-graphics-regression-${{ github.run_id }}-${{ github.run_attempt }}\*\report.json
+            ${{ runner.temp }}\kyty-graphics-regression-${{ github.run_id }}-${{ github.run_attempt }}\*\report.log
+            ${{ runner.temp }}\kyty-graphics-regression-${{ github.run_id }}-${{ github.run_attempt }}\*\report.runner.json
+          if-no-files-found: warn
+          retention-days: 14
+          compression-level: 6
+
+      - name: Upload frame evidence
+        if: always() && inputs.upload_frame_evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.artifact_name }}-frame-evidence
+          path: ${{ runner.temp }}\kyty-graphics-regression-${{ github.run_id }}-${{ github.run_attempt }}\*\report.json_frames\**
+          if-no-files-found: warn
+          retention-days: 14
+          compression-level: 6

--- a/docs/graphics-regression.md
+++ b/docs/graphics-regression.md
@@ -1,0 +1,68 @@
+# Graphics regression testing
+
+Kyty can record and compare exact presented frames at selected zero-based presentation ordinals.
+The comparison happens on the normalized `PreparedFrame` image before the swapchain blit, so window
+size and desktop composition do not affect regular game frames. Synthesized blank frames inherit
+the prepared-frame pool format and should only be compared in the same pinned swapchain setup.
+
+Record a baseline:
+
+```text
+kyty_emulator --game <game> --regression-record baselines/game.json \
+  --regression-frames 60,120,300
+```
+
+Compare a later build:
+
+```text
+kyty_emulator --game <game> --regression-compare baselines/game.json \
+  --regression-report artifacts/game-report.json --regression-frames 60,120,300
+```
+
+For unattended jobs, use the timeout wrapper. It removes a stale report before starting, enforces
+the deadline, and validates that the new report is complete and contains exactly the requested
+matching frames:
+
+```text
+python tools/run_graphics_regression.py --emulator <kyty_emulator> --game <game> \
+  --baseline baselines/game.json --report artifacts/game-report.json \
+  --frames 60,120,300 --timeout-seconds 300
+```
+
+The emulator exits with code `0` when every selected frame matches and `2` for a mismatch, missing
+frame, invalid baseline, or capture failure. It exits as soon as all selected frames have been seen
+unless `--regression-exit-on-complete false` is specified. Raw frames, PPM previews for 8-bit RGBA
+formats, and PPM difference images are written beside the manifest by default. Use
+`--regression-save-raw false` when only hashes and metadata are needed.
+
+The oracle is intentionally exact: it hashes tightly packed source bytes with XXH3-128 and also
+checks width, height, pitch, byte size, and format. Baselines should therefore be recorded and
+compared with the same GPU model, driver, Vulkan settings, game state, and emulator configuration.
+Use a separate baseline per pinned CI graphics environment. A future tolerant-image policy can be
+added alongside the exact policy without weakening this signal.
+
+Recording refuses to overwrite an existing baseline. This avoids silently approving a rendering
+change; delete or move a baseline only as an explicit review action.
+
+## Commands-only GPU traces
+
+`--gpu-capture <path>` writes a versioned, little-endian trace of top-level graphics submissions,
+compute submissions, flip-preparation markers, and graphics-suspend requests. A suspend marker is
+recorded when the guest calls its suspend point, before Kyty waits for the GPU to become idle; it is
+not a completed-fence event. Every event has an XXH3 checksum and is flushed immediately, so all
+complete records written before a crash remain durable. A final record interrupted mid-write is
+reported as truncated by the loader.
+
+This format advertises the `commands_only` capability. It is not a standalone replay capture:
+indirect command buffers, guest-memory resources, aliases, texture contents, vertex/index buffers,
+and GPU-written state are not materialized. A replayable format must add range-scoped resource
+readback and guest-memory topology rather than treating top-level PM4 bytes as sufficient.
+
+## CI
+
+The Windows workflow builds the emulator and the two focused test executables, then runs tests for
+trace round trips, corruption/truncation handling, exact frame matches, mismatches, difference
+images, incomplete runs, and baseline overwrite protection. Game-specific jobs can then run the
+wrapper above on a pinned GPU runner and upload the report directory. Input scripting and
+save-state-driven checkpoints remain game-specific; use stable startup state before relying on a
+presentation ordinal.

--- a/docs/graphics-regression.md
+++ b/docs/graphics-regression.md
@@ -1,68 +1,112 @@
 # Graphics regression testing
 
 Kyty can record and compare exact presented frames at selected zero-based presentation ordinals.
-The comparison happens on the normalized `PreparedFrame` image before the swapchain blit, so window
-size and desktop composition do not affect regular game frames. Synthesized blank frames inherit
-the prepared-frame pool format and should only be compared in the same pinned swapchain setup.
+Capture happens on the normalized `PreparedFrame` image before the swapchain blit, so window size
+and desktop composition do not affect regular game frames. Synthesized blank frames inherit the
+prepared-frame pool format and require the same pinned swapchain setup.
 
-Record a baseline:
+## Baselines
+
+Choose a stable test ID that identifies the title revision and startup/input checkpoint. Record a
+baseline without reusing an existing manifest or artifact directory:
 
 ```text
 kyty_emulator --game <game> --regression-record baselines/game.json \
-  --regression-frames 60,120,300
+  --regression-test-id game-revision-checkpoint --regression-frames 60,120,300
 ```
 
 Compare a later build:
 
 ```text
 kyty_emulator --game <game> --regression-compare baselines/game.json \
-  --regression-report artifacts/game-report.json --regression-frames 60,120,300
+  --regression-report artifacts/game-report.json \
+  --regression-test-id game-revision-checkpoint --regression-frames 60,120,300
 ```
 
-For unattended jobs, use the timeout wrapper. It removes a stale report before starting, enforces
-the deadline, and validates that the new report is complete and contains exactly the requested
-matching frames:
+The baseline stores its build ID, test ID, GPU name/vendor/device/driver, Vulkan API version, and
+relevant renderer configuration. Comparison rejects a different test ID or environment before any
+frame is accepted. `--regression-allow-environment-mismatch true` is an explicit migration override;
+the report still records both environments and `environment_match: false`.
+
+Manifests and frame artifacts are flushed to same-directory temporary files and atomically replaced.
+Recording refuses existing baseline output. Comparison also protects the baseline manifest and all
+referenced baseline artifacts from report or GPU-capture path collisions. Small persistent
+`.kyty-lock` sidecars provide crash-safe, cross-process output reservations; they contain no game
+data and must remain beside the associated outputs.
+
+The oracle hashes tightly packed bytes with XXH3-128 and checks width, height, pitch, byte size, and
+format. Exact output still requires a pinned GPU, driver, renderer configuration, game revision, and
+checkpoint. Use separate baselines for different environments. A tolerant-image policy can be added
+later as a separate oracle without weakening exact comparisons.
+
+The emulator returns `0` when every selected frame matches and `2` for a mismatch, missing frame,
+invalid baseline, incompatible environment, or capture failure. It exits after the last selected
+frame by default. Direct emulator runs save raw frames and supported PPM previews by default; pass
+`--regression-save-raw false` for hashes only. Mismatch reports record any generated difference image
+and explicitly flag missing or corrupt baseline raw evidence.
+
+## Unattended single-game runs
+
+The wrapper preflights all paths and arguments, gives the emulator an owned isolated working
+directory, removes only previously marked runner output, retains an emulator log, strictly validates
+the schema-2 baseline and report, anchors every expected hash/layout and baseline-provenance field to
+the supplied baseline, and terminates the full process tree on timeout:
 
 ```text
-python tools/run_graphics_regression.py --emulator <kyty_emulator> --game <game> \
-  --baseline baselines/game.json --report artifacts/game-report.json \
-  --frames 60,120,300 --timeout-seconds 300
+python tools/run_graphics_regression.py \
+  --test-id game-revision-checkpoint \
+  --emulator <kyty_emulator> --game <game> \
+  --baseline baselines/game.json --report artifacts/game/report.json \
+  --work-dir artifacts/game/work --frames 60,120,300 --timeout-seconds 300
 ```
 
-The emulator exits with code `0` when every selected frame matches and `2` for a mismatch, missing
-frame, invalid baseline, or capture failure. It exits as soon as all selected frames have been seen
-unless `--regression-exit-on-complete false` is specified. Raw frames, PPM previews for 8-bit RGBA
-formats, and PPM difference images are written beside the manifest by default. Use
-`--regression-save-raw false` when only hashes and metadata are needed.
+The wrapper saves hashes only unless `--save-raw` is used. A work directory is reset between runs
+only after the wrapper has marked it as owned. `--reuse-work-dir` intentionally preserves save data
+and caches; use it only when that persistent state is part of the checkpoint contract. Additional
+emulator arguments go after `--`; regression-owned arguments cannot be overridden.
 
-The oracle is intentionally exact: it hashes tightly packed source bytes with XXH3-128 and also
-checks width, height, pitch, byte size, and format. Baselines should therefore be recorded and
-compared with the same GPU model, driver, Vulkan settings, game state, and emulator configuration.
-Use a separate baseline per pinned CI graphics environment. A future tolerant-image policy can be
-added alongside the exact policy without weakening this signal.
+## Suites
 
-Recording refuses to overwrite an existing baseline. This avoids silently approving a rendering
-change; delete or move a baseline only as an explicit review action.
+`tools/graphics-regression-suite.example.json` shows the strict suite format. Paths are resolved
+relative to the suite file, absolute paths are also accepted, case IDs must be unique, and the suite
+runs cases sequentially so they cannot compete for the GPU. Each case receives separate work,
+report, frame-evidence, log, and runner-result paths. A summary is updated after every case.
+
+```text
+python tools/run_graphics_regression_suite.py \
+  --suite D:/KytyTests/suite.json --emulator D:/Kyty/kyty_emulator.exe \
+  --output D:/KytyResults/current
+```
+
+Presentation ordinals are reliable only for deterministic startup sequences. Menus or gameplay that
+require input must use an external deterministic input/checkpoint mechanism passed through the case's
+`emulator_args`; the case ID must identify that checkpoint. The harness deliberately does not claim
+that an uncontrolled ordinal represents the same scene.
+
+## GPU-runner workflow
+
+The `Graphics Regression Suite` workflow is manual and targets a trusted self-hosted Windows x64
+runner with the custom `gpu` label. Commercial games and private baselines stay on that runner. The
+workflow accepts absolute emulator and suite paths, serializes all cases, and uploads only the
+summary, reports, emulator logs, and runner results, even when the suite fails or times out. Frame
+evidence is a separate opt-in artifact because it can contain game imagery; work directories are
+never uploaded. Protect the `graphics-regression` environment so only approved operators can start
+the job. Do not enable this workflow for untrusted pull-request code on a self-hosted machine.
+
+The normal Windows build workflow separately compiles and runs the C++ trace/frame tests and the
+Python runner tests. The Python tests cover pass/fail disagreement, malformed and missing reports,
+strict JSON types, stale artifact cleanup, suite validation, and timeout termination.
 
 ## Commands-only GPU traces
 
-`--gpu-capture <path>` writes a versioned, little-endian trace of top-level graphics submissions,
-compute submissions, flip-preparation markers, and graphics-suspend requests. A suspend marker is
-recorded when the guest calls its suspend point, before Kyty waits for the GPU to become idle; it is
-not a completed-fence event. Every event has an XXH3 checksum and is flushed immediately, so all
-complete records written before a crash remain durable. A final record interrupted mid-write is
-reported as truncated by the loader.
+`--gpu-capture <path>` writes a versioned little-endian diagnostic trace of top-level graphics and
+compute submissions plus flip-preparation and suspend-request markers. Existing captures are not
+overwritten. Every record covers canonical metadata and payload with an XXH3 checksum, and a final
+checksummed footer commits the event and command counts. Missing footer, whole-record truncation,
+partial writes, count changes, corruption, and incompatible versions are rejected by the loader.
 
-This format advertises the `commands_only` capability. It is not a standalone replay capture:
-indirect command buffers, guest-memory resources, aliases, texture contents, vertex/index buffers,
-and GPU-written state are not materialized. A replayable format must add range-scoped resource
-readback and guest-memory topology rather than treating top-level PM4 bytes as sufficient.
-
-## CI
-
-The Windows workflow builds the emulator and the two focused test executables, then runs tests for
-trace round trips, corruption/truncation handling, exact frame matches, mismatches, difference
-images, incomplete runs, and baseline overwrite protection. Game-specific jobs can then run the
-wrapper above on a pinned GPU runner and upload the report directory. Input scripting and
-save-state-driven checkpoints remain game-specific; use stable startup state before relying on a
-presentation ordinal.
+The footer marks the window-shutdown capture cutoff; submissions after that cutoff are intentionally
+not included. The format advertises `commands_only` and is not a standalone replay capture. Indirect
+command buffers, guest-memory resources and aliases, texture contents, vertex/index buffers, shaders,
+and GPU-written state are not materialized. Replay requires range-scoped memory/resource snapshots
+and guest-memory topology rather than only top-level PM4 bytes.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,8 @@ file(GLOB kyty_emulator_src CONFIGURE_DEPENDS
 	libs/*.h
 	graphics/*.cpp
 	graphics/*.h
+	graphics/capture/*.cpp
+	graphics/capture/*.h
 	graphics/guest_gpu/*.cpp
 	graphics/guest_gpu/*.h
 	graphics/guest_gpu/command_processor/*.cpp
@@ -164,6 +166,8 @@ file(GLOB kyty_emulator_src CONFIGURE_DEPENDS
 	graphics/presentation/*.h
 	graphics/presentation/window/*.cpp
 	graphics/presentation/window/*.h
+	graphics/regression/*.cpp
+	graphics/regression/*.h
 	kernel/*.cpp
 	kernel/*.h
 	loader/*.cpp
@@ -322,6 +326,20 @@ add_executable(image_page_table_tests EXCLUDE_FROM_ALL
 	../tests/ImagePageTableTests.cpp
 )
 target_include_directories(image_page_table_tests PRIVATE ${inc_headers})
+
+add_executable(gpu_trace_tests EXCLUDE_FROM_ALL
+	../tests/GpuTraceTests.cpp
+	graphics/capture/gpuTrace.cpp
+)
+target_link_libraries(gpu_trace_tests common xxhash)
+target_include_directories(gpu_trace_tests PRIVATE ${inc_headers})
+
+add_executable(frame_regression_tests EXCLUDE_FROM_ALL
+	../tests/FrameRegressionTests.cpp
+	graphics/regression/frameRegression.cpp
+)
+target_link_libraries(frame_regression_tests common xxhash nlohmann_json::nlohmann_json)
+target_include_directories(frame_regression_tests PRIVATE ${inc_headers})
 
 add_kyty_full_emulator_test(shader_recompiler_compute_tests ../tests/ShaderRecompilerComputeTests.cpp)
 

--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -1,8 +1,10 @@
 #include "common/emulatorConfig.h"
 
 #include "common/assert.h"
+#include "common/outputReservation.h"
 
 #include <algorithm>
+#include <cctype>
 #include <memory>
 
 namespace Config {
@@ -23,6 +25,91 @@ void Load(const ConfigOptions& cfg) {
 	EXIT_IF(g_config == nullptr);
 
 	*g_config = cfg;
+}
+
+namespace {
+
+std::string ComparablePath(const std::filesystem::path& path) {
+	std::error_code error;
+	auto normalized = std::filesystem::weakly_canonical(path, error);
+	if (error) {
+		normalized = std::filesystem::absolute(path, error);
+		if (error) {
+			normalized = path;
+		}
+	}
+	auto text = normalized.lexically_normal().generic_string();
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	std::transform(text.begin(), text.end(), text.begin(),
+	               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+#endif
+	return text;
+}
+
+std::filesystem::path FrameDirectory(const std::filesystem::path& manifest) {
+	return manifest.parent_path() / (manifest.filename().string() + "_frames");
+}
+
+bool SameOrWithin(const std::filesystem::path& candidate,
+	              const std::filesystem::path& directory) {
+	const auto path = ComparablePath(candidate);
+	auto       root = ComparablePath(directory);
+	if (path == root) {
+		return true;
+	}
+	if (!root.empty() && root.back() != '/') {
+		root.push_back('/');
+	}
+	return path.starts_with(root);
+}
+
+} // namespace
+
+bool ValidateFrameRegressionPaths(const ConfigOptions& cfg, std::string& error) {
+	error.clear();
+	if (cfg.frame_regression_mode == FrameRegressionMode::None) {
+		return true;
+	}
+	const auto& baseline = cfg.frame_regression_baseline;
+	const auto& report   = cfg.frame_regression_report;
+	const auto& capture  = cfg.gpu_capture_file;
+	if (Common::OutputReservation::IsReservedPath(baseline) ||
+	    (cfg.frame_regression_mode == FrameRegressionMode::Compare &&
+	     Common::OutputReservation::IsReservedPath(report)) ||
+	    (!capture.empty() && Common::OutputReservation::IsReservedPath(capture))) {
+		error = "regression output uses the reserved .kyty-lock suffix";
+		return false;
+	}
+	if (cfg.frame_regression_mode == FrameRegressionMode::Compare &&
+	    (ComparablePath(baseline) == ComparablePath(report) ||
+	     ComparablePath(baseline) ==
+	         ComparablePath(Common::OutputReservation::LockPath(report)) ||
+	     ComparablePath(FrameDirectory(baseline)) == ComparablePath(FrameDirectory(report)) ||
+	     SameOrWithin(report, FrameDirectory(baseline)) ||
+	     SameOrWithin(Common::OutputReservation::LockPath(report),
+	                  FrameDirectory(baseline)))) {
+		error = "regression baseline and report outputs collide";
+		return false;
+	}
+	if (!capture.empty() &&
+	    (ComparablePath(capture) == ComparablePath(baseline) ||
+	     ComparablePath(Common::OutputReservation::LockPath(capture)) ==
+	         ComparablePath(baseline) ||
+	     SameOrWithin(capture, FrameDirectory(baseline)) ||
+	     SameOrWithin(Common::OutputReservation::LockPath(capture), FrameDirectory(baseline)) ||
+	     (cfg.frame_regression_mode == FrameRegressionMode::Compare &&
+	      (ComparablePath(capture) == ComparablePath(report) ||
+	       ComparablePath(capture) ==
+	           ComparablePath(Common::OutputReservation::LockPath(report)) ||
+	       ComparablePath(Common::OutputReservation::LockPath(capture)) ==
+	           ComparablePath(report) ||
+	       SameOrWithin(capture, FrameDirectory(report)) ||
+	       SameOrWithin(Common::OutputReservation::LockPath(capture),
+	                    FrameDirectory(report)))))) {
+		error = "GPU capture and regression outputs collide";
+		return false;
+	}
+	return true;
 }
 
 uint32_t GetScreenWidth() {
@@ -113,12 +200,20 @@ const std::vector<uint64_t>& GetFrameRegressionFrames() {
 	return g_config->frame_regression_frames;
 }
 
+const std::string& GetFrameRegressionTestId() {
+	return g_config->frame_regression_test_id;
+}
+
 bool FrameRegressionSaveRaw() {
 	return g_config->frame_regression_save_raw;
 }
 
 bool FrameRegressionExitOnComplete() {
 	return g_config->frame_regression_exit_on_complete;
+}
+
+bool FrameRegressionAllowEnvironmentMismatch() {
+	return g_config->frame_regression_allow_environment_mismatch;
 }
 
 } // namespace Config

--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -93,4 +93,32 @@ bool NggRectlistDrawEnabled() {
 	return g_config->ngg_rectlist_draw_enabled;
 }
 
+std::filesystem::path GetGpuCaptureFile() {
+	return g_config->gpu_capture_file;
+}
+
+FrameRegressionMode GetFrameRegressionMode() {
+	return g_config->frame_regression_mode;
+}
+
+std::filesystem::path GetFrameRegressionBaseline() {
+	return g_config->frame_regression_baseline;
+}
+
+std::filesystem::path GetFrameRegressionReport() {
+	return g_config->frame_regression_report;
+}
+
+const std::vector<uint64_t>& GetFrameRegressionFrames() {
+	return g_config->frame_regression_frames;
+}
+
+bool FrameRegressionSaveRaw() {
+	return g_config->frame_regression_save_raw;
+}
+
+bool FrameRegressionExitOnComplete() {
+	return g_config->frame_regression_exit_on_complete;
+}
+
 } // namespace Config

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -5,6 +5,7 @@
 #include "common/subsystems.h"
 
 #include <filesystem>
+#include <vector>
 
 namespace Config {
 
@@ -17,6 +18,8 @@ enum class ShaderLogDirection { Silent, Console, File };
 enum class ProfilerDirection { None, Network };
 
 enum class OutputDirection { Silent, Console, File };
+
+enum class FrameRegressionMode { None, Record, Compare };
 
 struct ConfigOptions {
 	uint32_t               screen_width                = 1280;
@@ -36,6 +39,13 @@ struct ConfigOptions {
 	bool                   spirv_debug_printf_enabled  = false;
 	bool                   renderdoc_enabled           = false;
 	bool                   ngg_rectlist_draw_enabled   = true;
+	std::filesystem::path  gpu_capture_file;
+	FrameRegressionMode    frame_regression_mode = FrameRegressionMode::None;
+	std::filesystem::path  frame_regression_baseline;
+	std::filesystem::path  frame_regression_report = "_Regression/report.json";
+	std::vector<uint64_t>  frame_regression_frames;
+	bool                   frame_regression_save_raw         = true;
+	bool                   frame_regression_exit_on_complete = true;
 };
 
 void Load(const ConfigOptions& cfg);
@@ -64,6 +74,14 @@ bool SpirvDebugPrintfEnabled();
 
 bool RenderDocEnabled();
 bool NggRectlistDrawEnabled();
+
+std::filesystem::path       GetGpuCaptureFile();
+FrameRegressionMode         GetFrameRegressionMode();
+std::filesystem::path       GetFrameRegressionBaseline();
+std::filesystem::path       GetFrameRegressionReport();
+const std::vector<uint64_t>& GetFrameRegressionFrames();
+bool                        FrameRegressionSaveRaw();
+bool                        FrameRegressionExitOnComplete();
 
 } // namespace Config
 

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -5,6 +5,7 @@
 #include "common/subsystems.h"
 
 #include <filesystem>
+#include <string>
 #include <vector>
 
 namespace Config {
@@ -44,11 +45,14 @@ struct ConfigOptions {
 	std::filesystem::path  frame_regression_baseline;
 	std::filesystem::path  frame_regression_report = "_Regression/report.json";
 	std::vector<uint64_t>  frame_regression_frames;
+	std::string            frame_regression_test_id;
 	bool                   frame_regression_save_raw         = true;
 	bool                   frame_regression_exit_on_complete = true;
+	bool                   frame_regression_allow_environment_mismatch = false;
 };
 
 void Load(const ConfigOptions& cfg);
+[[nodiscard]] bool ValidateFrameRegressionPaths(const ConfigOptions& cfg, std::string& error);
 
 uint32_t GetScreenWidth();
 uint32_t GetScreenHeight();
@@ -80,8 +84,10 @@ FrameRegressionMode         GetFrameRegressionMode();
 std::filesystem::path       GetFrameRegressionBaseline();
 std::filesystem::path       GetFrameRegressionReport();
 const std::vector<uint64_t>& GetFrameRegressionFrames();
+const std::string&           GetFrameRegressionTestId();
 bool                        FrameRegressionSaveRaw();
 bool                        FrameRegressionExitOnComplete();
+bool                        FrameRegressionAllowEnvironmentMismatch();
 
 } // namespace Config
 

--- a/src/common/outputReservation.cpp
+++ b/src/common/outputReservation.cpp
@@ -1,0 +1,97 @@
+#include "common/outputReservation.h"
+
+#include "common/file.h"
+
+#include <algorithm>
+#include <cctype>
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h> // IWYU pragma: keep
+#else
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+#endif
+
+namespace Common {
+
+struct OutputReservation::Private {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	HANDLE handle = INVALID_HANDLE_VALUE;
+#else
+	int descriptor = -1;
+#endif
+};
+
+OutputReservation::OutputReservation(): m_private(std::make_unique<Private>()) {}
+
+OutputReservation::~OutputReservation() {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	if (m_private->handle != INVALID_HANDLE_VALUE) {
+		CloseHandle(m_private->handle);
+	}
+#else
+	if (m_private->descriptor >= 0) {
+		flock(m_private->descriptor, LOCK_UN);
+		close(m_private->descriptor);
+	}
+#endif
+}
+
+std::filesystem::path OutputReservation::LockPath(const std::filesystem::path& output) {
+	auto path = output;
+	path += ".kyty-lock";
+	return path;
+}
+
+bool OutputReservation::IsReservedPath(const std::filesystem::path& output) {
+	auto filename = output.filename().generic_string();
+	std::transform(filename.begin(), filename.end(), filename.begin(),
+	               [](unsigned char value) { return static_cast<char>(std::tolower(value)); });
+	return filename.ends_with(".kyty-lock");
+}
+
+std::unique_ptr<OutputReservation> OutputReservation::Acquire(
+    const std::filesystem::path& output, std::string& error) {
+	error.clear();
+	if (output.empty()) {
+		error = "output path is empty";
+		return {};
+	}
+	if (IsReservedPath(output)) {
+		error = "output path uses the reserved .kyty-lock suffix";
+		return {};
+	}
+	const auto lock = LockPath(output);
+	if (!lock.parent_path().empty() && !File::CreateDirectories(lock.parent_path())) {
+		error = "cannot create output reservation directory";
+		return {};
+	}
+	auto reservation = std::unique_ptr<OutputReservation>(new OutputReservation());
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	reservation->m_private->handle =
+	    CreateFileW(lock.wstring().c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_ALWAYS,
+	                FILE_ATTRIBUTE_NORMAL, nullptr);
+	if (reservation->m_private->handle == INVALID_HANDLE_VALUE) {
+		error = "output is already in use";
+		return {};
+	}
+#else
+	reservation->m_private->descriptor =
+	    open(lock.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR);
+	if (reservation->m_private->descriptor < 0 ||
+	    flock(reservation->m_private->descriptor, LOCK_EX | LOCK_NB) != 0) {
+		error = "output is already in use";
+		return {};
+	}
+#endif
+	return reservation;
+}
+
+} // namespace Common

--- a/src/common/outputReservation.h
+++ b/src/common/outputReservation.h
@@ -1,0 +1,31 @@
+#ifndef KYTY_COMMON_OUTPUTRESERVATION_H_
+#define KYTY_COMMON_OUTPUTRESERVATION_H_
+
+#include "common/common.h"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace Common {
+
+class OutputReservation {
+public:
+	static std::unique_ptr<OutputReservation> Acquire(const std::filesystem::path& output,
+	                                                   std::string& error);
+	static std::filesystem::path LockPath(const std::filesystem::path& output);
+	static bool IsReservedPath(const std::filesystem::path& output);
+
+	~OutputReservation();
+	KYTY_CLASS_NO_COPY(OutputReservation);
+
+private:
+	OutputReservation();
+
+	struct Private;
+	std::unique_ptr<Private> m_private;
+};
+
+} // namespace Common
+
+#endif // KYTY_COMMON_OUTPUTRESERVATION_H_

--- a/src/common/platform/sysLinuxFileIO.cpp
+++ b/src/common/platform/sysLinuxFileIO.cpp
@@ -363,7 +363,7 @@ bool SysFileDeleteFile(const std::filesystem::path& name) {
 
 bool SysFileFlush(sys_file_t& f) {
 	if (f.type == SYS_FILE_FILE && f.f != nullptr) {
-		return (fflush(f.f) == 0);
+		return fflush(f.f) == 0 && fsync(fileno(f.f)) == 0;
 	}
 
 	return false;

--- a/src/graphics/capture/gpuTrace.cpp
+++ b/src/graphics/capture/gpuTrace.cpp
@@ -1,0 +1,391 @@
+#include "graphics/capture/gpuTrace.h"
+
+#include "common/file.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <xxhash.h>
+
+namespace Libs::Graphics::Capture {
+namespace {
+
+constexpr std::array<uint8_t, 8> Magic {'K', 'Y', 'C', 'A', 'P', '\r', '\n', 0x1a};
+constexpr uint32_t HeaderSize       = 24;
+constexpr uint32_t RecordHeaderSize = 40;
+constexpr uint32_t InterruptFlag    = 1u << 0u;
+constexpr uint32_t NoQueue          = UINT32_MAX;
+
+void Put16(std::span<uint8_t> dst, size_t offset, uint16_t value) {
+	dst[offset]     = static_cast<uint8_t>(value);
+	dst[offset + 1] = static_cast<uint8_t>(value >> 8u);
+}
+
+void Put32(std::span<uint8_t> dst, size_t offset, uint32_t value) {
+	for (uint32_t i = 0; i < 4; i++) {
+		dst[offset + i] = static_cast<uint8_t>(value >> (i * 8u));
+	}
+}
+
+void Put64(std::span<uint8_t> dst, size_t offset, uint64_t value) {
+	for (uint32_t i = 0; i < 8; i++) {
+		dst[offset + i] = static_cast<uint8_t>(value >> (i * 8u));
+	}
+}
+
+uint16_t Get16(std::span<const uint8_t> src, size_t offset) {
+	return static_cast<uint16_t>(src[offset]) |
+	       static_cast<uint16_t>(src[offset + 1]) << 8u;
+}
+
+uint32_t Get32(std::span<const uint8_t> src, size_t offset) {
+	uint32_t value = 0;
+	for (uint32_t i = 0; i < 4; i++) {
+		value |= static_cast<uint32_t>(src[offset + i]) << (i * 8u);
+	}
+	return value;
+}
+
+uint64_t Get64(std::span<const uint8_t> src, size_t offset) {
+	uint64_t value = 0;
+	for (uint32_t i = 0; i < 8; i++) {
+		value |= static_cast<uint64_t>(src[offset + i]) << (i * 8u);
+	}
+	return value;
+}
+
+bool WriteExact(Common::File& file, const void* data, uint64_t size) {
+	const auto* bytes = static_cast<const uint8_t*>(data);
+	while (size != 0) {
+		const auto chunk = static_cast<uint32_t>(
+		    std::min<uint64_t>(size, std::numeric_limits<uint32_t>::max()));
+		uint32_t written = 0;
+		file.Write(bytes, chunk, &written);
+		if (written != chunk) {
+			return false;
+		}
+		bytes += chunk;
+		size -= chunk;
+	}
+	return true;
+}
+
+bool ReadExact(Common::File& file, void* data, uint64_t size) {
+	auto* bytes = static_cast<uint8_t*>(data);
+	while (size != 0) {
+		const auto chunk = static_cast<uint32_t>(
+		    std::min<uint64_t>(size, std::numeric_limits<uint32_t>::max()));
+		uint32_t read = 0;
+		file.Read(bytes, chunk, &read);
+		if (read != chunk) {
+			return false;
+		}
+		bytes += chunk;
+		size -= chunk;
+	}
+	return true;
+}
+
+bool RecordHash(std::span<const uint8_t> header, std::span<const uint8_t> payload,
+	            uint64_t& hash) {
+	if (header.size() != RecordHeaderSize) {
+		return false;
+	}
+	auto* state = XXH3_createState();
+	if (state == nullptr) {
+		return false;
+	}
+	auto header_copy = std::array<uint8_t, RecordHeaderSize> {};
+	std::copy(header.begin(), header.end(), header_copy.begin());
+	std::fill(header_copy.begin() + 32, header_copy.begin() + 40, 0);
+	const bool success = XXH3_64bits_reset(state) != XXH_ERROR &&
+	                     XXH3_64bits_update(state, header_copy.data(), header_copy.size()) !=
+	                         XXH_ERROR &&
+	                     XXH3_64bits_update(state, payload.data(), payload.size()) != XXH_ERROR;
+	if (success) {
+		hash = XXH3_64bits_digest(state);
+	}
+	XXH3_freeState(state);
+	return success;
+}
+
+bool IsKnownType(TraceEventType type) {
+	switch (type) {
+		case TraceEventType::GraphicsSubmit:
+		case TraceEventType::ComputeSubmit:
+		case TraceEventType::FlipPreparation:
+		case TraceEventType::SuspendRequest: return true;
+	}
+	return false;
+}
+
+bool ValidateEventShape(TraceEventType type, uint32_t queue, bool trigger_interrupt,
+	                    size_t primary_size, size_t secondary_size, std::string& error) {
+	switch (type) {
+		case TraceEventType::GraphicsSubmit:
+			if (queue != 0 || primary_size == 0) {
+				error = "invalid graphics submission";
+				return false;
+			}
+			return true;
+		case TraceEventType::ComputeSubmit:
+			if (queue < 0x20 || queue >= 0x58 || primary_size == 0 || secondary_size != 0) {
+				error = "invalid compute submission";
+				return false;
+			}
+			return true;
+		case TraceEventType::FlipPreparation:
+		case TraceEventType::SuspendRequest:
+			if (queue != NoQueue || trigger_interrupt || primary_size != 0 || secondary_size != 0) {
+				error = "invalid marker event";
+				return false;
+			}
+			return true;
+	}
+	error = "unknown trace event";
+	return false;
+}
+
+} // namespace
+
+struct TraceWriter::Private {
+	Common::File file;
+	std::mutex   mutex;
+	uint64_t     sequence = 0;
+	bool         open     = false;
+};
+
+TraceWriter::TraceWriter(std::filesystem::path path)
+    : m_path(std::move(path)), m_private(std::make_unique<Private>()) {}
+
+TraceWriter::~TraceWriter() {
+	Close();
+}
+
+std::unique_ptr<TraceWriter> TraceWriter::Create(const std::filesystem::path& path,
+	                                              std::string& error) {
+	error.clear();
+	if (path.empty()) {
+		error = "capture path is empty";
+		return {};
+	}
+	auto writer = std::unique_ptr<TraceWriter>(new TraceWriter(path));
+	if (!writer->Open(error)) {
+		return {};
+	}
+	return writer;
+}
+
+bool TraceWriter::Open(std::string& error) {
+	if (!m_path.parent_path().empty() &&
+	    !Common::File::CreateDirectories(m_path.parent_path())) {
+		error = "cannot create capture directory";
+		return false;
+	}
+	if (!m_private->file.Create(m_path)) {
+		error = "cannot create capture file";
+		return false;
+	}
+	std::array<uint8_t, HeaderSize> header {};
+	std::copy(Magic.begin(), Magic.end(), header.begin());
+	Put16(header, 8, TraceMajorVersion);
+	Put16(header, 10, TraceMinorVersion);
+	Put32(header, 12, HeaderSize);
+	Put32(header, 16, static_cast<uint32_t>(TraceCapability::CommandsOnly));
+	if (!WriteExact(m_private->file, header.data(), header.size()) || !m_private->file.Flush()) {
+		m_private->file.Close();
+		error = "cannot write capture header";
+		return false;
+	}
+	m_private->open = true;
+	return true;
+}
+
+bool TraceWriter::RecordGraphics(std::span<const uint32_t> draw,
+	                              std::span<const uint32_t> constants,
+	                              bool trigger_interrupt_on_done, std::string& error) {
+	return Record(TraceEventType::GraphicsSubmit, 0,
+	              trigger_interrupt_on_done ? InterruptFlag : 0, draw, constants, error);
+}
+
+bool TraceWriter::RecordCompute(uint32_t queue, std::span<const uint32_t> commands,
+	                             bool trigger_interrupt_on_done, std::string& error) {
+	return Record(TraceEventType::ComputeSubmit, queue,
+	              trigger_interrupt_on_done ? InterruptFlag : 0, commands, {}, error);
+}
+
+bool TraceWriter::RecordMarker(TraceEventType type, std::string& error) {
+	return Record(type, NoQueue, 0, {}, {}, error);
+}
+
+bool TraceWriter::Record(TraceEventType type, uint32_t queue, uint32_t flags,
+	                      std::span<const uint32_t> primary,
+	                      std::span<const uint32_t> secondary, std::string& error) {
+	error.clear();
+	if (!IsKnownType(type) ||
+	    !ValidateEventShape(type, queue, (flags & InterruptFlag) != 0, primary.size(),
+	                        secondary.size(), error)) {
+		return false;
+	}
+	if (primary.size() > UINT32_MAX || secondary.size() > UINT32_MAX ||
+	    primary.size() + secondary.size() > (UINT32_MAX - RecordHeaderSize) / sizeof(uint32_t)) {
+		error = "capture command payload is too large";
+		return false;
+	}
+
+	std::lock_guard lock(m_private->mutex);
+	if (!m_private->open) {
+		error = "capture file is closed";
+		return false;
+	}
+	const auto payload_size = (primary.size() + secondary.size()) * sizeof(uint32_t);
+	std::vector<uint8_t> record(RecordHeaderSize + payload_size);
+	Put32(record, 0, static_cast<uint32_t>(record.size()));
+	Put32(record, 4, static_cast<uint32_t>(type));
+	Put64(record, 8, ++m_private->sequence);
+	Put32(record, 16, queue);
+	Put32(record, 20, flags);
+	Put32(record, 24, static_cast<uint32_t>(primary.size()));
+	Put32(record, 28, static_cast<uint32_t>(secondary.size()));
+	size_t offset = RecordHeaderSize;
+	for (const auto word: primary) {
+		Put32(record, offset, word);
+		offset += sizeof(word);
+	}
+	for (const auto word: secondary) {
+		Put32(record, offset, word);
+		offset += sizeof(word);
+	}
+	const auto hash = XXH3_64bits(record.data(), record.size());
+	Put64(record, 32, hash);
+	if (!WriteExact(m_private->file, record.data(), record.size()) || !m_private->file.Flush()) {
+		error = "cannot append capture event";
+		return false;
+	}
+	return true;
+}
+
+void TraceWriter::Close() {
+	if (m_private == nullptr) {
+		return;
+	}
+	std::lock_guard lock(m_private->mutex);
+	if (m_private->open) {
+		m_private->file.Flush();
+		m_private->file.Close();
+		m_private->open = false;
+	}
+}
+
+bool LoadTrace(const std::filesystem::path& path, Trace& trace, std::string& error,
+	           const TraceReadLimits& limits) {
+	trace = {};
+	error.clear();
+	Common::File file;
+	if (!file.Open(path, Common::File::Mode::Read)) {
+		error = "cannot open capture file";
+		return false;
+	}
+	const auto close = [&file]() { file.Close(); };
+	std::array<uint8_t, HeaderSize> header {};
+	if (file.Size() < HeaderSize || !ReadExact(file, header.data(), header.size())) {
+		close();
+		error = "truncated capture header";
+		return false;
+	}
+	if (!std::equal(Magic.begin(), Magic.end(), header.begin()) || Get16(header, 8) != TraceMajorVersion ||
+	    Get16(header, 10) > TraceMinorVersion || Get32(header, 12) != HeaderSize ||
+	    Get32(header, 16) != static_cast<uint32_t>(TraceCapability::CommandsOnly) ||
+	    Get32(header, 20) != 0) {
+		close();
+		error = "unsupported capture header";
+		return false;
+	}
+	trace.capability = TraceCapability::CommandsOnly;
+	uint64_t command_dwords = 0;
+	uint64_t last_sequence  = 0;
+	while (file.Tell() < file.Size()) {
+		if (file.Size() - file.Tell() < RecordHeaderSize) {
+			close();
+			error = "truncated capture event header";
+			return false;
+		}
+		std::array<uint8_t, RecordHeaderSize> record_header {};
+		if (!ReadExact(file, record_header.data(), record_header.size())) {
+			close();
+			error = "cannot read capture event header";
+			return false;
+		}
+		const auto record_size  = Get32(record_header, 0);
+		const auto primary_dw   = Get32(record_header, 24);
+		const auto secondary_dw = Get32(record_header, 28);
+		const auto dwords       = static_cast<uint64_t>(primary_dw) + secondary_dw;
+		if (record_size < RecordHeaderSize ||
+		    static_cast<uint64_t>(record_size) != RecordHeaderSize + dwords * sizeof(uint32_t) ||
+		    record_size - RecordHeaderSize > file.Size() - file.Tell()) {
+			close();
+			error = "invalid capture event size";
+			return false;
+		}
+		if (trace.events.size() >= limits.max_events ||
+		    dwords > limits.max_command_dwords - command_dwords) {
+			close();
+			error = "capture exceeds configured limits";
+			return false;
+		}
+		std::vector<uint8_t> payload(static_cast<size_t>(dwords * sizeof(uint32_t)));
+		if (!payload.empty() && !ReadExact(file, payload.data(), payload.size())) {
+			close();
+			error = "truncated capture event payload";
+			return false;
+		}
+		uint64_t hash = 0;
+		if (!RecordHash(record_header, payload, hash)) {
+			close();
+			error = "cannot calculate capture event checksum";
+			return false;
+		}
+		if (hash != Get64(record_header, 32)) {
+			close();
+			error = "capture event checksum mismatch";
+			return false;
+		}
+		TraceEvent event;
+		event.type                      = static_cast<TraceEventType>(Get32(record_header, 4));
+		event.sequence                  = Get64(record_header, 8);
+		event.queue                     = Get32(record_header, 16);
+		const auto flags                = Get32(record_header, 20);
+		event.trigger_interrupt_on_done = (flags & InterruptFlag) != 0;
+		if (!IsKnownType(event.type) || (flags & ~InterruptFlag) != 0 ||
+		    event.sequence != last_sequence + 1) {
+			close();
+			error = "invalid capture event metadata";
+			return false;
+		}
+		event.primary.resize(primary_dw);
+		event.secondary.resize(secondary_dw);
+		size_t offset = 0;
+		for (auto& word: event.primary) {
+			word = Get32(payload, offset);
+			offset += sizeof(word);
+		}
+		for (auto& word: event.secondary) {
+			word = Get32(payload, offset);
+			offset += sizeof(word);
+		}
+		if (!ValidateEventShape(event.type, event.queue, event.trigger_interrupt_on_done,
+		                        event.primary.size(), event.secondary.size(), error)) {
+			close();
+			return false;
+		}
+		last_sequence = event.sequence;
+		command_dwords += dwords;
+		trace.events.push_back(std::move(event));
+	}
+	close();
+	return true;
+}
+
+} // namespace Libs::Graphics::Capture

--- a/src/graphics/capture/gpuTrace.cpp
+++ b/src/graphics/capture/gpuTrace.cpp
@@ -1,6 +1,7 @@
 #include "graphics/capture/gpuTrace.h"
 
 #include "common/file.h"
+#include "common/outputReservation.h"
 
 #include <algorithm>
 #include <array>
@@ -9,12 +10,19 @@
 #include <mutex>
 #include <xxhash.h>
 
+#if KYTY_PLATFORM != KYTY_PLATFORM_WINDOWS
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 namespace Libs::Graphics::Capture {
 namespace {
 
 constexpr std::array<uint8_t, 8> Magic {'K', 'Y', 'C', 'A', 'P', '\r', '\n', 0x1a};
+constexpr std::array<uint8_t, 8> FooterMagic {'K', 'Y', 'C', 'E', 'N', 'D', '\r', '\n'};
 constexpr uint32_t HeaderSize       = 24;
 constexpr uint32_t RecordHeaderSize = 40;
+constexpr uint32_t FooterSize       = 32;
 constexpr uint32_t InterruptFlag    = 1u << 0u;
 constexpr uint32_t NoQueue          = UINT32_MAX;
 
@@ -121,6 +129,23 @@ bool IsKnownType(TraceEventType type) {
 	return false;
 }
 
+bool SyncParentDirectory(const std::filesystem::path& path) {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	(void)path;
+	return true;
+#else
+	const auto parent = path.parent_path().empty() ? std::filesystem::path(".")
+	                                               : path.parent_path();
+	const int directory = open(parent.c_str(), O_RDONLY | O_DIRECTORY);
+	if (directory < 0) {
+		return false;
+	}
+	const bool synced = fsync(directory) == 0;
+	close(directory);
+	return synced;
+#endif
+}
+
 bool ValidateEventShape(TraceEventType type, uint32_t queue, bool trigger_interrupt,
 	                    size_t primary_size, size_t secondary_size, std::string& error) {
 	switch (type) {
@@ -152,16 +177,22 @@ bool ValidateEventShape(TraceEventType type, uint32_t queue, bool trigger_interr
 
 struct TraceWriter::Private {
 	Common::File file;
+	std::unique_ptr<Common::OutputReservation> reservation;
 	std::mutex   mutex;
 	uint64_t     sequence = 0;
+	uint64_t     command_dwords = 0;
 	bool         open     = false;
+	bool         finalized = false;
 };
 
 TraceWriter::TraceWriter(std::filesystem::path path)
     : m_path(std::move(path)), m_private(std::make_unique<Private>()) {}
 
 TraceWriter::~TraceWriter() {
-	Close();
+	std::string ignored;
+	if (!Finalize(ignored)) {
+		CloseFile();
+	}
 }
 
 std::unique_ptr<TraceWriter> TraceWriter::Create(const std::filesystem::path& path,
@@ -182,6 +213,14 @@ bool TraceWriter::Open(std::string& error) {
 	if (!m_path.parent_path().empty() &&
 	    !Common::File::CreateDirectories(m_path.parent_path())) {
 		error = "cannot create capture directory";
+		return false;
+	}
+	m_private->reservation = Common::OutputReservation::Acquire(m_path, error);
+	if (m_private->reservation == nullptr) {
+		return false;
+	}
+	if (Common::File::IsFileExisting(m_path)) {
+		error = "refusing to overwrite an existing capture file";
 		return false;
 	}
 	if (!m_private->file.Create(m_path)) {
@@ -264,16 +303,53 @@ bool TraceWriter::Record(TraceEventType type, uint32_t queue, uint32_t flags,
 		error = "cannot append capture event";
 		return false;
 	}
+	m_private->command_dwords += primary.size() + secondary.size();
 	return true;
 }
 
-void TraceWriter::Close() {
+bool TraceWriter::Finalize(std::string& error) {
+	error.clear();
+	if (m_private == nullptr) {
+		error = "capture writer is unavailable";
+		return false;
+	}
+	std::lock_guard lock(m_private->mutex);
+	if (m_private->finalized) {
+		return true;
+	}
+	if (!m_private->open) {
+		error = "capture file is closed";
+		return false;
+	}
+	std::array<uint8_t, FooterSize> footer {};
+	std::copy(FooterMagic.begin(), FooterMagic.end(), footer.begin());
+	Put64(footer, 8, m_private->sequence);
+	Put64(footer, 16, m_private->command_dwords);
+	Put64(footer, 24, XXH3_64bits(footer.data(), footer.size()));
+	if (!WriteExact(m_private->file, footer.data(), footer.size()) || !m_private->file.Flush()) {
+		error = "cannot finalize capture file";
+		m_private->file.Close();
+		m_private->open = false;
+		m_private->reservation.reset();
+		return false;
+	}
+	m_private->file.Close();
+	m_private->open = false;
+	m_private->reservation.reset();
+	if (!SyncParentDirectory(m_path)) {
+		error = "cannot durably finalize capture directory";
+		return false;
+	}
+	m_private->finalized = true;
+	return true;
+}
+
+void TraceWriter::CloseFile() {
 	if (m_private == nullptr) {
 		return;
 	}
 	std::lock_guard lock(m_private->mutex);
 	if (m_private->open) {
-		m_private->file.Flush();
 		m_private->file.Close();
 		m_private->open = false;
 	}
@@ -306,7 +382,32 @@ bool LoadTrace(const std::filesystem::path& path, Trace& trace, std::string& err
 	trace.capability = TraceCapability::CommandsOnly;
 	uint64_t command_dwords = 0;
 	uint64_t last_sequence  = 0;
-	while (file.Tell() < file.Size()) {
+	while (true) {
+		const auto remaining = file.Size() - file.Tell();
+		if (remaining == FooterSize) {
+			std::array<uint8_t, FooterSize> footer {};
+			if (!ReadExact(file, footer.data(), footer.size())) {
+				close();
+				error = "truncated capture footer";
+				return false;
+			}
+			const auto expected_hash = Get64(footer, 24);
+			Put64(footer, 24, 0);
+			if (!std::equal(FooterMagic.begin(), FooterMagic.end(), footer.begin()) ||
+			    Get64(footer, 8) != trace.events.size() || Get64(footer, 16) != command_dwords ||
+			    XXH3_64bits(footer.data(), footer.size()) != expected_hash) {
+				close();
+				error = "invalid capture footer";
+				return false;
+			}
+			close();
+			return true;
+		}
+		if (remaining == 0) {
+			close();
+			error = "capture is not finalized";
+			return false;
+		}
 		if (file.Size() - file.Tell() < RecordHeaderSize) {
 			close();
 			error = "truncated capture event header";
@@ -384,8 +485,6 @@ bool LoadTrace(const std::filesystem::path& path, Trace& trace, std::string& err
 		command_dwords += dwords;
 		trace.events.push_back(std::move(event));
 	}
-	close();
-	return true;
 }
 
 } // namespace Libs::Graphics::Capture

--- a/src/graphics/capture/gpuTrace.h
+++ b/src/graphics/capture/gpuTrace.h
@@ -1,0 +1,79 @@
+#ifndef KYTY_GRAPHICS_CAPTURE_GPUTRACE_H_
+#define KYTY_GRAPHICS_CAPTURE_GPUTRACE_H_
+
+#include "common/common.h"
+
+#include <filesystem>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace Libs::Graphics::Capture {
+
+constexpr uint16_t TraceMajorVersion = 1;
+constexpr uint16_t TraceMinorVersion = 0;
+
+enum class TraceCapability : uint32_t {
+	CommandsOnly = 1u << 0u,
+};
+
+enum class TraceEventType : uint32_t {
+	GraphicsSubmit = 1,
+	ComputeSubmit,
+	FlipPreparation,
+	SuspendRequest,
+};
+
+struct TraceEvent {
+	uint64_t              sequence = 0;
+	TraceEventType        type     = TraceEventType::GraphicsSubmit;
+	uint32_t              queue    = 0;
+	bool                  trigger_interrupt_on_done = false;
+	std::vector<uint32_t> primary;
+	std::vector<uint32_t> secondary;
+};
+
+struct Trace {
+	TraceCapability        capability = TraceCapability::CommandsOnly;
+	std::vector<TraceEvent> events;
+};
+
+struct TraceReadLimits {
+	uint64_t max_events         = 1'000'000;
+	uint64_t max_command_dwords = 64ull * 1024ull * 1024ull;
+};
+
+[[nodiscard]] bool LoadTrace(const std::filesystem::path& path, Trace& trace, std::string& error,
+	                         const TraceReadLimits& limits = {});
+
+class TraceWriter {
+public:
+	static std::unique_ptr<TraceWriter> Create(const std::filesystem::path& path,
+	                                           std::string& error);
+	~TraceWriter();
+	KYTY_CLASS_NO_COPY(TraceWriter);
+
+	[[nodiscard]] bool RecordGraphics(std::span<const uint32_t> draw,
+	                                  std::span<const uint32_t> constants,
+	                                  bool trigger_interrupt_on_done, std::string& error);
+	[[nodiscard]] bool RecordCompute(uint32_t queue, std::span<const uint32_t> commands,
+	                                 bool trigger_interrupt_on_done, std::string& error);
+	[[nodiscard]] bool RecordMarker(TraceEventType type, std::string& error);
+	void               Close();
+
+private:
+	explicit TraceWriter(std::filesystem::path path);
+	[[nodiscard]] bool Open(std::string& error);
+	[[nodiscard]] bool Record(TraceEventType type, uint32_t queue, uint32_t flags,
+	                          std::span<const uint32_t> primary,
+	                          std::span<const uint32_t> secondary, std::string& error);
+
+	struct Private;
+	std::filesystem::path m_path;
+	std::unique_ptr<Private> m_private;
+};
+
+} // namespace Libs::Graphics::Capture
+
+#endif // KYTY_GRAPHICS_CAPTURE_GPUTRACE_H_

--- a/src/graphics/capture/gpuTrace.h
+++ b/src/graphics/capture/gpuTrace.h
@@ -11,7 +11,7 @@
 
 namespace Libs::Graphics::Capture {
 
-constexpr uint16_t TraceMajorVersion = 1;
+constexpr uint16_t TraceMajorVersion = 2;
 constexpr uint16_t TraceMinorVersion = 0;
 
 enum class TraceCapability : uint32_t {
@@ -60,7 +60,7 @@ public:
 	[[nodiscard]] bool RecordCompute(uint32_t queue, std::span<const uint32_t> commands,
 	                                 bool trigger_interrupt_on_done, std::string& error);
 	[[nodiscard]] bool RecordMarker(TraceEventType type, std::string& error);
-	void               Close();
+	[[nodiscard]] bool Finalize(std::string& error);
 
 private:
 	explicit TraceWriter(std::filesystem::path path);
@@ -68,6 +68,7 @@ private:
 	[[nodiscard]] bool Record(TraceEventType type, uint32_t queue, uint32_t flags,
 	                          std::span<const uint32_t> primary,
 	                          std::span<const uint32_t> secondary, std::string& error);
+	void CloseFile();
 
 	struct Private;
 	std::filesystem::path m_path;

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -7,6 +7,7 @@
 #include "common/stringUtils.h"
 #include "common/threads.h"
 #include "graphics/asyncJob.h"
+#include "graphics/capture/gpuTrace.h"
 #include "graphics/guest_gpu/command_processor/commandProcessor.h"
 #include "graphics/guest_gpu/command_processor/pm4Dispatch.h"
 #include "graphics/guest_gpu/hardwareContext.h"
@@ -29,6 +30,8 @@
 #include <atomic>
 #include <cstdio>
 #include <list>
+#include <memory>
+#include <span>
 #include <thread>
 #include <vector>
 
@@ -227,6 +230,10 @@ public:
 private:
 	void Init();
 	void WaitLocked();
+	void CaptureGraphics(const OwnedCmdBuffer& draw, const OwnedCmdBuffer& constants,
+	                     bool trigger_interrupt);
+	void CaptureCompute(uint32_t queue, const OwnedCmdBuffer& commands, bool trigger_interrupt);
+	void CaptureMarker(Capture::TraceEventType type);
 
 	ComputeRing* GetRing(uint32_t ring_id);
 
@@ -237,6 +244,7 @@ private:
 
 	CommandProcessor* m_compute_cp[8]    = {};
 	ComputeRing*      m_compute_ring[64] = {};
+	std::unique_ptr<Capture::TraceWriter> m_capture;
 
 	std::atomic_int m_done_num = 0;
 };
@@ -263,6 +271,7 @@ void Gpu::Submit(uint32_t* cmd_draw_buffer, uint32_t num_draw_dw, uint32_t* cmd_
 	OwnedCmdBuffer draw_buffer(cmd_draw_buffer, num_draw_dw);
 	OwnedCmdBuffer const_buffer(cmd_const_buffer, num_const_dw);
 	GpuMutexLock   lock(m_mutex);
+	CaptureGraphics(draw_buffer, const_buffer, trigger_agc_interrupt_on_done);
 
 	m_gfx_ring->Submit(std::move(draw_buffer), std::move(const_buffer), 0, 0, 0, 0,
 	                   trigger_agc_interrupt_on_done);
@@ -288,11 +297,13 @@ void Gpu::SubmitCompute(uint32_t queue, uint32_t* cmd_buffer, uint32_t num_dw,
 
 	auto* ring = GetRing(ring_id);
 
+	CaptureCompute(queue, buffer, trigger_agc_interrupt_on_done);
 	ring->Submit(std::move(buffer), trigger_agc_interrupt_on_done);
 }
 
 void Gpu::SubmitFlipPreparation() {
 	GpuMutexLock lock(m_mutex);
+	CaptureMarker(Capture::TraceEventType::FlipPreparation);
 	m_gfx_ring->SubmitFlipPreparation();
 }
 
@@ -304,6 +315,7 @@ void Gpu::Done() {
 
 	{
 		GpuMutexLock lock(m_mutex);
+		CaptureMarker(Capture::TraceEventType::SuspendRequest);
 
 		gfx_ring = m_gfx_ring;
 		gfx_cp   = m_gfx_cp;
@@ -383,8 +395,50 @@ void Gpu::Init() {
 	m_gfx_ring = new GraphicsRing;
 	m_gfx_cp->SetQueue(GraphicContext::QUEUE_GFX);
 	m_gfx_ring->SetCp(*m_gfx_cp);
+	if (const auto path = Config::GetGpuCaptureFile(); !path.empty()) {
+		std::string error;
+		m_capture = Capture::TraceWriter::Create(path, error);
+		if (m_capture == nullptr) {
+			EXIT("GPU command capture initialization failed: %s\n", error.c_str());
+		}
+		LOGF("Recording commands-only GPU trace to %s\n", path.string().c_str());
+	}
 
 	EXIT_IF(GraphicContext::QUEUE_COMPUTE_NUM < 8);
+}
+
+void Gpu::CaptureGraphics(const OwnedCmdBuffer& draw, const OwnedCmdBuffer& constants,
+	                      bool trigger_interrupt) {
+	if (m_capture == nullptr) {
+		return;
+	}
+	std::string error;
+	if (!m_capture->RecordGraphics({draw.data, draw.num_dw}, {constants.data, constants.num_dw},
+	                               trigger_interrupt, error)) {
+		EXIT("GPU command capture failed: %s\n", error.c_str());
+	}
+}
+
+void Gpu::CaptureCompute(uint32_t queue, const OwnedCmdBuffer& commands,
+	                     bool trigger_interrupt) {
+	if (m_capture == nullptr) {
+		return;
+	}
+	std::string error;
+	if (!m_capture->RecordCompute(queue, {commands.data, commands.num_dw}, trigger_interrupt,
+	                              error)) {
+		EXIT("GPU command capture failed: %s\n", error.c_str());
+	}
+}
+
+void Gpu::CaptureMarker(Capture::TraceEventType type) {
+	if (m_capture == nullptr) {
+		return;
+	}
+	std::string error;
+	if (!m_capture->RecordMarker(type, error)) {
+		EXIT("GPU command capture failed: %s\n", error.c_str());
+	}
 }
 
 ComputeRing* Gpu::GetRing(uint32_t ring_id) {

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -226,6 +226,7 @@ public:
 	void PauseSubmissions();
 	void ResumeSubmissions();
 	int  GetFrameNum();
+	[[nodiscard]] bool FinalizeCapture(std::string& error);
 
 private:
 	void Init();
@@ -439,6 +440,15 @@ void Gpu::CaptureMarker(Capture::TraceEventType type) {
 	if (!m_capture->RecordMarker(type, error)) {
 		EXIT("GPU command capture failed: %s\n", error.c_str());
 	}
+}
+
+bool Gpu::FinalizeCapture(std::string& error) {
+	std::unique_ptr<Capture::TraceWriter> capture;
+	{
+		GpuMutexLock lock(m_mutex);
+		capture = std::move(m_capture);
+	}
+	return capture == nullptr || capture->Finalize(error);
 }
 
 ComputeRing* Gpu::GetRing(uint32_t ring_id) {
@@ -1951,6 +1961,19 @@ void GraphicsRunDone() {
 	EXIT_IF(g_gpu == nullptr);
 
 	g_gpu->Done();
+}
+
+int GraphicsRunFinalizeCapture() {
+	if (g_gpu == nullptr) {
+		return 0;
+	}
+	std::string error;
+	if (!g_gpu->FinalizeCapture(error)) {
+		::printf("GPU command capture finalization failed: %s\n", error.c_str());
+		LOGF("GPU command capture finalization failed: %s\n", error.c_str());
+		return 2;
+	}
+	return 0;
 }
 
 int GraphicsRunGetFrameNum() {

--- a/src/graphics/guest_gpu/graphicsRun.h
+++ b/src/graphics/guest_gpu/graphicsRun.h
@@ -24,6 +24,7 @@ void GraphicsRunSubmitCompute(uint32_t queue, uint32_t* cmd_buffer, uint32_t num
 void GraphicsRunSubmitFlipPreparation();
 void GraphicsRunWait();
 void GraphicsRunDone();
+[[nodiscard]] int GraphicsRunFinalizeCapture();
 int  GraphicsRunGetFrameNum();
 [[nodiscard]] bool              GraphicsRunIsCommandProcessorThread() noexcept;
 [[nodiscard]] CommandProcessor* GraphicsRunCurrentCommandProcessor() noexcept;

--- a/src/graphics/presentation/window.h
+++ b/src/graphics/presentation/window.h
@@ -12,6 +12,7 @@ struct PreparedFrame;
 
 void           WindowInit(uint32_t width, uint32_t height);
 void           WindowRun();
+void           WindowRequestExit(int exit_code);
 PreparedFrame& WindowPrepareFrame(CommandBuffer& buffer, VideoOutVulkanImage& image);
 PreparedFrame& WindowPrepareBlankFrame(CommandBuffer& buffer, uint32_t width, uint32_t height,
                                        bool opaque);

--- a/src/graphics/presentation/window/swapchain.cpp
+++ b/src/graphics/presentation/window/swapchain.cpp
@@ -36,6 +36,7 @@
 #include "graphics/presentation/videoOut.h"
 #include "graphics/presentation/window.h"
 #include "graphics/presentation/window/windowInternal.h"
+#include "graphics/regression/frameRegressionVulkan.h"
 #include "libs/controller.h"
 #include "loader/systemContent.h"
 
@@ -428,6 +429,10 @@ void WindowPresentFrame(PreparedFrame& frame) {
 		~ReleaseScope() { GetPreparedFramePool()->Release(frame); }
 	};
 	ReleaseScope release {&frame};
+	if (Regression::ObservePresentedFrame(frame.image)) {
+		WindowRequestExit(Regression::FinalizeFrameRegression());
+		return;
+	}
 
 	if (g_window_ctx->window_hidden) {
 		WindowUpdateIcon();

--- a/src/graphics/presentation/window/window.cpp
+++ b/src/graphics/presentation/window/window.cpp
@@ -37,6 +37,7 @@
 #include "graphics/presentation/videoOut.h"
 #include "graphics/presentation/window/windowInternal.h"
 #include "graphics/regression/frameRegressionVulkan.h"
+#include "graphics/guest_gpu/graphicsRun.h"
 #include "libs/controller.h"
 #include "loader/systemContent.h"
 
@@ -981,8 +982,9 @@ void WindowRun() {
 	// TODO: replace std::_Exit shutdown with full Vulkan teardown, then destroy
 	// the VMA allocator immediately before vkDestroyDevice.
 	const auto regression_exit_code = Regression::FinalizeFrameRegression();
+	const auto capture_exit_code    = GraphicsRunFinalizeCapture();
 	Common::SubsystemsListSingleton::Instance()->ShutdownAll();
-	std::_Exit(std::max(g_window_exit_code, regression_exit_code));
+	std::_Exit(std::max({g_window_exit_code, regression_exit_code, capture_exit_code}));
 }
 
 static int WindowIconRead(void* user, char* data, int size) {

--- a/src/graphics/presentation/window/window.cpp
+++ b/src/graphics/presentation/window/window.cpp
@@ -36,6 +36,7 @@
 #include "graphics/presentation/renderDoc.h"
 #include "graphics/presentation/videoOut.h"
 #include "graphics/presentation/window/windowInternal.h"
+#include "graphics/regression/frameRegressionVulkan.h"
 #include "libs/controller.h"
 #include "loader/systemContent.h"
 
@@ -243,6 +244,7 @@ struct WindowGamePrivate {
 
 WindowContext* g_window_ctx = nullptr;
 static WindowGame g_window_game;
+static int        g_window_exit_code = 0;
 
 constexpr const char* KYTY_SDL_WINDOW_CAPTION = "Game";
 constexpr uint32_t    KYTY_SDL_WINDOW_FLAGS =
@@ -961,6 +963,14 @@ void WindowInit(uint32_t width, uint32_t height) {
 	WindowCreate(*g_window_ctx);
 	VulkanCreate(*g_window_ctx);
 	GraphicsRenderInit(g_window_ctx->graphic_ctx);
+	if (!Regression::InitializeFrameRegression()) {
+		WindowRequestExit(2);
+	}
+}
+
+void WindowRequestExit(int exit_code) {
+	g_window_exit_code             = std::max(g_window_exit_code, exit_code);
+	g_window_game.m_game_need_exit = true;
 }
 
 void WindowRun() {
@@ -970,8 +980,9 @@ void WindowRun() {
 
 	// TODO: replace std::_Exit shutdown with full Vulkan teardown, then destroy
 	// the VMA allocator immediately before vkDestroyDevice.
+	const auto regression_exit_code = Regression::FinalizeFrameRegression();
 	Common::SubsystemsListSingleton::Instance()->ShutdownAll();
-	std::_Exit(0);
+	std::_Exit(std::max(g_window_exit_code, regression_exit_code));
 }
 
 static int WindowIconRead(void* user, char* data, int size) {

--- a/src/graphics/regression/frameRegression.cpp
+++ b/src/graphics/regression/frameRegression.cpp
@@ -1,11 +1,14 @@
 #include "graphics/regression/frameRegression.h"
 
 #include "common/file.h"
+#include "common/outputReservation.h"
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cctype>
 #include <charconv>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <limits>
@@ -16,14 +19,28 @@
 #include <vector>
 #include <xxhash.h>
 
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h> // IWYU pragma: keep
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 namespace Libs::Graphics::Regression {
 namespace {
 
-constexpr uint32_t SchemaVersion = 1;
+constexpr uint32_t SchemaVersion = 2;
 constexpr int      FailureExitCode = 2;
 constexpr uint64_t MaxManifestBytes = 4ull * 1024ull * 1024ull;
 constexpr size_t   MaxManifestFrames = 4096;
 constexpr size_t   MaxArtifactPathLength = 1024;
+constexpr size_t   MaxProvenanceTextLength = 4096;
 
 struct Digest {
 	uint64_t low  = 0;
@@ -41,6 +58,7 @@ struct FrameRecord {
 	Digest      digest;
 	std::string raw_file;
 	std::string image_file;
+	std::string diff_file;
 	std::string status;
 	Digest      expected;
 	bool        has_expected = false;
@@ -116,12 +134,41 @@ bool ReadText(const std::filesystem::path& path, std::string& text) {
 	return read == text.size();
 }
 
+bool ReplaceFile(const std::filesystem::path& temporary, const std::filesystem::path& path) {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	return MoveFileExW(temporary.wstring().c_str(), path.wstring().c_str(),
+	                   MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != 0;
+#else
+	std::error_code error;
+	std::filesystem::rename(temporary, path, error);
+	if (error) {
+		return false;
+	}
+	const auto directory_path = path.parent_path().empty() ? std::filesystem::path(".")
+	                                                      : path.parent_path();
+	const int directory = open(directory_path.c_str(), O_RDONLY | O_DIRECTORY);
+	if (directory < 0) {
+		return false;
+	}
+	const bool synced = fsync(directory) == 0;
+	close(directory);
+	return synced;
+#endif
+}
+
 bool WriteBytes(const std::filesystem::path& path, const void* data, uint64_t size) {
 	if (!path.parent_path().empty() && !Common::File::CreateDirectories(path.parent_path())) {
 		return false;
 	}
+	static std::atomic<uint64_t> temporary_sequence = 0;
+	auto temporary = path;
+	temporary += ".tmp." +
+	             std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + "." +
+	             std::to_string(temporary_sequence.fetch_add(1, std::memory_order_relaxed));
+	std::error_code remove_error;
+	std::filesystem::remove(temporary, remove_error);
 	Common::File file;
-	if (!file.Create(path)) {
+	if (!file.Create(temporary)) {
 		return false;
 	}
 	const auto* bytes = static_cast<const uint8_t*>(data);
@@ -132,6 +179,7 @@ bool WriteBytes(const std::filesystem::path& path, const void* data, uint64_t si
 		file.Write(bytes, chunk, &written);
 		if (written != chunk) {
 			file.Close();
+			std::filesystem::remove(temporary, remove_error);
 			return false;
 		}
 		bytes += chunk;
@@ -139,7 +187,11 @@ bool WriteBytes(const std::filesystem::path& path, const void* data, uint64_t si
 	}
 	const bool flushed = file.Flush();
 	file.Close();
-	return flushed;
+	if (!flushed || !ReplaceFile(temporary, path)) {
+		std::filesystem::remove(temporary, remove_error);
+		return false;
+	}
+	return true;
 }
 
 bool WriteText(const std::filesystem::path& path, const std::string& text) {
@@ -147,14 +199,17 @@ bool WriteText(const std::filesystem::path& path, const std::string& text) {
 }
 
 std::filesystem::path FrameDirectory(const std::filesystem::path& manifest) {
-	return manifest.parent_path() / (manifest.stem().string() + "_frames");
+	return manifest.parent_path() / (manifest.filename().string() + "_frames");
 }
 
 std::string ComparablePath(const std::filesystem::path& path) {
 	std::error_code error;
-	auto normalized = std::filesystem::absolute(path, error);
+	auto normalized = std::filesystem::weakly_canonical(path, error);
 	if (error) {
-		normalized = path;
+		normalized = std::filesystem::absolute(path, error);
+		if (error) {
+			normalized = path;
+		}
 	}
 	auto text = normalized.lexically_normal().generic_string();
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
@@ -198,11 +253,17 @@ bool SavePpm(const std::filesystem::path& path, const FrameView& frame,
 		const auto row = static_cast<size_t>(y) * frame.row_pitch;
 		for (uint32_t x = 0; x < frame.width; x++) {
 			const auto offset = row + static_cast<size_t>(x) * 4u;
+			const auto alpha_delta = expected.empty()
+			                             ? 0
+			                             : std::abs(static_cast<int>(frame.bytes[offset + 3]) -
+			                                        expected[offset + 3]);
 			const auto channel = [&](uint32_t index) {
 				const auto actual = frame.bytes[offset + index];
-				return expected.empty() ? actual
-				                        : static_cast<uint8_t>(std::abs(
-				                              static_cast<int>(actual) - expected[offset + index]));
+				return expected.empty()
+				           ? actual
+				           : static_cast<uint8_t>(std::max(
+				                 alpha_delta,
+				                 std::abs(static_cast<int>(actual) - expected[offset + index])));
 			};
 			if (rgba) {
 				rgb.push_back(channel(0));
@@ -225,6 +286,11 @@ bool SavePpm(const std::filesystem::path& path, const FrameView& frame,
 	std::copy_n(reinterpret_cast<const uint8_t*>(header), header_size, ppm.begin());
 	std::copy(rgb.begin(), rgb.end(), ppm.begin() + header_size);
 	return WriteBytes(path, ppm.data(), ppm.size());
+}
+
+bool SupportsPpm(PixelFormat format) {
+	return format == PixelFormat::Rgba8Unorm || format == PixelFormat::Rgba8Srgb ||
+	       format == PixelFormat::Bgra8Unorm || format == PixelFormat::Bgra8Srgb;
 }
 
 bool SameLayout(const FrameRecord& expected, const FrameRecord& actual) {
@@ -265,7 +331,7 @@ FrameRecord ParseRecord(const nlohmann::json& json, std::string& error) {
 		error = "invalid frame format or digest";
 		return {};
 	}
-	for (const auto* name: {"raw_file", "image_file"}) {
+	for (const auto* name: {"raw_file", "image_file", "diff_file", "status"}) {
 		if (json.contains(name) && !json[name].is_string()) {
 			error = "invalid frame artifact path";
 			return {};
@@ -274,14 +340,21 @@ FrameRecord ParseRecord(const nlohmann::json& json, std::string& error) {
 	if ((json.contains("raw_file") &&
 	     json["raw_file"].get_ref<const std::string&>().size() > MaxArtifactPathLength) ||
 	    (json.contains("image_file") &&
-	     json["image_file"].get_ref<const std::string&>().size() > MaxArtifactPathLength)) {
+	     json["image_file"].get_ref<const std::string&>().size() > MaxArtifactPathLength) ||
+	    (json.contains("diff_file") &&
+	     json["diff_file"].get_ref<const std::string&>().size() > MaxArtifactPathLength) ||
+	    (json.contains("status") &&
+	     json["status"].get_ref<const std::string&>().size() > 64)) {
 		error = "frame artifact path is too long";
 		return {};
 	}
 	record.raw_file   = json.contains("raw_file") ? json["raw_file"].get<std::string>() : "";
 	record.image_file = json.contains("image_file") ? json["image_file"].get<std::string>() : "";
+	record.diff_file  = json.contains("diff_file") ? json["diff_file"].get<std::string>() : "";
+	record.status     = json.contains("status") ? json["status"].get<std::string>() : "";
 	if ((!record.raw_file.empty() && !IsSafeArtifactPath(record.raw_file)) ||
-	    (!record.image_file.empty() && !IsSafeArtifactPath(record.image_file))) {
+	    (!record.image_file.empty() && !IsSafeArtifactPath(record.image_file)) ||
+	    (!record.diff_file.empty() && !IsSafeArtifactPath(record.diff_file))) {
 		error = "unsafe frame artifact path";
 		return {};
 	}
@@ -289,7 +362,8 @@ FrameRecord ParseRecord(const nlohmann::json& json, std::string& error) {
 	if (record.width == 0 || record.height == 0 || bytes_per_pixel == 0 ||
 	    record.width > UINT32_MAX / bytes_per_pixel ||
 	    record.row_pitch != record.width * bytes_per_pixel ||
-	    record.byte_size != static_cast<uint64_t>(record.row_pitch) * record.height) {
+	    record.byte_size != static_cast<uint64_t>(record.row_pitch) * record.height ||
+	    record.byte_size > MaxFrameBytes) {
 		error = "invalid frame dimensions";
 		return {};
 	}
@@ -316,6 +390,9 @@ nlohmann::ordered_json RecordJson(const FrameRecord& record) {
 	if (!record.image_file.empty()) {
 		json["image_file"] = record.image_file;
 	}
+	if (!record.diff_file.empty()) {
+		json["diff_file"] = record.diff_file;
+	}
 	if (!record.status.empty()) {
 		json["status"] = record.status;
 	}
@@ -324,6 +401,43 @@ nlohmann::ordered_json RecordJson(const FrameRecord& record) {
 		json["expected_hash_high"] = Hex(record.expected.high);
 	}
 	return json;
+}
+
+nlohmann::ordered_json ProvenanceJson(const Provenance& provenance) {
+	return {{"test_id", provenance.test_id},
+	        {"build_id", provenance.build_id},
+	        {"gpu_name", provenance.gpu_name},
+	        {"gpu_vendor_id", provenance.gpu_vendor_id},
+	        {"gpu_device_id", provenance.gpu_device_id},
+	        {"gpu_driver", provenance.gpu_driver},
+	        {"vulkan_api", provenance.vulkan_api},
+	        {"configuration", provenance.configuration}};
+}
+
+bool ParseProvenance(const nlohmann::json& json, Provenance& provenance) {
+	const auto text = [&json](const char* name, std::string& value) {
+		if (!json.contains(name) || !json[name].is_string() ||
+		    json[name].get_ref<const std::string&>().empty() ||
+		    json[name].get_ref<const std::string&>().size() > MaxProvenanceTextLength) {
+			return false;
+		}
+		value = json[name].get<std::string>();
+		return true;
+	};
+	const auto number = [&json](const char* name, uint32_t& value) {
+		if (!json.contains(name) || !json[name].is_number_unsigned() ||
+		    json[name].get<uint64_t>() > UINT32_MAX) {
+			return false;
+		}
+		value = json[name].get<uint32_t>();
+		return true;
+	};
+	return json.is_object() && text("test_id", provenance.test_id) &&
+	       text("build_id", provenance.build_id) && text("gpu_name", provenance.gpu_name) &&
+	       text("configuration", provenance.configuration) &&
+	       number("gpu_vendor_id", provenance.gpu_vendor_id) &&
+	       number("gpu_device_id", provenance.gpu_device_id) &&
+	       number("gpu_driver", provenance.gpu_driver) && number("vulkan_api", provenance.vulkan_api);
 }
 
 } // namespace
@@ -341,9 +455,19 @@ uint32_t BytesPerPixel(PixelFormat format) {
 	return 0;
 }
 
+bool Provenance::CompatibleWith(const Provenance& other) const {
+	return test_id == other.test_id && gpu_name == other.gpu_name &&
+	       configuration == other.configuration && gpu_vendor_id == other.gpu_vendor_id &&
+	       gpu_device_id == other.gpu_device_id && gpu_driver == other.gpu_driver &&
+	       vulkan_api == other.vulkan_api;
+}
+
 struct Session::Private {
 	std::map<uint64_t, FrameRecord> expected;
 	std::map<uint64_t, FrameRecord> actual;
+	Provenance                     baseline_provenance;
+	std::vector<std::unique_ptr<Common::OutputReservation>> reservations;
+	bool                           environment_compatible = true;
 	bool                            failed    = false;
 	bool                            finalized = false;
 };
@@ -368,6 +492,24 @@ bool Session::Initialize(std::string& error) {
 		error = "regression baseline, report, and frame ordinals are required";
 		return false;
 	}
+	if (Common::OutputReservation::IsReservedPath(m_options.baseline) ||
+	    (m_options.mode == Mode::Compare &&
+	     Common::OutputReservation::IsReservedPath(m_options.report)) ||
+	    (!m_options.capture.empty() &&
+	     Common::OutputReservation::IsReservedPath(m_options.capture))) {
+		error = "regression output uses the reserved .kyty-lock suffix";
+		return false;
+	}
+	const auto valid_provenance_text = [](const std::string& value) {
+		return !value.empty() && value.size() <= MaxProvenanceTextLength;
+	};
+	if (!valid_provenance_text(m_options.provenance.test_id) ||
+	    !valid_provenance_text(m_options.provenance.build_id) ||
+	    !valid_provenance_text(m_options.provenance.gpu_name) ||
+	    !valid_provenance_text(m_options.provenance.configuration)) {
+		error = "regression provenance is incomplete";
+		return false;
+	}
 	if (m_options.frame_ordinals.size() > MaxManifestFrames) {
 		error = "too many regression frame ordinals";
 		return false;
@@ -378,21 +520,76 @@ bool Session::Initialize(std::string& error) {
 		error = "regression frame ordinals must be unique";
 		return false;
 	}
+	const auto reserve_outputs = [this, &error](const std::filesystem::path& manifest) {
+		std::array paths {manifest, FrameDirectory(manifest)};
+		std::sort(paths.begin(), paths.end(), [](const auto& first, const auto& second) {
+			return ComparablePath(first) < ComparablePath(second);
+		});
+		for (const auto& path: paths) {
+			auto reservation = Common::OutputReservation::Acquire(path, error);
+			if (reservation == nullptr) {
+				m_private->reservations.clear();
+				return false;
+			}
+			m_private->reservations.push_back(std::move(reservation));
+		}
+		return true;
+	};
 	if (m_options.mode == Mode::Record) {
-		if (Common::File::IsFileExisting(m_options.baseline)) {
+		const auto baseline_lock = Common::OutputReservation::LockPath(m_options.baseline);
+		if (!m_options.capture.empty() &&
+		    (ComparablePath(m_options.capture) == ComparablePath(m_options.baseline) ||
+		     ComparablePath(m_options.capture) == ComparablePath(baseline_lock) ||
+		     ComparablePath(Common::OutputReservation::LockPath(m_options.capture)) ==
+		         ComparablePath(m_options.baseline) ||
+		     SameOrWithin(m_options.capture, FrameDirectory(m_options.baseline)) ||
+		     SameOrWithin(Common::OutputReservation::LockPath(m_options.capture),
+		                  FrameDirectory(m_options.baseline)))) {
+			error = "GPU capture and regression baseline outputs collide";
+			return false;
+		}
+		if (!reserve_outputs(m_options.baseline)) {
+			return false;
+		}
+		if (Common::File::IsFileExisting(m_options.baseline) ||
+		    Common::File::IsDirectoryExisting(m_options.baseline) ||
+		    Common::File::IsDirectoryExisting(FrameDirectory(m_options.baseline))) {
 			error = "refusing to overwrite an existing regression baseline";
 			return false;
 		}
 		return true;
 	}
 	if (ComparablePath(m_options.baseline) == ComparablePath(m_options.report) ||
+	    ComparablePath(m_options.baseline) ==
+	        ComparablePath(Common::OutputReservation::LockPath(m_options.report)) ||
 	    ComparablePath(FrameDirectory(m_options.baseline)) ==
 	        ComparablePath(FrameDirectory(m_options.report)) ||
-	    SameOrWithin(m_options.report, FrameDirectory(m_options.baseline))) {
+	    SameOrWithin(m_options.report, FrameDirectory(m_options.baseline)) ||
+	    SameOrWithin(Common::OutputReservation::LockPath(m_options.report),
+	                 FrameDirectory(m_options.baseline))) {
 		error = "regression baseline and report outputs collide";
 		return false;
 	}
-
+	if (Common::File::IsDirectoryExisting(m_options.report)) {
+		error = "regression report path is an existing directory";
+		return false;
+	}
+	if (!m_options.capture.empty() &&
+	    (ComparablePath(m_options.capture) == ComparablePath(m_options.baseline) ||
+	     ComparablePath(m_options.capture) == ComparablePath(m_options.report) ||
+	     ComparablePath(m_options.capture) ==
+	         ComparablePath(Common::OutputReservation::LockPath(m_options.report)) ||
+	     ComparablePath(Common::OutputReservation::LockPath(m_options.capture)) ==
+	         ComparablePath(m_options.report) ||
+	     SameOrWithin(m_options.capture, FrameDirectory(m_options.baseline)) ||
+	     SameOrWithin(m_options.capture, FrameDirectory(m_options.report)) ||
+	     SameOrWithin(Common::OutputReservation::LockPath(m_options.capture),
+	                  FrameDirectory(m_options.baseline)) ||
+	     SameOrWithin(Common::OutputReservation::LockPath(m_options.capture),
+	                  FrameDirectory(m_options.report)))) {
+		error = "GPU capture and regression outputs collide";
+		return false;
+	}
 	std::string source;
 	if (!ReadText(m_options.baseline, source)) {
 		error = "cannot read regression baseline";
@@ -405,6 +602,10 @@ bool Session::Initialize(std::string& error) {
 	    !json["algorithm"].is_string() ||
 	    json["algorithm"].get<std::string>() != "xxh3_128" || !json.contains("complete") ||
 	    !json["complete"].is_boolean() || !json["complete"].get<bool>() ||
+	    !json.contains("mode") || json["mode"] != "record" || !json.contains("passed") ||
+	    !json["passed"].is_boolean() || !json["passed"].get<bool>() ||
+	    !json.contains("provenance") ||
+	    !ParseProvenance(json["provenance"], m_private->baseline_provenance) ||
 	    !json.contains("frames") || !json["frames"].is_array() ||
 	    json["frames"].size() > MaxManifestFrames) {
 		error = "invalid or incomplete regression baseline";
@@ -413,6 +614,10 @@ bool Session::Initialize(std::string& error) {
 	for (const auto& entry: json["frames"]) {
 		auto record = ParseRecord(entry, error);
 		if (!error.empty()) {
+			return false;
+		}
+		if (record.status != "recorded") {
+			error = "regression baseline contains a non-record frame";
 			return false;
 		}
 		if (!m_private->expected.emplace(record.ordinal, std::move(record)).second) {
@@ -426,7 +631,14 @@ bool Session::Initialize(std::string& error) {
 			return false;
 		}
 	}
+	m_private->environment_compatible =
+	    m_private->baseline_provenance.CompatibleWith(m_options.provenance);
+	if (!m_private->environment_compatible && !m_options.allow_environment_mismatch) {
+		error = "regression environment does not match baseline provenance";
+		return false;
+	}
 	std::unordered_set<std::string> protected_artifacts;
+	protected_artifacts.insert(ComparablePath(m_options.baseline));
 	for (const auto& [ordinal, record]: m_private->expected) {
 		(void)ordinal;
 		if (!record.raw_file.empty()) {
@@ -438,8 +650,17 @@ bool Session::Initialize(std::string& error) {
 			    ComparablePath(m_options.baseline.parent_path() / record.image_file));
 		}
 	}
-	if (protected_artifacts.contains(ComparablePath(m_options.report))) {
+	if (protected_artifacts.contains(ComparablePath(m_options.report)) ||
+	    protected_artifacts.contains(
+	        ComparablePath(Common::OutputReservation::LockPath(m_options.report)))) {
 		error = "regression report would overwrite a baseline artifact";
+		return false;
+	}
+	if (!m_options.capture.empty() &&
+	    (protected_artifacts.contains(ComparablePath(m_options.capture)) ||
+	     protected_artifacts.contains(
+	         ComparablePath(Common::OutputReservation::LockPath(m_options.capture))))) {
+		error = "GPU capture would overwrite a baseline artifact";
 		return false;
 	}
 	if (m_options.save_raw_frames) {
@@ -454,11 +675,15 @@ bool Session::Initialize(std::string& error) {
 			}
 		}
 	}
+	if (!reserve_outputs(m_options.report)) {
+		return false;
+	}
 	return true;
 }
 
 bool Session::WantsFrame(uint64_t ordinal) const {
-	return std::binary_search(m_options.frame_ordinals.begin(), m_options.frame_ordinals.end(),
+	return !m_private->finalized &&
+	       std::binary_search(m_options.frame_ordinals.begin(), m_options.frame_ordinals.end(),
 	                          ordinal) &&
 	       !m_private->actual.contains(ordinal);
 }
@@ -473,7 +698,8 @@ bool Session::Observe(const FrameView& frame, std::string& error) {
 	if (frame.width == 0 || frame.height == 0 || bytes_per_pixel == 0 ||
 	    frame.width > UINT32_MAX / bytes_per_pixel ||
 	    frame.row_pitch != frame.width * bytes_per_pixel ||
-	    frame.bytes.size() != static_cast<uint64_t>(frame.row_pitch) * frame.height) {
+	    frame.bytes.size() != static_cast<uint64_t>(frame.row_pitch) * frame.height ||
+	    frame.bytes.size() > MaxFrameBytes) {
 		error = "invalid regression frame layout";
 		return false;
 	}
@@ -496,8 +722,7 @@ bool Session::Observe(const FrameView& frame, std::string& error) {
 			error = "cannot write regression raw frame";
 			return false;
 		}
-		if (frame.format == PixelFormat::Rgba8Unorm || frame.format == PixelFormat::Rgba8Srgb ||
-		    frame.format == PixelFormat::Bgra8Unorm || frame.format == PixelFormat::Bgra8Srgb) {
+		if (SupportsPpm(frame.format)) {
 			record.image_file =
 			    (directory.filename() / FrameName(frame.ordinal, "ppm")).generic_string();
 			if (!SavePpm(manifest.parent_path() / record.image_file, frame)) {
@@ -518,7 +743,7 @@ bool Session::Observe(const FrameView& frame, std::string& error) {
 		record.status       = match ? "match" : "mismatch";
 		m_private->failed   = m_private->failed || !match;
 		if (!match && m_options.save_raw_frames && !expected.raw_file.empty() &&
-		    SameLayout(expected, record)) {
+		    SameLayout(expected, record) && SupportsPpm(frame.format)) {
 			Common::File expected_file;
 			const auto expected_path = m_options.baseline.parent_path() / expected.raw_file;
 			if (expected_file.Open(expected_path, Common::File::Mode::Read) &&
@@ -528,16 +753,28 @@ bool Session::Observe(const FrameView& frame, std::string& error) {
 				expected_file.Read(expected_bytes.data(), static_cast<uint32_t>(expected_bytes.size()),
 				                   &read);
 				expected_file.Close();
-				if (read == expected_bytes.size()) {
+				const auto expected_hash = XXH3_128bits(expected_bytes.data(), expected_bytes.size());
+				if (read == expected_bytes.size() && expected_hash.low64 == expected.digest.low &&
+				    expected_hash.high64 == expected.digest.high) {
 					const auto diff = FrameDirectory(m_options.report) /
 					                  ("diff_" + FrameName(frame.ordinal, "ppm"));
 					if (!SavePpm(diff, frame, expected_bytes)) {
 						record.status     = "mismatch_diff_write_failed";
 						diff_write_failed = true;
+					} else {
+						record.diff_file =
+						    (FrameDirectory(m_options.report).filename() /
+						     ("diff_" + FrameName(frame.ordinal, "ppm")))
+						        .generic_string();
 					}
+				} else {
+					record.status = "mismatch_reference_unavailable";
 				}
 			} else if (!expected_file.IsInvalid()) {
 				expected_file.Close();
+				record.status = "mismatch_reference_unavailable";
+			} else {
+				record.status = "mismatch_reference_unavailable";
 			}
 		}
 	}
@@ -563,6 +800,13 @@ bool Session::WriteManifest(bool complete, std::string& error) const {
 	json["mode"]           = m_options.mode == Mode::Record ? "record" : "compare";
 	json["complete"]       = complete;
 	json["passed"]         = complete && !m_private->failed;
+	if (m_options.mode == Mode::Record) {
+		json["provenance"] = ProvenanceJson(m_options.provenance);
+	} else {
+		json["baseline_provenance"] = ProvenanceJson(m_private->baseline_provenance);
+		json["run_provenance"]      = ProvenanceJson(m_options.provenance);
+		json["environment_match"]   = m_private->environment_compatible;
+	}
 	json["frames"]         = nlohmann::ordered_json::array();
 	for (const auto ordinal: m_options.frame_ordinals) {
 		if (const auto it = m_private->actual.find(ordinal); it != m_private->actual.end()) {
@@ -593,9 +837,12 @@ int Session::Finalize(std::string& error) {
 	}
 	if (!WriteManifest(Complete(), error)) {
 		m_private->failed = true;
+		m_private->reservations.clear();
 		return FailureExitCode;
 	}
-	return ExitCode();
+	const auto exit_code = ExitCode();
+	m_private->reservations.clear();
+	return exit_code;
 }
 
 int Session::ExitCode() const {

--- a/src/graphics/regression/frameRegression.cpp
+++ b/src/graphics/regression/frameRegression.cpp
@@ -1,0 +1,605 @@
+#include "graphics/regression/frameRegression.h"
+
+#include "common/file.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <charconv>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <system_error>
+#include <unordered_set>
+#include <vector>
+#include <xxhash.h>
+
+namespace Libs::Graphics::Regression {
+namespace {
+
+constexpr uint32_t SchemaVersion = 1;
+constexpr int      FailureExitCode = 2;
+constexpr uint64_t MaxManifestBytes = 4ull * 1024ull * 1024ull;
+constexpr size_t   MaxManifestFrames = 4096;
+constexpr size_t   MaxArtifactPathLength = 1024;
+
+struct Digest {
+	uint64_t low  = 0;
+	uint64_t high = 0;
+	bool operator==(const Digest&) const = default;
+};
+
+struct FrameRecord {
+	uint64_t    ordinal   = 0;
+	uint32_t    width     = 0;
+	uint32_t    height    = 0;
+	uint32_t    row_pitch = 0;
+	uint64_t    byte_size = 0;
+	PixelFormat format    = PixelFormat::Rgba8Unorm;
+	Digest      digest;
+	std::string raw_file;
+	std::string image_file;
+	std::string status;
+	Digest      expected;
+	bool        has_expected = false;
+};
+
+std::string Hex(uint64_t value) {
+	std::array<char, 17> text {};
+	std::snprintf(text.data(), text.size(), "%016" PRIx64, value);
+	return text.data();
+}
+
+bool ParseHex(const std::string& text, uint64_t& value) {
+	if (text.size() != 16) {
+		return false;
+	}
+	const auto result = std::from_chars(text.data(), text.data() + text.size(), value, 16);
+	return result.ec == std::errc {} && result.ptr == text.data() + text.size();
+}
+
+const char* PixelFormatName(PixelFormat format) {
+	switch (format) {
+		case PixelFormat::Rgba8Unorm: return "rgba8_unorm";
+		case PixelFormat::Rgba8Srgb: return "rgba8_srgb";
+		case PixelFormat::Bgra8Unorm: return "bgra8_unorm";
+		case PixelFormat::Bgra8Srgb: return "bgra8_srgb";
+		case PixelFormat::A2b10g10r10Unorm: return "a2b10g10r10_unorm";
+		case PixelFormat::A2r10g10b10Unorm: return "a2r10g10b10_unorm";
+		case PixelFormat::Rgba16Float: return "rgba16_float";
+	}
+	return "unknown";
+}
+
+bool ParsePixelFormat(const std::string& text, PixelFormat& format) {
+	for (const auto candidate: {PixelFormat::Rgba8Unorm, PixelFormat::Rgba8Srgb,
+	                            PixelFormat::Bgra8Unorm, PixelFormat::Bgra8Srgb,
+	                            PixelFormat::A2b10g10r10Unorm,
+	                            PixelFormat::A2r10g10b10Unorm, PixelFormat::Rgba16Float}) {
+		if (text == PixelFormatName(candidate)) {
+			format = candidate;
+			return true;
+		}
+	}
+	return false;
+}
+
+bool IsSafeArtifactPath(const std::string& text) {
+	const std::filesystem::path path(text);
+	if (path.empty() || path.is_absolute() || path.has_root_name() || path.has_root_directory()) {
+		return false;
+	}
+	for (const auto& component: path) {
+		if (component == "..") {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool ReadText(const std::filesystem::path& path, std::string& text) {
+	Common::File file;
+	if (!file.Open(path, Common::File::Mode::Read) || file.Size() > MaxManifestBytes) {
+		if (!file.IsInvalid()) {
+			file.Close();
+		}
+		return false;
+	}
+	text.resize(static_cast<size_t>(file.Size()));
+	uint32_t read = 0;
+	if (!text.empty()) {
+		file.Read(text.data(), static_cast<uint32_t>(text.size()), &read);
+	}
+	file.Close();
+	return read == text.size();
+}
+
+bool WriteBytes(const std::filesystem::path& path, const void* data, uint64_t size) {
+	if (!path.parent_path().empty() && !Common::File::CreateDirectories(path.parent_path())) {
+		return false;
+	}
+	Common::File file;
+	if (!file.Create(path)) {
+		return false;
+	}
+	const auto* bytes = static_cast<const uint8_t*>(data);
+	while (size != 0) {
+		const auto chunk = static_cast<uint32_t>(
+		    std::min<uint64_t>(size, std::numeric_limits<uint32_t>::max()));
+		uint32_t written = 0;
+		file.Write(bytes, chunk, &written);
+		if (written != chunk) {
+			file.Close();
+			return false;
+		}
+		bytes += chunk;
+		size -= chunk;
+	}
+	const bool flushed = file.Flush();
+	file.Close();
+	return flushed;
+}
+
+bool WriteText(const std::filesystem::path& path, const std::string& text) {
+	return WriteBytes(path, text.data(), text.size());
+}
+
+std::filesystem::path FrameDirectory(const std::filesystem::path& manifest) {
+	return manifest.parent_path() / (manifest.stem().string() + "_frames");
+}
+
+std::string ComparablePath(const std::filesystem::path& path) {
+	std::error_code error;
+	auto normalized = std::filesystem::absolute(path, error);
+	if (error) {
+		normalized = path;
+	}
+	auto text = normalized.lexically_normal().generic_string();
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	std::transform(text.begin(), text.end(), text.begin(),
+	               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+#endif
+	return text;
+}
+
+bool SameOrWithin(const std::filesystem::path& candidate,
+	              const std::filesystem::path& directory) {
+	const auto path = ComparablePath(candidate);
+	auto       root = ComparablePath(directory);
+	if (path == root) {
+		return true;
+	}
+	if (!root.empty() && root.back() != '/') {
+		root.push_back('/');
+	}
+	return path.starts_with(root);
+}
+
+std::string FrameName(uint64_t ordinal, const char* extension) {
+	char name[64] = {};
+	std::snprintf(name, sizeof(name), "frame_%08" PRIu64 ".%s", ordinal, extension);
+	return name;
+}
+
+bool SavePpm(const std::filesystem::path& path, const FrameView& frame,
+	         std::span<const uint8_t> expected = {}) {
+	const bool rgba = frame.format == PixelFormat::Rgba8Unorm ||
+	                  frame.format == PixelFormat::Rgba8Srgb;
+	const bool bgra = frame.format == PixelFormat::Bgra8Unorm ||
+	                  frame.format == PixelFormat::Bgra8Srgb;
+	if ((!rgba && !bgra) || (!expected.empty() && expected.size() != frame.bytes.size())) {
+		return false;
+	}
+	std::vector<uint8_t> rgb;
+	rgb.reserve(static_cast<size_t>(frame.width) * frame.height * 3u);
+	for (uint32_t y = 0; y < frame.height; y++) {
+		const auto row = static_cast<size_t>(y) * frame.row_pitch;
+		for (uint32_t x = 0; x < frame.width; x++) {
+			const auto offset = row + static_cast<size_t>(x) * 4u;
+			const auto channel = [&](uint32_t index) {
+				const auto actual = frame.bytes[offset + index];
+				return expected.empty() ? actual
+				                        : static_cast<uint8_t>(std::abs(
+				                              static_cast<int>(actual) - expected[offset + index]));
+			};
+			if (rgba) {
+				rgb.push_back(channel(0));
+				rgb.push_back(channel(1));
+				rgb.push_back(channel(2));
+			} else {
+				rgb.push_back(channel(2));
+				rgb.push_back(channel(1));
+				rgb.push_back(channel(0));
+			}
+		}
+	}
+	char header[96] = {};
+	const auto header_size = std::snprintf(header, sizeof(header), "P6\n%u %u\n255\n", frame.width,
+	                                       frame.height);
+	if (header_size <= 0) {
+		return false;
+	}
+	std::vector<uint8_t> ppm(static_cast<size_t>(header_size) + rgb.size());
+	std::copy_n(reinterpret_cast<const uint8_t*>(header), header_size, ppm.begin());
+	std::copy(rgb.begin(), rgb.end(), ppm.begin() + header_size);
+	return WriteBytes(path, ppm.data(), ppm.size());
+}
+
+bool SameLayout(const FrameRecord& expected, const FrameRecord& actual) {
+	return expected.width == actual.width && expected.height == actual.height &&
+	       expected.row_pitch == actual.row_pitch && expected.byte_size == actual.byte_size &&
+	       expected.format == actual.format;
+}
+
+FrameRecord ParseRecord(const nlohmann::json& json, std::string& error) {
+	FrameRecord record;
+	const auto unsigned_field = [&json](const char* name, uint64_t& value) {
+		if (!json.contains(name) || !json[name].is_number_unsigned()) {
+			return false;
+		}
+		value = json[name].get<uint64_t>();
+		return true;
+	};
+	uint64_t width = 0;
+	uint64_t height = 0;
+	uint64_t row_pitch = 0;
+	if (!json.is_object() || !unsigned_field("ordinal", record.ordinal) ||
+	    !unsigned_field("width", width) || !unsigned_field("height", height) ||
+	    !unsigned_field("row_pitch", row_pitch) ||
+	    !unsigned_field("byte_size", record.byte_size) || width > UINT32_MAX ||
+	    height > UINT32_MAX || row_pitch > UINT32_MAX || !json.contains("format") ||
+	    !json["format"].is_string() || !json.contains("hash_low") ||
+	    !json["hash_low"].is_string() || !json.contains("hash_high") ||
+	    !json["hash_high"].is_string()) {
+		error = "invalid frame record";
+		return {};
+	}
+	record.width     = static_cast<uint32_t>(width);
+	record.height    = static_cast<uint32_t>(height);
+	record.row_pitch = static_cast<uint32_t>(row_pitch);
+	if (!ParsePixelFormat(json["format"].get<std::string>(), record.format) ||
+	    !ParseHex(json["hash_low"].get<std::string>(), record.digest.low) ||
+	    !ParseHex(json["hash_high"].get<std::string>(), record.digest.high)) {
+		error = "invalid frame format or digest";
+		return {};
+	}
+	for (const auto* name: {"raw_file", "image_file"}) {
+		if (json.contains(name) && !json[name].is_string()) {
+			error = "invalid frame artifact path";
+			return {};
+		}
+	}
+	if ((json.contains("raw_file") &&
+	     json["raw_file"].get_ref<const std::string&>().size() > MaxArtifactPathLength) ||
+	    (json.contains("image_file") &&
+	     json["image_file"].get_ref<const std::string&>().size() > MaxArtifactPathLength)) {
+		error = "frame artifact path is too long";
+		return {};
+	}
+	record.raw_file   = json.contains("raw_file") ? json["raw_file"].get<std::string>() : "";
+	record.image_file = json.contains("image_file") ? json["image_file"].get<std::string>() : "";
+	if ((!record.raw_file.empty() && !IsSafeArtifactPath(record.raw_file)) ||
+	    (!record.image_file.empty() && !IsSafeArtifactPath(record.image_file))) {
+		error = "unsafe frame artifact path";
+		return {};
+	}
+	const auto bytes_per_pixel = BytesPerPixel(record.format);
+	if (record.width == 0 || record.height == 0 || bytes_per_pixel == 0 ||
+	    record.width > UINT32_MAX / bytes_per_pixel ||
+	    record.row_pitch != record.width * bytes_per_pixel ||
+	    record.byte_size != static_cast<uint64_t>(record.row_pitch) * record.height) {
+		error = "invalid frame dimensions";
+		return {};
+	}
+	return record;
+}
+
+nlohmann::ordered_json RecordJson(const FrameRecord& record) {
+	nlohmann::ordered_json json;
+	json["ordinal"] = record.ordinal;
+	if (record.status == "missing") {
+		json["status"] = record.status;
+		return json;
+	}
+	json["width"]      = record.width;
+	json["height"]     = record.height;
+	json["row_pitch"]  = record.row_pitch;
+	json["byte_size"]  = record.byte_size;
+	json["format"]     = PixelFormatName(record.format);
+	json["hash_low"]   = Hex(record.digest.low);
+	json["hash_high"]  = Hex(record.digest.high);
+	if (!record.raw_file.empty()) {
+		json["raw_file"] = record.raw_file;
+	}
+	if (!record.image_file.empty()) {
+		json["image_file"] = record.image_file;
+	}
+	if (!record.status.empty()) {
+		json["status"] = record.status;
+	}
+	if (record.has_expected) {
+		json["expected_hash_low"]  = Hex(record.expected.low);
+		json["expected_hash_high"] = Hex(record.expected.high);
+	}
+	return json;
+}
+
+} // namespace
+
+uint32_t BytesPerPixel(PixelFormat format) {
+	switch (format) {
+		case PixelFormat::Rgba8Unorm:
+		case PixelFormat::Rgba8Srgb:
+		case PixelFormat::Bgra8Unorm:
+		case PixelFormat::Bgra8Srgb:
+		case PixelFormat::A2b10g10r10Unorm:
+		case PixelFormat::A2r10g10b10Unorm: return 4;
+		case PixelFormat::Rgba16Float: return 8;
+	}
+	return 0;
+}
+
+struct Session::Private {
+	std::map<uint64_t, FrameRecord> expected;
+	std::map<uint64_t, FrameRecord> actual;
+	bool                            failed    = false;
+	bool                            finalized = false;
+};
+
+Session::Session(Options options)
+    : m_options(std::move(options)), m_private(std::make_unique<Private>()) {}
+
+Session::~Session() = default;
+
+std::unique_ptr<Session> Session::Create(Options options, std::string& error) {
+	error.clear();
+	auto session = std::unique_ptr<Session>(new Session(std::move(options)));
+	if (!session->Initialize(error)) {
+		return {};
+	}
+	return session;
+}
+
+bool Session::Initialize(std::string& error) {
+	if (m_options.baseline.empty() || m_options.frame_ordinals.empty() ||
+	    (m_options.mode == Mode::Compare && m_options.report.empty())) {
+		error = "regression baseline, report, and frame ordinals are required";
+		return false;
+	}
+	if (m_options.frame_ordinals.size() > MaxManifestFrames) {
+		error = "too many regression frame ordinals";
+		return false;
+	}
+	std::sort(m_options.frame_ordinals.begin(), m_options.frame_ordinals.end());
+	if (std::adjacent_find(m_options.frame_ordinals.begin(), m_options.frame_ordinals.end()) !=
+	    m_options.frame_ordinals.end()) {
+		error = "regression frame ordinals must be unique";
+		return false;
+	}
+	if (m_options.mode == Mode::Record) {
+		if (Common::File::IsFileExisting(m_options.baseline)) {
+			error = "refusing to overwrite an existing regression baseline";
+			return false;
+		}
+		return true;
+	}
+	if (ComparablePath(m_options.baseline) == ComparablePath(m_options.report) ||
+	    ComparablePath(FrameDirectory(m_options.baseline)) ==
+	        ComparablePath(FrameDirectory(m_options.report)) ||
+	    SameOrWithin(m_options.report, FrameDirectory(m_options.baseline))) {
+		error = "regression baseline and report outputs collide";
+		return false;
+	}
+
+	std::string source;
+	if (!ReadText(m_options.baseline, source)) {
+		error = "cannot read regression baseline";
+		return false;
+	}
+	auto json = nlohmann::json::parse(source, nullptr, false);
+	if (json.is_discarded() || !json.is_object() || !json.contains("schema_version") ||
+	    !json["schema_version"].is_number_unsigned() ||
+	    json["schema_version"].get<uint64_t>() != SchemaVersion || !json.contains("algorithm") ||
+	    !json["algorithm"].is_string() ||
+	    json["algorithm"].get<std::string>() != "xxh3_128" || !json.contains("complete") ||
+	    !json["complete"].is_boolean() || !json["complete"].get<bool>() ||
+	    !json.contains("frames") || !json["frames"].is_array() ||
+	    json["frames"].size() > MaxManifestFrames) {
+		error = "invalid or incomplete regression baseline";
+		return false;
+	}
+	for (const auto& entry: json["frames"]) {
+		auto record = ParseRecord(entry, error);
+		if (!error.empty()) {
+			return false;
+		}
+		if (!m_private->expected.emplace(record.ordinal, std::move(record)).second) {
+			error = "duplicate frame in regression baseline";
+			return false;
+		}
+	}
+	for (const auto ordinal: m_options.frame_ordinals) {
+		if (!m_private->expected.contains(ordinal)) {
+			error = "requested frame is missing from regression baseline";
+			return false;
+		}
+	}
+	std::unordered_set<std::string> protected_artifacts;
+	for (const auto& [ordinal, record]: m_private->expected) {
+		(void)ordinal;
+		if (!record.raw_file.empty()) {
+			protected_artifacts.insert(
+			    ComparablePath(m_options.baseline.parent_path() / record.raw_file));
+		}
+		if (!record.image_file.empty()) {
+			protected_artifacts.insert(
+			    ComparablePath(m_options.baseline.parent_path() / record.image_file));
+		}
+	}
+	if (protected_artifacts.contains(ComparablePath(m_options.report))) {
+		error = "regression report would overwrite a baseline artifact";
+		return false;
+	}
+	if (m_options.save_raw_frames) {
+		const auto output_directory = FrameDirectory(m_options.report);
+		for (const auto ordinal: m_options.frame_ordinals) {
+			for (const auto& name: {FrameName(ordinal, "raw"), FrameName(ordinal, "ppm"),
+			                       "diff_" + FrameName(ordinal, "ppm")}) {
+				if (protected_artifacts.contains(ComparablePath(output_directory / name))) {
+					error = "regression output would overwrite a baseline artifact";
+					return false;
+				}
+			}
+		}
+	}
+	return true;
+}
+
+bool Session::WantsFrame(uint64_t ordinal) const {
+	return std::binary_search(m_options.frame_ordinals.begin(), m_options.frame_ordinals.end(),
+	                          ordinal) &&
+	       !m_private->actual.contains(ordinal);
+}
+
+bool Session::Observe(const FrameView& frame, std::string& error) {
+	error.clear();
+	if (!WantsFrame(frame.ordinal)) {
+		error = "unexpected or duplicate regression frame";
+		return false;
+	}
+	const auto bytes_per_pixel = BytesPerPixel(frame.format);
+	if (frame.width == 0 || frame.height == 0 || bytes_per_pixel == 0 ||
+	    frame.width > UINT32_MAX / bytes_per_pixel ||
+	    frame.row_pitch != frame.width * bytes_per_pixel ||
+	    frame.bytes.size() != static_cast<uint64_t>(frame.row_pitch) * frame.height) {
+		error = "invalid regression frame layout";
+		return false;
+	}
+	const auto hash = XXH3_128bits(frame.bytes.data(), frame.bytes.size());
+	FrameRecord record;
+	record.ordinal   = frame.ordinal;
+	record.width     = frame.width;
+	record.height    = frame.height;
+	record.row_pitch = frame.row_pitch;
+	record.byte_size = frame.bytes.size();
+	record.format    = frame.format;
+	record.digest    = {.low = hash.low64, .high = hash.high64};
+
+	const auto& manifest = m_options.mode == Mode::Record ? m_options.baseline : m_options.report;
+	if (m_options.save_raw_frames) {
+		const auto directory = FrameDirectory(manifest);
+		record.raw_file = (directory.filename() / FrameName(frame.ordinal, "raw")).generic_string();
+		if (!WriteBytes(manifest.parent_path() / record.raw_file, frame.bytes.data(),
+		                frame.bytes.size())) {
+			error = "cannot write regression raw frame";
+			return false;
+		}
+		if (frame.format == PixelFormat::Rgba8Unorm || frame.format == PixelFormat::Rgba8Srgb ||
+		    frame.format == PixelFormat::Bgra8Unorm || frame.format == PixelFormat::Bgra8Srgb) {
+			record.image_file =
+			    (directory.filename() / FrameName(frame.ordinal, "ppm")).generic_string();
+			if (!SavePpm(manifest.parent_path() / record.image_file, frame)) {
+				error = "cannot write regression preview image";
+				return false;
+			}
+		}
+	}
+
+	bool diff_write_failed = false;
+	if (m_options.mode == Mode::Record) {
+		record.status = "recorded";
+	} else {
+		const auto& expected = m_private->expected.at(frame.ordinal);
+		record.expected     = expected.digest;
+		record.has_expected = true;
+		const bool match    = SameLayout(expected, record) && expected.digest == record.digest;
+		record.status       = match ? "match" : "mismatch";
+		m_private->failed   = m_private->failed || !match;
+		if (!match && m_options.save_raw_frames && !expected.raw_file.empty() &&
+		    SameLayout(expected, record)) {
+			Common::File expected_file;
+			const auto expected_path = m_options.baseline.parent_path() / expected.raw_file;
+			if (expected_file.Open(expected_path, Common::File::Mode::Read) &&
+			    expected_file.Size() == frame.bytes.size() && frame.bytes.size() <= UINT32_MAX) {
+				std::vector<uint8_t> expected_bytes(frame.bytes.size());
+				uint32_t              read = 0;
+				expected_file.Read(expected_bytes.data(), static_cast<uint32_t>(expected_bytes.size()),
+				                   &read);
+				expected_file.Close();
+				if (read == expected_bytes.size()) {
+					const auto diff = FrameDirectory(m_options.report) /
+					                  ("diff_" + FrameName(frame.ordinal, "ppm"));
+					if (!SavePpm(diff, frame, expected_bytes)) {
+						record.status     = "mismatch_diff_write_failed";
+						diff_write_failed = true;
+					}
+				}
+			} else if (!expected_file.IsInvalid()) {
+				expected_file.Close();
+			}
+		}
+	}
+	m_private->actual.emplace(frame.ordinal, std::move(record));
+	if (!WriteManifest(Complete(), error)) {
+		return false;
+	}
+	if (diff_write_failed) {
+		error = "cannot write regression difference image";
+		return false;
+	}
+	return true;
+}
+
+bool Session::Complete() const {
+	return m_private->actual.size() == m_options.frame_ordinals.size();
+}
+
+bool Session::WriteManifest(bool complete, std::string& error) const {
+	nlohmann::ordered_json json;
+	json["schema_version"] = SchemaVersion;
+	json["algorithm"]      = "xxh3_128";
+	json["mode"]           = m_options.mode == Mode::Record ? "record" : "compare";
+	json["complete"]       = complete;
+	json["passed"]         = complete && !m_private->failed;
+	json["frames"]         = nlohmann::ordered_json::array();
+	for (const auto ordinal: m_options.frame_ordinals) {
+		if (const auto it = m_private->actual.find(ordinal); it != m_private->actual.end()) {
+			json["frames"].push_back(RecordJson(it->second));
+		} else {
+			FrameRecord missing;
+			missing.ordinal = ordinal;
+			missing.status  = "missing";
+			json["frames"].push_back(RecordJson(missing));
+		}
+	}
+	const auto& path = m_options.mode == Mode::Record ? m_options.baseline : m_options.report;
+	if (!WriteText(path, json.dump(2) + "\n")) {
+		error = "cannot write regression manifest";
+		return false;
+	}
+	return true;
+}
+
+int Session::Finalize(std::string& error) {
+	error.clear();
+	if (m_private->finalized) {
+		return ExitCode();
+	}
+	m_private->finalized = true;
+	if (!Complete()) {
+		m_private->failed = true;
+	}
+	if (!WriteManifest(Complete(), error)) {
+		m_private->failed = true;
+		return FailureExitCode;
+	}
+	return ExitCode();
+}
+
+int Session::ExitCode() const {
+	return m_private->failed ? FailureExitCode : 0;
+}
+
+} // namespace Libs::Graphics::Regression

--- a/src/graphics/regression/frameRegression.h
+++ b/src/graphics/regression/frameRegression.h
@@ -1,0 +1,69 @@
+#ifndef KYTY_GRAPHICS_REGRESSION_FRAMEREGRESSION_H_
+#define KYTY_GRAPHICS_REGRESSION_FRAMEREGRESSION_H_
+
+#include "common/common.h"
+
+#include <filesystem>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace Libs::Graphics::Regression {
+
+enum class Mode { Record, Compare };
+
+enum class PixelFormat : uint32_t {
+	Rgba8Unorm = 1,
+	Rgba8Srgb,
+	Bgra8Unorm,
+	Bgra8Srgb,
+	A2b10g10r10Unorm,
+	A2r10g10b10Unorm,
+	Rgba16Float,
+};
+
+struct Options {
+	Mode                  mode = Mode::Compare;
+	std::filesystem::path baseline;
+	std::filesystem::path report;
+	std::vector<uint64_t> frame_ordinals;
+	bool                  save_raw_frames = true;
+};
+
+struct FrameView {
+	uint64_t                 ordinal  = 0;
+	uint32_t                 width    = 0;
+	uint32_t                 height   = 0;
+	uint32_t                 row_pitch = 0;
+	PixelFormat              format   = PixelFormat::Rgba8Unorm;
+	std::span<const uint8_t> bytes;
+};
+
+class Session {
+public:
+	static std::unique_ptr<Session> Create(Options options, std::string& error);
+	~Session();
+	KYTY_CLASS_NO_COPY(Session);
+
+	[[nodiscard]] bool WantsFrame(uint64_t ordinal) const;
+	[[nodiscard]] bool Observe(const FrameView& frame, std::string& error);
+	[[nodiscard]] bool Complete() const;
+	[[nodiscard]] int  Finalize(std::string& error);
+	[[nodiscard]] int  ExitCode() const;
+
+private:
+	explicit Session(Options options);
+	[[nodiscard]] bool Initialize(std::string& error);
+	[[nodiscard]] bool WriteManifest(bool complete, std::string& error) const;
+
+	struct Private;
+	Options                  m_options;
+	std::unique_ptr<Private> m_private;
+};
+
+[[nodiscard]] uint32_t BytesPerPixel(PixelFormat format);
+
+} // namespace Libs::Graphics::Regression
+
+#endif // KYTY_GRAPHICS_REGRESSION_FRAMEREGRESSION_H_

--- a/src/graphics/regression/frameRegression.h
+++ b/src/graphics/regression/frameRegression.h
@@ -11,6 +11,8 @@
 
 namespace Libs::Graphics::Regression {
 
+inline constexpr uint64_t MaxFrameBytes = 512ull * 1024ull * 1024ull;
+
 enum class Mode { Record, Compare };
 
 enum class PixelFormat : uint32_t {
@@ -23,12 +25,28 @@ enum class PixelFormat : uint32_t {
 	Rgba16Float,
 };
 
+struct Provenance {
+	std::string test_id;
+	std::string build_id;
+	std::string gpu_name;
+	std::string configuration;
+	uint32_t    gpu_vendor_id    = 0;
+	uint32_t    gpu_device_id    = 0;
+	uint32_t    gpu_driver       = 0;
+	uint32_t    vulkan_api       = 0;
+
+	[[nodiscard]] bool CompatibleWith(const Provenance& other) const;
+};
+
 struct Options {
 	Mode                  mode = Mode::Compare;
 	std::filesystem::path baseline;
 	std::filesystem::path report;
+	std::filesystem::path capture;
 	std::vector<uint64_t> frame_ordinals;
+	Provenance            provenance;
 	bool                  save_raw_frames = true;
+	bool                  allow_environment_mismatch = false;
 };
 
 struct FrameView {

--- a/src/graphics/regression/frameRegressionVulkan.cpp
+++ b/src/graphics/regression/frameRegressionVulkan.cpp
@@ -1,0 +1,158 @@
+#include "graphics/regression/frameRegressionVulkan.h"
+
+#include "common/emulatorConfig.h"
+#include "common/logging/log.h"
+#include "graphics/host_gpu/graphicContext.h"
+#include "graphics/host_gpu/transfer.h"
+#include "graphics/regression/frameRegression.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace Libs::Graphics::Regression {
+namespace {
+
+constexpr int FailureExitCode = 2;
+
+class Controller {
+public:
+	bool Initialize() {
+		const auto configured_mode = Config::GetFrameRegressionMode();
+		if (configured_mode == Config::FrameRegressionMode::None) {
+			return true;
+		}
+		enabled            = true;
+		exit_on_complete   = Config::FrameRegressionExitOnComplete();
+		Options options {
+		    .mode = configured_mode == Config::FrameRegressionMode::Record ? Mode::Record
+		                                                                 : Mode::Compare,
+		    .baseline = Config::GetFrameRegressionBaseline(),
+		    .report = Config::GetFrameRegressionReport(),
+		    .frame_ordinals = Config::GetFrameRegressionFrames(),
+		    .save_raw_frames = Config::FrameRegressionSaveRaw(),
+		};
+		session = Session::Create(std::move(options), error);
+		if (session == nullptr) {
+			Fail("initialization", error);
+			return false;
+		}
+		LOGF("Frame regression enabled for %zu presentation ordinal(s)\n",
+		     Config::GetFrameRegressionFrames().size());
+		return true;
+	}
+
+	bool Observe(VulkanImage& image) {
+		const auto ordinal = next_ordinal++;
+		if (!enabled || session == nullptr || !session->WantsFrame(ordinal)) {
+			return failed;
+		}
+
+		const auto format = ToPixelFormat(image.format);
+		if (!format.has_value()) {
+			Fail("readback", "unsupported presented-frame Vulkan format");
+			return true;
+		}
+		const auto bytes_per_pixel = BytesPerPixel(*format);
+		if (image.extent.width == 0 || image.extent.height == 0 || bytes_per_pixel == 0 ||
+		    image.extent.width > std::numeric_limits<uint32_t>::max() / bytes_per_pixel) {
+			Fail("readback", "invalid presented-frame dimensions");
+			return true;
+		}
+		const auto row_pitch = image.extent.width * bytes_per_pixel;
+		const auto byte_size = static_cast<uint64_t>(row_pitch) * image.extent.height;
+		if (byte_size > std::numeric_limits<size_t>::max()) {
+			Fail("readback", "presented frame is too large for host memory");
+			return true;
+		}
+
+		std::vector<uint8_t> bytes(static_cast<size_t>(byte_size));
+		// Vulkan bufferRowLength is measured in texels; FrameView::row_pitch is measured in bytes.
+		Transfer::DownloadImage(bytes.data(), byte_size, image.extent.width, image,
+		                        vk::ImageLayout::eTransferSrcOptimal);
+		FrameView frame {.ordinal = ordinal,
+		                 .width = image.extent.width,
+		                 .height = image.extent.height,
+		                 .row_pitch = row_pitch,
+		                 .format = *format,
+		                 .bytes = bytes};
+		error.clear();
+		if (!session->Observe(frame, error)) {
+			Fail("observation", error);
+			return true;
+		}
+		if (session->Complete()) {
+			LOGF("Frame regression completed with exit code %d\n", session->ExitCode());
+			return exit_on_complete;
+		}
+		return false;
+	}
+
+	int Finalize() {
+		if (!enabled) {
+			return 0;
+		}
+		if (session == nullptr) {
+			return FailureExitCode;
+		}
+		error.clear();
+		const auto result = session->Finalize(error);
+		if (!error.empty()) {
+			Fail("finalization", error);
+		}
+		return failed ? FailureExitCode : result;
+	}
+
+private:
+	static std::optional<PixelFormat> ToPixelFormat(vk::Format format) {
+		switch (format) {
+			case vk::Format::eR8G8B8A8Unorm: return PixelFormat::Rgba8Unorm;
+			case vk::Format::eR8G8B8A8Srgb: return PixelFormat::Rgba8Srgb;
+			case vk::Format::eB8G8R8A8Unorm: return PixelFormat::Bgra8Unorm;
+			case vk::Format::eB8G8R8A8Srgb: return PixelFormat::Bgra8Srgb;
+			case vk::Format::eA2B10G10R10UnormPack32: return PixelFormat::A2b10g10r10Unorm;
+			case vk::Format::eA2R10G10B10UnormPack32: return PixelFormat::A2r10g10b10Unorm;
+			case vk::Format::eR16G16B16A16Sfloat: return PixelFormat::Rgba16Float;
+			default: return {};
+		}
+	}
+
+	void Fail(const char* stage, const std::string& message) {
+		failed = true;
+		::printf("Frame regression %s failed: %s\n", stage, message.c_str());
+		LOGF("Frame regression %s failed: %s\n", stage, message.c_str());
+	}
+
+	std::unique_ptr<Session> session;
+	std::string              error;
+	uint64_t                 next_ordinal     = 0;
+	bool                     enabled          = false;
+	bool                     failed           = false;
+	bool                     exit_on_complete = true;
+};
+
+std::unique_ptr<Controller> g_controller;
+
+} // namespace
+
+bool InitializeFrameRegression() {
+	if (g_controller != nullptr) {
+		return false;
+	}
+	g_controller = std::make_unique<Controller>();
+	return g_controller->Initialize();
+}
+
+bool ObservePresentedFrame(VulkanImage& image) {
+	return g_controller != nullptr && g_controller->Observe(image);
+}
+
+int FinalizeFrameRegression() {
+	return g_controller == nullptr ? 0 : g_controller->Finalize();
+}
+
+} // namespace Libs::Graphics::Regression

--- a/src/graphics/regression/frameRegressionVulkan.cpp
+++ b/src/graphics/regression/frameRegressionVulkan.cpp
@@ -3,11 +3,14 @@
 #include "common/emulatorConfig.h"
 #include "common/logging/log.h"
 #include "graphics/host_gpu/graphicContext.h"
+#include "graphics/host_gpu/renderer/renderContext.h"
 #include "graphics/host_gpu/transfer.h"
 #include "graphics/regression/frameRegression.h"
+#include "kytyGitVersion.h"
 
 #include <algorithm>
 #include <cstdio>
+#include <fmt/format.h>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -28,13 +31,33 @@ public:
 		}
 		enabled            = true;
 		exit_on_complete   = Config::FrameRegressionExitOnComplete();
+		const auto& properties = GetRenderContext().GetGraphics().GetPhysicalDeviceProperties();
 		Options options {
 		    .mode = configured_mode == Config::FrameRegressionMode::Record ? Mode::Record
 		                                                                 : Mode::Compare,
 		    .baseline = Config::GetFrameRegressionBaseline(),
 		    .report = Config::GetFrameRegressionReport(),
+		    .capture = Config::GetGpuCaptureFile(),
 		    .frame_ordinals = Config::GetFrameRegressionFrames(),
+		    .provenance = {
+		        .test_id = Config::GetFrameRegressionTestId(),
+		        .build_id = KYTY_GIT_VERSION,
+		        .gpu_name = properties.deviceName.data(),
+		        .configuration = fmt::format(
+		            "screen={}x{};vblank={};vulkan_validation={};shader_validation={};"
+		            "shader_optimization={};spirv_debug_printf={};ngg_rectlist={}",
+		            Config::GetScreenWidth(), Config::GetScreenHeight(), Config::GetVblankFrequency(),
+		            Config::VulkanValidationEnabled(), Config::ShaderValidationEnabled(),
+		            static_cast<uint32_t>(Config::GetShaderOptimizationType()),
+		            Config::SpirvDebugPrintfEnabled(), Config::NggRectlistDrawEnabled()),
+		        .gpu_vendor_id = properties.vendorID,
+		        .gpu_device_id = properties.deviceID,
+		        .gpu_driver = properties.driverVersion,
+		        .vulkan_api = properties.apiVersion,
+		    },
 		    .save_raw_frames = Config::FrameRegressionSaveRaw(),
+		    .allow_environment_mismatch =
+		        Config::FrameRegressionAllowEnvironmentMismatch(),
 		};
 		session = Session::Create(std::move(options), error);
 		if (session == nullptr) {
@@ -65,7 +88,7 @@ public:
 		}
 		const auto row_pitch = image.extent.width * bytes_per_pixel;
 		const auto byte_size = static_cast<uint64_t>(row_pitch) * image.extent.height;
-		if (byte_size > std::numeric_limits<size_t>::max()) {
+		if (byte_size > std::numeric_limits<size_t>::max() || byte_size > MaxFrameBytes) {
 			Fail("readback", "presented frame is too large for host memory");
 			return true;
 		}

--- a/src/graphics/regression/frameRegressionVulkan.h
+++ b/src/graphics/regression/frameRegressionVulkan.h
@@ -1,0 +1,20 @@
+#ifndef KYTY_GRAPHICS_REGRESSION_FRAMEREGRESSIONVULKAN_H_
+#define KYTY_GRAPHICS_REGRESSION_FRAMEREGRESSIONVULKAN_H_
+
+#include "common/common.h"
+
+namespace Libs::Graphics {
+
+struct VulkanImage;
+
+namespace Regression {
+
+// These functions form the only Vulkan-facing edge of the CPU-testable regression module.
+[[nodiscard]] bool InitializeFrameRegression();
+[[nodiscard]] bool ObservePresentedFrame(VulkanImage& image);
+[[nodiscard]] int  FinalizeFrameRegression();
+
+} // namespace Regression
+} // namespace Libs::Graphics
+
+#endif // KYTY_GRAPHICS_REGRESSION_FRAMEREGRESSIONVULKAN_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,8 +10,11 @@
 #include "emulator.h"
 #include "kytyGitVersion.h"
 
+#include <charconv>
 #include <cstdio>
 #include <fmt/format.h>
+#include <string_view>
+#include <vector>
 
 using namespace Common;
 using namespace Emulator;
@@ -60,6 +63,13 @@ static void PrintUsage() {
 	::printf("  --ngg-rectlist-draw <true|false>     Draw rect-list auto draws using the NGG "
 	         "4-vertex path.\n");
 	::printf("  --rd                                 Enable RenderDoc capture.\n");
+	::printf("  --gpu-capture <path>                 Record a commands-only GPU trace.\n");
+	::printf("  --regression-record <path>           Record selected presented frames.\n");
+	::printf("  --regression-compare <path>          Compare against a frame baseline.\n");
+	::printf("  --regression-report <path>           Comparison report path.\n");
+	::printf("  --regression-frames <n[,n...]>       Zero-based presentation ordinals.\n");
+	::printf("  --regression-save-raw <true|false>   Save raw frames and previews.\n");
+	::printf("  --regression-exit-on-complete <true|false> Exit after selected frames.\n");
 }
 
 static bool NextArg(int argc, char* argv[], int& index, std::string& out) {
@@ -86,6 +96,29 @@ static bool ParseBool(const std::string& value, bool& out) {
 	}
 
 	return false;
+}
+
+static bool ParseFrameOrdinals(std::string_view value, std::vector<uint64_t>& out) {
+	out.clear();
+	while (!value.empty()) {
+		const auto comma = value.find(',');
+		const auto token = value.substr(0, comma);
+		uint64_t   ordinal = 0;
+		const auto result = std::from_chars(token.data(), token.data() + token.size(), ordinal);
+		if (token.empty() || result.ec != std::errc {} ||
+		    result.ptr != token.data() + token.size()) {
+			return false;
+		}
+		out.push_back(ordinal);
+		if (comma == std::string_view::npos) {
+			break;
+		}
+		if (comma + 1 == value.size()) {
+			return false;
+		}
+		value.remove_prefix(comma + 1);
+	}
+	return !out.empty();
 }
 
 template <typename E>
@@ -210,10 +243,44 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
 				return false;
 			}
+		} else if (arg == "--gpu-capture") {
+			options.config.gpu_capture_file = value;
+		} else if (arg == "--regression-record" || arg == "--regression-compare") {
+			if (options.config.frame_regression_mode != Config::FrameRegressionMode::None) {
+				::printf("regression mode can only be specified once\n");
+				return false;
+			}
+			options.config.frame_regression_mode =
+			    arg == "--regression-record" ? Config::FrameRegressionMode::Record
+			                                 : Config::FrameRegressionMode::Compare;
+			options.config.frame_regression_baseline = value;
+		} else if (arg == "--regression-report") {
+			options.config.frame_regression_report = value;
+		} else if (arg == "--regression-frames") {
+			if (!ParseFrameOrdinals(value, options.config.frame_regression_frames)) {
+				::printf("invalid frame ordinal list: %s\n", value.c_str());
+				return false;
+			}
+		} else if (arg == "--regression-save-raw") {
+			if (!ParseBool(value, options.config.frame_regression_save_raw)) {
+				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
+				return false;
+			}
+		} else if (arg == "--regression-exit-on-complete") {
+			if (!ParseBool(value, options.config.frame_regression_exit_on_complete)) {
+				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
+				return false;
+			}
 		} else {
 			::printf("unknown option: %s\n", arg.c_str());
 			return false;
 		}
+	}
+
+	if (options.config.frame_regression_mode != Config::FrameRegressionMode::None &&
+	    options.config.frame_regression_frames.empty()) {
+		::printf("--regression-frames is required with a regression mode\n");
+		return false;
 	}
 
 	return show_help || (!options.app0_dir.empty() && !options.elf.empty());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,8 +68,10 @@ static void PrintUsage() {
 	::printf("  --regression-compare <path>          Compare against a frame baseline.\n");
 	::printf("  --regression-report <path>           Comparison report path.\n");
 	::printf("  --regression-frames <n[,n...]>       Zero-based presentation ordinals.\n");
+	::printf("  --regression-test-id <id>            Stable game/revision/checkpoint identity.\n");
 	::printf("  --regression-save-raw <true|false>   Save raw frames and previews.\n");
 	::printf("  --regression-exit-on-complete <true|false> Exit after selected frames.\n");
+	::printf("  --regression-allow-environment-mismatch <true|false> Override provenance checks.\n");
 }
 
 static bool NextArg(int argc, char* argv[], int& index, std::string& out) {
@@ -261,6 +263,8 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 				::printf("invalid frame ordinal list: %s\n", value.c_str());
 				return false;
 			}
+		} else if (arg == "--regression-test-id") {
+			options.config.frame_regression_test_id = value;
 		} else if (arg == "--regression-save-raw") {
 			if (!ParseBool(value, options.config.frame_regression_save_raw)) {
 				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
@@ -268,6 +272,11 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 			}
 		} else if (arg == "--regression-exit-on-complete") {
 			if (!ParseBool(value, options.config.frame_regression_exit_on_complete)) {
+				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
+				return false;
+			}
+		} else if (arg == "--regression-allow-environment-mismatch") {
+			if (!ParseBool(value, options.config.frame_regression_allow_environment_mismatch)) {
 				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
 				return false;
 			}
@@ -280,6 +289,16 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 	if (options.config.frame_regression_mode != Config::FrameRegressionMode::None &&
 	    options.config.frame_regression_frames.empty()) {
 		::printf("--regression-frames is required with a regression mode\n");
+		return false;
+	}
+	if (options.config.frame_regression_mode != Config::FrameRegressionMode::None &&
+	    options.config.frame_regression_test_id.empty()) {
+		::printf("--regression-test-id is required with a regression mode\n");
+		return false;
+	}
+	std::string path_error;
+	if (!Config::ValidateFrameRegressionPaths(options.config, path_error)) {
+		::printf("%s\n", path_error.c_str());
 		return false;
 	}
 

--- a/tests/FrameRegressionTests.cpp
+++ b/tests/FrameRegressionTests.cpp
@@ -14,6 +14,7 @@ using Libs::Graphics::Regression::FrameView;
 using Libs::Graphics::Regression::Mode;
 using Libs::Graphics::Regression::Options;
 using Libs::Graphics::Regression::PixelFormat;
+using Libs::Graphics::Regression::Provenance;
 using Libs::Graphics::Regression::Session;
 
 void Check(bool condition, const char* message) {
@@ -32,12 +33,25 @@ FrameView View(uint64_t ordinal, const std::vector<uint8_t>& pixels) {
 	        .bytes = pixels};
 }
 
+Provenance TestProvenance() {
+	return {.test_id = "test-game/revision/checkpoint",
+	        .build_id = "test-build",
+	        .gpu_name = "test-gpu",
+	        .configuration = "test-configuration",
+	        .gpu_vendor_id = 1,
+	        .gpu_device_id = 2,
+	        .gpu_driver = 3,
+	        .vulkan_api = 4};
+}
+
 std::unique_ptr<Session> Create(Mode mode, const std::filesystem::path& baseline,
 	                            const std::filesystem::path& report, std::string& error) {
 	return Session::Create(Options {.mode = mode,
 	                                .baseline = baseline,
 	                                .report = report,
+	                                .capture = {},
 	                                .frame_ordinals = {1, 3},
+	                                .provenance = TestProvenance(),
 	                                .save_raw_frames = true},
 	                       error);
 }
@@ -59,27 +73,58 @@ int main() {
 	std::string error;
 	auto record = Create(Mode::Record, baseline, {}, error);
 	Check(record != nullptr, error.c_str());
+	Check(Create(Mode::Record, root / "reserved.kyty-lock", {}, error) == nullptr &&
+	          error.find("reserved") != std::string::npos,
+	      "reservation suffix protection");
+	Check(Create(Mode::Record, baseline, {}, error) == nullptr &&
+	          error.find("use") != std::string::npos,
+	      "concurrent baseline writer protection");
+	error.clear();
 	Check(!record->WantsFrame(0) && record->WantsFrame(1), "frame selection");
 	Check(record->Observe(View(1, first), error), error.c_str());
 	Check(record->Observe(View(3, second), error), error.c_str());
 	Check(record->Complete() && record->Finalize(error) == 0, "baseline completion");
 	Check(std::filesystem::is_regular_file(baseline), "baseline manifest");
-	Check(std::filesystem::is_regular_file(root / "baseline_frames/frame_00000001.ppm"),
+	Check(std::filesystem::is_regular_file(root / "baseline.json_frames/frame_00000001.ppm"),
 	      "baseline preview");
+
+	const auto parallel_json = root / "parallel.json";
+	const auto parallel_text = root / "parallel.txt";
+	auto parallel_first = Create(Mode::Record, parallel_json, {}, error);
+	auto parallel_second = Create(Mode::Record, parallel_text, {}, error);
+	Check(parallel_first != nullptr && parallel_second != nullptr,
+	      "same-stem outputs must have independent reservations");
+	Check(parallel_first->Observe(View(1, first), error) &&
+	          parallel_first->Observe(View(3, second), error) &&
+	          parallel_first->Finalize(error) == 0,
+	      "first parallel baseline");
+	Check(parallel_second->Observe(View(1, first), error) &&
+	          parallel_second->Observe(View(3, second), error) &&
+	          parallel_second->Finalize(error) == 0,
+	      "second parallel baseline");
+	Check(std::filesystem::is_directory(root / "parallel.json_frames") &&
+	          std::filesystem::is_directory(root / "parallel.txt_frames"),
+	      "same-stem artifact isolation");
 
 	error.clear();
 	Check(Create(Mode::Record, baseline, {}, error) == nullptr &&
 	          error.find("overwrite") != std::string::npos,
 	      "baseline overwrite protection");
+	const auto directory_report = root / "directory-report.json";
+	std::filesystem::create_directory(directory_report);
+	Check(Create(Mode::Compare, baseline, directory_report, error) == nullptr &&
+	          error.find("directory") != std::string::npos,
+	      "report directory protection");
 
 	Check(Create(Mode::Compare, baseline, baseline, error) == nullptr &&
 	          error.find("collide") != std::string::npos,
 	      "baseline manifest collision protection");
-	Check(Create(Mode::Compare, baseline, root / "baseline.txt", error) == nullptr &&
+	Check(Create(Mode::Compare, baseline, root / "baseline.json_frames/report.json", error) ==
+	          nullptr &&
 	          error.find("collide") != std::string::npos,
 	      "baseline artifact collision protection");
 	Check(Create(Mode::Compare, baseline,
-	             root / "baseline_frames/frame_00000001.raw", error) == nullptr &&
+	             root / "baseline.json_frames/frame_00000001.raw", error) == nullptr &&
 	          error.find("collide") != std::string::npos,
 	      "baseline referenced-artifact collision protection");
 
@@ -99,6 +144,23 @@ int main() {
 	Check(compare->Observe(View(1, first), error), error.c_str());
 	Check(compare->Observe(View(3, second), error), error.c_str());
 	Check(compare->Finalize(error) == 0, "exact comparison");
+	Check(!compare->Observe(View(1, first), error), "finalized session must reject frames");
+
+	auto incompatible_options = Options {.mode = Mode::Compare,
+	                                     .baseline = baseline,
+	                                     .report = root / "incompatible.json",
+	                                     .capture = {},
+	                                     .frame_ordinals = {1, 3},
+	                                     .provenance = TestProvenance(),
+	                                     .save_raw_frames = false};
+	incompatible_options.provenance.gpu_driver++;
+	error.clear();
+	Check(Session::Create(incompatible_options, error) == nullptr &&
+	          error.find("provenance") != std::string::npos,
+	      "environment mismatch protection");
+	incompatible_options.allow_environment_mismatch = true;
+	Check(Session::Create(incompatible_options, error) != nullptr,
+	      "explicit environment mismatch override");
 
 	auto changed = second;
 	changed[5] ^= 0x40;
@@ -109,14 +171,61 @@ int main() {
 	Check(mismatch->Observe(View(3, changed), error), error.c_str());
 	Check(mismatch->Finalize(error) == 2, "mismatch exit code");
 	Check(std::filesystem::is_regular_file(
-	          root / "mismatch_frames/diff_frame_00000003.ppm"),
+	          root / "mismatch.json_frames/diff_frame_00000003.ppm"),
 	      "mismatch diff image");
+	error.clear();
+	Check(Create(Mode::Compare, mismatch_report, root / "invalid-baseline-report.json", error) ==
+	          nullptr &&
+	          error.find("baseline") != std::string::npos,
+	      "failed comparison report cannot become a baseline");
+
+	auto alpha_changed = first;
+	alpha_changed[3] = 0;
+	const auto alpha_report = root / "alpha.json";
+	auto alpha_mismatch = Create(Mode::Compare, baseline, alpha_report, error);
+	Check(alpha_mismatch != nullptr, error.c_str());
+	Check(alpha_mismatch->Observe(View(1, alpha_changed), error), error.c_str());
+	Check(alpha_mismatch->Observe(View(3, second), error), error.c_str());
+	Check(alpha_mismatch->Finalize(error) == 2, "alpha mismatch exit code");
+	const auto alpha_diff = root / "alpha.json_frames/diff_frame_00000001.ppm";
+	std::ifstream alpha_stream(alpha_diff, std::ios::binary);
+	const std::vector<uint8_t> alpha_bytes {std::istreambuf_iterator<char>(alpha_stream), {}};
+	Check(alpha_bytes.size() >= 12 &&
+	          std::any_of(alpha_bytes.end() - 12, alpha_bytes.end(), [](uint8_t byte) { return byte != 0; }),
+	      "alpha mismatch must be visible in difference image");
+
+	{
+		std::ofstream corrupt(root / "baseline.json_frames/frame_00000003.raw",
+		                      std::ios::binary | std::ios::trunc);
+		corrupt << "corrupt";
+	}
+	const auto corrupt_raw_report = root / "corrupt_raw.json";
+	auto corrupt_raw = Create(Mode::Compare, baseline, corrupt_raw_report, error);
+	Check(corrupt_raw != nullptr, error.c_str());
+	Check(corrupt_raw->Observe(View(1, first), error), error.c_str());
+	Check(corrupt_raw->Observe(View(3, changed), error), error.c_str());
+	Check(corrupt_raw->Finalize(error) == 2, "corrupt reference raw exit code");
+	std::ifstream corrupt_report_stream(corrupt_raw_report);
+	const std::string corrupt_report {std::istreambuf_iterator<char>(corrupt_report_stream), {}};
+	Check(corrupt_report.find("mismatch_reference_unavailable") != std::string::npos,
+	      "corrupt reference raw diagnostic");
 
 	const auto incomplete_report = root / "incomplete.json";
 	auto incomplete = Create(Mode::Compare, baseline, incomplete_report, error);
 	Check(incomplete != nullptr, error.c_str());
 	Check(incomplete->Observe(View(1, first), error), error.c_str());
 	Check(incomplete->Finalize(error) == 2, "incomplete exit code");
+
+	const auto reverse_baseline = root / "reverse.json_frames/frame_00000001.raw";
+	auto reverse_record = Create(Mode::Record, reverse_baseline, {}, error);
+	Check(reverse_record != nullptr, error.c_str());
+	Check(reverse_record->Observe(View(1, first), error), error.c_str());
+	Check(reverse_record->Observe(View(3, second), error), error.c_str());
+	Check(reverse_record->Finalize(error) == 0, "reverse baseline creation");
+	error.clear();
+	Check(Create(Mode::Compare, reverse_baseline, root / "reverse.json", error) == nullptr &&
+	          error.find("overwrite") != std::string::npos,
+	      "report artifact cannot overwrite baseline manifest");
 
 	std::filesystem::remove_all(root);
 	return 0;

--- a/tests/FrameRegressionTests.cpp
+++ b/tests/FrameRegressionTests.cpp
@@ -44,6 +44,16 @@ Provenance TestProvenance() {
 	        .vulkan_api = 4};
 }
 
+std::vector<uint8_t> ReadBytes(const std::filesystem::path& path) {
+	std::ifstream stream(path, std::ios::binary);
+	return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+std::string ReadText(const std::filesystem::path& path) {
+	std::ifstream stream(path);
+	return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
 std::unique_ptr<Session> Create(Mode mode, const std::filesystem::path& baseline,
 	                            const std::filesystem::path& report, std::string& error) {
 	return Session::Create(Options {.mode = mode,
@@ -188,10 +198,10 @@ int main() {
 	Check(alpha_mismatch->Observe(View(3, second), error), error.c_str());
 	Check(alpha_mismatch->Finalize(error) == 2, "alpha mismatch exit code");
 	const auto alpha_diff = root / "alpha.json_frames/diff_frame_00000001.ppm";
-	std::ifstream alpha_stream(alpha_diff, std::ios::binary);
-	const std::vector<uint8_t> alpha_bytes {std::istreambuf_iterator<char>(alpha_stream), {}};
+	const auto alpha_bytes = ReadBytes(alpha_diff);
 	Check(alpha_bytes.size() >= 12 &&
-	          std::any_of(alpha_bytes.end() - 12, alpha_bytes.end(), [](uint8_t byte) { return byte != 0; }),
+	          std::any_of(alpha_bytes.end() - 12, alpha_bytes.end(),
+	                      [](uint8_t byte) { return byte != 0; }),
 	      "alpha mismatch must be visible in difference image");
 
 	{
@@ -205,8 +215,7 @@ int main() {
 	Check(corrupt_raw->Observe(View(1, first), error), error.c_str());
 	Check(corrupt_raw->Observe(View(3, changed), error), error.c_str());
 	Check(corrupt_raw->Finalize(error) == 2, "corrupt reference raw exit code");
-	std::ifstream corrupt_report_stream(corrupt_raw_report);
-	const std::string corrupt_report {std::istreambuf_iterator<char>(corrupt_report_stream), {}};
+	const auto corrupt_report = ReadText(corrupt_raw_report);
 	Check(corrupt_report.find("mismatch_reference_unavailable") != std::string::npos,
 	      "corrupt reference raw diagnostic");
 
@@ -227,6 +236,8 @@ int main() {
 	          error.find("overwrite") != std::string::npos,
 	      "report artifact cannot overwrite baseline manifest");
 
-	std::filesystem::remove_all(root);
+	std::error_code cleanup_error;
+	std::filesystem::remove_all(root, cleanup_error);
+	Check(!cleanup_error, "temporary output cleanup");
 	return 0;
 }

--- a/tests/FrameRegressionTests.cpp
+++ b/tests/FrameRegressionTests.cpp
@@ -1,0 +1,123 @@
+#include "graphics/regression/frameRegression.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Libs::Graphics::Regression::FrameView;
+using Libs::Graphics::Regression::Mode;
+using Libs::Graphics::Regression::Options;
+using Libs::Graphics::Regression::PixelFormat;
+using Libs::Graphics::Regression::Session;
+
+void Check(bool condition, const char* message) {
+	if (!condition) {
+		std::fprintf(stderr, "FrameRegressionTests failed: %s\n", message);
+		std::abort();
+	}
+}
+
+FrameView View(uint64_t ordinal, const std::vector<uint8_t>& pixels) {
+	return {.ordinal = ordinal,
+	        .width = 2,
+	        .height = 2,
+	        .row_pitch = 8,
+	        .format = PixelFormat::Rgba8Unorm,
+	        .bytes = pixels};
+}
+
+std::unique_ptr<Session> Create(Mode mode, const std::filesystem::path& baseline,
+	                            const std::filesystem::path& report, std::string& error) {
+	return Session::Create(Options {.mode = mode,
+	                                .baseline = baseline,
+	                                .report = report,
+	                                .frame_ordinals = {1, 3},
+	                                .save_raw_frames = true},
+	                       error);
+}
+
+} // namespace
+
+int main() {
+	const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+	const auto root = std::filesystem::temp_directory_path() /
+	                  ("kyty_frame_regression_tests_" + std::to_string(unique));
+	std::filesystem::create_directories(root);
+	const auto baseline = root / "baseline.json";
+	const auto report   = root / "report.json";
+	const std::vector<uint8_t> first {0, 1, 2, 255, 3, 4, 5, 255,
+	                                  6, 7, 8, 255, 9, 10, 11, 255};
+	const std::vector<uint8_t> second {20, 21, 22, 255, 23, 24, 25, 255,
+	                                   26, 27, 28, 255, 29, 30, 31, 255};
+
+	std::string error;
+	auto record = Create(Mode::Record, baseline, {}, error);
+	Check(record != nullptr, error.c_str());
+	Check(!record->WantsFrame(0) && record->WantsFrame(1), "frame selection");
+	Check(record->Observe(View(1, first), error), error.c_str());
+	Check(record->Observe(View(3, second), error), error.c_str());
+	Check(record->Complete() && record->Finalize(error) == 0, "baseline completion");
+	Check(std::filesystem::is_regular_file(baseline), "baseline manifest");
+	Check(std::filesystem::is_regular_file(root / "baseline_frames/frame_00000001.ppm"),
+	      "baseline preview");
+
+	error.clear();
+	Check(Create(Mode::Record, baseline, {}, error) == nullptr &&
+	          error.find("overwrite") != std::string::npos,
+	      "baseline overwrite protection");
+
+	Check(Create(Mode::Compare, baseline, baseline, error) == nullptr &&
+	          error.find("collide") != std::string::npos,
+	      "baseline manifest collision protection");
+	Check(Create(Mode::Compare, baseline, root / "baseline.txt", error) == nullptr &&
+	          error.find("collide") != std::string::npos,
+	      "baseline artifact collision protection");
+	Check(Create(Mode::Compare, baseline,
+	             root / "baseline_frames/frame_00000001.raw", error) == nullptr &&
+	          error.find("collide") != std::string::npos,
+	      "baseline referenced-artifact collision protection");
+
+	const auto oversized_baseline = root / "oversized.json";
+	{
+		std::ofstream stream(oversized_baseline, std::ios::binary | std::ios::trunc);
+		const std::string oversized(4 * 1024 * 1024 + 1, ' ');
+		stream.write(oversized.data(), static_cast<std::streamsize>(oversized.size()));
+	}
+	Check(Create(Mode::Compare, oversized_baseline, root / "oversized_report.json", error) ==
+	          nullptr &&
+	          error.find("read") != std::string::npos,
+	      "oversized baseline protection");
+
+	auto compare = Create(Mode::Compare, baseline, report, error);
+	Check(compare != nullptr, error.c_str());
+	Check(compare->Observe(View(1, first), error), error.c_str());
+	Check(compare->Observe(View(3, second), error), error.c_str());
+	Check(compare->Finalize(error) == 0, "exact comparison");
+
+	auto changed = second;
+	changed[5] ^= 0x40;
+	const auto mismatch_report = root / "mismatch.json";
+	auto mismatch = Create(Mode::Compare, baseline, mismatch_report, error);
+	Check(mismatch != nullptr, error.c_str());
+	Check(mismatch->Observe(View(1, first), error), error.c_str());
+	Check(mismatch->Observe(View(3, changed), error), error.c_str());
+	Check(mismatch->Finalize(error) == 2, "mismatch exit code");
+	Check(std::filesystem::is_regular_file(
+	          root / "mismatch_frames/diff_frame_00000003.ppm"),
+	      "mismatch diff image");
+
+	const auto incomplete_report = root / "incomplete.json";
+	auto incomplete = Create(Mode::Compare, baseline, incomplete_report, error);
+	Check(incomplete != nullptr, error.c_str());
+	Check(incomplete->Observe(View(1, first), error), error.c_str());
+	Check(incomplete->Finalize(error) == 2, "incomplete exit code");
+
+	std::filesystem::remove_all(root);
+	return 0;
+}

--- a/tests/GpuTraceTests.cpp
+++ b/tests/GpuTraceTests.cpp
@@ -46,8 +46,18 @@ int main() {
 	const auto capture = root / "commands.kycap";
 
 	std::string error;
+	Check(TraceWriter::Create(root / "reserved.kyty-lock", error) == nullptr &&
+	          error.find("reserved") != std::string::npos,
+	      "reservation suffix protection");
 	auto        writer = TraceWriter::Create(capture, error);
 	Check(writer != nullptr, error.c_str());
+	std::filesystem::remove(capture);
+	Check(TraceWriter::Create(capture, error) == nullptr && error.find("use") != std::string::npos,
+	      "concurrent capture writer protection");
+	writer.reset();
+	writer = TraceWriter::Create(capture, error);
+	Check(writer != nullptr, error.c_str());
+	error.clear();
 	const std::array<uint32_t, 3> draw {0xc0011000, 0x11223344, 0x55667788};
 	const std::array<uint32_t, 2> constants {0xc0007600, 0xaabbccdd};
 	const std::array<uint32_t, 2> compute {0xc0001500, 0x12345678};
@@ -55,7 +65,8 @@ int main() {
 	Check(writer->RecordCompute(0x27, compute, false, error), error.c_str());
 	Check(writer->RecordMarker(TraceEventType::FlipPreparation, error), error.c_str());
 	Check(writer->RecordMarker(TraceEventType::SuspendRequest, error), error.c_str());
-	writer->Close();
+	Check(writer->Finalize(error), error.c_str());
+	Check(writer->Finalize(error), "capture finalization must be idempotent");
 
 	Trace trace;
 	Check(LoadTrace(capture, trace, error), error.c_str());
@@ -75,7 +86,7 @@ int main() {
 
 	auto corrupted = ReadBytes(capture);
 	Check(corrupted.size() > 64, "capture size");
-	corrupted.back() ^= 0x80;
+	corrupted[corrupted.size() - 32 - 1] ^= 0x80;
 	const auto corrupt_path = root / "corrupt.kycap";
 	WriteBytes(corrupt_path, corrupted);
 	error.clear();
@@ -98,6 +109,32 @@ int main() {
 	WriteBytes(truncated_path, truncated);
 	error.clear();
 	Check(!LoadTrace(truncated_path, trace, error), "truncation validation");
+
+	auto missing_footer = ReadBytes(capture);
+	missing_footer.resize(missing_footer.size() - 32);
+	const auto missing_footer_path = root / "missing_footer.kycap";
+	WriteBytes(missing_footer_path, missing_footer);
+	error.clear();
+	Check(!LoadTrace(missing_footer_path, trace, error) &&
+	          error.find("finalized") != std::string::npos,
+	      "whole-footer truncation validation");
+
+	auto missing_record = ReadBytes(capture);
+	constexpr size_t last_marker_size = 40;
+	missing_record.erase(missing_record.end() - 32 - last_marker_size,
+	                     missing_record.end() - 32);
+	const auto missing_record_path = root / "missing_record.kycap";
+	WriteBytes(missing_record_path, missing_record);
+	error.clear();
+	Check(!LoadTrace(missing_record_path, trace, error) && error.find("footer") != std::string::npos,
+	      "whole-record truncation validation");
+
+	const auto header_only_path = root / "header_only.kycap";
+	auto header_only = ReadBytes(capture);
+	header_only.resize(24);
+	WriteBytes(header_only_path, header_only);
+	error.clear();
+	Check(!LoadTrace(header_only_path, trace, error), "header-only capture validation");
 
 	error.clear();
 	Check(!LoadTrace(capture, trace, error,

--- a/tests/GpuTraceTests.cpp
+++ b/tests/GpuTraceTests.cpp
@@ -1,0 +1,109 @@
+#include "graphics/capture/gpuTrace.h"
+
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Libs::Graphics::Capture::LoadTrace;
+using Libs::Graphics::Capture::Trace;
+using Libs::Graphics::Capture::TraceEventType;
+using Libs::Graphics::Capture::TraceReadLimits;
+using Libs::Graphics::Capture::TraceWriter;
+
+void Check(bool condition, const char* message) {
+	if (!condition) {
+		std::fprintf(stderr, "GpuTraceTests failed: %s\n", message);
+		std::abort();
+	}
+}
+
+std::vector<uint8_t> ReadBytes(const std::filesystem::path& path) {
+	std::ifstream stream(path, std::ios::binary);
+	return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+void WriteBytes(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
+	std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+	stream.write(reinterpret_cast<const char*>(bytes.data()),
+	             static_cast<std::streamsize>(bytes.size()));
+	Check(stream.good(), "could not write test fixture");
+}
+
+} // namespace
+
+int main() {
+	const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+	const auto root = std::filesystem::temp_directory_path() /
+	                  ("kyty_gpu_trace_tests_" + std::to_string(unique));
+	std::filesystem::create_directories(root);
+	const auto capture = root / "commands.kycap";
+
+	std::string error;
+	auto        writer = TraceWriter::Create(capture, error);
+	Check(writer != nullptr, error.c_str());
+	const std::array<uint32_t, 3> draw {0xc0011000, 0x11223344, 0x55667788};
+	const std::array<uint32_t, 2> constants {0xc0007600, 0xaabbccdd};
+	const std::array<uint32_t, 2> compute {0xc0001500, 0x12345678};
+	Check(writer->RecordGraphics(draw, constants, true, error), error.c_str());
+	Check(writer->RecordCompute(0x27, compute, false, error), error.c_str());
+	Check(writer->RecordMarker(TraceEventType::FlipPreparation, error), error.c_str());
+	Check(writer->RecordMarker(TraceEventType::SuspendRequest, error), error.c_str());
+	writer->Close();
+
+	Trace trace;
+	Check(LoadTrace(capture, trace, error), error.c_str());
+	Check(trace.events.size() == 4, "event count");
+	Check(trace.events[0].sequence == 1 && trace.events[0].primary ==
+	                                             std::vector<uint32_t>(draw.begin(), draw.end()),
+	      "graphics event");
+	Check(trace.events[0].secondary ==
+	          std::vector<uint32_t>(constants.begin(), constants.end()) &&
+	          trace.events[0].trigger_interrupt_on_done,
+	      "graphics constants and flags");
+	Check(trace.events[1].queue == 0x27 && !trace.events[1].trigger_interrupt_on_done,
+	      "compute event");
+	Check(trace.events[2].type == TraceEventType::FlipPreparation &&
+	          trace.events[3].type == TraceEventType::SuspendRequest,
+	      "marker events");
+
+	auto corrupted = ReadBytes(capture);
+	Check(corrupted.size() > 64, "capture size");
+	corrupted.back() ^= 0x80;
+	const auto corrupt_path = root / "corrupt.kycap";
+	WriteBytes(corrupt_path, corrupted);
+	error.clear();
+	Check(!LoadTrace(corrupt_path, trace, error) && error.find("checksum") != std::string::npos,
+	      "checksum validation");
+
+	auto metadata_corrupted = ReadBytes(capture);
+	constexpr size_t second_record_queue_offset = 24 + 40 + 5 * sizeof(uint32_t) + 16;
+	Check(metadata_corrupted.size() > second_record_queue_offset, "capture metadata size");
+	metadata_corrupted[second_record_queue_offset] ^= 1;
+	const auto metadata_path = root / "metadata_corrupt.kycap";
+	WriteBytes(metadata_path, metadata_corrupted);
+	error.clear();
+	Check(!LoadTrace(metadata_path, trace, error) && error.find("checksum") != std::string::npos,
+	      "metadata checksum validation");
+
+	auto truncated = ReadBytes(capture);
+	truncated.resize(truncated.size() - 3);
+	const auto truncated_path = root / "truncated.kycap";
+	WriteBytes(truncated_path, truncated);
+	error.clear();
+	Check(!LoadTrace(truncated_path, trace, error), "truncation validation");
+
+	error.clear();
+	Check(!LoadTrace(capture, trace, error,
+	                 TraceReadLimits {.max_events = 2, .max_command_dwords = 100}),
+	      "event limit");
+
+	std::filesystem::remove_all(root);
+	return 0;
+}

--- a/tests/GraphicsRegressionRunnerTests.py
+++ b/tests/GraphicsRegressionRunnerTests.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from graphics_regression import CaseSpec, run_case  # noqa: E402
+from graphics_regression.report import validate_report  # noqa: E402
+from graphics_regression.suite import load_suite, run_suite  # noqa: E402
+
+
+class RunnerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="kyty_regression_runner_")
+        self.root = Path(self.temporary.name)
+        self.game = self.root / "game"
+        self.game.mkdir()
+        self.baseline = self.root / "baseline.json"
+        self.write_baseline(self.baseline, "fixture-revision-checkpoint", [1, 3])
+        self.fixture = ROOT / "tests/fixtures/fake_graphics_emulator.py"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    @staticmethod
+    def write_baseline(path: Path, test_id: str, frames: list[int]) -> None:
+        provenance = {
+            "test_id": test_id,
+            "build_id": "fixture-build",
+            "gpu_name": "fixture-gpu",
+            "gpu_vendor_id": 1,
+            "gpu_device_id": 2,
+            "gpu_driver": 3,
+            "vulkan_api": 4,
+            "configuration": "fixture-configuration",
+        }
+        records = [{
+            "ordinal": ordinal,
+            "width": 2,
+            "height": 2,
+            "row_pitch": 8,
+            "byte_size": 16,
+            "format": "rgba8_unorm",
+            "hash_low": "0123456789abcdef",
+            "hash_high": "fedcba9876543210",
+            "status": "recorded",
+        } for ordinal in frames]
+        path.write_text(json.dumps({
+            "schema_version": 2,
+            "algorithm": "xxh3_128",
+            "mode": "record",
+            "complete": True,
+            "passed": True,
+            "provenance": provenance,
+            "frames": records,
+        }), encoding="utf-8")
+
+    def spec(self, mode: str = "pass", timeout: float = 5.0) -> CaseSpec:
+        output = self.root / "output"
+        return CaseSpec(
+            test_id="fixture-revision-checkpoint",
+            emulator=Path(sys.executable),
+            launcher_args=(str(self.fixture),),
+            game=self.game,
+            baseline=self.baseline,
+            report=output / "report.json",
+            work_dir=output / "work",
+            frames=[1, 3],
+            timeout_seconds=timeout,
+            emulator_args=("--fake-mode", mode),
+        )
+
+    def test_pass_and_log(self) -> None:
+        result = run_case(self.spec())
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(Path(result.log).is_file())
+
+    def test_mismatch_and_process_report_disagreement(self) -> None:
+        self.assertEqual(run_case(self.spec("mismatch")).exit_code, 2)
+        self.assertEqual(run_case(self.spec("nonzero-pass")).exit_code, 7)
+
+    def test_missing_and_non_object_reports_fail_cleanly(self) -> None:
+        self.assertEqual(run_case(self.spec("no-report")).exit_code, 2)
+        self.assertEqual(run_case(self.spec("malformed")).exit_code, 2)
+
+    def test_timeout(self) -> None:
+        result = run_case(self.spec("sleep", timeout=0.1))
+        self.assertEqual(result.exit_code, 124)
+        self.assertTrue(result.timed_out)
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object integration test")
+    def test_windows_timeout_terminates_descendants(self) -> None:
+        import ctypes
+        from ctypes import wintypes
+
+        spec = self.spec("spawn-child-sleep", timeout=2.0)
+        result = run_case(spec)
+        self.assertEqual(result.exit_code, 124)
+        child_pid = int((spec.work_dir / "child.pid").read_text(encoding="utf-8"))
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        handle = kernel32.OpenProcess(0x1000, False, child_pid)
+        if handle:
+            exit_code = wintypes.DWORD()
+            self.assertTrue(kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)))
+            kernel32.CloseHandle(handle)
+            self.assertNotEqual(exit_code.value, 259)
+
+    def test_stale_artifacts_are_removed(self) -> None:
+        spec = self.spec("artifact")
+        self.assertEqual(run_case(spec).exit_code, 0)
+        stale = spec.report.parent / "report.json_frames/current.txt"
+        self.assertTrue(stale.is_file())
+        missing = self.spec("no-report")
+        self.assertEqual(run_case(missing).exit_code, 2)
+        self.assertFalse(stale.exists())
+
+    def test_json_types_are_strict(self) -> None:
+        spec = self.spec("bad-types")
+        result = run_case(spec)
+        self.assertEqual(result.exit_code, 2)
+        valid, _ = validate_report(spec.report, spec.baseline, spec.frames, spec.test_id)
+        self.assertFalse(valid)
+
+    def test_matching_report_requires_equal_expected_hashes(self) -> None:
+        spec = self.spec()
+        self.assertEqual(run_case(spec).exit_code, 0)
+        report = json.loads(spec.report.read_text(encoding="utf-8"))
+        del report["frames"][0]["expected_hash_low"]
+        spec.report.write_text(json.dumps(report), encoding="utf-8")
+        self.assertFalse(validate_report(spec.report, spec.baseline, spec.frames, spec.test_id)[0])
+        report["frames"][0]["expected_hash_low"] = "ffffffffffffffff"
+        spec.report.write_text(json.dumps(report), encoding="utf-8")
+        self.assertFalse(validate_report(spec.report, spec.baseline, spec.frames, spec.test_id)[0])
+
+    def test_report_is_anchored_to_baseline_content(self) -> None:
+        spec = self.spec()
+        self.assertEqual(run_case(spec).exit_code, 0)
+        report = json.loads(spec.report.read_text(encoding="utf-8"))
+        report["frames"][0]["hash_low"] = "aaaaaaaaaaaaaaaa"
+        report["frames"][0]["expected_hash_low"] = "aaaaaaaaaaaaaaaa"
+        spec.report.write_text(json.dumps(report), encoding="utf-8")
+        self.assertFalse(validate_report(spec.report, spec.baseline, spec.frames, spec.test_id)[0])
+        self.assertEqual(run_case(spec).exit_code, 0)
+        report = json.loads(spec.report.read_text(encoding="utf-8"))
+        report["baseline_provenance"]["build_id"] = "forged-build"
+        spec.report.write_text(json.dumps(report), encoding="utf-8")
+        self.assertFalse(validate_report(spec.report, spec.baseline, spec.frames, spec.test_id)[0])
+
+    def test_invalid_baseline_cannot_produce_a_pass(self) -> None:
+        spec = self.spec()
+        spec.baseline.write_text("{}", encoding="utf-8")
+        self.assertEqual(run_case(spec).exit_code, 2)
+
+    def test_result_write_does_not_use_fixed_temporary_path(self) -> None:
+        spec = self.spec()
+        fixed_temporary = spec.report.parent / "report.runner.json.tmp"
+        fixed_temporary.parent.mkdir(parents=True)
+        fixed_temporary.write_text("do not replace", encoding="utf-8")
+        self.assertEqual(run_case(spec).exit_code, 0)
+        self.assertEqual(fixed_temporary.read_text(encoding="utf-8"), "do not replace")
+
+    def test_report_rejects_native_reservation_suffix(self) -> None:
+        spec = replace(self.spec(), report=self.root / "result.kyty-lock")
+        with self.assertRaisesRegex(ValueError, "reserved"):
+            run_case(spec)
+
+    def test_suite_rejects_duplicate_ids_before_running(self) -> None:
+        suite = self.root / "suite.json"
+        case = {"id": "duplicate", "game": "game", "baseline": "baseline.json", "frames": [1]}
+        suite.write_text(json.dumps({"schema_version": 1, "cases": [case, case]}), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            load_suite(suite, Path(sys.executable), self.root / "suite-output",
+                       (str(self.fixture),), False)
+
+    def test_suite_rejects_portable_path_aliases(self) -> None:
+        suite = self.root / "suite.json"
+        cases = [
+            {"id": "Game", "game": "game", "baseline": "baseline.json", "frames": [1]},
+            {"id": "game", "game": "game", "baseline": "baseline.json", "frames": [2]},
+        ]
+        suite.write_text(json.dumps({"schema_version": 1, "cases": cases}), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            load_suite(suite, Path(sys.executable), self.root / "suite-output",
+                       (str(self.fixture),), False)
+        cases = [{"id": "NUL.txt", "game": "game", "baseline": "baseline.json", "frames": [1]}]
+        suite.write_text(json.dumps({"schema_version": 1, "cases": cases}), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "invalid"):
+            load_suite(suite, Path(sys.executable), self.root / "suite-output",
+                       (str(self.fixture),), False)
+
+    def test_suite_runs_sequentially_and_writes_summary(self) -> None:
+        suite = self.root / "suite.json"
+        self.write_baseline(self.root / "passing.json", "passing-case", [1])
+        self.write_baseline(self.root / "failing.json", "failing-case", [2])
+        cases = [
+            {"id": "passing-case", "game": "game", "baseline": "passing.json", "frames": [1]},
+            {"id": "failing-case", "game": "game", "baseline": "failing.json", "frames": [2],
+             "emulator_args": ["--fake-mode", "mismatch"]},
+        ]
+        suite.write_text(json.dumps({"schema_version": 1, "cases": cases}), encoding="utf-8")
+        output = self.root / "suite-output"
+        specs = load_suite(suite, Path(sys.executable), output, (str(self.fixture),), False)
+        self.assertEqual(run_suite(specs, output), 2)
+        summary = json.loads((output / "summary.json").read_text(encoding="utf-8"))
+        self.assertEqual([result["exit_code"] for result in summary["results"]], [0, 2])
+
+    def test_suite_removes_disabled_case_outputs(self) -> None:
+        suite = self.root / "suite.json"
+        self.write_baseline(self.root / "kept.json", "kept-case", [1])
+        self.write_baseline(self.root / "removed.json", "removed-case", [2])
+        cases = [
+            {"id": "kept-case", "game": "game", "baseline": "kept.json", "frames": [1]},
+            {"id": "removed-case", "game": "game", "baseline": "removed.json", "frames": [2]},
+        ]
+        suite.write_text(json.dumps({"schema_version": 1, "cases": cases}), encoding="utf-8")
+        output = self.root / "suite-output"
+        specs = load_suite(suite, Path(sys.executable), output, (str(self.fixture),), False)
+        self.assertEqual(run_suite(specs, output), 0)
+        stale = output / "removed-case" / "private-cache.bin"
+        stale.write_bytes(b"stale")
+        cases[1]["enabled"] = False
+        suite.write_text(json.dumps({"schema_version": 1, "cases": cases}), encoding="utf-8")
+        specs = load_suite(suite, Path(sys.executable), output, (str(self.fixture),), False)
+        self.assertEqual(run_suite(specs, output), 0)
+        self.assertFalse(stale.parent.exists())
+
+    def test_suite_output_cannot_overwrite_a_baseline(self) -> None:
+        output = self.root / "suite-output"
+        output.mkdir()
+        baseline = output / "summary.json"
+        baseline.write_text("{}", encoding="utf-8")
+        suite = self.root / "suite.json"
+        suite.write_text(json.dumps({"schema_version": 1, "cases": [{
+            "id": "collision", "game": "game", "baseline": str(baseline), "frames": [1]
+        }]}), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "overlaps"):
+            load_suite(suite, Path(sys.executable), output, (str(self.fixture),), False)
+
+    def test_case_output_cannot_overlap_another_case_input(self) -> None:
+        output = self.root / "suite-output"
+        cross_case_game = output / "first-case"
+        cross_case_game.mkdir(parents=True)
+        suite = self.root / "suite.json"
+        cases = [
+            {"id": "first-case", "game": "game", "baseline": "baseline.json", "frames": [1]},
+            {"id": "second-case", "game": str(cross_case_game),
+             "baseline": "baseline.json", "frames": [2]},
+        ]
+        suite.write_text(json.dumps({"schema_version": 1, "cases": cases}), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "overlaps"):
+            load_suite(suite, Path(sys.executable), output, (str(self.fixture),), False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fixtures/fake_graphics_emulator.py
+++ b/tests/fixtures/fake_graphics_emulator.py
@@ -1,0 +1,84 @@
+"""Test fixture implementing the emulator report contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def provenance(test_id: str) -> dict[str, object]:
+    return {
+        "test_id": test_id,
+        "build_id": "fixture-build",
+        "gpu_name": "fixture-gpu",
+        "gpu_vendor_id": 1,
+        "gpu_device_id": 2,
+        "gpu_driver": 3,
+        "vulkan_api": 4,
+        "configuration": "fixture-configuration",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--game")
+    parser.add_argument("--regression-compare")
+    parser.add_argument("--regression-report", type=Path)
+    parser.add_argument("--regression-frames")
+    parser.add_argument("--regression-test-id")
+    parser.add_argument("--regression-save-raw")
+    parser.add_argument("--regression-allow-environment-mismatch")
+    parser.add_argument("--fake-mode", default="pass")
+    args, _ = parser.parse_known_args()
+    if args.fake_mode == "spawn-child-sleep":
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        (Path.cwd() / "child.pid").write_text(str(child.pid), encoding="utf-8")
+        time.sleep(30)
+    if args.fake_mode == "sleep":
+        time.sleep(30)
+    if args.fake_mode == "no-report":
+        return 0
+    args.regression_report.parent.mkdir(parents=True, exist_ok=True)
+    if args.fake_mode == "malformed":
+        args.regression_report.write_text("null\n", encoding="utf-8")
+        return 0
+    frames = [int(value) for value in args.regression_frames.split(",")]
+    matched = args.fake_mode not in ("mismatch", "bad-types")
+    records = [{
+        "ordinal": float(frame) if args.fake_mode == "bad-types" else frame,
+        "width": 2,
+        "height": 2,
+        "row_pitch": 8,
+        "byte_size": 16,
+        "format": "rgba8_unorm",
+        "hash_low": "0123456789abcdef",
+        "hash_high": "fedcba9876543210",
+        "expected_hash_low": "0123456789abcdef",
+        "expected_hash_high": "fedcba9876543210",
+        "status": "match" if matched else "mismatch",
+    } for frame in frames]
+    report = {
+        "schema_version": True if args.fake_mode == "bad-types" else 2,
+        "algorithm": "xxh3_128",
+        "mode": "compare",
+        "complete": True,
+        "passed": matched,
+        "baseline_provenance": provenance(args.regression_test_id),
+        "run_provenance": provenance(args.regression_test_id),
+        "environment_match": True,
+        "frames": records,
+    }
+    args.regression_report.write_text(json.dumps(report), encoding="utf-8")
+    if args.fake_mode == "artifact":
+        artifacts = args.regression_report.parent / f"{args.regression_report.name}_frames"
+        artifacts.mkdir(exist_ok=True)
+        (artifacts / "current.txt").write_text("current", encoding="utf-8")
+    return 7 if args.fake_mode == "nonzero-pass" else (0 if matched else 2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/graphics-regression-suite.example.json
+++ b/tools/graphics-regression-suite.example.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "sample-title-revision-checkpoint",
+      "game": "D:/Games/SampleTitle",
+      "baseline": "D:/KytyBaselines/sample-title.json",
+      "frames": [60, 120, 300],
+      "timeout_seconds": 300,
+      "save_raw": false,
+      "reuse_work_dir": false,
+      "emulator_args": []
+    }
+  ]
+}

--- a/tools/graphics_regression/__init__.py
+++ b/tools/graphics_regression/__init__.py
@@ -1,0 +1,5 @@
+"""Production helpers for Kyty graphics regression jobs."""
+
+from .core import CaseResult, CaseSpec, run_case, validate_case
+
+__all__ = ["CaseResult", "CaseSpec", "run_case", "validate_case"]

--- a/tools/graphics_regression/atomic.py
+++ b/tools/graphics_regression/atomic.py
@@ -1,0 +1,29 @@
+"""Durable same-directory atomic writes for runner metadata."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def write_text(path: Path, contents: str) -> None:
+    """Write text without following a predictable temporary path."""
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", text=True)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as output:
+            output.write(contents)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+        if os.name != "nt":
+            directory = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise

--- a/tools/graphics_regression/core.py
+++ b/tools/graphics_regression/core.py
@@ -1,0 +1,180 @@
+"""Single-case graphics regression orchestration."""
+
+from __future__ import annotations
+
+import json
+import math
+import shutil
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from .atomic import write_text as atomic_write_text
+from .process import TIMEOUT_EXIT_CODE, run_process
+from .report import validate_report
+
+FAILURE = 2
+MAX_FRAMES = 4096
+MAX_ORDINAL = (1 << 64) - 1
+_OWNED_FLAGS = frozenset({
+    "--game", "--regression-record", "--regression-compare", "--regression-report",
+    "--regression-frames", "--regression-test-id", "--regression-save-raw",
+    "--regression-exit-on-complete", "--regression-allow-environment-mismatch",
+})
+
+
+@dataclass(frozen=True)
+class CaseSpec:
+    test_id: str
+    emulator: Path
+    game: Path
+    baseline: Path
+    report: Path
+    work_dir: Path
+    frames: list[int]
+    timeout_seconds: float = 300.0
+    save_raw: bool = False
+    reuse_work_dir: bool = False
+    allow_environment_mismatch: bool = False
+    launcher_args: tuple[str, ...] = ()
+    emulator_args: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    test_id: str
+    exit_code: int
+    message: str
+    timed_out: bool
+    duration_seconds: float
+    report: str
+    log: str
+
+
+def _artifact_directory(report: Path) -> Path:
+    return report.parent / f"{report.name}_frames"
+
+
+def _contains_owned_flag(arguments: tuple[str, ...]) -> bool:
+    return any(argument.split("=", 1)[0] in _OWNED_FLAGS for argument in arguments)
+
+
+def validate_case(spec: CaseSpec) -> None:
+    if not spec.test_id or len(spec.test_id) > 4096:
+        raise ValueError("test ID must contain 1-4096 characters")
+    if (not spec.frames or len(spec.frames) > MAX_FRAMES or len(spec.frames) != len(set(spec.frames)) or
+            any(type(frame) is not int or frame < 0 or frame > MAX_ORDINAL for frame in spec.frames)):
+        raise ValueError("frames must be unique unsigned 64-bit integers (maximum 4096)")
+    if (isinstance(spec.timeout_seconds, bool) or not isinstance(spec.timeout_seconds, (int, float)) or
+            not math.isfinite(spec.timeout_seconds) or spec.timeout_seconds <= 0):
+        raise ValueError("timeout must be a finite positive number")
+    if any(type(value) is not bool for value in (spec.save_raw, spec.reuse_work_dir,
+                                                 spec.allow_environment_mismatch)):
+        raise ValueError("runner policy fields must be booleans")
+    if any(not isinstance(value, str) for value in (*spec.launcher_args, *spec.emulator_args)):
+        raise ValueError("launcher and emulator arguments must be strings")
+    for name, path in (("emulator", spec.emulator), ("game", spec.game),
+                       ("baseline", spec.baseline)):
+        if not path.exists():
+            raise ValueError(f"{name} does not exist: {path}")
+    if not spec.emulator.is_file() or not spec.baseline.is_file():
+        raise ValueError("emulator and baseline must be files")
+    if spec.report.name.casefold().endswith(".kyty-lock"):
+        raise ValueError("report path uses the reserved .kyty-lock suffix")
+    if spec.report == spec.baseline or spec.work_dir in (spec.report, spec.baseline):
+        raise ValueError("work, report, and baseline paths must be distinct")
+    artifact_dir = _artifact_directory(spec.report)
+    outputs = {spec.report, spec.report.with_suffix(".log"),
+               spec.report.with_name(f"{spec.report.stem}.runner.json")}
+    owned_files = outputs | {path.with_name(path.name + ".runner-owned") for path in outputs}
+    protected = (spec.emulator, spec.game, spec.baseline)
+    if any(path in owned_files for path in protected):
+        raise ValueError("runner output collides with an input")
+    for path in protected:
+        if (spec.work_dir == path or spec.work_dir in path.parents or path in spec.work_dir.parents or
+                artifact_dir == path or artifact_dir in path.parents or path in artifact_dir.parents):
+            raise ValueError("runner-owned directories overlap an input")
+    if _contains_owned_flag(spec.emulator_args):
+        raise ValueError("emulator arguments cannot override regression-owned options")
+
+
+def _clean_owned_directory(path: Path, marker_name: str, reuse: bool) -> None:
+    marker = path / marker_name
+    if path.is_symlink():
+        raise ValueError(f"owned output directory cannot be a symlink: {path}")
+    if path.exists() and not path.is_dir():
+        raise ValueError(f"owned output path is not a directory: {path}")
+    path.mkdir(parents=True, exist_ok=True)
+    entries = list(path.iterdir())
+    if entries and (not marker.is_file() or marker.is_symlink()):
+        raise ValueError(f"refusing to clean unowned directory: {path}")
+    marker.touch(exist_ok=True)
+    if reuse:
+        return
+    for entry in path.iterdir():
+        if entry == marker:
+            continue
+        if entry.is_symlink() or entry.is_file():
+            entry.unlink()
+        else:
+            shutil.rmtree(entry)
+
+
+def _prepare_outputs(spec: CaseSpec) -> Path:
+    spec.report.parent.mkdir(parents=True, exist_ok=True)
+
+    def prepare_file(path: Path) -> None:
+        marker = path.with_name(path.name + ".runner-owned")
+        if marker.is_symlink() or (marker.exists() and not marker.is_file()):
+            raise ValueError(f"invalid ownership marker: {marker}")
+        if path.exists() and not marker.is_file():
+            raise ValueError(f"refusing to replace unowned output: {path}")
+        marker.touch(exist_ok=True)
+        path.unlink(missing_ok=True)
+
+    prepare_file(spec.report)
+    _clean_owned_directory(_artifact_directory(spec.report), ".runner-owned", reuse=False)
+    _clean_owned_directory(spec.work_dir, ".runner-owned", reuse=spec.reuse_work_dir)
+    log = spec.report.with_suffix(".log")
+    prepare_file(log)
+    prepare_file(spec.report.with_name(f"{spec.report.stem}.runner.json"))
+    return log
+
+
+def _write_result(spec: CaseSpec, result: CaseResult) -> None:
+    path = spec.report.with_name(f"{spec.report.stem}.runner.json")
+    atomic_write_text(path, json.dumps(asdict(result), indent=2) + "\n")
+
+
+def run_case(spec: CaseSpec) -> CaseResult:
+    validate_case(spec)
+    log = _prepare_outputs(spec)
+    frames = ",".join(str(frame) for frame in sorted(spec.frames))
+    command = [str(spec.emulator), *spec.launcher_args, "--game", str(spec.game),
+               "--regression-compare", str(spec.baseline), "--regression-report", str(spec.report),
+               "--regression-frames", frames, "--regression-test-id", spec.test_id,
+               "--regression-save-raw", "true" if spec.save_raw else "false"]
+    if spec.allow_environment_mismatch:
+        command += ["--regression-allow-environment-mismatch", "true"]
+    command += list(spec.emulator_args)
+
+    started = time.monotonic()
+    try:
+        process_exit, timed_out = run_process(command, spec.work_dir, log, spec.timeout_seconds)
+    except OSError as error:
+        process_exit, timed_out = FAILURE, False
+        message = f"could not start emulator: {error}"
+    else:
+        if timed_out:
+            message = f"timed out after {spec.timeout_seconds:g}s"
+        else:
+            passed, message = validate_report(spec.report, spec.baseline, spec.frames, spec.test_id,
+                                              spec.allow_environment_mismatch)
+            if passed and process_exit != 0:
+                message = f"passing report but emulator returned {process_exit}"
+            elif not passed and process_exit == 0:
+                process_exit = FAILURE
+    result = CaseResult(spec.test_id, process_exit, message, timed_out,
+                        round(time.monotonic() - started, 3), str(spec.report), str(log))
+    _write_result(spec, result)
+    return result

--- a/tools/graphics_regression/process.py
+++ b/tools/graphics_regression/process.py
@@ -1,0 +1,66 @@
+"""Run and reliably terminate one isolated emulator process tree."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+TIMEOUT_EXIT_CODE = 124
+_CREATE_SUSPENDED = 0x00000004
+
+
+def _terminate_tree(process: subprocess.Popen[bytes], windows_job: int | None) -> None:
+    if os.name == "nt":
+        if windows_job is not None:
+            from . import windows_job as jobs
+            jobs.terminate(windows_job, TIMEOUT_EXIT_CODE)
+        elif process.poll() is None:
+            subprocess.run(["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if process.poll() is None:
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+def run_process(command: list[str], cwd: Path, log: Path, timeout_seconds: float) -> tuple[int, bool]:
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP | _CREATE_SUSPENDED
+    with log.open("wb") as output:
+        process = subprocess.Popen(command, cwd=cwd, stdout=output, stderr=subprocess.STDOUT,
+                                   creationflags=creationflags, start_new_session=os.name != "nt")
+        job: int | None = None
+        try:
+            if os.name == "nt":
+                from . import windows_job as jobs
+                handle = int(process._handle)  # type: ignore[attr-defined]
+                job = jobs.attach(handle)
+                if job is None:
+                    raise OSError("could not assign emulator to a kill-on-close Windows Job Object")
+                if not jobs.resume(handle):
+                    raise OSError("could not resume emulator after Windows Job Object assignment")
+            try:
+                exit_code = process.wait(timeout=timeout_seconds)
+                if os.name != "nt":
+                    _terminate_tree(process, job)
+                return exit_code, False
+            except subprocess.TimeoutExpired:
+                _terminate_tree(process, job)
+                return TIMEOUT_EXIT_CODE, True
+        except BaseException:
+            _terminate_tree(process, job)
+            raise
+        finally:
+            if job is not None:
+                from . import windows_job as jobs
+                jobs.close(job)

--- a/tools/graphics_regression/report.py
+++ b/tools/graphics_regression/report.py
@@ -1,0 +1,164 @@
+"""Strict validation for emulator-generated graphics regression reports."""
+
+from __future__ import annotations
+
+import json
+import string
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+SCHEMA_VERSION = 2
+MAX_REPORT_BYTES = 4 * 1024 * 1024
+MAX_FRAME_BYTES = 512 * 1024 * 1024
+MAX_FRAMES = 4096
+MAX_ORDINAL = (1 << 64) - 1
+_HEX = frozenset(string.hexdigits)
+_PROVENANCE_TEXT = ("test_id", "build_id", "gpu_name", "configuration")
+_PROVENANCE_NUMBERS = ("gpu_vendor_id", "gpu_device_id", "gpu_driver", "vulkan_api")
+_PROVENANCE_FIELDS = (*_PROVENANCE_TEXT, *_PROVENANCE_NUMBERS)
+_LAYOUT_FIELDS = ("width", "height", "row_pitch", "byte_size", "format")
+_FORMAT_BYTES = {
+    "rgba8_unorm": 4, "rgba8_srgb": 4, "bgra8_unorm": 4, "bgra8_srgb": 4,
+    "a2b10g10r10_unorm": 4, "a2r10g10b10_unorm": 4, "rgba16_float": 8,
+}
+
+
+def _integer(value: object, *, positive: bool = False) -> bool:
+    return type(value) is int and (value > 0 if positive else 0 <= value <= MAX_ORDINAL)
+
+
+def _digest(value: object) -> bool:
+    return isinstance(value, str) and len(value) == 16 and all(char in _HEX for char in value)
+
+
+def _provenance(value: object, test_id: str) -> bool:
+    if not isinstance(value, dict) or value.get("test_id") != test_id:
+        return False
+    if any(not isinstance(value.get(name), str) or not value[name] or len(value[name]) > 4096
+           for name in _PROVENANCE_TEXT):
+        return False
+    return all(_integer(value.get(name)) and value[name] <= 0xffffffff
+               for name in _PROVENANCE_NUMBERS)
+
+
+def _same_environment(first: dict[str, object], second: dict[str, object]) -> bool:
+    fields = ("test_id", "gpu_name", "configuration", *_PROVENANCE_NUMBERS)
+    return all(first[name] == second[name] for name in fields)
+
+
+def _same_provenance(first: dict[str, object], second: dict[str, object]) -> bool:
+    return all(first[name] == second[name] for name in _PROVENANCE_FIELDS)
+
+
+def _same_digest(first: object, second: object) -> bool:
+    return _digest(first) and _digest(second) and first.casefold() == second.casefold()
+
+
+def _valid_layout(record: dict[str, object]) -> bool:
+    bytes_per_pixel = _FORMAT_BYTES.get(record.get("format"))
+    return (bytes_per_pixel is not None and
+            _integer(record.get("width"), positive=True) and
+            _integer(record.get("height"), positive=True) and
+            _integer(record.get("row_pitch"), positive=True) and
+            _integer(record.get("byte_size"), positive=True) and
+            record["row_pitch"] == record["width"] * bytes_per_pixel and
+            record["byte_size"] == record["row_pitch"] * record["height"] and
+            record["byte_size"] <= MAX_FRAME_BYTES)
+
+
+def _safe_artifact(value: object) -> bool:
+    if not isinstance(value, str) or not value or len(value) > 1024:
+        return False
+    windows = PureWindowsPath(value)
+    posix = PurePosixPath(value)
+    return (not windows.is_absolute() and not windows.drive and not posix.is_absolute() and
+            ".." not in windows.parts and ".." not in posix.parts)
+
+
+def _read_object(path: Path, kind: str) -> tuple[dict[str, object] | None, str]:
+    try:
+        if path.stat().st_size > MAX_REPORT_BYTES:
+            return None, f"{kind} exceeds the size limit"
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        return None, f"cannot read a valid {kind}: {error}"
+    if not isinstance(value, dict):
+        return None, f"{kind} root must be an object"
+    return value, ""
+
+
+def _load_baseline(path: Path, frames: list[int], test_id: str) -> tuple[
+        dict[str, object] | None, dict[int, dict[str, object]] | None, str]:
+    baseline, error = _read_object(path, "baseline")
+    if baseline is None:
+        return None, None, error
+    provenance = baseline.get("provenance")
+    records = baseline.get("frames")
+    if (baseline.get("schema_version") != SCHEMA_VERSION or
+            baseline.get("mode") != "record" or baseline.get("algorithm") != "xxh3_128" or
+            baseline.get("complete") is not True or baseline.get("passed") is not True or
+            not _provenance(provenance, test_id) or not isinstance(records, list) or
+            not records or len(records) > MAX_FRAMES):
+        return None, None, "baseline metadata is invalid or incomplete"
+    by_ordinal: dict[int, dict[str, object]] = {}
+    for record in records:
+        if (not isinstance(record, dict) or not _integer(record.get("ordinal")) or
+                record.get("status") != "recorded" or not _valid_layout(record) or
+                not _digest(record.get("hash_low")) or not _digest(record.get("hash_high")) or
+                any(name in record and not _safe_artifact(record[name])
+                    for name in ("raw_file", "image_file")) or
+                record["ordinal"] in by_ordinal):
+            return None, None, "baseline contains an invalid frame record"
+        by_ordinal[record["ordinal"]] = record
+    if any(ordinal not in by_ordinal for ordinal in frames):
+        return None, None, "baseline does not contain every requested frame"
+    return provenance, by_ordinal, ""
+
+
+def validate_report(path: Path, baseline_path: Path, frames: list[int], test_id: str,
+                    allow_environment_mismatch: bool = False) -> tuple[bool, str]:
+    baseline_provenance, baseline_frames, error = _load_baseline(baseline_path, frames, test_id)
+    if baseline_provenance is None or baseline_frames is None:
+        return False, error
+    report, error = _read_object(path, "report")
+    if report is None:
+        return False, error
+    if (report.get("schema_version") != SCHEMA_VERSION or report.get("mode") != "compare" or
+            report.get("algorithm") != "xxh3_128" or report.get("complete") is not True or
+            type(report.get("passed")) is not bool):
+        return False, "report metadata is invalid or incomplete"
+    reported_baseline = report.get("baseline_provenance")
+    run_provenance = report.get("run_provenance")
+    if (not _provenance(reported_baseline, test_id) or
+            not _provenance(run_provenance, test_id) or
+            type(report.get("environment_match")) is not bool or
+            not _same_provenance(reported_baseline, baseline_provenance)):
+        return False, "report provenance is invalid or does not match the baseline"
+    environments_match = _same_environment(reported_baseline, run_provenance)
+    if report["environment_match"] != environments_match:
+        return False, "report environment result is inconsistent"
+    if not environments_match and not allow_environment_mismatch:
+        return False, "report environment does not match the baseline"
+
+    records = report.get("frames")
+    if not isinstance(records, list) or len(records) != len(frames):
+        return False, "report does not contain exactly the requested frames"
+    for record, ordinal in zip(records, sorted(frames), strict=True):
+        if (not isinstance(record, dict) or not _integer(record.get("ordinal")) or
+                record["ordinal"] != ordinal):
+            return False, "report does not contain exactly the requested frames"
+        if record.get("status") == "match":
+            baseline_record = baseline_frames[ordinal]
+            if (not _valid_layout(record) or not _digest(record.get("hash_low")) or
+                    not _digest(record.get("hash_high")) or
+                    not _digest(record.get("expected_hash_low")) or
+                    not _digest(record.get("expected_hash_high"))):
+                return False, "report contains an invalid matching frame"
+            if (not _same_digest(record["hash_low"], record["expected_hash_low"]) or
+                    not _same_digest(record["hash_high"], record["expected_hash_high"])):
+                return False, "matching frame hashes are inconsistent"
+            if (not _same_digest(record["expected_hash_low"], baseline_record["hash_low"]) or
+                    not _same_digest(record["expected_hash_high"], baseline_record["hash_high"]) or
+                    any(record[name] != baseline_record[name] for name in _LAYOUT_FIELDS)):
+                return False, "matching frame does not match the baseline"
+    passed = report["passed"] and all(record.get("status") == "match" for record in records)
+    return passed, "all selected frames match" if passed else "one or more frames differ"

--- a/tools/graphics_regression/suite.py
+++ b/tools/graphics_regression/suite.py
@@ -1,0 +1,123 @@
+"""Validated sequential suite orchestration for one pinned GPU runner."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import asdict
+from pathlib import Path
+
+from .atomic import write_text as atomic_write_text
+from .core import CaseSpec, run_case, validate_case
+
+_CASE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")
+_WINDOWS_DEVICE = re.compile(r"(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?", re.IGNORECASE)
+_CASE_KEYS = frozenset({"id", "game", "baseline", "frames", "timeout_seconds", "save_raw",
+                        "reuse_work_dir", "emulator_args", "enabled"})
+
+
+def _overlaps(first: Path, second: Path) -> bool:
+    return first == second or first in second.parents or second in first.parents
+
+
+def load_suite(path: Path, emulator: Path, output: Path, launcher_args: tuple[str, ...],
+               allow_environment_mismatch: bool) -> list[CaseSpec]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read suite: {error}") from error
+    if (not isinstance(document, dict) or type(document.get("schema_version")) is not int or
+            document["schema_version"] != 1 or not isinstance(document.get("cases"), list)):
+        raise ValueError("suite must be a schema-version-1 object with a cases array")
+    base = path.resolve().parent
+    specs: list[CaseSpec] = []
+    identifiers: set[str] = set()
+    for entry in document["cases"]:
+        if not isinstance(entry, dict) or set(entry) - _CASE_KEYS:
+            raise ValueError("suite contains an invalid case object or unknown field")
+        if "enabled" in entry and type(entry["enabled"]) is not bool:
+            raise ValueError("suite case enabled field must be a boolean")
+        if entry.get("enabled", True) is False:
+            continue
+        identifier = entry.get("id")
+        portable_identifier = identifier.casefold() if isinstance(identifier, str) else ""
+        if (not isinstance(identifier, str) or not _CASE_ID.fullmatch(identifier) or
+                identifier.endswith(".") or _WINDOWS_DEVICE.fullmatch(identifier) or
+                portable_identifier in identifiers):
+            raise ValueError(f"invalid or duplicate case ID: {identifier!r}")
+        identifiers.add(portable_identifier)
+        if not isinstance(entry.get("game"), str) or not isinstance(entry.get("baseline"), str):
+            raise ValueError(f"case {identifier} requires game and baseline paths")
+        frames = entry.get("frames")
+        if not isinstance(frames, list):
+            raise ValueError(f"case {identifier} requires a frames array")
+        arguments = entry.get("emulator_args", [])
+        if not isinstance(arguments, list) or any(not isinstance(value, str) for value in arguments):
+            raise ValueError(f"case {identifier} emulator_args must be strings")
+        case_output = output.resolve() / identifier
+        spec = CaseSpec(
+            test_id=identifier,
+            emulator=emulator.resolve(),
+            game=(base / entry["game"]).resolve(),
+            baseline=(base / entry["baseline"]).resolve(),
+            report=case_output / "report.json",
+            work_dir=case_output / "work",
+            frames=frames,
+            timeout_seconds=entry.get("timeout_seconds", 300.0),
+            save_raw=entry.get("save_raw", False),
+            reuse_work_dir=entry.get("reuse_work_dir", False),
+            allow_environment_mismatch=allow_environment_mismatch,
+            launcher_args=launcher_args,
+            emulator_args=tuple(arguments),
+        )
+        validate_case(spec)
+        specs.append(spec)
+    if not specs:
+        raise ValueError("suite has no enabled cases")
+    output_root = output.resolve()
+    inputs = [path.resolve(), emulator.resolve()]
+    inputs += [value for spec in specs for value in (spec.game, spec.baseline)]
+    if any(_overlaps(output_root, value) for value in inputs):
+        raise ValueError("suite output directory overlaps a suite input")
+    return specs
+
+
+def run_suite(specs: list[CaseSpec], output: Path) -> int:
+    output = output.resolve()
+    if any(_overlaps(output, value) for spec in specs
+           for value in (spec.emulator, spec.game, spec.baseline)):
+        raise ValueError("suite output directory overlaps a case input")
+    if any(spec.report.parent.parent != output or spec.work_dir.parent != spec.report.parent
+           for spec in specs):
+        raise ValueError("suite case outputs do not belong to the suite output directory")
+    if output.is_symlink():
+        raise ValueError(f"suite output directory cannot be a symlink: {output}")
+    if output.exists() and not output.is_dir():
+        raise ValueError(f"suite output path is not a directory: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+    marker = output / ".runner-owned"
+    if any(output.iterdir()) and (not marker.is_file() or marker.is_symlink()):
+        raise ValueError(f"refusing to use unowned suite output directory: {output}")
+    marker.touch(exist_ok=True)
+    summary_path = output / "summary.json"
+    current_case_directories = {spec.report.parent for spec in specs}
+    for case_directory in current_case_directories:
+        if case_directory.is_symlink() or (case_directory.exists() and not case_directory.is_dir()):
+            raise ValueError(f"invalid suite case output directory: {case_directory}")
+    for entry in output.iterdir():
+        if entry == marker or entry in current_case_directories:
+            continue
+        if entry.is_symlink() or entry.is_file():
+            entry.unlink()
+        else:
+            shutil.rmtree(entry)
+    results = []
+    for spec in specs:
+        result = run_case(spec)
+        results.append(asdict(result))
+        atomic_write_text(
+            summary_path,
+            json.dumps({"schema_version": 1, "results": results}, indent=2) + "\n")
+        print(f"graphics regression [{result.test_id}]: {result.message}")
+    return 0 if all(result["exit_code"] == 0 for result in results) else 2

--- a/tools/graphics_regression/windows_job.py
+++ b/tools/graphics_regression/windows_job.py
@@ -1,0 +1,87 @@
+"""Minimal Windows Job Object wrapper with kill-on-close semantics."""
+
+from __future__ import annotations
+
+import ctypes
+from ctypes import wintypes
+
+_KILL_ON_CLOSE = 0x00002000
+_EXTENDED_LIMIT_INFORMATION = 9
+
+
+class _IoCounters(ctypes.Structure):
+    _fields_ = [(name, ctypes.c_uint64) for name in (
+        "ReadOperationCount", "WriteOperationCount", "OtherOperationCount",
+        "ReadTransferCount", "WriteTransferCount", "OtherTransferCount")]
+
+
+class _BasicLimitInformation(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", ctypes.c_int64),
+        ("PerJobUserTimeLimit", ctypes.c_int64),
+        ("LimitFlags", wintypes.DWORD),
+        ("MinimumWorkingSetSize", ctypes.c_size_t),
+        ("MaximumWorkingSetSize", ctypes.c_size_t),
+        ("ActiveProcessLimit", wintypes.DWORD),
+        ("Affinity", ctypes.c_size_t),
+        ("PriorityClass", wintypes.DWORD),
+        ("SchedulingClass", wintypes.DWORD),
+    ]
+
+
+class _ExtendedLimitInformation(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", _BasicLimitInformation),
+        ("IoInfo", _IoCounters),
+        ("ProcessMemoryLimit", ctypes.c_size_t),
+        ("JobMemoryLimit", ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed", ctypes.c_size_t),
+    ]
+
+
+def attach(process_handle: int) -> int | None:
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.argtypes = (ctypes.c_void_p, wintypes.LPCWSTR)
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    kernel32.SetInformationJobObject.argtypes = (
+        wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD)
+    kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    kernel32.AssignProcessToJobObject.argtypes = (wintypes.HANDLE, wintypes.HANDLE)
+    kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        return None
+    info = _ExtendedLimitInformation()
+    info.BasicLimitInformation.LimitFlags = _KILL_ON_CLOSE
+    configured = kernel32.SetInformationJobObject(
+        job, _EXTENDED_LIMIT_INFORMATION, ctypes.byref(info), ctypes.sizeof(info))
+    assigned = configured and kernel32.AssignProcessToJobObject(job, wintypes.HANDLE(process_handle))
+    if not assigned:
+        kernel32.CloseHandle(job)
+        return None
+    return int(job)
+
+
+def terminate(job: int, exit_code: int) -> bool:
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.TerminateJobObject.argtypes = (wintypes.HANDLE, wintypes.UINT)
+    kernel32.TerminateJobObject.restype = wintypes.BOOL
+    return bool(kernel32.TerminateJobObject(wintypes.HANDLE(job), exit_code))
+
+
+def resume(process_handle: int) -> bool:
+    """Resume a process created with CREATE_SUSPENDED after job assignment."""
+    ntdll = ctypes.WinDLL("ntdll", use_last_error=True)
+    ntdll.NtResumeProcess.argtypes = (wintypes.HANDLE,)
+    ntdll.NtResumeProcess.restype = wintypes.LONG
+    return ntdll.NtResumeProcess(wintypes.HANDLE(process_handle)) >= 0
+
+
+def close(job: int) -> None:
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    kernel32.CloseHandle(wintypes.HANDLE(job))

--- a/tools/run_graphics_regression.py
+++ b/tools/run_graphics_regression.py
@@ -1,17 +1,12 @@
 #!/usr/bin/env python3
-"""Run one deterministic graphics comparison with timeout and report validation."""
+"""Run one isolated graphics regression comparison."""
 
 from __future__ import annotations
 
 import argparse
-import json
-import subprocess
-import sys
 from pathlib import Path
 
-
-FAILURE = 2
-TIMEOUT = 124
+from graphics_regression import CaseSpec, run_case
 
 
 def frame_ordinals(value: str) -> list[int]:
@@ -19,82 +14,56 @@ def frame_ordinals(value: str) -> list[int]:
         frames = [int(part) for part in value.split(",")]
     except ValueError as error:
         raise argparse.ArgumentTypeError("frames must be comma-separated integers") from error
-    if not frames or any(frame < 0 for frame in frames) or len(frames) != len(set(frames)):
-        raise argparse.ArgumentTypeError("frames must be unique non-negative integers")
+    if not frames:
+        raise argparse.ArgumentTypeError("at least one frame is required")
     return frames
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--test-id", required=True)
     parser.add_argument("--emulator", required=True, type=Path)
     parser.add_argument("--game", required=True, type=Path)
     parser.add_argument("--baseline", required=True, type=Path)
     parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--work-dir", type=Path)
     parser.add_argument("--frames", required=True, type=frame_ordinals)
     parser.add_argument("--timeout-seconds", type=float, default=300.0)
-    parser.add_argument("--no-save-raw", action="store_true")
+    parser.add_argument("--save-raw", action="store_true")
+    parser.add_argument("--reuse-work-dir", action="store_true")
+    parser.add_argument("--allow-environment-mismatch", action="store_true")
+    parser.add_argument("--launcher-arg", action="append", default=[])
     parser.add_argument("emulator_args", nargs=argparse.REMAINDER,
                         help="additional emulator arguments after --")
-    args = parser.parse_args()
-    if args.timeout_seconds <= 0:
-        parser.error("--timeout-seconds must be positive")
-    return args
-
-
-def validate_report(path: Path, frames: list[int]) -> tuple[bool, str]:
-    try:
-        report = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as error:
-        return False, f"cannot read a valid report: {error}"
-    if (report.get("schema_version") != 1 or report.get("mode") != "compare" or
-            report.get("algorithm") != "xxh3_128" or report.get("complete") is not True):
-        return False, "report metadata is invalid or incomplete"
-    records = report.get("frames")
-    if (not isinstance(records, list) or any(not isinstance(record, dict) for record in records) or
-            [record.get("ordinal") for record in records] != sorted(frames)):
-        return False, "report does not contain exactly the requested frames"
-    passed = report.get("passed") is True and all(record.get("status") == "match"
-                                                    for record in records)
-    return passed, "all selected frames match" if passed else "one or more frames differ"
+    return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    emulator_args = args.emulator_args[1:] if args.emulator_args[:1] == ["--"] else args.emulator_args
+    report = args.report.resolve()
+    spec = CaseSpec(
+        test_id=args.test_id,
+        emulator=args.emulator.resolve(),
+        game=args.game.resolve(),
+        baseline=args.baseline.resolve(),
+        report=report,
+        work_dir=(args.work_dir or report.parent / f"{report.stem}_work").resolve(),
+        frames=args.frames,
+        timeout_seconds=args.timeout_seconds,
+        save_raw=args.save_raw,
+        reuse_work_dir=args.reuse_work_dir,
+        allow_environment_mismatch=args.allow_environment_mismatch,
+        launcher_args=tuple(args.launcher_arg),
+        emulator_args=tuple(emulator_args),
+    )
     try:
-        args.report.parent.mkdir(parents=True, exist_ok=True)
-        # A timed-out run must not reuse a stale successful report.
-        args.report.unlink(missing_ok=True)
-    except OSError as error:
-        print(f"cannot prepare report path: {error}", file=sys.stderr)
-        return FAILURE
-    frames = ",".join(str(frame) for frame in args.frames)
-    command = [
-        str(args.emulator), "--game", str(args.game),
-        "--regression-compare", str(args.baseline),
-        "--regression-report", str(args.report),
-        "--regression-frames", frames,
-        "--regression-save-raw", "false" if args.no_save_raw else "true",
-    ]
-    if args.emulator_args and args.emulator_args[0] == "--":
-        args.emulator_args.pop(0)
-    command.extend(args.emulator_args)
-    try:
-        result = subprocess.run(command, timeout=args.timeout_seconds, check=False)
-    except subprocess.TimeoutExpired:
-        print(f"graphics regression timed out after {args.timeout_seconds:g}s", file=sys.stderr)
-        return TIMEOUT
-    except OSError as error:
-        print(f"could not start emulator: {error}", file=sys.stderr)
-        return FAILURE
-
-    passed, message = validate_report(args.report, args.frames)
-    print(f"graphics regression: {message}")
-    if not passed:
-        return result.returncode if result.returncode != 0 else FAILURE
-    if result.returncode != 0:
-        print(f"emulator returned {result.returncode} despite a passing report", file=sys.stderr)
-        return result.returncode
-    return 0
+        result = run_case(spec)
+    except (OSError, ValueError) as error:
+        print(f"graphics regression: {error}")
+        return 2
+    print(f"graphics regression [{result.test_id}]: {result.message}")
+    return result.exit_code
 
 
 if __name__ == "__main__":

--- a/tools/run_graphics_regression.py
+++ b/tools/run_graphics_regression.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Run one deterministic graphics comparison with timeout and report validation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+FAILURE = 2
+TIMEOUT = 124
+
+
+def frame_ordinals(value: str) -> list[int]:
+    try:
+        frames = [int(part) for part in value.split(",")]
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("frames must be comma-separated integers") from error
+    if not frames or any(frame < 0 for frame in frames) or len(frames) != len(set(frames)):
+        raise argparse.ArgumentTypeError("frames must be unique non-negative integers")
+    return frames
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--emulator", required=True, type=Path)
+    parser.add_argument("--game", required=True, type=Path)
+    parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--frames", required=True, type=frame_ordinals)
+    parser.add_argument("--timeout-seconds", type=float, default=300.0)
+    parser.add_argument("--no-save-raw", action="store_true")
+    parser.add_argument("emulator_args", nargs=argparse.REMAINDER,
+                        help="additional emulator arguments after --")
+    args = parser.parse_args()
+    if args.timeout_seconds <= 0:
+        parser.error("--timeout-seconds must be positive")
+    return args
+
+
+def validate_report(path: Path, frames: list[int]) -> tuple[bool, str]:
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        return False, f"cannot read a valid report: {error}"
+    if (report.get("schema_version") != 1 or report.get("mode") != "compare" or
+            report.get("algorithm") != "xxh3_128" or report.get("complete") is not True):
+        return False, "report metadata is invalid or incomplete"
+    records = report.get("frames")
+    if (not isinstance(records, list) or any(not isinstance(record, dict) for record in records) or
+            [record.get("ordinal") for record in records] != sorted(frames)):
+        return False, "report does not contain exactly the requested frames"
+    passed = report.get("passed") is True and all(record.get("status") == "match"
+                                                    for record in records)
+    return passed, "all selected frames match" if passed else "one or more frames differ"
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        # A timed-out run must not reuse a stale successful report.
+        args.report.unlink(missing_ok=True)
+    except OSError as error:
+        print(f"cannot prepare report path: {error}", file=sys.stderr)
+        return FAILURE
+    frames = ",".join(str(frame) for frame in args.frames)
+    command = [
+        str(args.emulator), "--game", str(args.game),
+        "--regression-compare", str(args.baseline),
+        "--regression-report", str(args.report),
+        "--regression-frames", frames,
+        "--regression-save-raw", "false" if args.no_save_raw else "true",
+    ]
+    if args.emulator_args and args.emulator_args[0] == "--":
+        args.emulator_args.pop(0)
+    command.extend(args.emulator_args)
+    try:
+        result = subprocess.run(command, timeout=args.timeout_seconds, check=False)
+    except subprocess.TimeoutExpired:
+        print(f"graphics regression timed out after {args.timeout_seconds:g}s", file=sys.stderr)
+        return TIMEOUT
+    except OSError as error:
+        print(f"could not start emulator: {error}", file=sys.stderr)
+        return FAILURE
+
+    passed, message = validate_report(args.report, args.frames)
+    print(f"graphics regression: {message}")
+    if not passed:
+        return result.returncode if result.returncode != 0 else FAILURE
+    if result.returncode != 0:
+        print(f"emulator returned {result.returncode} despite a passing report", file=sys.stderr)
+        return result.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_graphics_regression_suite.py
+++ b/tools/run_graphics_regression_suite.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Run a validated graphics regression suite sequentially on one GPU."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from graphics_regression.suite import load_suite, run_suite
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", required=True, type=Path)
+    parser.add_argument("--emulator", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--launcher-arg", action="append", default=[])
+    parser.add_argument("--allow-environment-mismatch", action="store_true")
+    args = parser.parse_args()
+    try:
+        specs = load_suite(args.suite, args.emulator, args.output, tuple(args.launcher_arg),
+                           args.allow_environment_mismatch)
+        return run_suite(specs, args.output.resolve())
+    except (OSError, ValueError) as error:
+        print(f"graphics regression suite: {error}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add exact presented-frame baseline recording and comparison with enforced environment provenance
- add versioned commands-only GPU traces with checksummed completion footers
- add isolated single-game and sequential suite runners with process-tree timeouts
- add focused native/Python tests, documentation, and a trusted self-hosted GPU workflow

## Reliability

- atomic, durable manifests and frame artifacts with cross-process output reservations
- strict schema, bounds, corruption, provenance, baseline-anchor, and output-collision validation
- per-case work directories, logs, reports, summaries, and retained failure evidence
- suspended Windows process launch before Job Object assignment
- explicit artifact allowlist; frame evidence is opt-in and work directories are never uploaded
- commercial game content and baselines remain outside the repository

## Validation

- GPU trace tests
- frame regression tests
- 18 graphics regression runner tests
- CLI smoke checks
- C++20 no-exceptions warning-as-error focused compilation
- production source syntax checks
- three independent final audits with no release blocker found