### PR TITLE
Makes launcher build optional

### DIFF
--- a/src/launcher/CMakeLists.txt
+++ b/src/launcher/CMakeLists.txt
@@ -1,3 +1,8 @@
+option(KYTY_BUILD_LAUNCHER "Build Qt launcher" ON)
+
+if(NOT KYTY_BUILD_LAUNCHER)
+	return()
+endif()
 
 find_package(Qt6 COMPONENTS Concurrent Network Widgets REQUIRED)
 


### PR DESCRIPTION
Adds a `KYTY_BUILD_LAUNCHER` CMake option (ON by default). When disabled, the launcher is excluded (only launcher) from the default build, allowing the rest of the project to be built without Qt6. Previously, the only way to do this was to explicitly specify every non-launcher target on the build command line.

The option is enabled by default, so existing developer configurations and CI remain unaffected.