### PR TITLE
fix: keep hint-less guest mappings at the canonical PS5 base (fixes the #135 macOS regression)

### DIFF
--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -817,6 +817,11 @@ static void                  MemoryPoolSubtractCommitted(uint64_t len);
 // Keep host mappings, physical blocks, placeholders, and virtual ranges in step.
 static std::recursive_mutex g_memory_operation_mutex;
 
+// The base address the PS5 kernel hands out for hint-less user mappings. Guest code can
+// assume mappings it did not place explicitly are at or above this (Sony's libc rejects a
+// heap below it), so hint-less searches must not fall back to the low system-managed range.
+static constexpr uint64_t GUEST_DEFAULT_MAP_BASE = 0x200000000ull;
+
 static uint64_t FindGuestFreeRange(uint64_t search_addr, uint64_t size, uint64_t alignment) {
 	EXIT_IF(g_guest_address_space == nullptr || g_virtual_ranges == nullptr);
 
@@ -844,8 +849,11 @@ static uint64_t FindGuestFreeRange(uint64_t search_addr, uint64_t size, uint64_t
 	if (search_addr != 0) {
 		return find_in(search_addr, HOST_USER_MAX + 1u);
 	}
-	auto addr = find_in(HOST_SYSTEM_MANAGED_MIN, HOST_SYSTEM_MANAGED_MAX + 1u);
-	return addr != 0 ? addr : find_in(HOST_USER_MIN, HOST_USER_MAX + 1u);
+	auto addr = find_in(GUEST_DEFAULT_MAP_BASE, HOST_SYSTEM_MANAGED_MAX + 1u);
+	if (addr == 0) {
+		addr = find_in(HOST_USER_MIN, HOST_USER_MAX + 1u);
+	}
+	return addr != 0 ? addr : find_in(HOST_SYSTEM_MANAGED_MIN, HOST_SYSTEM_MANAGED_MAX + 1u);
 }
 
 bool TryWriteBacking(uint64_t vaddr, const void* data, uint64_t size) {

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -853,7 +853,7 @@ static uint64_t FindGuestFreeRange(uint64_t search_addr, uint64_t size, uint64_t
 	if (addr == 0) {
 		addr = find_in(HOST_USER_MIN, HOST_USER_MAX + 1u);
 	}
-	return addr != 0 ? addr : find_in(HOST_SYSTEM_MANAGED_MIN, HOST_SYSTEM_MANAGED_MAX + 1u);
+	return addr;
 }
 
 bool TryWriteBacking(uint64_t vaddr, const void* data, uint64_t size) {

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -38,7 +38,10 @@
 #include <windows.h>
 #else
 #include <dlfcn.h>
-#if KYTY_PLATFORM == KYTY_PLATFORM_LINUX && !defined(__APPLE__)
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#elif KYTY_PLATFORM == KYTY_PLATFORM_LINUX
 #include <sys/uio.h>
 #include <unistd.h>
 #endif
@@ -722,7 +725,26 @@ static bool IsReadableRange(uint64_t addr, uint64_t size) {
 		}
 		current = std::min(region_end, end);
 	}
-#elif KYTY_PLATFORM == KYTY_PLATFORM_LINUX && !defined(__APPLE__)
+#elif defined(__APPLE__)
+	// Walk the Mach regions covering the range and require read permission. The fatal
+	// report dumps memory behind raw register values, and a fault inside the reporter
+	// re-enters the signal handler and wedges the reporting thread.
+	uint64_t current = addr;
+	while (current < end) {
+		mach_vm_address_t              region_addr = current;
+		mach_vm_size_t                 region_size = 0;
+		vm_region_basic_info_data_64_t info {};
+		mach_msg_type_number_t         count       = VM_REGION_BASIC_INFO_COUNT_64;
+		mach_port_t                    object_name = MACH_PORT_NULL;
+		if (mach_vm_region(mach_task_self(), &region_addr, &region_size, VM_REGION_BASIC_INFO_64,
+		                   reinterpret_cast<vm_region_info_t>(&info), &count,
+		                   &object_name) != KERN_SUCCESS ||
+		    region_addr > current || (info.protection & VM_PROT_READ) == 0) {
+			return false;
+		}
+		current = region_addr + region_size;
+	}
+#elif KYTY_PLATFORM == KYTY_PLATFORM_LINUX
 	const auto page_size = static_cast<uint64_t>(sysconf(_SC_PAGESIZE));
 	if (page_size == 0) {
 		return false;
@@ -752,7 +774,7 @@ static bool IsReadableRange(uint64_t addr, uint64_t size) {
 }
 
 static bool IsDumpableRange(uint64_t addr, uint64_t size) {
-#if KYTY_PLATFORM == KYTY_PLATFORM_LINUX && !defined(__APPLE__)
+#if KYTY_PLATFORM == KYTY_PLATFORM_LINUX
 	return IsReadableRange(addr, size);
 #else
 	(void)size;

--- a/tests/VirtualMemoryAllocationTests.cpp
+++ b/tests/VirtualMemoryAllocationTests.cpp
@@ -1359,6 +1359,135 @@ void TestLargeDirectMapAliasesAcrossChunks() {
 	std::printf("[host]    %-48s ok\n", test);
 }
 
+void TestHintlessDirectMapUsesCanonicalGuestBase() {
+	// Mirrors the allocation Sony's libc.prx makes for its internal heap: 4 MiB of
+	// direct memory, 2 MiB aligned, mapped with no address hint. The PS5 kernel never
+	// places hint-less user mappings below 0x200000000 and guest code relies on that
+	// (libc fails its mspace setup for a lower heap address, and the first malloc then
+	// dereferences a null mspace). Writes through the mapping must also stick.
+	const char* test = "HintlessDirectMapUsesCanonicalGuestBase";
+
+	constexpr uint64_t Len   = 0x400000;
+	constexpr uint64_t Align = 0x200000;
+
+	int64_t phys_addr = 0;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelAllocateDirectMemory(0, 0x260000000ull, Len, Align, 12,
+	                                                            &phys_addr),
+	        "KernelAllocateDirectMemory");
+
+	void* address = nullptr;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelMapNamedDirectMemory(&address, Len, SceKernelProtCpuRw,
+	                                                            0, phys_addr, Align, "libc_heap"),
+	        "KernelMapNamedDirectMemory");
+	const auto base = reinterpret_cast<uint64_t>(address);
+	{
+		char message[128] = {};
+		std::snprintf(message, sizeof(message),
+		              "hint-less direct map landed below the PS5 base: 0x%016" PRIx64, base);
+		Check(test, base >= 0x200000000ull, message);
+	}
+
+	auto* header = reinterpret_cast<uint64_t*>(base);
+	header[0]    = 0x4d53504143453030ull; // "MSPACE00"
+	header[7]    = 0x58585858ull;         // magic at +0x38, like the libc mspace
+	*reinterpret_cast<uint64_t*>(base + Len - 8) = 0x454e444d41524bull;
+
+	Check(test, header[0] == 0x4d53504143453030ull, "immediate readback of header[0] failed");
+	Check(test, header[7] == 0x58585858ull, "immediate readback of header[7] failed");
+	Check(test, *reinterpret_cast<const uint64_t*>(base + Len - 8) == 0x454e444d41524bull,
+	      "immediate readback of tail failed");
+
+	uint64_t backing = 0;
+	Check(test, Libs::LibKernel::Memory::TryReadBacking(base + 0x38, &backing, sizeof(backing)),
+	      "TryReadBacking(header+0x38)");
+	Check(test, backing == 0x58585858ull, "backing store does not see the guest write at +0x38");
+
+	CheckOk(test, Libs::LibKernel::Memory::KernelMunmap(base, Len), "KernelMunmap");
+	CheckOk(test, Libs::LibKernel::Memory::KernelReleaseDirectMemory(phys_addr, Len),
+	        "KernelReleaseDirectMemory");
+
+	std::printf("[host]    %-48s ok\n", test);
+}
+
+void TestDirectMemoryContentPersistsAcrossRemap() {
+	const char* test = "DirectMemoryContentPersistsAcrossRemap";
+
+	constexpr uint64_t MapSize = SceKernelPageSize * 4;
+
+	int64_t phys_addr = 0;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelAllocateDirectMemory(
+	            SceKernelDirectMemoryStart, Libs::LibKernel::Memory::KernelGetDirectMemorySize(),
+	            MapSize, SceKernelPageSize, SceKernelMtypeC, &phys_addr),
+	        "KernelAllocateDirectMemory");
+
+	// Direct memory is physical: contents must survive unmapping and remapping, including
+	// a remap of a sub-range at a nonzero physical offset.
+	void* address = nullptr;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelMapNamedDirectMemory(&address, MapSize,
+	                                                            SceKernelProtCpuRw, 0, phys_addr,
+	                                                            SceKernelPageSize, "persist_a"),
+	        "KernelMapNamedDirectMemory(first)");
+	const auto base = reinterpret_cast<uint64_t>(address);
+	for (uint64_t offset = 0; offset < MapSize; offset += sizeof(uint64_t)) {
+		*reinterpret_cast<uint64_t*>(base + offset) = offset ^ 0x4b5954595045525aull; // "KYTYPERZ"
+	}
+	CheckOk(test, Libs::LibKernel::Memory::KernelMunmap(base, MapSize), "KernelMunmap(first)");
+
+	void* remap = nullptr;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelMapNamedDirectMemory(&remap, MapSize,
+	                                                            SceKernelProtCpuRw, 0, phys_addr,
+	                                                            SceKernelPageSize, "persist_b"),
+	        "KernelMapNamedDirectMemory(remap)");
+	const auto remap_base = reinterpret_cast<uint64_t>(remap);
+	for (uint64_t offset = 0; offset < MapSize; offset += sizeof(uint64_t)) {
+		const auto expected = offset ^ 0x4b5954595045525aull;
+		const auto actual   = *reinterpret_cast<const uint64_t*>(remap_base + offset);
+		if (actual != expected) {
+			char message[160] = {};
+			std::snprintf(message, sizeof(message),
+			              "content lost across remap at offset 0x%" PRIx64 ": expected 0x%016" PRIx64
+			              ", read 0x%016" PRIx64,
+			              offset, expected, actual);
+			Fail(test, message);
+		}
+	}
+	CheckOk(test, Libs::LibKernel::Memory::KernelMunmap(remap_base, MapSize), "KernelMunmap(remap)");
+
+	// Sub-range remap at a nonzero physical offset: page 2 of the original allocation.
+	void* partial = nullptr;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelMapNamedDirectMemory(
+	            &partial, SceKernelPageSize, SceKernelProtCpuRw, 0,
+	            phys_addr + static_cast<int64_t>(SceKernelPageSize * 2), SceKernelPageSize,
+	            "persist_c"),
+	        "KernelMapNamedDirectMemory(partial)");
+	const auto partial_base = reinterpret_cast<uint64_t>(partial);
+	for (uint64_t offset = 0; offset < SceKernelPageSize; offset += sizeof(uint64_t)) {
+		const auto expected = (SceKernelPageSize * 2 + offset) ^ 0x4b5954595045525aull;
+		const auto actual   = *reinterpret_cast<const uint64_t*>(partial_base + offset);
+		if (actual != expected) {
+			char message[160] = {};
+			std::snprintf(message, sizeof(message),
+			              "content lost in partial remap at offset 0x%" PRIx64
+			              ": expected 0x%016" PRIx64 ", read 0x%016" PRIx64,
+			              offset, expected, actual);
+			Fail(test, message);
+		}
+	}
+	CheckOk(test, Libs::LibKernel::Memory::KernelMunmap(partial_base, SceKernelPageSize),
+	        "KernelMunmap(partial)");
+
+	CheckOk(test, Libs::LibKernel::Memory::KernelReleaseDirectMemory(phys_addr, MapSize),
+	        "KernelReleaseDirectMemory");
+
+	std::printf("[host]    %-48s ok\n", test);
+}
+
 void TestDirectMapUnmapReusesHostAddress() {
 	const char* test = "DirectMapUnmapReusesHostAddress";
 
@@ -2153,6 +2282,8 @@ int main() {
 	RunTest(TestDirectAlignmentStaysWithinSearchRange);
 	RunTest(TestDefaultDirectMapUsesSystemAddressRange);
 	RunTest(TestLargeDirectMapAliasesAcrossChunks);
+	RunTest(TestHintlessDirectMapUsesCanonicalGuestBase);
+	RunTest(TestDirectMemoryContentPersistsAcrossRemap);
 	RunTest(TestDirectMapUnmapReusesHostAddress);
 	RunTest(TestFixedReserveReplacesPartialDirectMapping);
 	RunTest(TestFixedReserveRollbackConsumesRestoredPlaceholder);


### PR DESCRIPTION
This is the root cause and fix for the Raiden III regression I reported in #136 after #135 landed.

## What broke

FindGuestFreeRange searches the low system-managed range first for mappings with no address hint, so the first hint-less direct-memory map could land as low as 0x200000. The PS5 kernel never places hint-less user mappings below 0x200000000, and guest code relies on that. Sony's libc.prx maps 4 MiB of direct memory for its internal heap during module init, fails its mspace setup when the returned address is that low, and leaves its default mspace null. The first malloc then does `cmp [rdi+0x38], magic` with rdi = 0, which is the read at 0x38 from my report. On macOS this killed Raiden III on the main guest thread about 2 seconds after boot, 100 percent reproducible with --printf-direction Silent.

The fix anchors hint-less searches at 0x200000000 (the same base the mmap path already uses), falls back to the user range, and does not fall through to HOST_SYSTEM_MANAGED_MIN. This is shared code, so it applies to all platforms. I believe Windows and Linux have the same latent hazard and just have not been observed hitting it yet. Two regression tests are included and run in the existing virtual_memory_allocation suite on Windows and macOS CI: the libc-shaped allocation must come back at or above the canonical base and hold writes, and direct-memory content must survive an unmap and remap of the same physical range.

## Why it looked like a timing bug

The crash actually fired on every run in every log mode. What differed was the reporting. On macOS, IsReadableRange accepted any nonzero address, so the fatal report's guest memory dumps dereferenced whatever the crashed thread had in its registers (rbx was 0x30). The reporter faulted, re-entered the signal handler, and the reporting thread wedged in a fault loop while the rest of the game kept running. So with Console or File logging the game appeared healthy, and only Silent mode (which skips the dumps) ever reported the crash. The second commit makes the macOS reporter walk the Mach regions and require read permission before dumping, matching what the Linux implementation already does, so a real crash can never be swallowed like this again.

## Tested

On an M3 Pro MacBook Pro, on top of current main:

- Raiden III: was 6 out of 6 crashes at about 5 seconds with Silent logging, now 3 out of 3 clean runs, plays normally at 60 fps
- Metal Slug Tactics: unaffected, still reaches menus and gameplay (its remaining issue is the separate Rosetta AVX EmulateForward abort, unrelated to this)
- virtual_memory_allocation tests: all pass, including the two new cases
