### PR TITLE
Report Vulkan validation errors instead of ending the process

### DIFF
--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -754,10 +754,14 @@ static VKAPI_ATTR vk::Bool32 VKAPI_CALL VulkanDebugMessengerCallback(
 		default: severity_str = "?";
 	}
 
-	if (error) {
-		EXIT_COLOR(severity_style, "[Vulkan][%s][%u]: %s\n", severity_str,
-		           static_cast<uint32_t>(message_types), callback_data->pMessage);
-	}
+	// Report, do not abort.
+	//
+	// --vulkan-validation decides whether validation runs; it should not also decide whether a
+	// spec violation ends the process, because those are separate questions. Failing fast
+	// suits working on the emulator, but it makes the option unusable for anyone who wants the
+	// diagnostics: a single violation ends the session, and the launcher enables validation by
+	// default. Errors are never skipped below, so the message still reaches the log.
+	(void)error;
 
 	if (!skip) {
 		LOGF_COLOR(severity_style, "[Vulkan][%s][%u]: %s\n", severity_str,


### PR DESCRIPTION
`--vulkan-validation` decides whether validation runs. It also decides whether a spec violation kills the emulator, and those are two different questions.

The debug callback calls `EXIT_COLOR` on any validation-type error, so the first violation ends the session whatever the title was doing. The launcher turns validation on by default (`vulkan_validation_enabled = true` in `configuration.h`), so this is the configuration most people are actually in — the option is effectively unusable for anyone who just wants the diagnostics.

Failing fast is useful when you are working on the emulator itself. It is not a good default for someone trying to run a game.

## Change

Drop the abort. Errors are never skipped by the filter just below, so every message still reaches the log — only the process death is gone.

## Testing

PAC-MAN WORLD Re-PAC with validation on:

| | before | after |
| --- | --- | --- |
| result | dies | runs the whole window |
| log lines | 31,460 | 31,668,560 |

It still reports the violations it hits (10x VUID-vkCmdDrawIndexed-None-07749, 10x VUID-vkCmdBeginRendering-pRenderingInfo-09588 in that run) — it just does not die on them. I have separate changes for both of those violations.
