### PR TITLE
launcher: add per-test log output option

### DIFF
--- a/src/launcher/forms/configuration_edit_dialog.ui
+++ b/src/launcher/forms/configuration_edit_dialog.ui
@@ -203,7 +203,7 @@
       <item row="7" column="1">
        <widget class="QComboBox" name="comboBox_printf_direction">
         <property name="toolTip">
-         <string>Print logs to file or console window. If enabled may decrease emulator performance</string>
+         <string>Print logs to the console or a file. File per test creates a new file for every test</string>
         </property>
        </widget>
       </item>

--- a/src/launcher/include/configuration.h
+++ b/src/launcher/include/configuration.h
@@ -63,7 +63,7 @@ public:
 	enum class ProfilerDirection { None, Network };
 	Q_ENUM(ProfilerDirection)
 
-	enum class LogDirection { Silent, Console, File };
+	enum class LogDirection { Silent, Console, File, FilePerTest };
 	Q_ENUM(LogDirection)
 
 	enum class GameStatus { Unknown, InGame, Logo, DoesntBoot, MainMenu };

--- a/src/launcher/src/configurationEditDialog.cpp
+++ b/src/launcher/src/configurationEditDialog.cpp
@@ -58,6 +58,8 @@ static QString GameDirectoryKey(const QString& dir) {
 #endif
 }
 
