### PR TITLE
fix: stop a connected controller from disabling keyboard input

### DIFF
--- a/src/libs/controller.cpp
+++ b/src/libs/controller.cpp
@@ -208,7 +208,8 @@ void GameController::AddState(const ControllerState& state) {
 void GameController::Button(int id, uint32_t button, bool down) {
 	Common::LockGuard lock(m_mutex);
 
-	if (m_active_id == id) {
+	// The keyboard shares the player-1 pad with the active gamepad.
+	if (m_active_id == id || id == HOST_INPUT_CONTROLLER_ID) {
 		auto state = GetLastState();
 
 		state.time = LibKernel::KernelGetProcessTime();
@@ -226,7 +227,7 @@ void GameController::Button(int id, uint32_t button, bool down) {
 void GameController::Axis(int id, Controller::Axis axis, int value) {
 	Common::LockGuard lock(m_mutex);
 
-	if (m_active_id == id) {
+	if (m_active_id == id || id == HOST_INPUT_CONTROLLER_ID) {
 		auto state = GetLastState();
 
 		state.time = LibKernel::KernelGetProcessTime();


### PR DESCRIPTION
## Problem 
When connecting a controller the emulator drops all the keyboard inputs and that very annoying because now I have to control the game through the controller only 

## The fix
Just merge the inputs from the controller and the keyboard and make them act as Player-1 input