### PR TITLE
feat(media): play self-decoded movies on the host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,8 @@ file(GLOB kyty_emulator_src CONFIGURE_DEPENDS
 	"${KYTY_SOURCE_DIR}/libs/*.h"
 	"${KYTY_SOURCE_DIR}/graphics/*.cpp"
 	"${KYTY_SOURCE_DIR}/graphics/*.h"
+	"${KYTY_SOURCE_DIR}/graphics/media/*.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/media/*.h"
 	"${KYTY_SOURCE_DIR}/graphics/guest_gpu/*.cpp"
 	"${KYTY_SOURCE_DIR}/graphics/guest_gpu/*.h"
 	"${KYTY_SOURCE_DIR}/graphics/guest_gpu/command_processor/*.cpp"

--- a/src/graphics/media/binkHost.cpp
+++ b/src/graphics/media/binkHost.cpp
@@ -1,0 +1,310 @@
+#include "graphics/media/binkHost.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libswscale/swscale.h>
+}
+
+namespace Libs::Graphics::BinkHost {
+
+namespace {
+
+// Only the entry points a decode needs. Bound by name so a build of ffmpeg that carries
+// binkvideo2 can be dropped in without relinking the emulator.
+struct Api {
+	int (*open_input)(AVFormatContext**, const char*, const AVInputFormat*,
+	                  AVDictionary**)                                   = nullptr;
+	int (*find_stream_info)(AVFormatContext*, AVDictionary**)           = nullptr;
+	void (*close_input)(AVFormatContext**)                              = nullptr;
+	int (*read_frame)(AVFormatContext*, AVPacket*)                      = nullptr;
+	const AVCodec* (*find_decoder)(AVCodecID)                           = nullptr;
+	AVCodecContext* (*alloc_context)(const AVCodec*)                    = nullptr;
+	int (*params_to_context)(AVCodecContext*, const AVCodecParameters*) = nullptr;
+	int (*codec_open)(AVCodecContext*, const AVCodec*, AVDictionary**)  = nullptr;
+	int (*send_packet)(AVCodecContext*, const AVPacket*)                = nullptr;
+	int (*receive_frame)(AVCodecContext*, AVFrame*)                     = nullptr;
+	void (*free_context)(AVCodecContext**)                              = nullptr;
+	AVPacket* (*packet_alloc)()                                         = nullptr;
+	void (*packet_free)(AVPacket**)                                     = nullptr;
+	void (*packet_unref)(AVPacket*)                                     = nullptr;
+	AVFrame* (*frame_alloc)()                                           = nullptr;
+	void (*frame_free)(AVFrame**)                                       = nullptr;
+	SwsContext* (*get_sws)(int, int, AVPixelFormat, int, int, AVPixelFormat, int, SwsFilter*,
+	                       SwsFilter*, const double*)                   = nullptr;
+	int (*sws_scale_fn)(SwsContext*, const uint8_t* const*, const int*, int, int, uint8_t* const*,
+	                    const int*)                                     = nullptr;
+	void (*free_sws)(SwsContext*)                                       = nullptr;
+	bool ready                                                          = false;
+};
+
+std::mutex       g_lock;
+Api              g_api;
+bool             g_load_attempted = false;
+std::string      g_path;
+AVFormatContext* g_format  = nullptr;
+AVCodecContext*  g_codec   = nullptr;
+AVFrame*         g_frame   = nullptr;
+AVPacket*        g_packet  = nullptr;
+SwsContext*      g_sws     = nullptr;
+int              g_sws_w   = 0;
+int              g_sws_h   = 0;
+AVPixelFormat    g_sws_fmt = AV_PIX_FMT_NONE;
+int              g_stream  = -1;
+
+#if defined(_WIN32)
+template <typename T>
+bool Bind(T& slot, HMODULE module, const char* name) {
+	auto* symbol = GetProcAddress(module, name);
+	slot         = reinterpret_cast<T>(symbol);
+	if (symbol == nullptr) {
+		std::fprintf(stderr, "[bink] missing ffmpeg symbol %s\n", name);
+		return false;
+	}
+	return true;
+}
+#endif
+
+bool LoadApi() {
+	if (g_load_attempted) {
+		return g_api.ready;
+	}
+	g_load_attempted = true;
+
+#if defined(_WIN32)
+	const char* directory = std::getenv("KYTY_BINK_FFMPEG_DIR");
+	if (directory == nullptr) {
+		std::fprintf(stderr, "[bink] KYTY_BINK_FFMPEG_DIR is not set; host playback disabled\n");
+		return false;
+	}
+	SetDllDirectoryA(directory);
+	char    path[1024];
+	HMODULE avutil   = nullptr;
+	HMODULE avcodec  = nullptr;
+	HMODULE avformat = nullptr;
+	HMODULE swscale  = nullptr;
+	// Load in dependency order; avcodec pulls avutil and swresample.
+	const char* names[] = {"avutil-59.dll", "swresample-5.dll", "avcodec-61.dll", "avformat-61.dll",
+	                       "swscale-8.dll"};
+	HMODULE*    slots[] = {&avutil, nullptr, &avcodec, &avformat, &swscale};
+	for (int i = 0; i < 5; i++) {
+		std::snprintf(path, sizeof(path), "%s\\%s", directory, names[i]);
+		HMODULE module = LoadLibraryA(path);
+		if (module == nullptr) {
+			std::fprintf(stderr, "[bink] could not load %s\n", path);
+			return false;
+		}
+		if (slots[i] != nullptr) {
+			*slots[i] = module;
+		}
+	}
+
+	bool ok = true;
+	ok &= Bind(g_api.open_input, avformat, "avformat_open_input");
+	ok &= Bind(g_api.find_stream_info, avformat, "avformat_find_stream_info");
+	ok &= Bind(g_api.close_input, avformat, "avformat_close_input");
+	ok &= Bind(g_api.read_frame, avformat, "av_read_frame");
+	ok &= Bind(g_api.find_decoder, avcodec, "avcodec_find_decoder");
+	ok &= Bind(g_api.alloc_context, avcodec, "avcodec_alloc_context3");
+	ok &= Bind(g_api.params_to_context, avcodec, "avcodec_parameters_to_context");
+	ok &= Bind(g_api.codec_open, avcodec, "avcodec_open2");
+	ok &= Bind(g_api.send_packet, avcodec, "avcodec_send_packet");
+	ok &= Bind(g_api.receive_frame, avcodec, "avcodec_receive_frame");
+	ok &= Bind(g_api.free_context, avcodec, "avcodec_free_context");
+	ok &= Bind(g_api.packet_alloc, avcodec, "av_packet_alloc");
+	ok &= Bind(g_api.packet_free, avcodec, "av_packet_free");
+	ok &= Bind(g_api.packet_unref, avcodec, "av_packet_unref");
+	// av_frame_alloc/av_frame_free live in avutil, not avcodec.
+	ok &= Bind(g_api.frame_alloc, avutil, "av_frame_alloc");
+	ok &= Bind(g_api.frame_free, avutil, "av_frame_free");
+	ok &= Bind(g_api.get_sws, swscale, "sws_getContext");
+	ok &= Bind(g_api.sws_scale_fn, swscale, "sws_scale");
+	ok &= Bind(g_api.free_sws, swscale, "sws_freeContext");
+	g_api.ready = ok;
+	if (ok) {
+		std::fprintf(stderr, "[bink] ffmpeg bound from %s\n", directory);
+		std::fflush(stderr);
+	}
+	return ok;
+#else
+	return false;
+#endif
+}
+
+void CloseLocked() {
+	if (g_sws != nullptr && g_api.free_sws != nullptr) {
+		g_api.free_sws(g_sws);
+	}
+	g_sws = nullptr;
+	if (g_frame != nullptr) {
+		g_api.frame_free(&g_frame);
+	}
+	if (g_packet != nullptr) {
+		g_api.packet_free(&g_packet);
+	}
+	if (g_codec != nullptr) {
+		g_api.free_context(&g_codec);
+	}
+	if (g_format != nullptr) {
+		g_api.close_input(&g_format);
+	}
+	g_stream = -1;
+	// Clear the path too: NotifyFileOpen skips reopening a file it believes is already open, so a
+	// stale path here would refuse the second play of a movie the title runs more than once.
+	g_path.clear();
+	g_sws_w   = 0;
+	g_sws_h   = 0;
+	g_sws_fmt = AV_PIX_FMT_NONE;
+}
+
+bool EndsWithBk2(const std::string& path) {
+	if (path.size() < 4) {
+		return false;
+	}
+	std::string tail = path.substr(path.size() - 4);
+	std::transform(tail.begin(), tail.end(), tail.begin(),
+	               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+	return tail == ".bk2";
+}
+
+bool OpenLocked(const std::string& path) {
+	CloseLocked();
+	if (g_api.open_input(&g_format, path.c_str(), nullptr, nullptr) < 0) {
+		std::fprintf(stderr, "[bink] could not open %s\n", path.c_str());
+		g_format = nullptr;
+		return false;
+	}
+	g_api.find_stream_info(g_format, nullptr);
+	for (unsigned i = 0; i < g_format->nb_streams; i++) {
+		if (g_format->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+			g_stream = static_cast<int>(i);
+			break;
+		}
+	}
+	if (g_stream < 0) {
+		CloseLocked();
+		return false;
+	}
+	auto*       params  = g_format->streams[g_stream]->codecpar;
+	const auto* decoder = g_api.find_decoder(params->codec_id);
+	if (decoder == nullptr) {
+		std::fprintf(stderr, "[bink] no decoder for codec_id=%d (need binkvideo2)\n",
+		             static_cast<int>(params->codec_id));
+		CloseLocked();
+		return false;
+	}
+	g_codec = g_api.alloc_context(decoder);
+	g_api.params_to_context(g_codec, params);
+	if (g_api.codec_open(g_codec, decoder, nullptr) < 0) {
+		CloseLocked();
+		return false;
+	}
+	g_frame  = g_api.frame_alloc();
+	g_packet = g_api.packet_alloc();
+	std::fprintf(stderr, "[bink] playing %s with %s %dx%d\n", path.c_str(), decoder->name,
+	             params->width, params->height);
+	std::fflush(stderr);
+	return true;
+}
+
+} // namespace
+
+void NotifyFileOpen(const std::string& host_path) {
+	if (std::getenv("KYTY_BINK_HOST") == nullptr || !EndsWithBk2(host_path)) {
+		return;
+	}
+	std::lock_guard lock(g_lock);
+	if (!LoadApi()) {
+		return;
+	}
+	if (g_path == host_path && g_format != nullptr) {
+		return;
+	}
+	// Record the path only after the open succeeds: OpenLocked starts by closing, and closing
+	// clears the path, so assigning first would leave it empty and defeat the check above.
+	if (OpenLocked(host_path)) {
+		g_path = host_path;
+	}
+}
+
+bool Active() {
+	std::lock_guard lock(g_lock);
+	return g_format != nullptr && g_codec != nullptr;
+}
+
+bool NextFrame(uint32_t width, uint32_t height, int av_pixel_format, uint32_t bytes_per_pixel,
+               std::vector<uint8_t>& rgba) {
+	std::lock_guard lock(g_lock);
+	if (g_format == nullptr || g_codec == nullptr || width == 0 || height == 0) {
+		return false;
+	}
+
+	bool decoded = false;
+	// Drain anything already buffered before pulling more packets.
+	if (g_api.receive_frame(g_codec, g_frame) == 0) {
+		decoded = true;
+	}
+	for (int guard = 0; guard < 4096 && !decoded; guard++) {
+		if (g_api.read_frame(g_format, g_packet) < 0) {
+			std::fprintf(stderr, "[bink] end of %s\n", g_path.c_str());
+			std::fflush(stderr);
+			// Release the movie the moment it finishes instead of parking it as "ended". Holding
+			// the contexts open kept the decoder and its last frame alive for the rest of the run,
+			// and the retained path blocked reopening the same file.
+			CloseLocked();
+			return false;
+		}
+		if (g_packet->stream_index != g_stream) {
+			g_api.packet_unref(g_packet);
+			continue;
+		}
+		const int sent = g_api.send_packet(g_codec, g_packet);
+		g_api.packet_unref(g_packet);
+		if (sent < 0) {
+			continue;
+		}
+		if (g_api.receive_frame(g_codec, g_frame) == 0) {
+			decoded = true;
+		}
+	}
+	if (!decoded) {
+		return false;
+	}
+
+	const auto target_w = static_cast<int>(width);
+	const auto target_h = static_cast<int>(height);
+	const auto want     = static_cast<AVPixelFormat>(av_pixel_format);
+	if (g_sws == nullptr || g_sws_w != target_w || g_sws_h != target_h || g_sws_fmt != want) {
+		if (g_sws != nullptr) {
+			g_api.free_sws(g_sws);
+		}
+		g_sws     = g_api.get_sws(g_frame->width, g_frame->height,
+		                          static_cast<AVPixelFormat>(g_frame->format), target_w, target_h, want,
+		                          SWS_BILINEAR, nullptr, nullptr, nullptr);
+		g_sws_w   = target_w;
+		g_sws_h   = target_h;
+		g_sws_fmt = want;
+	}
+	if (g_sws == nullptr) {
+		return false;
+	}
+
+	rgba.resize(static_cast<size_t>(target_w) * target_h * bytes_per_pixel);
+	uint8_t* destination[4]      = {rgba.data(), nullptr, nullptr, nullptr};
+	int      destination_line[4] = {target_w * static_cast<int>(bytes_per_pixel), 0, 0, 0};
+	g_api.sws_scale_fn(g_sws, g_frame->data, g_frame->linesize, 0, g_frame->height, destination,
+	                   destination_line);
+	return true;
+}
+
+} // namespace Libs::Graphics::BinkHost

--- a/src/graphics/media/binkHost.h
+++ b/src/graphics/media/binkHost.h
@@ -1,0 +1,39 @@
+#ifndef EMULATOR_SRC_GRAPHICS_MEDIA_BINKHOST_H_
+#define EMULATOR_SRC_GRAPHICS_MEDIA_BINKHOST_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace Libs::Graphics::BinkHost {
+
+// Host-side playback for movies the guest decodes inside its own executable.
+//
+// Demon's Souls' logo and title screen are 4K Bink 2 (.bk2) files. The game never calls
+// libSceVideodec or sceAvPlayer for them - it runs its own decoder on its own threads - so there
+// is no HLE export to intercept and no texture-cache fix that reaches them; what the guest
+// produces is garbage and we faithfully present it. Instead the kernel's file opens tell us which
+// movie is playing and we decode it on the host, exactly as SharpEmu does.
+//
+// Enabled by KYTY_BINK_HOST=1. ffmpeg is bound at RUNTIME from KYTY_BINK_FFMPEG_DIR because our
+// bundled avcodec is built without the binkvideo2 decoder; loading a build that has it needs no
+// import library and no CMake change, and is safe here only because both are avcodec 61.19.101,
+// so our headers describe those binaries' structures exactly.
+
+// Called for every guest file open, with the resolved host path.
+void NotifyFileOpen(const std::string& host_path);
+
+// True once a .bk2 has been opened and ffmpeg is usable.
+[[nodiscard]] bool Active();
+
+// Next frame of the active movie, tightly packed at the requested size and converted to
+// `av_pixel_format` (an AVPixelFormat). The caller passes whatever matches the swapchain image so
+// the result copies in with no conversion - Demon's Souls presents 10-bit A2B10G10R10, not RGBA,
+// and writing 8-bit pixels into it misaligns every channel.
+// Returns false when playback is not running, the size is invalid, or the movie has ended.
+[[nodiscard]] bool NextFrame(uint32_t width, uint32_t height, int av_pixel_format,
+                             uint32_t bytes_per_pixel, std::vector<uint8_t>& out);
+
+} // namespace Libs::Graphics::BinkHost
+
+#endif // EMULATOR_SRC_GRAPHICS_MEDIA_BINKHOST_H_

