### PR TITLE
feat: identify build provenance in the crash log report

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -12,9 +12,6 @@ endif()
 
 add_library(common STATIC ${common_src} ${common_headers})
 
-# assert.cpp stamps the build label into crash reports.
-add_dependencies(common KytyGitVersion)
-
 target_include_directories(common
 	PUBLIC ${KYTY_SOURCE_DIR}
 	PRIVATE
@@ -27,6 +24,7 @@ target_link_libraries(common
 		Tracy::TracyClient
 	PRIVATE
 		cpuinfo
+		kyty_git_version
 		spdlog::spdlog
 )
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -12,6 +12,9 @@ endif()
 
 add_library(common STATIC ${common_src} ${common_headers})
 
+# assert.cpp stamps the build label into crash reports.
+add_dependencies(common KytyGitVersion)
+
 target_include_directories(common
 	PUBLIC ${KYTY_SOURCE_DIR}
 	PRIVATE

--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -3,6 +3,7 @@
 #include "common/debug.h"
 #include "common/logging/log.h"
 #include "common/subsystems.h"
+#include "kytyGitVersion.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -23,7 +24,7 @@ static std::string BuildFatalReport(const char* title, std::string_view text, co
 	DebugStack stack;
 	DebugStack::Trace(&stack);
 
-	std::string report = "--- Stack Trace ---\n";
+	std::string report = "--- Build ---\n" KYTY_BUILD_LABEL "\n--- Stack Trace ---\n";
 	for (int i = PRINT_STACK_FROM; i < stack.depth; i++) {
 		report += fmt::format("[{}] {:016x}\n", i - PRINT_STACK_FROM,
 		                      static_cast<uint64_t>(stack.GetAddr(i)));

--- a/src/graphics/presentation/window/window.cpp
+++ b/src/graphics/presentation/window/window.cpp
@@ -938,13 +938,6 @@ void WindowContext::UpdateTitle() {
 	static constexpr auto build_type = "Unknown";
 #endif
 
-#if defined(KYTY_OFFICIAL_BUILD)
-	static constexpr auto build_label = "Official build " KYTY_RELEASE_TAG;
-#elif defined(KYTY_FORK_BUILD)
-	static constexpr auto build_label = "Fork build " KYTY_BUILD_REPOSITORY " " KYTY_GIT_HASH;
-#else
-	static constexpr auto build_label = "Source build " KYTY_GIT_HASH;
-#endif
 
 	const auto now       = Common::Timer::QueryPerformanceCounter();
 	const auto frequency = Common::Timer::QueryPerformanceFrequency();
@@ -957,7 +950,7 @@ void WindowContext::UpdateTitle() {
 		fps_frames  = 0;
 	}
 
-	auto fps = fmt::format("[{} | {}] {}{}{}{}{}{}[{}] [{}], frame: {}, fps: {:f}", build_label,
+	auto fps = fmt::format("[{} | {}] {}{}{}{}{}{}[{}] [{}], frame: {}, fps: {:f}", KYTY_BUILD_LABEL,
 	                       build_type, (has_title ? title : ""), (has_title ? ", " : ""),
 	                       (has_title_id ? title_id : ""), (has_title_id ? ", " : ""),
 	                       (has_app_ver ? app_ver : ""), (has_app_ver ? " " : ""), device_name,

--- a/src/kytyGitVersion.h.in
+++ b/src/kytyGitVersion.h.in
@@ -1,2 +1,13 @@
+#include "cmake_config.h"
+
 #define KYTY_GIT_VERSION "@KYTY_GIT_VERSION@"
 #define KYTY_GIT_HASH "@KYTY_GIT_HASH@"
+
+/* Build provenance, shown in the window title and in crash reports. */
+#if defined(KYTY_OFFICIAL_BUILD)
+#define KYTY_BUILD_LABEL "Official build " KYTY_RELEASE_TAG
+#elif defined(KYTY_FORK_BUILD)
+#define KYTY_BUILD_LABEL "Fork build " KYTY_BUILD_REPOSITORY " " KYTY_GIT_HASH
+#else
+#define KYTY_BUILD_LABEL "Source build " KYTY_GIT_HASH
+#endif


### PR DESCRIPTION
## Summary
Adds KytyPS5 build provenance to the beginning of the crash log so screenshots and compatibility reports identify
the exact emulator build being used.

## Examples

### Official build

```text
--- Build ---
Official build KytyPS5-2026-08-04-abcdef0
--- Stack Trace ---
[0] 000000014043f669
[1] 000000014040883b
[2] 0000000140444162
[3] 00007ffb70f72d26
[4] 000000090196b91a
--- Error ---
Access violation: Read [ffffffffffffffff] (Unpatched object)
 in src/loader/runtimeLinker.cpp:1029
```

### Local source build

```text
--- Build ---
Source build d09c81d
--- Stack Trace ---
[0] 0000000140496279
[1] 000000014045f42e
[2] 000000014049abdf
[3] 00007ffd9f619e96
[4] 000000090000819e
--- Error ---
Access violation: Write [0000000000000000]
 in src/loader/runtimeLinker.cpp:1029
```

### Modified local source tree

```text
--- Build ---
Source build d09c81d-dirty
--- Stack Trace ---
[0] 00000001404c1a80
[1] 00000001404b3ee5
[2] 000000014051d7c4
[3] 00000001405f0913
[4] 00007ffd9f765d1e
--- Fatal Error ---
Not implemented (tile mode 0x2b) in src/graphics/guest_gpu/gpu_format.cpp:412
```

### GitHub Actions build in a fork

```text
--- Build ---
Fork build almo7aya/KytyPS5 d09c81d
--- Stack Trace ---
[0] 000000014043f669
[1] 00000001404087a2
[2] 0000000140443f10
[3] 00007ffb70f72d26
[4] 000000090196b91a
--- Fatal Error ---
Error: condition (buf == nullptr) is true in sr
```