### PR TITLE
Keep a sampled depth attachment in a layout both uses agree on

### DIFF
--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -1135,15 +1135,19 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 				                            vk::AccessFlagBits2::eShaderWrite
 				                      : vk::AccessFlagBits2::eShaderRead,
 				              range, vk_buffer);
-			} else if ((image.binding.force_general || image.binding.is_target) &&
-			           !image.info.IsDepth()) {
+			} else if (image.binding.force_general || image.binding.is_target) {
+				// Depth reaches this branch too: AcquireRenderTargets sets force_general on a
+				// depth attachment the same draw samples, and both sides must agree on eGeneral.
+				const auto attachment_access =
+				    image.info.IsDepth() ? vk::AccessFlagBits2::eDepthStencilAttachmentRead |
+				                               vk::AccessFlagBits2::eDepthStencilAttachmentWrite
+				                         : vk::AccessFlagBits2::eColorAttachmentRead |
+				                               vk::AccessFlagBits2::eColorAttachmentWrite;
 				const vk::AccessFlags2 storage_access = image.binding.shader_write
 				                                            ? vk::AccessFlagBits2::eShaderWrite
 				                                            : vk::AccessFlags2 {};
 				image.Transit(vk::ImageLayout::eGeneral,
-				              vk::AccessFlagBits2::eShaderRead | storage_access |
-				                  vk::AccessFlagBits2::eColorAttachmentRead |
-				                  vk::AccessFlagBits2::eColorAttachmentWrite,
+				              vk::AccessFlagBits2::eShaderRead | storage_access | attachment_access,
 				              {}, vk_buffer);
 			} else if (storage) {
 				image.Transit(vk::ImageLayout::eGeneral,

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -664,7 +664,17 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 			EXIT("mixed color/depth sample counts are unsupported: %u and %u\n", attachment_samples,
 			     depth.samples);
 		}
-		const auto layout = depth_attachment_layout(depth);
+		// A depth image the same draw also samples cannot stay in an attachment-optimal
+		// layout: CommitBindings runs after this point and moves it to a read-only layout,
+		// which leaves the layout declared to vkCmdBeginRendering stale and trips
+		// VUID-vkCmdBeginRendering-pRenderingInfo-09588. The colour path above already solves
+		// this with eGeneral, valid both as an attachment and as a sampled image; mark the
+		// image so the descriptor path settles on the same layout.
+		auto layout = depth_attachment_layout(depth);
+		if (image.binding.is_bound) {
+			image.binding.force_general = true;
+			layout                      = vk::ImageLayout::eGeneral;
+		}
 		const auto writes = depth.AttachmentWriteAspects();
 		auto       access = vk::AccessFlags2 {vk::AccessFlagBits2::eDepthStencilAttachmentRead};
 		if (writes) {


### PR DESCRIPTION
When a draw uses the same depth image as its depth attachment and as a sampled texture, the layout recorded for `vkCmdBeginRendering` is already stale by the time the draw happens:

```
vkCmdBeginRendering(): pDepthAttachment is expected to have layout
DEPTH_STENCIL_ATTACHMENT_OPTIMAL but previous known layout is
DEPTH_STENCIL_READ_ONLY_OPTIMAL
(VUID-vkCmdBeginRendering-pRenderingInfo-09588)
```

The order in the draw path is:

```
AcquireRenderTargets   transitions the depth image and records that layout
CommitBindings         transitions it again, to a read-only layout, because it is sampled
BeginRendering         declares the layout recorded in the first step
```

## Fix

The colour path already solves exactly this: the attachment uses `eGeneral` when the image is also bound as a shader resource, and the descriptor path uses `eGeneral` for images that are render targets. Depth had neither check, and the descriptor branch excluded depth outright.

This mirrors the colour behaviour for depth. Access flags are now picked by aspect, since that shared branch previously assumed colour.

I used `force_general` rather than `is_target` deliberately: `is_target` also drives image merging in the texture cache, and this change has no business reaching there. `force_general` is per-draw state that `ResetBindings` clears.

## Testing

STORY OF SEASONS with validation on:

| | before | after |
| --- | --- | --- |
| result | dies on the VUID | survives the full window |
| log lines | 503,751 | 46,887,049 |
| validation errors | 2 | 0 |

PAC-MAN WORLD Re-PAC and Double Dragon Gaiden show no regression.

Re-verified after rebasing onto current main, since two recent renderer commits touch this path.
