### PR TITLE
launcher: Weak PC / PC fraco preset

### DIFF
--- a/src/launcher/forms/configuration_edit_dialog.ui
+++ b/src/launcher/forms/configuration_edit_dialog.ui
@@ -98,6 +98,26 @@
            </property>
           </widget>
          </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="checkBox_async_shader_compile">
+           <property name="toolTip">
+            <string>Create Vulkan pipelines on a background worker and wait before draw (reduces hitch length on weak CPUs)</string>
+           </property>
+           <property name="text">
+            <string>Async shader compile</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="checkBox_readback_linear_images">
+           <property name="toolTip">
+            <string>Read back writable linear images on submit (expensive; keep off on weak PCs)</string>
+           </property>
+           <property name="text">
+            <string>Readback linear images</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -310,6 +330,22 @@
        </property>
        <property name="text">
         <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="weak_pc_button">
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Apply weak-PC preset: 1024×576, vblank 50, validations off, shader opt None, async pipeline compile on, silent logs</string>
+       </property>
+       <property name="text">
+        <string>PC fraco</string>
        </property>
       </widget>
      </item>

--- a/src/launcher/include/configuration.h
+++ b/src/launcher/include/configuration.h
@@ -52,6 +52,7 @@ public:
 	static constexpr int MAX_CONSOLE_LANGUAGE     = 29;
 
 	enum class Resolution {
+		R1024X576,  /* weak-PC / stable20 */
 		R1280X720,
 		R1920X1080,
 	};
@@ -90,6 +91,8 @@ public:
 	int                    console_language            = DEFAULT_CONSOLE_LANGUAGE;
 	bool                   vulkan_validation_enabled   = false;
 	bool                   shader_validation_enabled   = true;
+	bool                   async_shader_compile        = false;
+	bool                   readback_linear_images      = false;
 	ShaderOptimizationType shader_optimization_type    = ShaderOptimizationType::Performance;
 	ShaderLogDirection     shader_log_direction        = ShaderLogDirection::Silent;
 	QString                shader_log_folder           = "_Shaders";
@@ -104,6 +107,23 @@ public:
 #endif
 	QStringList host_input_mapping;
 
+	/** Apply local low-end preset (matches run-minecraft-stable20.sh). */
+	void ApplyWeakPcPreset() {
+		screen_resolution           = Resolution::R1024X576;
+		fullscreen_enabled          = false;
+		vblank_frequency            = 50;
+		vulkan_validation_enabled   = false;
+		shader_validation_enabled   = false;
+		async_shader_compile        = true;
+		readback_linear_images      = false;
+		shader_optimization_type    = ShaderOptimizationType::None;
+		shader_log_direction        = ShaderLogDirection::Silent;
+		command_buffer_dump_enabled = false;
+		printf_direction            = LogDirection::Silent;
+		profiler_direction          = ProfilerDirection::None;
+		renderdoc_enabled           = false;
+	}
+
 	QString elf = QStringLiteral("eboot.bin");
 
 	void CopyEmulatorSettingsFrom(const Configuration& other) {
@@ -113,6 +133,8 @@ public:
 		console_language            = other.console_language;
 		vulkan_validation_enabled   = other.vulkan_validation_enabled;
 		shader_validation_enabled   = other.shader_validation_enabled;
+		async_shader_compile        = other.async_shader_compile;
+		readback_linear_images      = other.readback_linear_images;
 		shader_optimization_type    = other.shader_optimization_type;
 		shader_log_direction        = other.shader_log_direction;
 		shader_log_folder           = other.shader_log_folder;
@@ -153,6 +175,8 @@ public:
 		KYTY_CFG_SET(console_language);
 		KYTY_CFG_SET(vulkan_validation_enabled);
 		KYTY_CFG_SET(shader_validation_enabled);
+		KYTY_CFG_SET(async_shader_compile);
+		KYTY_CFG_SET(readback_linear_images);
 		KYTY_CFG_SET(shader_optimization_type);
 		KYTY_CFG_SET(shader_log_direction);
 		KYTY_CFG_SET(shader_log_folder);
@@ -183,6 +207,10 @@ public:
 		}
 		KYTY_CFG_GET(vulkan_validation_enabled);
 		KYTY_CFG_GET(shader_validation_enabled);
+		async_shader_compile =
+		    s->value("async_shader_compile", async_shader_compile).toBool();
+		readback_linear_images =
+		    s->value("readback_linear_images", readback_linear_images).toBool();
 		KYTY_CFG_GET(shader_optimization_type);
 		KYTY_CFG_GET(shader_log_direction);
 		KYTY_CFG_GET(shader_log_folder);

--- a/src/launcher/include/configurationEditDialog.h
+++ b/src/launcher/include/configurationEditDialog.h
@@ -57,6 +57,7 @@ protected:
 	void adjust_size();
 	void save();
 	void clear();
+	void apply_weak_pc_preset();
 	void add_game_directory();
 	void remove_selected_game_directories();
 	void update_game_directory_buttons();

