### PR TITLE
Stop discarding depth while DEPTH_CLEAR_ENABLE stays set

### DIFF
--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
@@ -143,7 +143,15 @@ PipelineCache::GraphicsPipeline& PipelineCache::CreateGraphicsPipeline(
 	}
 	static_params.with_depth         = with_depth;
 	static_params.depth_test_enable  = depth.depth_test_enable;
-	static_params.depth_write_enable = (depth.depth_write_enable && !depth.depth_clear_enable);
+	// DB_RENDER_CONTROL.DEPTH_CLEAR_ENABLE makes the depth unit substitute DB_DEPTH_CLEAR for
+	// the fragment's own depth. Titles set it for the full-screen rect that clears depth and
+	// then leave it set, so suppressing depth writes for every draw while it is on erases the
+	// world: ordinary colour draws stop contributing depth and later geometry overwrites
+	// earlier geometry regardless of distance. Only the clear itself is depth-only
+	// (color_count == 0), so restrict the suppression to that case and let colour draws write
+	// real fragment depth.
+	static_params.depth_write_enable =
+	    depth.depth_write_enable && (color_count > 0 || !depth.depth_clear_enable);
 	static_params.depth_compare_op   = depth.depth_compare_op;
 	static_params.depth_bounds_test_enable = depth.depth_bounds_test_enable;
 	static_params.depth_min_bounds         = depth.depth_min_bounds;

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -592,7 +592,11 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 		attachment.clear_value[0] = std::bit_cast<uint32_t>(depth.depth_clear_value);
 		attachment.clear_value[1] = depth.stencil_clear_value;
 		attachment.has_depth      = static_cast<bool>(aspects & vk::ImageAspectFlagBits::eDepth);
-		attachment.depth_clear    = depth.depth_load_clear_enable;
+		// Titles leave DEPTH_CLEAR_ENABLE set for the whole frame, so the bit cannot be read
+		// as a per-pass load-clear request: clearing again at every render-state change
+		// discards the depth earlier draws accumulated and erases the world. Only the
+		// depth-only clear rect (no colour attachments) is the actual clear.
+		attachment.depth_clear    = depth.depth_load_clear_enable && color_count == 0;
 		attachment.has_stencil    = static_cast<bool>(aspects & vk::ImageAspectFlagBits::eStencil);
 		attachment.stencil_clear  = depth.stencil_clear_enable;
 	}

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -596,7 +596,17 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 		// as a per-pass load-clear request: clearing again at every render-state change
 		// discards the depth earlier draws accumulated and erases the world. Only the
 		// depth-only clear rect (no colour attachments) is the actual clear.
-		attachment.depth_clear    = depth.depth_load_clear_enable && color_count == 0;
+		// Two different things ask for a load-clear here and only one of them is a per-frame
+		// register. DEPTH_CLEAR_ENABLE is left set for a whole frame by titles that clear once
+		// with a depth-only rect, so honouring it on every render-state change throws away the
+		// depth those draws accumulated. The HTILE meta clear is not like that: it is consumed
+		// once, and a title can raise it on a draw that has colour attachments.
+		//
+		// Gate only the register. STORY OF SEASONS shows clear=1 meta=0 on every draw and needs
+		// the gate; Double Dragon Gaiden shows clear=0 throughout with meta=1 on a colour draw,
+		// and suppressing that clear leaves stale depth its floor then fails against.
+		attachment.depth_clear = depth.depth_meta_clear_enable ||
+		                         (depth.depth_clear_enable && color_count == 0);
 		attachment.has_stencil    = static_cast<bool>(aspects & vk::ImageAspectFlagBits::eStencil);
 		attachment.stencil_clear  = depth.stencil_clear_enable;
 	}


### PR DESCRIPTION
STORY OF SEASONS: A Wonderful Life renders almost nothing of its scene — the title screen is a pale wash with sky and water but no terrain, no props, no lampposts.

The cause is how `DB_RENDER_CONTROL.DEPTH_CLEAR_ENABLE` is interpreted. That bit makes the depth unit substitute `DB_DEPTH_CLEAR` for the fragment's own depth. Titles set it for the full-screen rect that clears depth and then leave it set for the whole frame, so it cannot be read as "clear on this pass" — but two places did read it that way:

- `pipelineCache.cpp` suppressed depth writes for every draw while the bit is on, so ordinary colour draws stopped contributing depth.
- `renderDraw.cpp` load-cleared the depth attachment at every render-state change, discarding the depth earlier draws had accumulated.

Together the depth buffer stays pinned at the clear value and geometry stops occluding correctly.

## Change

Only the depth-only clear rect — no colour attachments — is the actual clear, so both places gate on that.

The third commit is a correction worth calling out. `depth_load_clear_enable` carries **two** different requests: the `DEPTH_CLEAR_ENABLE` register, which is left set for a whole frame and therefore needs gating, and the HTILE meta clear, which is consumed once and can legitimately be raised on a draw that has colour attachments. Gating both broke Double Dragon Gaiden. Only the register is gated now.

## Testing

Two titles, chosen because they exercise opposite sides of that distinction. One line per distinct depth state:

```
STORY OF SEASONS   clear=1 meta=0  on all 11 states
Double Dragon      clear=0         on all 9 states, meta=1 on one with colour attachments
```

**STORY OF SEASONS**, title screen, compared pixel-by-pixel against a build known to render it correctly:

| | pixels differing from reference |
| --- | --- |
| before | 61.74% |
| write-suppression fix only | 61.73% |
| both | 31.22% |

For scale: two captures 60 s apart from the reference build itself differ by 62.86%, because the scene animates. So the remaining 31% sits well inside animation variance, and either half alone is worth nothing without the other. Visually the valley is back — terrain, trees, fence, dirt path, riverbank rocks, both lampposts.

**Double Dragon Gaiden**, in-game: its floor disappears if the meta clear is gated, and renders correctly once only the register is.

Verified after rebasing onto current main, since two recent renderer commits touch this path.
