### PR TITLE
Don't declare colorWriteEnable dynamic state on depth-only pipelines

### DIFF
--- a/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
@@ -951,11 +951,17 @@ void CreatePipelineInternal(
 	    vk::DynamicState::eStencilReference,
 	    vk::DynamicState::eStencilWriteMask,
 #if !defined(__APPLE__)
+	    // Keep last so depth-only pipelines can omit this dynamic state.
 	    vk::DynamicState::eColorWriteEnableEXT, // unsupported by MoltenVK; static mask instead
 #endif
 	};
-	const auto dynamic_states_count =
+	auto dynamic_states_count =
 	    static_cast<uint32_t>(sizeof(dynamic_states) / sizeof(dynamic_states[0]));
+#if !defined(__APPLE__)
+	if (static_params.color_count == 0) {
+		dynamic_states_count--;
+	}
+#endif
 
 	vk::PipelineDynamicStateCreateInfo dynamic_state {};
 	dynamic_state.sType             = vk::StructureType::ePipelineDynamicStateCreateInfo;


### PR DESCRIPTION
Pipelines are created with `VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT` unconditionally on non-Apple platforms, but the draw path only calls `vkCmdSetColorWriteEnableEXT` when there is at least one color attachment (`renderDraw.cpp:405`).

So a depth-only draw — a shadow pass or a depth prepass — reaches `vkCmdDrawIndexed` with the dynamic state declared and never set. That is what `VUID-vkCmdDrawIndexed-None-07749` forbids:

```
vkCmdDrawIndexed(): VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT state is dynamic,
but the command buffer never called vkCmdSetColorWriteEnableEXT.
```

## Why it shows up now

The launcher turns validation on by default (`vulkan_validation_enabled = true` in `configuration.h`), and the debug callback currently treats validation errors as fatal, so PAC-MAN WORLD Re-PAC dies a few seconds after launch. From the command line with `--vulkan-validation false` the same build runs fine, which is probably why this went unnoticed.

Even without validation running, the draw is still out of spec — the value of colorWriteEnable is undefined at that point. This change is about the violation; whether a violation should end the process is a separate question.

## Fix

Only declare the dynamic state when the pipeline has color attachments.

Both places read `state.color_count` from the same draw (`renderDraw.cpp:1057` for pipeline creation, `:1084` for the dynamic params), so the two conditions now match instead of drifting apart.

One file, 12 lines.

## Testing

PAC-MAN WORLD Re-PAC with validation on:

| | before | after |
| --- | --- | --- |
| shaders compiled | 7 | 21 |
| VUID-07749 | 2 | 0 |
| result | dies | runs |

Reproduce with:

```
kyty_emulator.exe --vulkan-validation true --game "<PAC-MAN WORLD Re-PAC eboot.bin>"
```

Two other unrelated validation errors still show up in both runs. I left those alone.