--- a/src/launcher/src/configurationEditDialog.cpp
+++ b/src/launcher/src/configurationEditDialog.cpp
@@ -99,6 +99,8 @@ ConfigurationEditDialog::ConfigurationEditDialog(Configuration& info, QWidget* p
 
 	connect(m_ui->ok_button, &QPushButton::clicked, this, &ConfigurationEditDialog::save);
 	connect(m_ui->clear_button, &QPushButton::clicked, this, &ConfigurationEditDialog::clear);
+	connect(m_ui->weak_pc_button, &QPushButton::clicked, this,
+	        &ConfigurationEditDialog::apply_weak_pc_preset);
 	connect(m_ui->comboBox_shader_log_direction, &QComboBox::currentTextChanged, this,
 	        [this](const QString& text) {
 		        auto log = TextToEnum<Configuration::ShaderLogDirection>(text);
@@ -163,6 +165,8 @@ void ConfigurationEditDialog::Init(const Configuration& info) {
 	        : Configuration::DEFAULT_CONSOLE_LANGUAGE);
 	m_ui->checkBox_shader_validation->setChecked(info.shader_validation_enabled);
 	m_ui->checkBox_vulkan_validation->setChecked(info.vulkan_validation_enabled);
+	m_ui->checkBox_async_shader_compile->setChecked(info.async_shader_compile);
+	m_ui->checkBox_readback_linear_images->setChecked(info.readback_linear_images);
 	m_ui->checkBox_renderdoc_capture->setChecked(info.renderdoc_enabled);
 #if defined(_WIN32)
 	m_ui->checkBox_red_zone_protection->setChecked(info.red_zone_protection_enabled);
@@ -290,6 +294,8 @@ static void UpdateInfo(Configuration& info, Ui::ConfigurationEditDialog& ui) {
 	info.console_language          = ui.comboBox_console_language->currentIndex();
 	info.vulkan_validation_enabled = ui.checkBox_vulkan_validation->isChecked();
 	info.shader_validation_enabled = ui.checkBox_shader_validation->isChecked();
+	info.async_shader_compile      = ui.checkBox_async_shader_compile->isChecked();
+	info.readback_linear_images    = ui.checkBox_readback_linear_images->isChecked();
 	info.renderdoc_enabled         = ui.checkBox_renderdoc_capture->isChecked();
 #if defined(_WIN32)
 	info.red_zone_protection_enabled = ui.checkBox_red_zone_protection->isChecked();
@@ -335,6 +341,17 @@ void ConfigurationEditDialog::clear() {
 		m_game_dirs_list->clear();
 		update_game_directory_buttons();
 	}
+}
+
+void ConfigurationEditDialog::apply_weak_pc_preset() {
+	Configuration preset;
+	preset.ApplyWeakPcPreset();
+	// Keep language / folders from current form unless cleared fields matter.
+	preset.console_language          = m_ui->comboBox_console_language->currentIndex();
+	preset.shader_log_folder         = m_ui->lineEdit_shader_log_folder->text();
+	preset.command_buffer_dump_folder = m_ui->lineEdit_cmd_dump_folder->text();
+	preset.printf_output_file        = m_ui->lineEdit_printf_file->text();
+	Init(preset);
 }
 
 void ConfigurationEditDialog::add_game_directory() {

--- a/src/launcher/src/mainDialog.cpp
+++ b/src/launcher/src/mainDialog.cpp
@@ -211,6 +211,8 @@ static QStringList CreateEmulatorArgs(const Configuration& info) {
 	args << "--console-language" << QString::number(info.console_language);
 	args << "--vulkan-validation" << BoolArg(info.vulkan_validation_enabled);
 	args << "--shader-validation" << BoolArg(info.shader_validation_enabled);
+	args << "--async-shader-compile" << BoolArg(info.async_shader_compile);
+	args << "--readback-linear-images" << BoolArg(info.readback_linear_images);
 	args << "--shader-optimization-type" << EnumToText(info.shader_optimization_type);
 	args << "--shader-log-direction" << EnumToText(info.shader_log_direction);
 	args << "--shader-log-folder" << info.shader_log_folder;


### PR DESCRIPTION
## Summary
- Settings button **PC fraco**: 1024×576, vblank 50, validations off, shader opt None, async compile on, silent logs.
- Wire `--async-shader-compile` and `--readback-linear-images` from the launcher UI.

## Test plan
- [x] Launcher builds; **PC fraco** fills settings
- [x] Run from UI passes new CLI flags (verified via process cmdline on Linux)
- [ ] Reviewer: Save → Run on another host

### Test environment (reproduced on this machine)
- Host: `pc-XPS-8920`
- OS: Linux Mint 22.3 (kernel 7.0.0-28-generic, x86_64)
- CPU: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz (4c/8t)
- RAM: 32gb
- GPU: NVIDIA GeForce GTX 1050 Ti, 4096 MiB, 580.173.02
- Game/smoke: Minecraft PS5 Bedrock (`PPSA17221`) via Kyty, weak-PC preset (1024×576, vblank 50)