### PR TITLE
macOS boot hang after "Relocate program": ProtectGuestMemory applies guest-only protection to the host mapping (regression from #135)

### DIFF
--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -3642,7 +3642,17 @@ bool ProtectGuestMemory(uint64_t vaddr, uint64_t size, VirtualMemory::Mode mode,
 		*old_mode = static_cast<VirtualMemory::Mode>(
 		    ranges.front().protection & (PROT_CPU_READ | PROT_CPU_WRITE | PROT_CPU_EXEC));
 	}
-	if (!g_guest_address_space->Protect(aligned_addr, aligned_size, mode)) {
+	// The guest-visible protection lives in the range tracker; the host mapping must stay
+	// writable so loader/runtime patching of guest pages (relocations, PLT stubs) never
+	// faults against a guest-only protection. Restoring a tracker mode verbatim used to
+	// leave program pages host-read-only and livelock the first relocation write.
+	// NoAccess is kept intact: guard pages must trap. Mirrors SetProgramMemoryProtection.
+	const auto host_mode =
+	    mode == VirtualMemory::Mode::NoAccess
+	        ? VirtualMemory::Mode::NoAccess
+	        : (VirtualMemory::IsExecute(mode) ? VirtualMemory::Mode::ExecuteReadWrite
+	                                          : VirtualMemory::Mode::ReadWrite);
+	if (!g_guest_address_space->Protect(aligned_addr, aligned_size, host_mode)) {
 		return false;
 	}
 	g_virtual_ranges->Protect(aligned_addr, aligned_size, ProgramProtection(mode));


### PR DESCRIPTION
## Symptom

Since the guest memory rework (#135, first bad commit `2f5396c`, found by bisect between `f6e01e5` and `a65d17a` with a validated good/bad oracle), nothing boots on macOS: both homebrew samples and games freeze right after `--- Relocate program: ... ---`, with one thread spinning at 100% CPU and no further output. Before #135 (`f6e01e5`), the same binaries execute guest code normally.

This looks related to the Raiden III regression reported around #136 — same first bad commit territory, and #136 (signal dispatch) does not fix this hang.

## Root cause

#135 establishes the invariant that guest-visible protection lives in the virtual range tracker while host mappings stay writable, and applies exactly that clamp in `SetProgramMemoryProtection`:

```cpp
const auto host_mode = VirtualMemory::IsExecute(mode) ? VirtualMemory::Mode::ExecuteReadWrite
                                                      : VirtualMemory::Mode::ReadWrite;
```

But `ProtectGuestMemory` still applies the requested guest mode verbatim to the host mapping. The broken sequence on every boot:

1. `InstallRelocateHandler` calls `ProtectGuestMemory(pltgot, Write, &old_mode)`. `old_mode` is read from the range tracker, so for the pltgot (inside a read-only RELRO segment) it comes back as `Read`.
2. After patching `pltgot[1]`/`pltgot[2]`, it restores `old_mode` — and the restore mprotects the host page to read-only.
3. The first relocation write in `RelocateRecords` (`PatchGuestMemory64`, a plain store) faults. The GPU fault handler path finds the page inside a GPU-mapped range, runs an invalidate that is a no-op (no GPU resources exist at boot), returns "handled" **without changing any protection**, and the retried store faults again. Infinite fault livelock.

Measured on macOS: 8,000+ identical faults (rip = `RelocateRecords`, fault addr = pltgot+0x18, page-fault error code 0x6 = user-mode write) with the handler returning "resolved" every time. Windows presumably survives because its fault path resolves the write differently, but the defect itself is platform-independent code.

## Fix

Clamp the host mode in `ProtectGuestMemory` exactly like `SetProgramMemoryProtection` already does, preserving `NoAccess` so guard pages still trap. The tracker keeps recording the requested guest mode.

## Validation

- On pure `a65d17a` + this patch alone: guest code executes again on macOS (unresolved-import stub calls resume, where before the process never left `Relocate`).
- On our macOS branch (this patch plus unrelated local work): full test suite passes (15/17, the 2 failures are the pre-existing Linux-only `memory_tracker`/`page_manager`), and the Mandelbrot homebrew sample renders byte-identical to its pre-#135 reference dump.

## Two adjacent notes (no patch attached, maintainer's call)

1. `KernelMprotect` has the same shape (applies the guest mode verbatim to the host mapping). Since that one is the guest-facing syscall, faithfully applying guest protection may be intentional — but any guest that mprotects its own memory read-only and later gets patched by the runtime linker will hit the same livelock. Possibly the actual Raiden III mechanism.
2. #135 narrowed `KernelMapNamedFlexibleMemory`'s accepted flags to the sce namespace and reused bit `0x400` (previously accepted as POSIX `MAP_STACK`) as `MAP_DMEM_COMPAT`. That silently breaks any POSIX-style mmap shim written against the old contract (`MAP_PRIVATE|MAP_ANON` = 0x1002 now returns EINVAL). Worth a mention in the changelog if the narrowing is intentional.

---

*Disclosure (README § AI Use): this fix was developed with AI assistance. I reviewed the analysis and the code, ran the validation on my machine, and take responsibility for this submission.*