--- a/src/graphics/presentation/window/swapchain.cpp
+++ b/src/graphics/presentation/window/swapchain.cpp
@@ -27,6 +27,11 @@
 #include "common/threads.h"
 #include "common/timer.h"
 #include "graphics/host_gpu/graphicContext.h"
+#include "graphics/media/binkHost.h"
+
+extern "C" {
+#include <libavutil/pixfmt.h>
+}
 #include "graphics/host_gpu/renderer/render.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
 #include "graphics/host_gpu/vma.h"
@@ -66,9 +71,16 @@ struct Presenter::Frame {
 	bool                           busy         = false;
 	bool                           reusing_last = false;
 
+	// Staging for host-decoded movie frames. One per Frame, so the frame's own fence is what
+	// governs reuse and no extra synchronisation is needed.
+	VulkanBuffer staging;
+	uint64_t     staging_size = 0;
+
 	void Configure(GraphicContext& graphics, vk::Extent2D extent, vk::Format format);
 	void Transit(vk::CommandBuffer command, vk::ImageLayout layout, vk::AccessFlags2 access);
 	void CopyFrom(CommandBuffer& command, Image& source);
+	void UploadRgba(GraphicContext& graphics, CommandBuffer& command,
+	                const std::vector<uint8_t>& rgba, uint32_t width, uint32_t height);
 	void Clear(CommandBuffer& command, const vk::ClearColorValue& color);
 };
 
