### PR TITLE
 kernel: do not release a waiter on a zero-count syncOnAddress wake (linux only)

### DIFF
--- a/src/kernel/syncOnAddress.cpp
+++ b/src/kernel/syncOnAddress.cpp
@@ -119,6 +119,14 @@ int WaitLinux(volatile T* address, T expected, const uint32_t* timeout_micros,
 }
 
 int WakeLinux(volatile void* address, int32_t count) {
+	// A count of 0 must release no waiters, but FUTEX_WAKE does not implement it that way: the
+	// kernel's wake loop tests `if (++ret >= nr_wake) break` *after* waking, so a zero count still
+	// releases one waiter. WakePortable already short-circuits this case, and the two backends of
+	// the same ABI have to agree.
+	if (count == 0) {
+		return OK;
+	}
+
 	const auto result = syscall(SYS_futex, const_cast<void*>(address), FUTEX_WAKE_PRIVATE, count,
 	                            nullptr, nullptr, 0);
 	return result < 0 ? KERNEL_ERROR_EINVAL : OK;

--- a/src/kernel/syncOnAddress.cpp
+++ b/src/kernel/syncOnAddress.cpp
@@ -119,10 +119,7 @@ int WaitLinux(volatile T* address, T expected, const uint32_t* timeout_micros,
 }
 
 int WakeLinux(volatile void* address, int32_t count) {
-	// A count of 0 must release no waiters, but FUTEX_WAKE does not implement it that way: the
-	// kernel's wake loop tests `if (++ret >= nr_wake) break` *after* waking, so a zero count still
-	// releases one waiter. WakePortable already short-circuits this case, and the two backends of
-	// the same ABI have to agree.
+	// The legacy FUTEX_WAKE path may wake one waiter when count is zero.
 	if (count == 0) {
 		return OK;
 	}


### PR DESCRIPTION
## Summary

 `sceKernelSyncOnAddressWake` with a count of 0 behaves differently on Linux than on every other
  host. `WakePortable` short-circuits `count == 0` and releases nobody; `WakeLinux` passes the count
  straight to `FUTEX_WAKE`, which does not treat 0 as "wake nobody" — measured directly, `FUTEX_WAKE`
  with `val = 0` returns 1 and releases a waiter. `Wake` admits 0 as valid (it rejects only
  `count < 0`), and `SyncOnAddressTests::TestWakeZeroIsNoOp` asserts that it releases no waiters, so
  the Linux path contradicts both the portable backend and the test — which is red on `main` on Linux.

  ## What's included

  ### Guest threading

  - Return early from `WakeLinux` when `count == 0` instead of issuing the syscall — without it a
    zero-count wake releases a waiter, which returns from `sceKernelSyncOnAddressWait` reporting
    success while the watched word is unchanged. Confirmed against the raw syscall: `FUTEX_WAKE`
    with `val = 0` returns 1.

  ## Platform impact

  - **Windows** — unchanged. The change is confined to `WakeLinux`, inside
    `#if KYTY_PLATFORM == KYTY_PLATFORM_LINUX && !defined(__APPLE__)`; Windows goes through
    `WakePortable`, which already had this guard.
  - **macOS** — unchanged, and for the same reason: Darwin is excluded from the Linux block and
    uses `WakePortable`.

  ## Testing

  Built Release on Linux (Clang, Ninja). `SyncOnAddressTests::TestWakeZeroIsNoOp` covers exactly
  this and fails on current `main`: 10/10 runs abort on "zero-count wake releases no waiters". With
  the fix, `ctest -R sync_on_address` passes 20/20 consecutive runs (36 checks).