### PR TITLE
renderer: Vulkan pipeline disk cache + async PSO compile

### DIFF
--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -101,6 +101,10 @@ bool ReadbackLinearImagesEnabled() {
 	return g_config->readback_linear_images;
 }
 
+bool AsyncShaderCompileEnabled() {
+	return g_config->async_shader_compile;
+}
+
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 bool RedZoneProtectionEnabled() {
 	return g_config->red_zone_protection_enabled;

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -45,6 +45,7 @@ struct ConfigOptions {
 	bool                   spirv_debug_printf_enabled  = false;
 	bool                   renderdoc_enabled           = false;
 	bool                   readback_linear_images      = false;
+	bool                   async_shader_compile        = false;
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	bool red_zone_protection_enabled = false;
 #endif
@@ -79,6 +80,7 @@ bool SpirvDebugPrintfEnabled();
 
 bool RenderDocEnabled();
 bool ReadbackLinearImagesEnabled();
+bool AsyncShaderCompileEnabled();
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 bool RedZoneProtectionEnabled();
 #endif

--- a/src/graphics/host_gpu/graphicContext.h
+++ b/src/graphics/host_gpu/graphicContext.h
@@ -36,6 +36,9 @@ struct GraphicContext: public VulkanInstance {
 
 	uint32_t screen_width  = 0;
 	uint32_t screen_height = 0;
+
+	// Persistent Vulkan pipeline cache (speeds up vkCreate*Pipelines on weak CPUs).
+	vk::PipelineCache pipeline_cache = nullptr;
 };
 
 struct VulkanMemory {

--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
@@ -1,9 +1,12 @@
 #include "graphics/host_gpu/renderer/pipeline/pipelineCache.h"
 
 #include "common/assert.h"
+#include "common/emulatorConfig.h"
+#include "common/file.h"
 #include "common/logging/log.h"
 #include "common/profiler.h"
 #include "graphics/guest_gpu/hardwareContext.h"
+#include "graphics/host_gpu/graphicContext.h"
 #include "graphics/host_gpu/renderer/colorRenderTarget.h"
 #include "graphics/host_gpu/renderer/debug.h"
 #include "graphics/host_gpu/renderer/depthRenderTarget.h"
@@ -13,12 +16,112 @@
 
 #include <atomic>
 #include <cstring>
+#include <filesystem>
 #include <span>
 #include <utility>
+#include <vector>
 
 namespace Libs::Graphics {
 
 namespace {
+
+constexpr const char* kVulkanPipelineCachePath = "_PipelineCache/vulkan_pipelines.bin";
+
+std::filesystem::path PipelineCacheFilePath() {
+	return std::filesystem::path(kVulkanPipelineCachePath);
+}
+
+std::vector<uint8_t> LoadPipelineCacheBlob() {
+	const auto path = PipelineCacheFilePath();
+	if (!Common::File::IsFileExisting(path)) {
+		return {};
+	}
+	Common::File file(path, Common::File::Mode::Read);
+	if (file.IsInvalid()) {
+		return {};
+	}
+	const auto size = file.Size();
+	if (size == 0 || size > (256ull * 1024ull * 1024ull)) {
+		return {};
+	}
+	auto buf = file.ReadWholeBuffer();
+	if (buf.Size() == 0) {
+		return {};
+	}
+	std::vector<uint8_t> out(static_cast<size_t>(buf.Size()));
+	std::memcpy(out.data(), buf.GetData(), out.size());
+	LOGF("VulkanPipelineCache: loaded %zu bytes from %s\n", out.size(),
+	     path.string().c_str());
+	return out;
+}
+
+void SavePipelineCacheBlob(GraphicContext& graphics) {
+	if (graphics.pipeline_cache == nullptr || graphics.device == nullptr) {
+		return;
+	}
+	const auto path = PipelineCacheFilePath();
+	Common::File::CreateDirectories(path.parent_path());
+
+	size_t data_size = 0;
+	auto   result    = graphics.device.getPipelineCacheData(graphics.pipeline_cache, &data_size,
+	                                                        nullptr);
+	if (result != vk::Result::eSuccess || data_size == 0) {
+		LOGF("VulkanPipelineCache: getPipelineCacheData size failed (%s)\n",
+		     VulkanToString(result).c_str());
+		return;
+	}
+	std::vector<uint8_t> data(data_size);
+	result = graphics.device.getPipelineCacheData(graphics.pipeline_cache, &data_size, data.data());
+	if (result != vk::Result::eSuccess) {
+		LOGF("VulkanPipelineCache: getPipelineCacheData failed (%s)\n",
+		     VulkanToString(result).c_str());
+		return;
+	}
+	data.resize(data_size);
+
+	Common::File file;
+	if (!file.Create(path)) {
+		LOGF("VulkanPipelineCache: cannot create %s\n", path.string().c_str());
+		return;
+	}
+	file.Write(data.data(), static_cast<uint32_t>(data.size()));
+	file.Close();
+	LOGF("VulkanPipelineCache: saved %zu bytes to %s\n", data.size(), path.string().c_str());
+}
+
+void CreateVulkanPipelineCache(GraphicContext& graphics) {
+	if (graphics.pipeline_cache != nullptr) {
+		return;
+	}
+	auto initial = LoadPipelineCacheBlob();
+
+	vk::PipelineCacheCreateInfo info {};
+	info.sType           = vk::StructureType::ePipelineCacheCreateInfo;
+	info.initialDataSize = initial.size();
+	info.pInitialData    = initial.empty() ? nullptr : initial.data();
+
+	const auto result =
+	    graphics.device.createPipelineCache(&info, nullptr, &graphics.pipeline_cache);
+	if (result != vk::Result::eSuccess) {
+		// Corrupt/incompatible blob (driver update): retry empty.
+		LOGF("VulkanPipelineCache: create with seed failed (%s), retrying empty\n",
+		     VulkanToString(result).c_str());
+		info.initialDataSize = 0;
+		info.pInitialData    = nullptr;
+		const auto retry =
+		    graphics.device.createPipelineCache(&info, nullptr, &graphics.pipeline_cache);
+		EXIT_NOT_IMPLEMENTED(retry != vk::Result::eSuccess);
+	}
+}
+
+void DestroyVulkanPipelineCache(GraphicContext& graphics) {
+	if (graphics.pipeline_cache == nullptr) {
+		return;
+	}
+	SavePipelineCacheBlob(graphics);
+	graphics.device.destroyPipelineCache(graphics.pipeline_cache, nullptr);
+	graphics.pipeline_cache = nullptr;
+}
 
 void NormalizeStaticParamsForDynamicState(PipelineStaticParameters& static_params) {
 	static_params.viewport_scale[0]  = 0.5f;
@@ -36,28 +139,103 @@ void NormalizeStaticParamsForDynamicState(PipelineStaticParameters& static_param
 
 } // namespace
 
+PipelineCache::PipelineCache(GraphicContext& graphics, DescriptorCache& descriptor_cache)
+    : m_graphics(graphics), m_descriptor_cache(descriptor_cache) {
+	EXIT_NOT_IMPLEMENTED(!Common::Thread::IsMainThread());
+	CreateVulkanPipelineCache(m_graphics);
+	if (Config::AsyncShaderCompileEnabled()) {
+		m_worker = std::jthread([this] { WorkerMain(); });
+	}
+}
+
 PipelineCache::~PipelineCache() {
+	{
+		Common::LockGuard lock(m_mutex);
+		m_shutdown = true;
+		m_job_cv.SignalAll();
+	}
+	if (m_worker.joinable()) {
+		m_worker.join();
+	}
 	auto destroy = [this](const auto& pipelines) {
 		for (const auto& [key, pipeline]: pipelines) {
 			(void)key;
-			m_graphics.device.destroyPipeline(pipeline->pipeline, nullptr);
-			m_graphics.device.destroyPipelineLayout(pipeline->pipeline_layout, nullptr);
+			if (pipeline->pipeline) {
+				m_graphics.device.destroyPipeline(pipeline->pipeline, nullptr);
+			}
+			if (pipeline->pipeline_layout) {
+				m_graphics.device.destroyPipelineLayout(pipeline->pipeline_layout, nullptr);
+			}
 		}
 	};
 	destroy(m_graphics_pipelines);
 	destroy(m_compute_pipelines);
+	DestroyVulkanPipelineCache(m_graphics);
+}
+
+void PipelineCache::WorkerMain() {
+	for (;;) {
+		CompileJob job;
+		{
+			Common::LockGuard lock(m_mutex);
+			while (m_jobs.empty() && !m_shutdown) {
+				m_job_cv.Wait(&m_mutex);
+			}
+			if (m_jobs.empty()) {
+				EXIT_IF(!m_shutdown);
+				return;
+			}
+			job = std::move(m_jobs.front());
+			m_jobs.pop_front();
+		}
+
+		if (job.graphics) {
+			auto& g = *job.graphics;
+			EXIT_IF(g.target == nullptr);
+			LogPipelineTrace("CreatePipelineInternal begin", g.vs_hash0, g.vs_crc32, g.ps_hash0,
+			                 g.ps_crc32);
+			{
+				Common::LockGuard create_lock(m_create_mutex);
+				CreatePipelineInternal(
+				    m_graphics, m_descriptor_cache, *g.target, g.rendering, g.vs_input_info,
+				    g.vs_spirv, g.ps_input_info ? &*g.ps_input_info : nullptr, g.ps_spirv,
+				    g.static_params, g.vs_hash0, g.vs_crc32, g.ps_hash0, g.ps_crc32, g.ps_active);
+			}
+			LogPipelineTrace("CreatePipelineInternal done", g.vs_hash0, g.vs_crc32, g.ps_hash0,
+			                 g.ps_crc32);
+			EXIT_NOT_IMPLEMENTED(g.target->pipeline == nullptr);
+			EXIT_NOT_IMPLEMENTED(g.target->pipeline_layout == nullptr);
+			Common::LockGuard lock(m_mutex);
+			g.target->state = CompileState::Ready;
+			m_ready_cv.SignalAll();
+		} else {
+			EXIT_IF(job.compute == nullptr);
+			auto& c = *job.compute;
+			EXIT_IF(c.target == nullptr);
+			{
+				Common::LockGuard create_lock(m_create_mutex);
+				CreatePipelineInternal(m_graphics, m_descriptor_cache, *c.target, c.input_info,
+				                       c.cs_spirv);
+			}
+			EXIT_NOT_IMPLEMENTED(c.target->pipeline == nullptr);
+			EXIT_NOT_IMPLEMENTED(c.target->pipeline_layout == nullptr);
+			Common::LockGuard lock(m_mutex);
+			c.target->state = CompileState::Ready;
+			m_ready_cv.SignalAll();
+		}
+	}
 }
 
 bool PipelineStaticParameters::operator==(const PipelineStaticParameters& other) const noexcept {
 	return std::memcmp(this, &other, sizeof(*this)) == 0;
 }
 
-PipelineCache::GraphicsPipeline& PipelineCache::CreateGraphicsPipeline(
+PipelineCache::GraphicsPipeline& PipelineCache::RequestGraphicsPipeline(
     RenderColorInfo* colors, uint32_t color_count, RenderDepthInfo& depth,
     ShaderVertexInputInfo& vs_input_info, RenderCommandBuffer& command,
     ShaderPixelInputInfo* ps_input_info, vk::PrimitiveTopology topology, bool ps_active,
     std::span<const uint32_t> vs_spirv, std::span<const uint32_t> ps_spirv) {
-	KYTY_PROFILER_BLOCK("PipelineCache::CreatePipeline(Gfx)", profiler::colors::DeepOrangeA200);
+	KYTY_PROFILER_BLOCK("PipelineCache::RequestPipeline(Gfx)", profiler::colors::DeepOrangeA200);
 
 	EXIT_IF(colors == nullptr);
 	EXIT_IF(color_count > RENDER_COLOR_ATTACHMENTS_MAX);
@@ -200,29 +378,84 @@ PipelineCache::GraphicsPipeline& PipelineCache::CreateGraphicsPipeline(
 		     ps_id.crc32, static_cast<uint64_t>(ps_spirv.size()));
 	}
 
-	auto cached = std::make_unique<GraphicsPipeline>(p);
-	LogPipelineTrace("CreatePipelineInternal begin", vs_id.hash0, vs_id.crc32, ps_id.hash0,
-	                 ps_id.crc32);
-	CreatePipelineInternal(m_graphics, m_descriptor_cache, *cached, rendering, vs_input_info,
-	                       vs_spirv, ps_input_info, ps_spirv, static_params, vs_id.hash0,
-	                       vs_id.crc32, ps_id.hash0, ps_id.crc32, ps_active);
-	LogPipelineTrace("CreatePipelineInternal done", vs_id.hash0, vs_id.crc32, ps_id.hash0,
-	                 ps_id.crc32);
-
-	EXIT_NOT_IMPLEMENTED(cached->pipeline == nullptr);
-	EXIT_NOT_IMPLEMENTED(cached->pipeline_layout == nullptr);
+	auto  cached = std::make_unique<GraphicsPipeline>(p);
+	auto* raw    = cached.get();
+	const bool async =
+	    Config::AsyncShaderCompileEnabled() && static_cast<bool>(m_worker.joinable());
+	raw->state = async ? CompileState::Compiling : CompileState::Ready;
 
 	auto [iter, inserted] = m_graphics_pipelines.emplace(std::move(key), std::move(cached));
 	EXIT_IF(!inserted);
 
-	return *iter->second;
+	if (!async) {
+		LogPipelineTrace("CreatePipelineInternal begin", vs_id.hash0, vs_id.crc32, ps_id.hash0,
+		                 ps_id.crc32);
+		{
+			Common::LockGuard create_lock(m_create_mutex);
+			CreatePipelineInternal(m_graphics, m_descriptor_cache, *raw, rendering, vs_input_info,
+			                       vs_spirv, ps_input_info, ps_spirv, static_params, vs_id.hash0,
+			                       vs_id.crc32, ps_id.hash0, ps_id.crc32, ps_active);
+		}
+		LogPipelineTrace("CreatePipelineInternal done", vs_id.hash0, vs_id.crc32, ps_id.hash0,
+		                 ps_id.crc32);
+		EXIT_NOT_IMPLEMENTED(raw->pipeline == nullptr);
+		EXIT_NOT_IMPLEMENTED(raw->pipeline_layout == nullptr);
+		raw->state = CompileState::Ready;
+		return *raw;
+	}
+
+	auto job           = std::make_unique<GraphicsCompileJob>();
+	job->target        = raw;
+	job->rendering     = rendering;
+	job->static_params = static_params;
+	job->vs_input_info = vs_input_info;
+	if (ps_active) {
+		job->ps_input_info = *ps_input_info;
+	}
+	job->vs_spirv.assign(vs_spirv.begin(), vs_spirv.end());
+	if (ps_active) {
+		job->ps_spirv.assign(ps_spirv.begin(), ps_spirv.end());
+	}
+	job->ps_active = ps_active;
+	job->vs_hash0  = vs_id.hash0;
+	job->vs_crc32  = vs_id.crc32;
+	job->ps_hash0  = ps_id.hash0;
+	job->ps_crc32  = ps_id.crc32;
+
+	CompileJob queued;
+	queued.graphics = std::move(job);
+	m_jobs.push_back(std::move(queued));
+	m_job_cv.Signal();
+	return *raw;
+}
+
+void PipelineCache::WaitGraphicsPipeline(GraphicsPipeline& pipeline) {
+	Common::LockGuard lock(m_mutex);
+	while (pipeline.state == CompileState::Compiling) {
+		m_ready_cv.Wait(&m_mutex);
+	}
+	EXIT_NOT_IMPLEMENTED(pipeline.pipeline == nullptr);
+	EXIT_NOT_IMPLEMENTED(pipeline.pipeline_layout == nullptr);
+}
+
+PipelineCache::GraphicsPipeline& PipelineCache::CreateGraphicsPipeline(
+    RenderColorInfo* colors, uint32_t color_count, RenderDepthInfo& depth,
+    ShaderVertexInputInfo& vs_input_info, RenderCommandBuffer& command,
+    ShaderPixelInputInfo* ps_input_info, vk::PrimitiveTopology topology, bool ps_active,
+    std::span<const uint32_t> vs_spirv, std::span<const uint32_t> ps_spirv) {
+	KYTY_PROFILER_BLOCK("PipelineCache::CreatePipeline(Gfx)", profiler::colors::DeepOrangeA200);
+	auto& pipeline =
+	    RequestGraphicsPipeline(colors, color_count, depth, vs_input_info, command, ps_input_info,
+	                            topology, ps_active, vs_spirv, ps_spirv);
+	WaitGraphicsPipeline(pipeline);
+	return pipeline;
 }
 
 PipelineCache::ComputePipeline&
-PipelineCache::CreateComputePipeline(ShaderComputeInputInfo&      input_info,
-                                     const HW::ComputeShaderInfo& cs_regs,
-                                     std::span<const uint32_t>    cs_spirv) {
-	KYTY_PROFILER_BLOCK("PipelineCache::CreatePipeline(Compute)", profiler::colors::RedA100);
+PipelineCache::RequestComputePipeline(ShaderComputeInputInfo&      input_info,
+                                      const HW::ComputeShaderInfo& cs_regs,
+                                      std::span<const uint32_t>    cs_spirv) {
+	KYTY_PROFILER_BLOCK("PipelineCache::RequestPipeline(Compute)", profiler::colors::RedA100);
 
 	EXIT_IF(cs_spirv.empty());
 
@@ -244,15 +477,52 @@ PipelineCache::CreateComputePipeline(ShaderComputeInputInfo&      input_info,
 		ShaderDbgDumpInputInfo(input_info);
 	}
 
-	auto cached = std::make_unique<ComputePipeline>(p);
-	CreatePipelineInternal(m_graphics, m_descriptor_cache, *cached, input_info, cs_spirv);
-
-	EXIT_NOT_IMPLEMENTED(cached->pipeline == nullptr);
-	EXIT_NOT_IMPLEMENTED(cached->pipeline_layout == nullptr);
+	auto  cached = std::make_unique<ComputePipeline>(p);
+	auto* raw    = cached.get();
+	const bool async =
+	    Config::AsyncShaderCompileEnabled() && static_cast<bool>(m_worker.joinable());
+	raw->state = async ? CompileState::Compiling : CompileState::Ready;
 
 	auto [iter, inserted] = m_compute_pipelines.emplace(std::move(key), std::move(cached));
 	EXIT_IF(!inserted);
 
-	return *iter->second;
+	if (!async) {
+		Common::LockGuard create_lock(m_create_mutex);
+		CreatePipelineInternal(m_graphics, m_descriptor_cache, *raw, input_info, cs_spirv);
+		EXIT_NOT_IMPLEMENTED(raw->pipeline == nullptr);
+		EXIT_NOT_IMPLEMENTED(raw->pipeline_layout == nullptr);
+		raw->state = CompileState::Ready;
+		return *raw;
+	}
+
+	auto job         = std::make_unique<ComputeCompileJob>();
+	job->target      = raw;
+	job->input_info  = input_info;
+	job->cs_spirv.assign(cs_spirv.begin(), cs_spirv.end());
+
+	CompileJob queued;
+	queued.compute = std::move(job);
+	m_jobs.push_back(std::move(queued));
+	m_job_cv.Signal();
+	return *raw;
+}
+
+void PipelineCache::WaitComputePipeline(ComputePipeline& pipeline) {
+	Common::LockGuard lock(m_mutex);
+	while (pipeline.state == CompileState::Compiling) {
+		m_ready_cv.Wait(&m_mutex);
+	}
+	EXIT_NOT_IMPLEMENTED(pipeline.pipeline == nullptr);
+	EXIT_NOT_IMPLEMENTED(pipeline.pipeline_layout == nullptr);
+}
+
+PipelineCache::ComputePipeline&
+PipelineCache::CreateComputePipeline(ShaderComputeInputInfo&      input_info,
+                                     const HW::ComputeShaderInfo& cs_regs,
+                                     std::span<const uint32_t>    cs_spirv) {
+	KYTY_PROFILER_BLOCK("PipelineCache::CreatePipeline(Compute)", profiler::colors::RedA100);
+	auto& pipeline = RequestComputePipeline(input_info, cs_regs, cs_spirv);
+	WaitComputePipeline(pipeline);
+	return pipeline;
 }
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.h
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.h
@@ -10,10 +10,14 @@
 #include "graphics/shader/shader.h"
 
 #include <cstddef>
+#include <deque>
 #include <memory>
+#include <optional>
 #include <span>
+#include <thread>
 #include <type_traits>
 #include <unordered_map>
+#include <vector>
 
 namespace Libs::Graphics {
 
@@ -97,16 +101,16 @@ struct PipelineRenderingState {
 
 class PipelineCache {
 public:
-	PipelineCache(GraphicContext& graphics, DescriptorCache& descriptor_cache)
-	    : m_graphics(graphics), m_descriptor_cache(descriptor_cache) {
-		EXIT_NOT_IMPLEMENTED(!Common::Thread::IsMainThread());
-	}
+	PipelineCache(GraphicContext& graphics, DescriptorCache& descriptor_cache);
 	~PipelineCache();
 	KYTY_CLASS_NO_COPY(PipelineCache);
+
+	enum class CompileState : uint8_t { Ready, Compiling };
 
 	struct Pipeline {
 		vk::PipelineLayout pipeline_layout = nullptr;
 		vk::Pipeline       pipeline        = nullptr;
+		CompileState       state           = CompileState::Ready;
 	};
 
 	struct GraphicsPipeline: Pipeline {
@@ -119,11 +123,25 @@ public:
 	};
 
 	GraphicsPipeline&
+	RequestGraphicsPipeline(RenderColorInfo* colors, uint32_t color_count, RenderDepthInfo& depth,
+	                        ShaderVertexInputInfo& vs_input_info, RenderCommandBuffer& command,
+	                        ShaderPixelInputInfo* ps_input_info, vk::PrimitiveTopology topology,
+	                        bool ps_active, std::span<const uint32_t> vs_spirv,
+	                        std::span<const uint32_t> ps_spirv);
+	void WaitGraphicsPipeline(GraphicsPipeline& pipeline);
+
+	GraphicsPipeline&
 	CreateGraphicsPipeline(RenderColorInfo* colors, uint32_t color_count, RenderDepthInfo& depth,
 	                       ShaderVertexInputInfo& vs_input_info, RenderCommandBuffer& command,
 	                       ShaderPixelInputInfo* ps_input_info, vk::PrimitiveTopology topology,
 	                       bool ps_active, std::span<const uint32_t> vs_spirv,
 	                       std::span<const uint32_t> ps_spirv);
+
+	ComputePipeline& RequestComputePipeline(ShaderComputeInputInfo&      input_info,
+	                                        const HW::ComputeShaderInfo& cs_regs,
+	                                        std::span<const uint32_t>    cs_spirv);
+	void             WaitComputePipeline(ComputePipeline& pipeline);
+
 	ComputePipeline& CreateComputePipeline(ShaderComputeInputInfo&      input_info,
 	                                       const HW::ComputeShaderInfo& cs_regs,
 	                                       std::span<const uint32_t>    cs_spirv);
@@ -200,14 +218,48 @@ private:
 		}
 	};
 
+	struct GraphicsCompileJob {
+		GraphicsPipeline*          target = nullptr;
+		PipelineRenderingState     rendering {};
+		PipelineStaticParameters   static_params {};
+		ShaderVertexInputInfo      vs_input_info {};
+		std::optional<ShaderPixelInputInfo> ps_input_info;
+		std::vector<uint32_t>      vs_spirv;
+		std::vector<uint32_t>      ps_spirv;
+		bool                       ps_active = false;
+		uint32_t                   vs_hash0  = 0;
+		uint32_t                   vs_crc32  = 0;
+		uint32_t                   ps_hash0  = 0;
+		uint32_t                   ps_crc32  = 0;
+	};
+
+	struct ComputeCompileJob {
+		ComputePipeline*         target = nullptr;
+		ShaderComputeInputInfo   input_info {};
+		std::vector<uint32_t>    cs_spirv;
+	};
+
+	struct CompileJob {
+		std::unique_ptr<GraphicsCompileJob> graphics;
+		std::unique_ptr<ComputeCompileJob>  compute;
+	};
+
+	void WorkerMain();
+
 	GraphicContext&  m_graphics;
 	DescriptorCache& m_descriptor_cache;
 	std::unordered_map<GraphicsPipelineKey, std::unique_ptr<GraphicsPipeline>,
 	                   GraphicsPipelineKeyHash>
 	    m_graphics_pipelines;
 	std::unordered_map<ComputePipelineKey, std::unique_ptr<ComputePipeline>, ComputePipelineKeyHash>
-	              m_compute_pipelines;
-	Common::Mutex m_mutex;
+	                   m_compute_pipelines;
+	Common::Mutex      m_mutex;
+	Common::Mutex      m_create_mutex;
+	Common::CondVar    m_job_cv;
+	Common::CondVar    m_ready_cv;
+	std::deque<CompileJob> m_jobs;
+	bool               m_shutdown = false;
+	std::jthread       m_worker;
 };
 
 void LogPipelineTrace(const char* phase, uint32_t vs_hash0, uint32_t vs_crc32, uint32_t ps_hash0,

--- a/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
@@ -1015,8 +1015,8 @@ void CreatePipelineInternal(
 		     viewport.y, viewport.width, viewport.height, scissor.offset.x, scissor.offset.y,
 		     scissor.extent.width, scissor.extent.height);
 	}
-	result = graphics.device.createGraphicsPipelines(nullptr, 1, &pipeline_info, nullptr,
-	                                                 &pipeline.pipeline);
+	result = graphics.device.createGraphicsPipelines(graphics.pipeline_cache, 1, &pipeline_info,
+	                                                 nullptr, &pipeline.pipeline);
 	if (graphics_debug_dump_enabled()) {
 		LOGF("PipelineTrace: vkCreateGraphicsPipelines done result=%s pipeline=%p\n",
 		     VulkanToString(result).c_str(), static_cast<void*>(pipeline.pipeline));
@@ -1119,7 +1119,8 @@ void CreatePipelineInternal(GraphicContext& graphics, DescriptorCache& descripto
 
 	LOGF("PipelineTrace: vkCreateComputePipelines begin layout=%p\n",
 	     static_cast<void*>(pipeline.pipeline_layout));
-	result = graphics.device.createComputePipelines(nullptr, 1, &info, nullptr, &pipeline.pipeline);
+	result = graphics.device.createComputePipelines(graphics.pipeline_cache, 1, &info, nullptr,
+	                                                &pipeline.pipeline);
 	LOGF("PipelineTrace: vkCreateComputePipelines done result=%s pipeline=%p\n",
 	     VulkanToString(result).c_str(), static_cast<void*>(pipeline.pipeline));
 	EXIT_NOT_IMPLEMENTED(result != vk::Result::eSuccess);

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -317,11 +317,12 @@ void RenderExecutor::DispatchDirect(uint64_t submit_id, RenderCommandBuffer& buf
 
 	buffer.EndRendering();
 	auto& pipeline =
-	    m_context.GetPipelineCache().CreateComputePipeline(input_info, sh_ctx.GetCs(), cs_shader);
+	    m_context.GetPipelineCache().RequestComputePipeline(input_info, sh_ctx.GetCs(), cs_shader);
 	auto bindings = PrepareBindings(buffer, input_info.stage, vk::ShaderStageFlagBits::eCompute,
 	                                DescriptorCache::Stage::Compute);
 	RebindBuffers(buffer, bindings);
 	RebindImages(buffer, bindings);
+	m_context.GetPipelineCache().WaitComputePipeline(pipeline);
 
 	auto vk_buffer = buffer.Handle();
 	CommitBindings(buffer, vk::PipelineBindPoint::eCompute, pipeline.pipeline_layout, bindings);

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -1100,6 +1100,13 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, RenderCommandBuffer
 	EXIT_IF(draw.name == nullptr);
 	auto& ucfg = buffer.GetUserConfig();
 
+	if (log_pipeline_phase) {
+		LogDrawPhase(draw.name, "RequestPipeline");
+	}
+	auto& pipeline = m_context.GetPipelineCache().RequestGraphicsPipeline(
+	    state.color_info, state.color_count, state.depth_info, state.vs_input_info, buffer,
+	    &state.ps_input_info, topology, state.ps_active, state.vs_shader, state.ps_shader);
+
 	LogDrawPhase(draw.name, "PrepareBindings");
 	auto bindings        = PrepareGraphicsBindings(buffer, state.vs_input_info.stage,
 	                                               state.ps_input_info.stage, state.ps_active);
@@ -1109,11 +1116,9 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, RenderCommandBuffer
 	    AcquireRenderTargets(buffer, state.color_info, state.color_count, state.depth_info);
 
 	if (log_pipeline_phase) {
-		LogDrawPhase(draw.name, "CreatePipeline");
+		LogDrawPhase(draw.name, "WaitPipeline");
 	}
-	auto& pipeline = m_context.GetPipelineCache().CreateGraphicsPipeline(
-	    state.color_info, state.color_count, state.depth_info, state.vs_input_info, buffer,
-	    &state.ps_input_info, topology, state.ps_active, state.vs_shader, state.ps_shader);
+	m_context.GetPipelineCache().WaitGraphicsPipeline(pipeline);
 
 	// Resource preparation above may synchronously finish and restart the scheduler. From this
 	// point onward, every operation targets the current command buffer and cannot touch guest

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,7 @@ static void PrintUsage() {
 	::printf("  --console-language <0-29>            Console language. Default: 1 (English US).\n");
 	::printf("  --vulkan-validation <true|false>     Enable Vulkan validation.\n");
 	::printf("  --shader-validation <true|false>     Enable shader validation.\n");
+	::printf("  --async-shader-compile <true|false>  Create Vulkan pipelines on a worker thread.\n");
 	::printf("  --shader-optimization-type <value>   None, Size, or Performance.\n");
 	::printf("  --shader-log-direction <value>       Silent, Console, or File.\n");
 	::printf("  --shader-log-folder <path>           Shader log output folder.\n");
@@ -209,6 +210,11 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 			}
 		} else if (arg == "--shader-validation") {
 			if (!ParseBool(value, options.config.shader_validation_enabled)) {
+				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
+				return false;
+			}
+		} else if (arg == "--async-shader-compile") {
+			if (!ParseBool(value, options.config.async_shader_compile)) {
 				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
 				return false;
 			}


### PR DESCRIPTION
## Summary
- Persist Vulkan pipeline cache to disk (`_PipelineCache/vulkan_pipelines.bin`).
- Add `--async-shader-compile` to create PSOs on a worker thread; GPU thread Request → prep → Wait (no draw skip / no flicker).
- Reorder graphics/compute paths to overlap binding/RT work with compile.

## Test plan
- [x] Built `kyty_emulator` on Linux (Clang/Ninja)
- [x] Minecraft PS5 (`PPSA17221`) with `--async-shader-compile true`
- [x] Warm run benefits from disk pipeline cache after clean exit
- [ ] Reviewer: confirm `--async-shader-compile false` stays sync

### Test environment (reproduced on this machine)
- Host: `pc-XPS-8920`
- OS: Linux Mint 22.3 (kernel 7.0.0-28-generic, x86_64)
- CPU: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz (4c/8t)
- RAM: 32gb
- GPU: NVIDIA GeForce GTX 1050 Ti, 4096 MiB, 580.173.02
- Game/smoke: Minecraft PS5 Bedrock (`PPSA17221`) via Kyty, weak-PC preset (1024×576, vblank 50)