@@ -308,6 +320,50 @@ void Presenter::Frame::CopyFrom(CommandBuffer& command_buffer, Image& source) {
 	EXIT_IF(copy.srcSubresource.layerCount != copy.dstSubresource.layerCount);
 	command.copyImage(source.backing.image, vk::ImageLayout::eTransferSrcOptimal, image.image,
 	                  vk::ImageLayout::eTransferDstOptimal, copy);
+	Transit(command, vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead);
+}
+
+// Put a host-decoded movie frame straight into the presented image, replacing whatever the guest
+// produced. The frame arrives as tightly packed RGBA already sized to this image.
+void Presenter::Frame::UploadRgba(GraphicContext& graphics, CommandBuffer& command_buffer,
+                                  const std::vector<uint8_t>& rgba, uint32_t width,
+                                  uint32_t height) {
+	const uint64_t needed = static_cast<uint64_t>(width) * height * 4;
+	if (rgba.size() < needed || needed == 0) {
+		return;
+	}
+	if (staging_size < needed) {
+		if (staging.buffer != nullptr) {
+			graphics.DeleteBuffer(staging);
+		}
+		staging.usage = vk::BufferUsageFlagBits::eTransferSrc;
+		// CreateBuffer picks the memory type from these flags; without them the allocation is
+		// device-local and vmaMapMemory fails.
+		staging.memory.property =
+		    vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent;
+		graphics.CreateBuffer(needed, staging);
+		staging_size = needed;
+	}
+	void* mapped = nullptr;
+	graphics.MapMemory(staging.memory, mapped);
+	if (mapped == nullptr) {
+		return;
+	}
+	std::memcpy(mapped, rgba.data(), needed);
+	graphics.UnmapMemory(staging.memory);
+
+	command_buffer.EndRendering();
+	auto command = command_buffer.Handle();
+	Transit(command, vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite);
+	vk::BufferImageCopy region {};
+	region.bufferOffset      = 0;
+	region.bufferRowLength   = width;
+	region.bufferImageHeight = height;
+	region.imageSubresource  = {vk::ImageAspectFlagBits::eColor, 0, 0, 1};
+	region.imageExtent       = {width, height, 1};
+	command.copyBufferToImage(staging.buffer, image.image, vk::ImageLayout::eTransferDstOptimal, 1,
+	                          &region);
+	// Leave the image where CopyFrom leaves it, so the present path is unchanged.
 	Transit(command, vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead);
 }
 
