### PR TITLE
macOS: anchor the guest address space in full-emulator test targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -312,6 +312,9 @@ function(add_kyty_full_emulator_test target source)
 		target_link_libraries(${target} onecore)
 		add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different "${KYTY_THIRD_PARTY_DIR}/winpthread/bin/libwinpthread-1.dll" $<TARGET_FILE_DIR:${target}>/libwinpthread-1.dll)
 	endif()
+	# The macOS x86_64 guest address space needs its .zerofill segments anchored
+	# by linker flags, or the kernel kills the binary on load (posix_spawn EIO).
+	configure_macos_guest_address_space(${target})
 endfunction()
 
 function(configure_macos_guest_address_space target)
@@ -431,7 +434,6 @@ target_sources(shader_recompiler_compute_tests PRIVATE
 add_kyty_full_emulator_test(virtual_memory_allocation_tests ../tests/VirtualMemoryAllocationTests.cpp)
 target_compile_definitions(virtual_memory_allocation_tests PRIVATE
 	KYTY_VIRTUAL_MEMORY_ALLOCATION_TESTS=1)
-configure_macos_guest_address_space(virtual_memory_allocation_tests)
 
 # These tests use exceptions.
 if(NOT KYTY_CLANG_CL)


### PR DESCRIPTION
## What changed

Move the `configure_macos_guest_address_space()` call into `add_kyty_full_emulator_test()` itself, so every target that function creates gets the linker flags that anchor the guest address-space segments. Drop the now-redundant explicit call on `virtual_memory_allocation_tests`. The `kyty_emulator` target is untouched.

## Why

Every target created by `add_kyty_full_emulator_test` compiles `kernel/macosGuestAddressSpace.cpp`, so it carries the ~620 GiB of `.zerofill` segments (SYSTEM_MANAGED, SYSTEM_RESERVED, USER_AREA). Only `kyty_emulator` and `virtual_memory_allocation_tests` also received the `-segaddr`/`-no_pie`/`-pagezero_size` flags that anchor those segments; every other full-emulator test binary got the segments at default placement, and macOS kills those binaries at load:

- direct exec dies with SIGKILL (exit 137) before `main()` runs
- `posix_spawn` fails with EIO
- ctest reports `Process not started [i/o error]`, so `shader_recompiler_compute_tests` and the 9 test entries that reuse that binary show up as BAD_COMMAND

CI does not catch this because the macOS job neither builds these test targets nor runs ctest.

## How verified

On Apple Silicon (M3 Ultra, macOS 26, x86_64 build under Rosetta 2):

- Before: `shader_recompiler_compute_tests` killed on exec; 10 ctest entries BAD_COMMAND.
- After: `ctest -R 'compute|scheduler|tiler|texture'` passes 7/7 (with `DYLD_LIBRARY_PATH` pointing at the install dir for MoltenVK).
- `virtual_memory_allocation_tests` still passes (19/19) after removing the duplicate call.
- `otool -l` confirms the segments are unchanged and now anchored in every full-emulator test binary.
