### PR TITLE
fix(kernel): reserve guest stack window before host GPU driver init

### DIFF
--- a/src/common/platform/sysWindowsVirtual.cpp
+++ b/src/common/platform/sysWindowsVirtual.cpp
@@ -160,7 +160,26 @@ bool SysVirtualAllocFixed(uint64_t address, uint64_t size, VirtualMemory::Mode m
 	if (ptr == 0) {
 		auto err = static_cast<uint32_t>(GetLastError());
 
-		printf("VirtualAlloc() failed: 0x%08" PRIx32 "\n", err);
+		printf("VirtualAlloc() failed: address=0x%016" PRIx64 ", size=0x%016" PRIx64
+		       ", err=0x%08" PRIx32 "\n",
+		       address, size, err);
+
+		// Report what already occupies the requested range so fixed-address
+		// conflicts can be attributed to their owner.
+		uint64_t current = address;
+		while (current < address + size) {
+			MEMORY_BASIC_INFORMATION info {};
+			if (VirtualQuery(reinterpret_cast<const void*>(current), &info, sizeof(info)) == 0) {
+				break;
+			}
+			printf("\t conflicting region: base=0x%016" PRIx64 ", size=0x%016" PRIx64
+			       ", alloc_base=0x%016" PRIx64 ", state=0x%08" PRIx32 ", type=0x%08" PRIx32 "\n",
+			       reinterpret_cast<uint64_t>(info.BaseAddress),
+			       static_cast<uint64_t>(info.RegionSize),
+			       reinterpret_cast<uint64_t>(info.AllocationBase),
+			       static_cast<uint32_t>(info.State), static_cast<uint32_t>(info.Type));
+			current = reinterpret_cast<uint64_t>(info.BaseAddress) + info.RegionSize;
+		}
 		return false;
 	}
 

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -8,6 +8,7 @@
 #include "common/virtualMemory.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/host_gpu/renderer/gpuResourceManager.h"
+#include "kernel/pthread.h"
 #include "libs/errno.h"
 #include "libs/libs.h"
 
@@ -1005,6 +1006,30 @@ static bool ReleaseReservedRange(uint64_t vaddr, uint64_t size) {
 
 static bool ReplaceFixedRangeWithReserved(uint64_t start, uint64_t size, bool* placeholder_backed);
 
+// Guest thread stacks are mapped with MAP_FIXED below GUEST_STACK_TOP. Reserve
+// that window before any host component (e.g. the GPU driver's address arena)
+// can occupy it; stack maps then commit from the placeholder-backed range.
+static void ReserveGuestStackArea() {
+	constexpr uint64_t RESERVE_ALIGNMENT = 0x10000;
+
+	const uint64_t end   = LibKernel::GUEST_STACK_TOP & ~(RESERVE_ALIGNMENT - 1u);
+	const uint64_t start = end - LibKernel::GUEST_STACK_AREA_SIZE;
+
+	if (!g_placeholder_address_space->ReserveFixed(start, LibKernel::GUEST_STACK_AREA_SIZE)) {
+		LOGF_COLOR(Log::Color::Yellow,
+		           "\t guest stack area is already occupied: addr=0x%016" PRIx64
+		           " size=0x%016" PRIx64 "\n",
+		           start, LibKernel::GUEST_STACK_AREA_SIZE);
+		return;
+	}
+
+	if (!g_virtual_ranges->Add(start, LibKernel::GUEST_STACK_AREA_SIZE, 0, 0, 0,
+	                           VirtualRangeType::Reserved, "guest_stack_area", false, true)) {
+		EXIT("failed to register guest stack area: addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
+		     start, LibKernel::GUEST_STACK_AREA_SIZE);
+	}
+}
+
 KYTY_SUBSYSTEM_INIT(Memory) {
 	g_flexible_memory_size      = DEFAULT_FLEXIBLE_MEMORY_SIZE;
 	g_physical_memory           = new PhysicalMemory;
@@ -1018,6 +1043,7 @@ KYTY_SUBSYSTEM_INIT(Memory) {
 	EXIT_IF(!g_direct_memory_backing->SelfTest());
 	g_placeholder_address_space->SelfTest();
 	SelfTestSub64SharedPlaceholderAlias();
+	ReserveGuestStackArea();
 }
 
 KYTY_SUBSYSTEM_UNEXPECTED_SHUTDOWN(Memory) {}

--- a/src/kernel/pthread.cpp
+++ b/src/kernel/pthread.cpp
@@ -66,7 +66,7 @@ constexpr size_t   PTHREAD_STACK_PAGE        = 0x4000;
 constexpr size_t   PTHREAD_STACK_GRANULARITY = 0x10000;
 constexpr size_t   PTHREAD_STACK_INITIAL     = 0x200000;
 constexpr size_t   PTHREAD_STACK_EXTRA       = 0x100000;
-constexpr uint64_t PTHREAD_STACK_TOP         = 0x7efff8000ull;
+constexpr uint64_t PTHREAD_STACK_TOP         = GUEST_STACK_TOP;
 constexpr uint32_t SIGNAL_APC_POLL_MICROS    = 10000;
 
 static constexpr KernelClockid KERNEL_CLOCK_REALTIME          = 0;

--- a/src/kernel/pthread.h
+++ b/src/kernel/pthread.h
@@ -21,6 +21,13 @@ namespace LibKernel {
 
 KYTY_SUBSYSTEM_DEFINE(Pthread);
 
+// Guest thread stacks are mapped top-down with MAP_FIXED starting below
+// GUEST_STACK_TOP (see CreateGuestStack in pthread.cpp). The Memory subsystem
+// pre-reserves GUEST_STACK_AREA_SIZE bytes below it at init so host-side
+// allocations (e.g. GPU driver address arenas) cannot occupy the fixed range.
+constexpr uint64_t GUEST_STACK_TOP       = 0x7efff8000ull;
+constexpr uint64_t GUEST_STACK_AREA_SIZE = 0x40000000ull;
+
 struct PthreadAttrPrivate;
 struct PthreadPrivate;
 struct PthreadMutexPrivate;

--- a/tests/VirtualMemoryAllocationTests.cpp
+++ b/tests/VirtualMemoryAllocationTests.cpp
@@ -4,6 +4,7 @@
 #include "common/subsystems.h"
 #include "common/threads.h"
 #include "kernel/memory.h"
+#include "kernel/pthread.h"
 #include "libs/errno.h"
 
 #include <cinttypes>
@@ -1454,6 +1455,45 @@ void TestProgramMemoryRegistrationAndProtection() {
 	std::printf("[host]    %-48s ok\n", test);
 }
 
+void TestGuestStackAreaIsReservedForFixedStackMaps() {
+	const char* test = "GuestStackAreaIsReservedForFixedStackMaps";
+
+	constexpr int SceKernelMapStack   = 0x400;
+	constexpr int SceKernelMapPrivate = 0x02;
+	constexpr int SceKernelMapAnon    = 0x1000;
+
+	// Same placement policy as CreateGuestStack: top-down below GUEST_STACK_TOP.
+	constexpr uint64_t map_size = 0x210000;
+	const uint64_t     map_addr =
+	    ((Libs::LibKernel::GUEST_STACK_TOP - 0x200000 - SceKernelPageSize) & ~uint64_t {0xffff}) -
+	    map_size;
+
+	const uint64_t area_end   = Libs::LibKernel::GUEST_STACK_TOP & ~uint64_t {0xffff};
+	const uint64_t area_start = area_end - Libs::LibKernel::GUEST_STACK_AREA_SIZE;
+	ExpectRange(test, Query(test, map_addr), area_start, area_end, 0, 0, 0, 0, 0,
+	            "guest_stack_area");
+
+	void* fixed = reinterpret_cast<void*>(map_addr);
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelMapNamedFlexibleMemory(
+	            &fixed, map_size, SceKernelProtCpuRead | SceKernelProtCpuRw,
+	            SceKernelMapFixed | SceKernelMapPrivate | SceKernelMapStack | SceKernelMapAnon,
+	            "stack"),
+	        "KernelMapNamedFlexibleMemory(MAP_FIXED stack)");
+	Check(test, reinterpret_cast<uint64_t>(fixed) == map_addr, "fixed stack mapping moved");
+
+	// The pages must be writable, as CreateGuestStack zero-fills them.
+	*reinterpret_cast<uint64_t*>(map_addr)                = 0x4b59545953544b31ull;
+	*reinterpret_cast<uint64_t*>(map_addr + map_size - 8) = 0x4b59545953544b32ull;
+	Check(test, *reinterpret_cast<uint64_t*>(map_addr) == 0x4b59545953544b31ull,
+	      "stack memory readback failed");
+
+	CheckOk(test, Libs::LibKernel::Memory::KernelMunmap(map_addr, map_size),
+	        "KernelMunmap(stack cleanup)");
+
+	std::printf("[host]    %-48s ok\n", test);
+}
+
 } // namespace
 
 int main() {
@@ -1463,6 +1503,7 @@ int main() {
 	RunTest(TestFlexibleMapQueryAndWholeMunmap);
 	RunTest(TestPartialFlexibleMunmapAndFindNext);
 	RunTest(TestReserveMapFixedAndNoOverwrite);
+	RunTest(TestGuestStackAreaIsReservedForFixedStackMaps);
 	RunTest(TestFixedNoOverwriteRejectsReservedRange);
 	RunTest(TestReleasedReserveCanBeReused);
 	RunTest(TestMunmapAcrossAdjacentFlexibleMappings);


### PR DESCRIPTION
Using build 8fe4765 the tested game Grand Theft Auto: San Andreas The Definitive Edition dies instantly on boot with

VirtualAlloc() failed: 0x000001e7 Not implemented (result != OK) in src/kernel/pthread.cpp:932
    
Error 0x1e7 is Windows' ERROR_INVALID_ADDRESS, a memory allocation was requested but the memory address is already occupied, the emulator gives every guest thread a stack that MUST live at exact addresses. On windows when the emu inits Vulkan, the GPU Driver (NVIDIA Game Ready Driver 610.74) reserves a massive section of address space for itself, measured ~256 GiB of reserved private memory in one block.
The blob covered the stack's expected range, when the game's main threa asked for it, it received an occupied signal and the emulator aborted before the game even started.
Note: The same blob also covers the preferred ELF load address (0x900000000), but it survives because it's allowed to relocate the binary elsewhere.

This symptom involves a degree of RNG as it most likely differs per machine/driver.

### The Fix

TLDR: fix(kernel): stake the memory territory before the GPU has a chance to, avoiding the occupied memory address conflict altogether.

- `src/kernel/pthread.h` — the stack-top constant moved here as `GUEST_STACK_TOP`, plus a new `GUEST_STACK_AREA_SIZE` (1 GiB) so both the pthread code and the memory code agree on the window.
- `src/kernel/memory.cpp` — new `ReserveGuestStackArea()`, called at the end of Memory subsystem init. The Memory subsystem initializes before the Graphics subsystem (which is when the driver does its thing), so the 1 GiB stack window below GUEST_STACK_TOP is reserved early, as a Windows "placeholder" reservation registered as a Reserved range named `guest_stack_area`.
- No changes needed in the stack-mapping path itself: the emulator already knows how to commit fixed mappings out of placeholder-backed Reserved ranges (that machinery existed for other features). Our reservation just makes stacks take that path instead of the raw-VirtualAlloc path.
- `src/common/platform/sysWindowsVirtual.cpp` — better diagnostics: when a fixed allocation fails, it now prints the requested address/size AND asks Windows what's occupying the range (VirtualQuery loop). This is how the root cause was found, and it stays in to make the next conflict obvious.
- If the window is somehow already occupied at init, it logs a warning and continues (old behavior), instead of failing hard.
  
**Fully generic fix, no game specific workarounds implemented.**
  
###  Investigation methodology

1. Baseline run crashed at pthread.cpp:932. Read the code path:
   `PthreadCreateMainGuestStack` → `CreateGuestStack` → `KernelMapNamedFlexibleMemory(MAP_FIXED)` → `VirtualAlloc` at fixed addr.
2. The failing error print didn't say WHAT was in the way, so the first step was adding the VirtualQuery conflict dump to `SysVirtualAllocFixed`.
3. One re-run produced the smoking gun: a single private MEM_RESERVE allocation based at 0x4a2590000 covering the entire stack window — and ending exactly at 0x44a2590000, which is where the ELF had been bumped to. That's a ~256 GiB reservation not made by any emulator code (searched the whole tree for large reservations — nothing matches), appearing between Memory init and ELF load, i.e. during Vulkan/driver init.
4. Fix: pre-reserve the window earlier. Verified the existing commit-from-reserved path handles the actual stack mapping.
   
### Testing
   
- New regression test: `GuestStackAreaIsReservedForFixedStackMaps` in `tests/VirtualMemoryAllocationTests.cpp`. It checks the window is registered after Memory init, then performs a MAP_FIXED stack-style mapping inside it (same flags as `CreateGuestStack`), writes/reads the memory, and unmaps. Passes.
 - Full local test sweep (12 suites): 10 pass. The 2 failures are PRE-EXISTING and were proven unrelated by disabling the new `ReserveGuestStackArea()` call and re-running — they fail identically without the fix:
- `virtual_memory_allocation_tests` → `DirectMapUnmapReusesHostAddress` (remap address changes 0x840000 → 0xc40000; deterministic on this machine, needs its own investigation)
- `shader_recompiler_compute_tests` → `ImageTransitionState` ("combined depth/stencil mip copy lost an aspect"; likely GPU/driver-dependent).
- Runtime: GTA SA: TDE previously aborted in <2 s. With the fix, a 150 s bounded run had zero fatal errors across a 1.2M-line log, played the 4 intro videos (AvPlayer), and reached in-engine rendering (render targets, instanced draws, dozens of guest threads), menu is reachable, the next block is on the post main menu loading splash screen probably texture related.
- Host used for testing: Windows 11 23H2, Ryzen 7 7745HX, NVIDIA RTX 4070 Laptop GPU (NVIDIA Game Ready Driver 610.74), Vulkan SDK 1.4.350, clang-cl (VS 2022 Build Tools), Release build.
   
  Tested with whole GTA Remaster Trilogy, same behavior across the board

### AI Disclosure

The investigation and initial implementation were AI-assisted, I personally managed, reviewed the diff, understood the root cause, rebuilt, ran the full test suite including the new regression test, and verified my test game boots (the intro videos play, the menu is reachable, you can continue past the menu but it hangs right after). Several MCP servers were used on top of repo wiki indexing, if anyone needs any of the MCPs IDA Pro (decompiler), PS5RS (binary analysis toolkit, Kyty MCP (Homebrew, for logging and emulation runs).

### Files in the diff (5 files, +95/-2)

- src/kernel/pthread.h                      (+7)  shared constants
- src/kernel/pthread.cpp                    (±1)  use shared constant
- src/kernel/memory.cpp                     (+26) ReserveGuestStackArea()
- src/common/platform/sysWindowsVirtual.cpp (+21/-1) conflict diagnostics
- tests/VirtualMemoryAllocationTests.cpp    (+41) regression test