### PR TITLE
Decode sRGB in the shader for formats the host image cannot carry

### DIFF
--- a/src/graphics/guest_gpu/gpu_format.cpp
+++ b/src/graphics/guest_gpu/gpu_format.cpp
@@ -216,6 +216,18 @@ bool IsUintTextureFormat(BufferFormat format) {
 	return info != nullptr && info->uint_texture;
 }
 
+bool IsShaderDecodedSrgbTextureFormat(BufferFormat format) {
+	// Deliberately an explicit two-case test rather than a column in the format table, because
+	// this is not a property of the guest format on its own - it is a property of what the host
+	// can express. k8Srgb and k8_8Srgb are created as unorm images (see the comment on their
+	// entries in vulkanCommon.cpp) because R8_SRGB and R8G8_SRGB are optional in Vulkan and
+	// plenty of devices expose no features for them at all, so their sRGB decode is owed by the
+	// shader. Every other guest sRGB format has a real host counterpart - k8_8_8_8Srgb maps to
+	// eR8G8B8A8Srgb and each BC*Srgb to a native sRGB block format - and the sampler already
+	// decodes those. A shared table column would sweep them in and decode them twice.
+	return format == BufferFormat::k8Srgb || format == BufferFormat::k8_8Srgb;
+}
+
 BufferFormat RemapTextureFormat(BufferFormat format) {
 	return format == BufferFormat::k11_11_10UInt ? BufferFormat::k32UInt : format;
 }

--- a/src/graphics/guest_gpu/gpu_format.h
+++ b/src/graphics/guest_gpu/gpu_format.h
@@ -44,6 +44,9 @@ uint32_t                   RenderTargetBytesPerElement(BufferFormat format);
 bool                       IsFmaskTextureFormat(BufferFormat format);
 bool                       IsSampledTextureFormat(BufferFormat format);
 bool                       IsUintTextureFormat(BufferFormat format);
+// True for the guest sRGB formats whose host image cannot carry the sRGB encoding, so the
+// decode has to be emitted into the shader instead of coming from the sampler.
+bool                       IsShaderDecodedSrgbTextureFormat(BufferFormat format);
 BufferFormat               RemapTextureFormat(BufferFormat format);
 
 } // namespace Libs::Graphics::Prospero