+static Configuration::LogDirection TextToLogDirection(const QString& text);
+
 ConfigurationEditDialog::ConfigurationEditDialog(Configuration& info, QWidget* parent)
     : QDialog(parent, Qt::WindowCloseButtonHint), m_ui(new Ui::ConfigurationEditDialog),
       m_info(info) {
@@ -76,8 +78,10 @@ ConfigurationEditDialog::ConfigurationEditDialog(Configuration& info, QWidget* p
 	        [this](bool flag) { m_ui->lineEdit_cmd_dump_folder->setEnabled(flag); });
 	connect(m_ui->comboBox_printf_direction, &QComboBox::currentTextChanged, this,
 	        [this](const QString& text) {
-		        auto log = TextToEnum<Configuration::LogDirection>(text);
-		        m_ui->lineEdit_printf_file->setEnabled(log == Configuration::LogDirection::File);
+		        auto log = TextToLogDirection(text);
+		        m_ui->lineEdit_printf_file->setEnabled(
+		            log == Configuration::LogDirection::File ||
+		            log == Configuration::LogDirection::FilePerTest);
 	        });
 
 	layout()->setSizeConstraint(QLayout::SetFixedSize);
@@ -118,6 +122,24 @@ static void ListInit(QComboBox* combo, T value) {
 	combo->setCurrentText(EnumToText(value));
 }
 
+static QString LogDirectionToText(Configuration::LogDirection value) {
+	return value == Configuration::LogDirection::FilePerTest ? QStringLiteral("File per test")
+	                                                         : EnumToText(value);
+}
+
+static Configuration::LogDirection TextToLogDirection(const QString& text) {
+	return text == QStringLiteral("File per test") ? Configuration::LogDirection::FilePerTest
+	                                               : TextToEnum<Configuration::LogDirection>(text);
+}
+
+static void LogDirectionListInit(QComboBox* combo, Configuration::LogDirection value) {
+	auto items = EnumToList<Configuration::LogDirection>();
+	items.replaceInStrings(QStringLiteral("FilePerTest"), QStringLiteral("File per test"));
+	combo->clear();
+	combo->addItems(items);
+	combo->setCurrentText(LogDirectionToText(value));
+}
+
 void ConfigurationEditDialog::Init(const Configuration& info) {
 	ListInit(m_ui->comboBox_screen_resolution, info.screen_resolution);
 	m_ui->spinBox_vblank_frequency->setValue(info.vblank_frequency);
@@ -133,10 +155,11 @@ void ConfigurationEditDialog::Init(const Configuration& info) {
 	m_ui->checkBox_cmd_dump->setChecked(info.command_buffer_dump_enabled);
 	m_ui->lineEdit_cmd_dump_folder->setText(info.command_buffer_dump_folder);
 	m_ui->lineEdit_cmd_dump_folder->setEnabled(info.command_buffer_dump_enabled);
-	ListInit(m_ui->comboBox_printf_direction, info.printf_direction);
+	LogDirectionListInit(m_ui->comboBox_printf_direction, info.printf_direction);
 	m_ui->lineEdit_printf_file->setText(info.printf_output_file);
-	m_ui->lineEdit_printf_file->setEnabled(info.printf_direction ==
-	                                       Configuration::LogDirection::File);
+	m_ui->lineEdit_printf_file->setEnabled(
+	    info.printf_direction == Configuration::LogDirection::File ||
+	    info.printf_direction == Configuration::LogDirection::FilePerTest);
 	ListInit(m_ui->comboBox_profiler_direction, info.profiler_direction);
 }
 
@@ -253,8 +276,7 @@ static void UpdateInfo(Configuration& info, Ui::ConfigurationEditDialog& ui) {
 	info.shader_log_folder           = ui.lineEdit_shader_log_folder->text();
 	info.command_buffer_dump_enabled = ui.checkBox_cmd_dump->isChecked();
 	info.command_buffer_dump_folder  = ui.lineEdit_cmd_dump_folder->text();
-	info.printf_direction =
-	    TextToEnum<Configuration::LogDirection>(ui.comboBox_printf_direction->currentText());
+	info.printf_direction   = TextToLogDirection(ui.comboBox_printf_direction->currentText());
 	info.printf_output_file = ui.lineEdit_printf_file->text();
 	info.profiler_direction =
 	    TextToEnum<Configuration::ProfilerDirection>(ui.comboBox_profiler_direction->currentText());

--- a/src/launcher/src/mainDialog.cpp
+++ b/src/launcher/src/mainDialog.cpp
@@ -8,6 +8,7 @@
 
 #include <QApplication>
 #include <QByteArray>
+#include <QDateTime>
 #include <QDialog>
 #include <QDir>
 #include <QFile>
@@ -194,6 +195,33 @@ static QString BoolArg(bool value) {
 	return value ? QStringLiteral("true") : QStringLiteral("false");
 }
 
+static QString CreateTestLogFile(const Configuration& info) {
+	QFileInfo configured_file(info.printf_output_file);
+	auto      game_id = info.title_id.trimmed();
+
+	if (game_id.isEmpty()) {
+		game_id = QDir(info.basedir).dirName();
+	}
+	if (game_id.isEmpty()) {
+		game_id = QStringLiteral("game");
+	}
+	game_id.replace(QRegularExpression(QStringLiteral("[^A-Za-z0-9._-]+")), QStringLiteral("_"));
+
+	auto base_name = configured_file.completeBaseName();
+	if (base_name.isEmpty()) {
+		base_name = QStringLiteral("_kyty");
+	}
+
+	const auto timestamp =
+	    QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd_HHmmss_zzz"));
+	auto file_name = QStringLiteral("%1_%2_%3").arg(base_name, game_id, timestamp);
+	if (!configured_file.suffix().isEmpty()) {
+		file_name += QStringLiteral(".") + configured_file.suffix();
+	}
+
+	return configured_file.dir().filePath(file_name);
+}
+
 static QStringList CreateEmulatorArgs(const Configuration& info) {
 	QStringList args;
 	auto        r = EnumToText(info.screen_resolution).split('x');
@@ -212,8 +240,14 @@ static QStringList CreateEmulatorArgs(const Configuration& info) {
 	args << "--shader-log-folder" << info.shader_log_folder;
 	args << "--command-buffer-dump" << BoolArg(info.command_buffer_dump_enabled);
 	args << "--command-buffer-dump-folder" << info.command_buffer_dump_folder;
-	args << "--printf-direction" << EnumToText(info.printf_direction);
-	args << "--printf-output-file" << info.printf_output_file;
+	args << "--printf-direction"
+	     << (info.printf_direction == Configuration::LogDirection::FilePerTest
+	             ? EnumToText(Configuration::LogDirection::File)
+	             : EnumToText(info.printf_direction));
+	args << "--printf-output-file"
+	     << (info.printf_direction == Configuration::LogDirection::FilePerTest
+	             ? CreateTestLogFile(info)
+	             : info.printf_output_file);
 	args << "--profiler-direction" << EnumToText(info.profiler_direction);
 	args << "--spirv-debug-printf" << "false";
 	args << "--ngg-rectlist-draw" << BoolArg(info.ngg_rectlist_draw_enabled);


### PR DESCRIPTION
## Description

While testing games, I often needed to preserve the log from each individual run. The existing `File` option always uses the same output path, so I had to manually rename the log before starting another game or test to prevent it from being overwritten.

This PR adds a new `File per test` option to the launcher's `Printf direction` setting. When selected, the launcher preserves the configured directory, base filename, and extension, but appends the game ID and a timestamp to the filename.

For example:

`_kyty_CUSA12345_20260731_153012_421.txt`

The existing `Silent`, `Console`, and `File` options remain unchanged. This is intentionally a small and simple improvement, since the logging system may receive more extensive changes in the future.

## Image
<img width="618" height="95" alt="log" src="https://github.com/user-attachments/assets/3992a1ff-9ed4-4823-bfcc-47e67fd16c42" />

<img width="569" height="116" alt="log2" src="https://github.com/user-attachments/assets/2c7324f3-03cf-46b4-97ad-577229ec4883" />

## Testing

- Built and tested locally on Windows.
- Verified that `File per test` creates a new log for each run.
- Verified that the regular `File` option keeps its existing behavior.
- Verified that the setting is saved and restored by the launcher.

## AI assistance

AI assistance was used to analyze the existing logging flow, implement the initial changes, and review the final diff. I reviewed the code, compiled it, tested the behavior locally, and take responsibility for the submitted changes.