@@ -769,6 +825,34 @@ Presenter::Frame& Presenter::PrepareFrame(CommandBuffer& buffer, const ImageInfo
 	frame->Configure(m_impl->window.graphic_ctx,
 	                 {image.backing.extent.width, image.backing.extent.height}, frame_format);
 	frame->CopyFrom(buffer, image);
+	// A movie the guest decodes itself never reaches us as pixels we can trust, so when one is
+	// playing the host-decoded frame replaces what the guest composed.
+	if (BinkHost::Active()) {
+		const uint32_t              width  = image.backing.extent.width;
+		const uint32_t              height = image.backing.extent.height;
+		static std::vector<uint8_t> rgba;
+		// Decode straight into the presented image's own format. Demon's Souls presents
+		// A2B10G10R10, so 8-bit pixels would land across the wrong bits and tint the whole frame.
+		int      av_format = AV_PIX_FMT_RGBA;
+		uint32_t bytes     = 4;
+		switch (frame_format) {
+			case vk::Format::eB8G8R8A8Unorm:
+			case vk::Format::eB8G8R8A8Srgb: av_format = AV_PIX_FMT_BGRA; break;
+			case vk::Format::eA2B10G10R10UnormPack32: av_format = AV_PIX_FMT_X2BGR10LE; break;
+			case vk::Format::eA2R10G10B10UnormPack32: av_format = AV_PIX_FMT_X2RGB10LE; break;
+			default: break;
+		}
+		static bool reported = false;
+		if (!reported) {
+			reported = true;
+			std::fprintf(stderr, "[bink] presenting %ux%u vk_format=%u av_format=%d\n", width,
+			             height, static_cast<uint32_t>(frame_format), av_format);
+			std::fflush(stderr);
+		}
+		if (BinkHost::NextFrame(width, height, av_format, bytes, rgba)) {
+			frame->UploadRgba(m_impl->window.graphic_ctx, buffer, rgba, width, height);
+		}
+	}
 	return *frame;
 }
 

