### PR TITLE
Drop redundant PROT_NONE tracking in reserve paths for Linux

### DIFF
--- a/src/common/platform/sysLinuxVirtual.cpp
+++ b/src/common/platform/sysLinuxVirtual.cpp
@@ -432,11 +432,6 @@ uint64_t SysVirtualReserveAligned(uint64_t address, uint64_t size, uint64_t alig
 
 	pthread_mutex_lock(&g_virtual_mutex);
 	record_alloc(ret_addr, size);
-	uintptr_t page_start  = ret_addr >> 12u;
-	uintptr_t page_end    = (ret_addr + size - 1) >> 12u;
-	for (uintptr_t page = page_start; page <= page_end; page++) {
-		(*g_protects)[page] = PROT_NONE;
-	}
 	pthread_mutex_unlock(&g_virtual_mutex);
 
 	return ret_addr;
@@ -470,11 +465,6 @@ bool SysVirtualReserveFixed(uint64_t address, uint64_t size) {
 	if (ptr != MAP_FAILED) {
 		pthread_mutex_lock(&g_virtual_mutex);
 		record_alloc(ret_addr, size);
-		uintptr_t page_start  = ret_addr >> 12u;
-		uintptr_t page_end    = (ret_addr + size - 1) >> 12u;
-		for (uintptr_t page = page_start; page <= page_end; page++) {
-			(*g_protects)[page] = PROT_NONE;
-		}
 		pthread_mutex_unlock(&g_virtual_mutex);
 
 		return true;


### PR DESCRIPTION
* Some UE4 games, such as The Pathless, reserve a 512 GiB virtual address range during libc startup. Tracking every 4 KiB page causes a long delay and is unnecessary since the range is already PROT_NONE, and untracked pages are treated as NoAccess.