--- a/src/graphics/host_gpu/vulkanCommon.cpp
+++ b/src/graphics/host_gpu/vulkanCommon.cpp
@@ -56,8 +56,13 @@ constexpr FormatMapping kFormatMappings[] = {
     {Prospero::BufferFormat::k32_32_32_32UInt, vk::Format::eR32G32B32A32Uint},
     {Prospero::BufferFormat::k32_32_32_32SInt, vk::Format::eR32G32B32A32Sint},
     {Prospero::BufferFormat::k32_32_32_32Float, vk::Format::eR32G32B32A32Sfloat},
-    // Narrow-channel sRGB formats are optional in Vulkan. Keep a same-width fallback until
-    // sampler-aware sRGB emulation is available.
+    // Unorm, deliberately, despite the sRGB name. R8_SRGB and R8G8_SRGB are optional in
+    // Vulkan and plenty of devices expose no features for them at all - asking for one fails
+    // at image creation and as a view it samples as zero. The sRGB decode these formats are
+    // owed is emitted into the shader instead; see
+    // Prospero::IsShaderDecodedSrgbTextureFormat, which is keyed on exactly these two guest
+    // formats. Do not "fix" this by mapping them to an sRGB format: that reintroduces the
+    // failure above, or double-decodes on a device that supports it.
     {Prospero::BufferFormat::k8Srgb, vk::Format::eR8Unorm},
     {Prospero::BufferFormat::k8_8Srgb, vk::Format::eR8G8Unorm},
     {Prospero::BufferFormat::k8_8_8_8Srgb, vk::Format::eR8G8B8A8Srgb},

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAluHelpers.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAluHelpers.cpp
@@ -381,6 +381,43 @@ uint32_t EmitFAbsValue(EmitterState& state, uint32_t value) {
 	return ret;
 }
 
+// The sRGB electro-optical transfer function, gamma to linear:
+//     v <= 0.04045 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4)
+// Emitted for texels the host image cannot decode by itself - see
+// Prospero::IsShaderDecodedSrgbTextureFormat for which formats those are and why.
+//
+// pow is spelled exp2(2.4 * log2(x)) rather than GLSL.std.450 Pow because Log2 and Exp2 are
+// already in the extended-instruction enum and Pow is not: this needs no new opcode number.
+//
+// Both arms are evaluated because OpSelect is not a branch. That is safe here: the log2
+// argument is (v + 0.055) * 0.94787, which is at least 0.052 for any v >= 0, and v is sampled
+// from an 8-bit unorm image so it cannot be negative.
+uint32_t EmitSrgbToLinearF32(EmitterState& state, uint32_t value) {
+	const auto FMul = [&state](uint32_t lhs, uint32_t rhs) {
+		const auto ret = state.builder.AllocateId();
+		state.builder.AddFunction({OpFMul, TypeF32(state), ret, lhs, rhs});
+		return ret;
+	};
+	const auto low    = FMul(value, ConstantF32Value(state, 1.0f / 12.92f));
+	const auto biased = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpFAdd, TypeF32(state), biased, value, ConstantF32Value(state, 0.055f)});
+	const auto scaled = FMul(biased, ConstantF32Value(state, 1.0f / 1.055f));
+	const auto log    = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpExtInst, TypeF32(state), log, GlslStd450(state), GlslLog2, scaled});
+	const auto exponent = FMul(log, ConstantF32Value(state, 2.4f));
+	const auto high     = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpExtInst, TypeF32(state), high, GlslStd450(state), GlslExp2, exponent});
+	const auto is_low = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpFOrdLessThanEqual, TypeBool(state), is_low, value, ConstantF32Value(state, 0.04045f)});
+	const auto ret = state.builder.AllocateId();
+	state.builder.AddFunction({OpSelect, TypeF32(state), ret, is_low, low, high});
+	return ret;
+}
+
 uint32_t EmitF16BitsToF32(EmitterState& state, uint32_t bits) {
 	const auto unpacked = state.builder.AllocateId();
 	const auto ret      = state.builder.AllocateId();

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
@@ -439,6 +439,51 @@ uint32_t UnpackImageGather(ValueEmitContext& ctx, const IR::MemoryInfo& mem, uin
 	return result;
 }
 
+// Decode the texels of an image the host cannot decode by itself, gamma to linear. Applied
+// to the sampled vector before ResultVector turns it into the four result dwords, since that
+// bitcasts each float to the integer bit pattern the VGPRs hold and decoding after the
+// bitcast would corrupt the value. Alpha is never decoded, matching Vulkan's own sRGB
+// sampling semantics. float_texels is false for a uint image, which carries no transfer
+// function, and for the depth-comparison forms, which yield comparison results not texels.
+uint32_t DecodeImageSrgb(ValueEmitContext& ctx, const IR::MemoryInfo& mem, bool float_texels,
+                         uint32_t texel) {
+	if (!float_texels || !ctx.state.program.info.images[mem.resource].srgb_decode) {
+		return texel;
+	}
+	uint32_t components[4] {};
+	for (uint32_t index = 0; index < 4u; index++) {
+		const auto component = ctx.state.builder.AllocateId();
+		ctx.state.builder.AddFunction(
+		    {OpCompositeExtract, TypeF32(ctx.state), component, texel, index});
+		components[index] = index < 3u ? EmitSrgbToLinearF32(ctx.state, component) : component;
+	}
+	const auto result = ctx.state.builder.AllocateId();
+	ctx.state.builder.AddFunction({OpCompositeConstruct, TypeF32Vector(ctx.state, 4), result,
+	                               components[0], components[1], components[2], components[3]});
+	return result;
+}
+
+// Gather4 returns one channel of four neighbouring texels, so the decode applies to all of
+// them and the alpha exclusion is decided once, on that chosen channel.
+uint32_t DecodeImageGatherSrgb(ValueEmitContext& ctx, const IR::MemoryInfo& mem, bool float_texels,
+                               uint32_t gathered) {
+	if (!float_texels || !ctx.state.program.info.images[mem.resource].srgb_decode ||
+	    ImageGatherComponent(mem.dmask) >= 3u) {
+		return gathered;
+	}
+	uint32_t lanes[4] {};
+	for (uint32_t lane = 0; lane < 4u; lane++) {
+		const auto value = ctx.state.builder.AllocateId();
+		ctx.state.builder.AddFunction(
+		    {OpCompositeExtract, TypeF32(ctx.state), value, gathered, lane});
+		lanes[lane] = EmitSrgbToLinearF32(ctx.state, value);
+	}
+	const auto result = ctx.state.builder.AllocateId();
+	ctx.state.builder.AddFunction({OpCompositeConstruct, TypeF32Vector(ctx.state, 4), result,
+	                               lanes[0], lanes[1], lanes[2], lanes[3]});
+	return result;
+}
+
 uint32_t PackImageTexel(ValueEmitContext& ctx, const IR::MemoryInfo& mem, uint32_t texel) {
 	const auto info = ImageConversionFormat(ctx.state, mem);
 	if (info.format == Prospero::BufferFormat::kInvalid) return texel;
@@ -581,8 +626,9 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 				             integer ? TypeU32Vector(state, 4) : TypeF32Vector(state, 4), color,
 				             image, coord, ImageOperandsLodMask, LodU32(ctx, mem, *address, view)});
 			        }