--- a/src/kernel/fileSystem.cpp
+++ b/src/kernel/fileSystem.cpp
@@ -9,6 +9,7 @@
 #include "common/logging/log.h"
 #include "common/stringUtils.h"
 #include "common/threads.h"
+#include "graphics/media/binkHost.h"
 #include "kernel/memory.h"
 #include "libs/errno.h"
 #include "libs/libs.h"
@@ -435,6 +436,13 @@ int KYTY_SYSV_ABI KernelOpen(const char* path, int flags, uint16_t mode) {
 
 	file->real_name = (directory ? g_mount_points->GetRealDirectory(file->name)
 	                             : g_mount_points->GetRealFilename(file->name));
+
+	// Games that decode video inside their own executable never call a decode export we can see,
+	// so the file open is the only announcement that a movie has started. Demon's Souls opens its
+	// .bk2 movies here.
+	if (!directory) {
+		Libs::Graphics::BinkHost::NotifyFileOpen(Common::PathToString(file->real_name));
+	}
 
 	if (trunc && rw_mode == Common::File::Mode::Read) {
 		return KERNEL_ERROR_EACCES;

--- a/src/launcher/src/mainDialog.cpp
+++ b/src/launcher/src/mainDialog.cpp
@@ -16,6 +16,7 @@
 #include <QLabel>
 #include <QMessageBox>
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QRadioButton>
 #include <QRegularExpression>
 #include <QSettings>
@@ -381,6 +382,27 @@ void MainDialog::RunInterpreter(QProcess* process, const Configuration& info) {
 	process->setArguments(args);
 #endif
 	process->setWorkingDirectory(dir.path());
+
+	// Some titles decode their movies inside their own executable rather than through a decode
+	// export we can see - Demon's Souls' .bk2 files do - so those frames are decoded on the host
+	// instead. That needs an ffmpeg carrying the binkvideo2 decoder, which our bundled build does
+	// not have, so point at a "plugins" folder beside the emulator when one is there. Anything the
+	// user has already set in the environment wins.
+	{
+		auto environment = QProcessEnvironment::systemEnvironment();
+		if (!environment.contains(QStringLiteral("KYTY_BINK_HOST"))) {
+			environment.insert(QStringLiteral("KYTY_BINK_HOST"), QStringLiteral("1"));
+		}
+		if (!environment.contains(QStringLiteral("KYTY_BINK_FFMPEG_DIR"))) {
+			const auto plugins = dir.filePath(QStringLiteral("plugins"));
+			if (QFileInfo::exists(plugins)) {
+				environment.insert(QStringLiteral("KYTY_BINK_FFMPEG_DIR"),
+				                   QDir::toNativeSeparators(plugins));
+			}
+		}
+		process->setProcessEnvironment(environment);
+	}
+
 #if defined(_WIN32)
 	process->setCreateProcessArgumentsModifier([](QProcess::CreateProcessArguments* args) {
 		args->flags |= static_cast<uint32_t>(CREATE_NEW_CONSOLE);


### PR DESCRIPTION
Some titles decode video inside their own executable rather than through sceAvPlayer or libSceVideodec. Demon's Souls does: its logo, attract movie and title screen are 4K Bink 2 (.bk2) files decoded on the game's own CPU threads. No HLE export sees those frames, so what reaches the presenter is whatever the guest decoder produced, and the intro renders as confetti.

Identify the active movie from the kernel file open and decode it on the host instead, presenting those frames in place of the guest's.

ffmpeg is bound at runtime from KYTY_BINK_FFMPEG_DIR rather than linked, because the bundled prebuilt is configured without the binkvideo2 decoder. Binding by name keeps this an optional capability that degrades to the old behaviour when the libraries are absent, and needs no dependency change.

Off unless KYTY_BINK_HOST is set. The launcher enables it and points at a "plugins" folder beside the emulator when one is present; anything already in the environment wins.

Note the presented image is A2B10G10R10 for this title, not 8-bit RGBA, so the decode target is chosen from the swapchain format.