### PR TITLE
Probabilistic boot hang: UnmapMemory waits for a full GPU drain while holding the memory-operation mutex (regression from #135)

### DIFF
--- a/src/graphics/host_gpu/rangeSet.h
+++ b/src/graphics/host_gpu/rangeSet.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <iterator>
 #include <map>
 #include <vector>
 
@@ -67,6 +68,15 @@ public:
 		}
 		--it;
 		return it->first <= address && it->second >= end;
+	}
+
+	[[nodiscard]] bool Intersects(uint64_t address, uint64_t size) const {
+		const auto end = End(address, size);
+		auto       it  = m_ranges.upper_bound(address);
+		if (it != m_ranges.begin() && std::prev(it)->second > address) {
+			return true;
+		}
+		return it != m_ranges.end() && it->first < end;
 	}
 
 	template <typename Func>

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -115,6 +115,32 @@ void GpuResourceManager::UnmapMemory(uint64_t vaddr, uint64_t size) {
 		unmap();
 		return;
 	}
+	const bool gpu_mapped = [&] {
+		std::shared_lock lock(m_mapped_ranges_mutex);
+		return m_mapped_ranges.Intersects(vaddr, size);
+	}();
+	// A range that never went through MapMemory has nothing cached the GPU could still
+	// reference, so skip the submission pause and full GPU drain (muro 40). Callers
+	// hold the global memory-operation mutex, and waiting for the GPU under it
+	// deadlocks against guest label writers the GPU is itself waiting on (three-way
+	// stall: memory op -> pause -> WaitRegMem -> guest writer blocked on the memory op).
+	if (!gpu_mapped) {
+		if (m_resource_mutex.IsOwnedByCurrentThread()) {
+			EXIT("cannot synchronously unmap from a resource transaction\n");
+		}
+		// The short path rests on "never MapMemory'd => nothing cached". Verify it and
+		// fail loud on a violation instead of silently re-creating the cross-thread
+		// wait this branch exists to avoid.
+		const bool cached = m_buffer_cache.HasPageOverlap(vaddr, size) ||
+		                    m_texture_cache.QueryRegion(vaddr, size).image_pages;
+		if (cached) {
+			EXIT("gpu-unmapped range still holds cached resources: addr=0x%016" PRIx64
+			     " size=0x%016" PRIx64 "\n",
+			     vaddr, size);
+		}
+		unmap();
+		return;
+	}
 	Gpu::SubmissionLock submissions(*m_gpu);
 	m_gpu->SendCommandSync(unmap);
 }


### PR DESCRIPTION
## Symptom

Roughly one in three boots (measured on a commercial title on macOS, but the mechanism is platform-independent) freezes at a wandering point: the process stays alive at low CPU, the log stops advancing, no crash. Sampling the live process shows a three-way stall:

1. A guest thread inside a memory syscall (holding the global memory-operation mutex) reached `GpuResourceManager::UnmapMemory`, which takes `Gpu::SubmissionLock` (`PauseSubmissions`: grabs the submission mutex) and then waits for a **full GPU drain** (`WaitLocked`).
2. The GPU thread retries a blocked submission every 100 ms: its PM4 stream sits in `WaitRegMem64` on a label that a guest thread is supposed to write.
3. The label writers never run: one was caught blocked in `GpuState::Submit` on the submission mutex held by the pauser, the rest block on the memory-operation mutex held by thread 1.

Since the memory rework (#135), `MapGpuRange`/`UnmapGpuRange` run inside the memory paths that hold the global mutex, so any unmap pays the pause + full-drain price there — and GPU progress can depend on guest threads that need that same mutex. The specific caller caught in the sample was `AllocateGuestRuntimeMemory` consuming a reserved span: a range that had never been GPU-mapped at all, paying a full GPU drain as a defensive no-op.

## Fix

If the range has no intersection with the GPU-mapped set (`m_mapped_ranges`), take the same no-pause local path the pre-renderer branch (`m_gpu == nullptr`) already uses. `RangeSet` grows an `Intersects` query — intersection, not containment, so partially mapped ranges still go through the full drain. The short path also verifies the "never mapped => nothing cached" invariant against both caches (`BufferCache::HasPageOverlap`, `TextureCache::QueryRegion().image_pages`) and fails loud on a violation instead of silently re-creating the cross-thread wait.

This narrows the window rather than restructuring the locking: unmaps of ranges that really are GPU-mapped still drain as before. A follow-up could revisit whether the full drain under the memory mutex is avoidable in general.

## Validation

- 13 consecutive boots of the affected title with no stall (previous reproduction rate ~1 in 3), the defensive check never firing.
- Full test suite unchanged; Mandelbrot homebrew still byte-identical to its reference.
- Applies and builds cleanly on `a65d17a`. Independent of the relocation-livelock fix submitted separately; boot-level validation on macOS ran with both applied (the livelock otherwise blocks boot there).

---

*Disclosure (README § AI Use): this fix was developed with AI assistance. I reviewed the analysis and the code, ran the validation on my machine, and take responsibility for this submission.*