-			        return ResultVector(ctx, UnpackImageTexel(ctx, mem, color), integer, false,
-			                            mem);
+			        return ResultVector(
+			            ctx, DecodeImageSrgb(ctx, mem, !integer, UnpackImageTexel(ctx, mem, color)),
+			            integer, false, mem);
 		        }));
 		return true;
 	}
@@ -642,8 +688,11 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 				words.push_back(PackedOffset(ctx, mem, *address, layout, view));
 			}
 			state.builder.AddFunction(words);
-			ctx.Define(inst, ResultVector(ctx, UnpackImageGather(ctx, mem, sample),
-			                              integer && !dref, false, mem, true));
+			ctx.Define(inst,
+			           ResultVector(ctx,
+			                        DecodeImageGatherSrgb(ctx, mem, !integer && !dref,
+			                                              UnpackImageGather(ctx, mem, sample)),
+			                        integer && !dref, false, mem, true));
 			return true;
 		}
 		const bool explicit_lod = HasFlag(mem, Decoder::ImageSampleFlagDerivative) ||
@@ -694,8 +743,12 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		const auto& image = state.program.info.images[mem.resource];
 		if (image.indirect_root != mem.resource) {
 			const auto sample = EmitSample(mem.resource);
-			ctx.Define(inst, ResultVector(ctx, dref ? sample : UnpackImageTexel(ctx, mem, sample),
-			                              integer, dref, mem));
+			ctx.Define(inst,
+			           ResultVector(ctx,
+			                        dref ? sample
+			                             : DecodeImageSrgb(ctx, mem, !integer,
+			                                               UnpackImageTexel(ctx, mem, sample)),
+			                        integer, dref, mem));
 			return true;
 		}
 		const auto* handle = image_arg.ResolveInstruction();
@@ -787,7 +840,10 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		EmitLabel(state, merge_label);
 		state.builder.AddFunction(phi_words);
 		ctx.Define(inst,
-		           ResultVector(ctx, dref ? phi_words[2] : UnpackImageTexel(ctx, mem, phi_words[2]),
+		           ResultVector(ctx,
+		                        dref ? phi_words[2]
+		                             : DecodeImageSrgb(ctx, mem, !integer,
+		                                               UnpackImageTexel(ctx, mem, phi_words[2])),
 		                        integer, dref, mem));
 		return true;
 	}

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
@@ -856,6 +856,8 @@ uint32_t EmitFAbsValue(EmitterState& state, uint32_t value);
 
 uint32_t EmitF16BitsToF32(EmitterState& state, uint32_t bits);
 
+uint32_t EmitSrgbToLinearF32(EmitterState& state, uint32_t value);
+
 bool EmitValueAlu(ValueEmitContext& ctx, const IR::Inst& inst);
 
 bool EmitValueFlow(ValueEmitContext& ctx, const IR::Inst& inst);

--- a/src/graphics/shader/recompiler/ir/ShaderIR.h
+++ b/src/graphics/shader/recompiler/ir/ShaderIR.h
@@ -146,6 +146,15 @@ struct ImageResource {
 	uint32_t                mip_count                 = 1;
 	Prospero::BufferFormat  conversion_format         = Prospero::BufferFormat::kInvalid;
 	uint32_t                shader_swizzle            = ShaderImageIdentitySwizzle;
+	// Set when the bound descriptor names a guest sRGB format the host image cannot carry, so
+	// the emitter has to decode the sampled texels itself. It is a specialisation fact rather
+	// than a tracking fact: the resource-tracking pass leaves it false and SpecializeResources
+	// fills it in from the runtime descriptor. The defaulted operator== below does NOT carry it
+	// into any cache key - nothing calls that operator. Two permutations that differ only in
+	// the decode produce different SPIR-V and must not be swapped for one another, and the only
+	// thing stopping that is ValidateResourceSpecialization, which the program cache runs
+	// before it reuses a permutation. Change one and you must change the other.
+	bool                    srgb_decode               = false;
 	bool                    read                      = false;
 	bool                    written                   = false;
 	bool                    atomic                    = false;

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -418,6 +418,7 @@ bool ValidateResourceSpecialization(const Program& program, const ResourceSnapsh
 				    program.info.images[root].mip_count != image.mip_count ||
 				    program.info.images[root].conversion_format != image.conversion_format ||
 				    program.info.images[root].shader_swizzle != image.shader_swizzle ||
+				    program.info.images[root].srgb_decode != image.srgb_decode ||
 				    program.info.images[root].cube != image.cube) {
 					if (error != nullptr) {
 						*error = fmt::format(
@@ -432,8 +433,10 @@ bool ValidateResourceSpecialization(const Program& program, const ResourceSnapsh
 			if (image.atomic) {
 				canonical_kind = image.kind == ResourceKind::StorageImageUint;
 			}
+			// srgb_decode is part of the null check too: a program specialized to decode sRGB
+			// must not be handed a null descriptor, which carries no format at all.
 			if (image.dimension != Decoder::ImageDimension::Dim2D || image.cube ||
-			    !canonical_kind) {
+			    !canonical_kind || image.srgb_decode) {
 				if (error != nullptr) {
 					*error = fmt::format(
 					    "image descriptor {} no longer matches canonical null specialization", i);
@@ -499,6 +502,20 @@ bool ValidateResourceSpecialization(const Program& program, const ResourceSnapsh
 					    i, descriptor.dwords[0], descriptor.dwords[1], descriptor.dwords[2],
 					    descriptor.dwords[3], descriptor.dwords[4], descriptor.dwords[5],
 					    descriptor.dwords[6], descriptor.dwords[7]);
+				}
+				return false;
+			}
+			// A permutation is reused only if this validation accepts the descriptor, so this is
+			// the only thing stopping a draw that samples an sRGB plane from picking up a
+			// permutation compiled without the decode - or the reverse. The uint check above
+			// cannot stand in for it: k8UNorm and k8Srgb are both non-uint and so are
+			// indistinguishable to it.
+			const bool srgb_descriptor = image.kind == ResourceKind::Image &&
+			                             Prospero::IsShaderDecodedSrgbTextureFormat(format);
+			if (srgb_descriptor != image.srgb_decode) {
+				if (error != nullptr) {
+					*error = fmt::format(
+					    "image descriptor {} no longer matches specialized sRGB decode", i);
 				}
 				return false;
 			}
@@ -793,6 +810,10 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 				default: break;
 			}
 		}
+		// After the promotion, so kind is final. Restricted to plain sampled images: storage
+		// images are written as well as read, and uint images carry no transfer function.
+		image.srgb_decode =
+		    image.kind == ResourceKind::Image && Prospero::IsShaderDecodedSrgbTextureFormat(format);
 	}
 	for (uint32_t root_index = 0; root_index < next.images.size(); root_index++) {
 		auto& root = next.images[root_index];
@@ -840,13 +861,17 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 				image.mip_count         = image_class.mip_count;
 				image.conversion_format = image_class.conversion_format;
 				image.shader_swizzle    = image_class.shader_swizzle;
+				image.srgb_decode       = image_class.srgb_decode;
 				image.cube              = image_class.cube;
 			}
+			// srgb_decode joins the binding class: one module is compiled for the whole table,
+			// so candidates that disagree about the decode cannot share it.
 			if (image.kind != image_class.kind || image.dimension != image_class.dimension ||
 			    image.mip_mode != image_class.mip_mode ||
 			    image.mip_count != image_class.mip_count ||
 			    image.conversion_format != image_class.conversion_format ||
 			    image.shader_swizzle != image_class.shader_swizzle ||
+			    image.srgb_decode != image_class.srgb_decode ||
 			    image.depth_compare != image_class.depth_compare ||
 			    image.cube != image_class.cube) {
 				if (error != nullptr) {

--- a/tests/ResourceTrackingTests.cpp
+++ b/tests/ResourceTrackingTests.cpp
@@ -716,6 +716,88 @@ void TestSampleAdjustSamplerScratch() {
                 "SampleAdjust canonicalization discarded border-mode bits");
 }
 
+void TestShaderDecodedSrgbSpecialization() {
+  const auto MakeSampleFixture = [] {
+    auto fixture = std::make_unique<Fixture>(ShaderType::Pixel);
+    const auto image =
+        fixture->Image({Value(0u), Value(0u), Value(0u), Value(0u), Value(0u),
+                        Value(0u), Value(0u), Value(0u)},
+                       0x100);
+    const auto sampler =
+        fixture->Sampler({Value(0u), Value(0u), Value(0u), Value(0u)}, 0x100);
+    MemoryInfo sample;
+    sample.kind = ResourceKind::Image;
+    sample.image_dimension = Decoder::ImageDimension::Dim2D;
+    const auto sampled =
+        fixture->Emit(ValueOpcode::ImageSampleRaw,
+                      {image, sampler, fixture->ImageAddress()},
+                      fixture->AddMemory(sample, 0x100));
+    fixture->Emit(ValueOpcode::ReferenceU32,
+                  {fixture->Emit(ValueOpcode::CompositeExtractU32x4,
+                                 {sampled, Value(0u)})});
+    fixture->PlanAndTrack();
+    return fixture;
+  };
+  const auto Descriptor = [](Libs::Graphics::Prospero::BufferFormat format) {
+    DescriptorValue descriptor{};
+    descriptor.dwords[0] = 0x1000u;
+    descriptor.dwords[1] = static_cast<uint32_t>(format) << 20u;
+    descriptor.dwords[2] = 3u | (3u << 14u);
+    descriptor.dwords[3] =
+        Libs::Graphics::DstSel(4, 5, 6, 7) |
+        (static_cast<uint32_t>(Libs::Graphics::Prospero::ImageType::kColor2D)
+         << 28u);
+    descriptor.dword_count = 8;
+    return descriptor;
+  };
+  const auto srgb =
+      Descriptor(Libs::Graphics::Prospero::BufferFormat::k8Srgb);
+  const auto unorm =
+      Descriptor(Libs::Graphics::Prospero::BufferFormat::k8UNorm);
+
+  DescriptorValue sampler_descriptor{};
+  sampler_descriptor.dword_count = 4;
+
+  auto decoded = MakeSampleFixture();
+  ResourceSnapshot snapshot;
+  snapshot.images.assign(1, srgb);
+  snapshot.samplers.assign(1, sampler_descriptor);
+  std::string error;
+  Check(SpecializeResources(decoded->program, snapshot, &error) &&
+            decoded->program.info.images[0].srgb_decode &&
+            ValidateResourceSpecialization(decoded->program, snapshot, &error),
+        "a k8Srgb sampled image was not specialized to a shader-side decode");
+
+  // The uint check cannot stand in for this: k8UNorm and k8Srgb are both
+  // non-uint, so only the sRGB comparison keeps the two permutations apart.
+  snapshot.images[0] = unorm;
+  Check(!ValidateResourceSpecialization(decoded->program, snapshot, &error) &&
+            error.find("sRGB decode") != std::string::npos,
+        "a unorm descriptor reused the permutation compiled with the decode");
+
+  DescriptorValue null_descriptor{};
+  null_descriptor.dword_count = 8;
+  snapshot.images[0] = null_descriptor;
+  Check(!ValidateResourceSpecialization(decoded->program, snapshot, &error),
+        "a null descriptor reused the permutation compiled with the decode");
+
+  auto plain = MakeSampleFixture();
+  ResourceSnapshot plain_snapshot;
+  plain_snapshot.images.assign(1, unorm);
+  plain_snapshot.samplers.assign(1, sampler_descriptor);
+  Check(SpecializeResources(plain->program, plain_snapshot, &error) &&
+            !plain->program.info.images[0].srgb_decode &&
+            ValidateResourceSpecialization(plain->program, plain_snapshot,
+                                           &error),
+        "a k8UNorm sampled image was specialized to a shader-side decode");
+  plain_snapshot.images[0] = srgb;
+  Check(!ValidateResourceSpecialization(plain->program, plain_snapshot,
+                                        &error) &&
+            error.find("sRGB decode") != std::string::npos,
+        "an sRGB descriptor reused the permutation compiled without the "
+        "decode");
+}
+
 void TestDynamicStorageMipTracking() {
   Fixture fixture;
   std::array<Value, 8> image_words;
@@ -1373,6 +1455,7 @@ int main() {
     Run("runtime unsigned min", TestRuntimeUnsignedMinDescriptor);
     Run("images and samplers", TestImagesSamplersAndAliases);
     Run("SampleAdjust sampler scratch", TestSampleAdjustSamplerScratch);
+    Run("shader-decoded sRGB", TestShaderDecodedSrgbSpecialization);
     Run("dynamic storage mips", TestDynamicStorageMipTracking);
     Run("invariant indirect images", TestInvariantIndirectImageMaterialization);
     Run("SRT runtime", TestSrtFlatteningAndRuntimeMemoization);


### PR DESCRIPTION
PAC-MAN WORLD 2 Re-PAC renders its cutscenes magenta. Everything is there — geometry, detail, motion — but drowned in pink.

`R8_SRGB` and `R8G8_SRGB` are optional in Vulkan and plenty of devices expose no features for them at all, so `k8Srgb` and `k8_8Srgb` are created as unorm images. That part is already here and is the right call. What is missing is the other half: nothing then supplies the sRGB decode those formats are owed, so the sampled texels stay gamma-encoded and any title that binds one gets a colour cast.

PAC-MAN WORLD 2 binds exactly these — its decoded-video planes are `k8Srgb` luma and `k8_8Srgb` chroma.

## Change

Emit the decode in the shader.

`IsShaderDecodedSrgbTextureFormat` names the two formats. It is deliberately not a column in the format table, because this is a property of what the host can express, not of the guest format: every other guest sRGB format has a real host counterpart whose sampler already decodes it, and a shared column would sweep those in and decode them twice.

Specialization carries it. `ResourceMaterialization` fills `srgb_decode` in from the runtime descriptor and rejects a descriptor that no longer matches the permutation that was compiled, and the flag joins the program key — two modules differing only in the decode produce different SPIR-V and must not collide. The uint check cannot stand in for it: `k8UNorm` and `k8Srgb` are both non-uint and indistinguishable to it.

Three details worth flagging for review:

- The decode runs **before** the bitcast, since the bitcast reinterprets the float as an integer bit pattern for VGPR storage and decoding after it would corrupt the value.
- Alpha is never decoded, matching Vulkan's own sRGB sampling semantics.
- `Gather4` returns one channel of four neighbouring texels, so it decides the alpha exclusion once, on that channel.

## Testing

Same cutscene frame, same second, mean channel values:

| | R | G | B |
| --- | --- | --- | --- |
| before | 239.0 | 88.1 | 253.2 |
| after | 68.8 | 79.6 | 106.3 |

Red and blue pinned high with green far below them is magenta, numerically. Green minus the average of red and blue goes from −158.0 to −7.9.

Verified again after rebasing onto current main.
