### PR TITLE
Unity Game Fixes - common/kernel: deliver guest signals only at safe points

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,13 @@ add_executable(resource_tracking_tests EXCLUDE_FROM_ALL
 target_link_libraries(resource_tracking_tests fmt::fmt)
 target_include_directories(resource_tracking_tests PRIVATE ${inc_headers})
 
+add_executable(signal_safety_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/SignalSafetyTests.cpp"
+)
+target_link_libraries(signal_safety_tests common)
+target_include_directories(signal_safety_tests PRIVATE ${inc_headers})
+
+
 add_executable(audio_out2_port_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/AudioOut2PortTests.cpp"
 	"${KYTY_SOURCE_DIR}/libs/libAudio2.cpp"
@@ -508,6 +515,7 @@ if(BUILD_TESTING)
 	add_test(NAME shader_vertex_metadata COMMAND $<TARGET_FILE:shader_vertex_metadata_tests>)
 	add_test(NAME shader_stage_runtime COMMAND $<TARGET_FILE:shader_stage_runtime_tests>)
 	add_test(NAME resource_tracking COMMAND $<TARGET_FILE:resource_tracking_tests>)
+	add_test(NAME signal_safety COMMAND $<TARGET_FILE:signal_safety_tests>)
 	add_test(NAME event_queue_lifetime COMMAND $<TARGET_FILE:event_queue_lifetime_tests>)
 	add_test(NAME sync_on_address COMMAND $<TARGET_FILE:sync_on_address_tests>)
 	add_test(NAME audio_out2_port COMMAND $<TARGET_FILE:audio_out2_port_tests>)

--- a/src/common/threads.cpp
+++ b/src/common/threads.cpp
@@ -433,6 +433,14 @@ bool CondVar::WaitFor(Mutex* mutex, uint32_t micros) {
 #else
 	ok = (m_cond_var->m_cv.wait_for(cpp_lock, std::chrono::microseconds(micros)) ==
 	      std::cv_status::no_timeout);
+	// Wait() polls through its 10 ms timeout, but this one can be given an arbitrarily long
+	// timeout, so a guest signal left pending by the host signal handler would sit here
+	// undelivered for all of it. Dispatch with the guest mutex released, as Wait() does.
+	if (auto* callback = g_cond_wait_poll_callback; callback != nullptr) {
+		cpp_lock.unlock();
+		callback();
+		cpp_lock.lock();
+	}
 	cpp_lock.release();
 #endif
 	UnregisterCondWaiter(m_cond_var.get());
@@ -454,12 +462,39 @@ void CondVar::SignalAll() {
 }
 
 void CondVar::SignalThread(int thread_id) {
-	std::lock_guard lock(g_cond_waiters_mutex);
-	for (const auto& waiter: g_cond_waiters) {
-		if (waiter.first == thread_id) {
-			WakeCondVar(waiter.second);
+	// Collect the targets under the registry lock, then wake them with it released.
+	// Waking is not guaranteed to be non-blocking: a condition-variable broadcast can
+	// block until the waiters it is retiring have left the variable, and they leave
+	// through UnregisterCondWaiter, which needs this same mutex. Waking while holding
+	// it therefore deadlocks the waker against every waiter it is trying to wake.
+	// Signal() and SignalAll() already wake without holding the registry lock.
+	std::vector<CondVarPrivate*> targets;
+	{
+		std::lock_guard lock(g_cond_waiters_mutex);
+		for (const auto& waiter: g_cond_waiters) {
+			if (waiter.first == thread_id) {
+				targets.push_back(waiter.second);
+			}
 		}
 	}
+	for (auto* cond_var: targets) {
+		WakeCondVar(cond_var);
+	}
+}
+
+static thread_local uint32_t g_hle_critical_depth = 0;
+
+HleCriticalSection::HleCriticalSection() {
+	g_hle_critical_depth++;
+}
+
+HleCriticalSection::~HleCriticalSection() {
+	EXIT_IF(g_hle_critical_depth == 0);
+	g_hle_critical_depth--;
+}
+
+bool InHleCriticalSection() {
+	return g_hle_critical_depth != 0;
 }
 
 int Thread::GetThreadIdUnique() {

--- a/src/common/threads.cpp
+++ b/src/common/threads.cpp
@@ -199,7 +199,8 @@ struct CondVarPrivate {
 };
 
 static std::recursive_mutex                         g_cond_waiters_mutex;
-static std::vector<std::pair<int, CondVarPrivate*>> g_cond_waiters;
+// Holds a strong reference; see CondVar::m_cond_var.
+static std::vector<std::pair<int, std::shared_ptr<CondVarPrivate>>> g_cond_waiters;
 static wait_poll_func_t                             g_cond_wait_poll_callback = nullptr;
 
 static void WakeCondVar(CondVarPrivate* cond_var) {
@@ -212,18 +213,18 @@ static void WakeCondVar(CondVarPrivate* cond_var) {
 #endif
 }
 
-static void RegisterCondWaiter(CondVarPrivate* cond_var) {
+static void RegisterCondWaiter(const std::shared_ptr<CondVarPrivate>& cond_var) {
 	std::lock_guard lock(g_cond_waiters_mutex);
 	g_cond_waiters.emplace_back(Thread::GetThreadIdUnique(), cond_var);
 }
 
-static void UnregisterCondWaiter(CondVarPrivate* cond_var) {
+static void UnregisterCondWaiter(const CondVarPrivate* cond_var) {
 	const auto      thread_id = Thread::GetThreadIdUnique();
 	std::lock_guard lock(g_cond_waiters_mutex);
 
 	const auto it = std::find_if(g_cond_waiters.begin(), g_cond_waiters.end(),
 	                             [thread_id, cond_var](const auto& waiter) {
-		                             return waiter.first == thread_id && waiter.second == cond_var;
+		                             return waiter.first == thread_id && waiter.second.get() == cond_var;
 	                             });
 	if (it != g_cond_waiters.end()) {
 		g_cond_waiters.erase(it);
@@ -363,14 +364,14 @@ bool Mutex::TryLock() {
 #endif
 }
 
-CondVar::CondVar(): m_cond_var(std::make_unique<CondVarPrivate>()) {}
+CondVar::CondVar(): m_cond_var(std::make_shared<CondVarPrivate>()) {}
 
 CondVar::~CondVar() {
 	m_cond_var.reset();
 }
 
 void CondVar::Wait(Mutex* mutex) {
-	RegisterCondWaiter(m_cond_var.get());
+	RegisterCondWaiter(m_cond_var);
 #ifndef KYTY_WIN_CS
 	std::unique_lock<std::recursive_mutex> cpp_lock(mutex->m_mutex->m_mutex, std::adopt_lock_t());
 #endif
@@ -420,7 +421,7 @@ void CondVar::SetWaitPollCallback(wait_poll_func_t callback) {
 
 bool CondVar::WaitFor(Mutex* mutex, uint32_t micros) {
 	bool ok = false;
-	RegisterCondWaiter(m_cond_var.get());
+	RegisterCondWaiter(m_cond_var);
 #ifndef KYTY_WIN_CS
 	std::unique_lock<std::recursive_mutex> cpp_lock(mutex->m_mutex->m_mutex, std::adopt_lock_t());
 #endif
@@ -468,7 +469,9 @@ void CondVar::SignalThread(int thread_id) {
 	// through UnregisterCondWaiter, which needs this same mutex. Waking while holding
 	// it therefore deadlocks the waker against every waiter it is trying to wake.
 	// Signal() and SignalAll() already wake without holding the registry lock.
-	std::vector<CondVarPrivate*> targets;
+	// The collected shared_ptrs keep each target alive across the gap, even if its waiter
+	// returns and its owning CondVar is destroyed before the wake below.
+	std::vector<std::shared_ptr<CondVarPrivate>> targets;
 	{
 		std::lock_guard lock(g_cond_waiters_mutex);
 		for (const auto& waiter: g_cond_waiters) {
@@ -477,8 +480,8 @@ void CondVar::SignalThread(int thread_id) {
 			}
 		}
 	}
-	for (auto* cond_var: targets) {
-		WakeCondVar(cond_var);
+	for (const auto& cond_var: targets) {
+		WakeCondVar(cond_var.get());
 	}
 }
 

--- a/src/common/threads.h
+++ b/src/common/threads.h
@@ -102,6 +102,21 @@ private:
 	mutex_type& m_mutex;
 };
 
+// A guest exception handler can block for an unbounded time -- IL2CPP's garbage collector parks
+// every managed thread in one until the collection finishes -- so one must never run while this
+// thread holds a lock that another guest thread needs to make progress. Scopes that take an
+// emulator-global lock declare themselves here, and pending-signal dispatch refuses to run a
+// handler inside one, leaving the signal queued until the scope unwinds.
+class HleCriticalSection {
+public:
+	HleCriticalSection();
+	~HleCriticalSection();
+
+	KYTY_CLASS_NO_COPY(HleCriticalSection);
+};
+
+[[nodiscard]] bool InHleCriticalSection();
+
 } // namespace Common
 
 #endif /* KYTY_COMMON_THREADS_H_ */

--- a/src/common/threads.h
+++ b/src/common/threads.h
@@ -84,7 +84,12 @@ public:
 	KYTY_CLASS_NO_COPY(CondVar);
 
 private:
-	std::unique_ptr<CondVarPrivate> m_cond_var;
+	// Shared rather than unique: SignalThread collects its targets under the waiter-registry
+	// lock and wakes them with it released (waking while holding it deadlocks the waker
+	// against the waiters it is retiring). Between the two, a waiter can return, unregister,
+	// and have its owning CondVar destroyed -- so the registry has to keep the private object
+	// alive across that gap.
+	std::shared_ptr<CondVarPrivate> m_cond_var;
 };
 
 class LockGuard {

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -57,6 +57,9 @@ public:
 
 private:
 	Common::Mutex& m_mutex;
+	// Holding this lock blocks every other guest thread's submissions, so a guest signal
+	// handler must not run while it is held.
+	Common::HleCriticalSection m_critical;
 };
 
 struct OwnedCmdBuffer {

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -818,6 +818,21 @@ static void                               MemoryPoolSubtractCommitted(uint64_t l
 // Keep host mappings, physical blocks, placeholders, and virtual ranges in step.
 static std::recursive_mutex g_memory_operation_mutex;
 
+// Every guest-visible memory operation serialises on the mutex above, so a guest signal handler
+// that blocks while it is held stalls every other guest thread. Mark the scope so pending-signal
+// dispatch skips it.
+namespace {
+class MemoryOperationLock final {
+public:
+	MemoryOperationLock(): m_lock(g_memory_operation_mutex) {}
+	KYTY_CLASS_NO_COPY(MemoryOperationLock);
+
+private:
+	std::lock_guard<std::recursive_mutex> m_lock;
+	Common::HleCriticalSection            m_critical;
+};
+} // namespace
+
 // The base address the PS5 kernel hands out for hint-less user mappings. Guest code can
 // assume mappings it did not place explicitly are at or above this (Sony's libc rejects a
 // heap below it), so hint-less searches must not fall back to the low system-managed range.
@@ -858,6 +873,7 @@ static uint64_t FindGuestFreeRange(uint64_t search_addr, uint64_t size, uint64_t
 }
 
 bool TryWriteBacking(uint64_t vaddr, const void* data, uint64_t size) {
+
 	return g_guest_address_space != nullptr &&
 	       g_guest_address_space->TryWriteBacking(vaddr, data, size);
 }
@@ -1023,7 +1039,7 @@ void RegisterCallbacks(callback_func_t alloc_func, callback_func_t free_func) {
 	EXIT_IF(g_alloc_callback != nullptr || g_free_callback != nullptr);
 	EXIT_IF(alloc_func == nullptr || free_func == nullptr);
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	g_alloc_callback = alloc_func;
 	g_free_callback  = free_func;
@@ -2170,7 +2186,7 @@ int32_t KYTY_SYSV_ABI KernelMapNamedFlexibleMemory(void** addr_in_out, size_t le
                                                    int flags, const char* name) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	EXIT_NOT_IMPLEMENTED(addr_in_out == nullptr);
 
@@ -2313,7 +2329,7 @@ int KYTY_SYSV_ABI KernelMapFlexibleMemory(void** addr_in_out, size_t len, int pr
 int KYTY_SYSV_ABI KernelSetPrtAperture(int index, void* addr, size_t len) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	const auto address = reinterpret_cast<uint64_t>(addr);
 
@@ -2391,7 +2407,7 @@ int KYTY_SYSV_ABI KernelGetPrtAperture(int index, void** addr, size_t* len) {
 int KYTY_SYSV_ABI KernelSetVirtualRangeName(const void* addr, uint64_t len, const char* name) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	auto vaddr = reinterpret_cast<uint64_t>(addr);
 
@@ -2500,7 +2516,7 @@ static int UnmapMemoryRange(uint64_t vaddr, size_t len) {
 int KYTY_SYSV_ABI KernelMunmap(uint64_t vaddr, size_t len) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t start = 0x%016" PRIx64 "\n"
 	     "\t len   = 0x%016" PRIx64 "\n",
@@ -2528,7 +2544,7 @@ int KYTY_SYSV_ABI KernelAvailableDirectMemorySize(int64_t search_start, int64_t 
                                                   size_t* size_out) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t search_start = 0x%016" PRIx64 "\n"
 	     "\t search_end   = 0x%016" PRIx64 "\n"
@@ -2576,7 +2592,7 @@ int KYTY_SYSV_ABI KernelGetPageTableStats(int* cpu_total, int* cpu_available, in
                                           int* gpu_available) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	if (cpu_total == nullptr || cpu_available == nullptr || gpu_total == nullptr ||
 	    gpu_available == nullptr) {
@@ -2609,7 +2625,7 @@ int KYTY_SYSV_ABI KernelGetPageTableStats(int* cpu_total, int* cpu_available, in
 int KYTY_SYSV_ABI KernelDirectMemoryQuery(int64_t offset, int flags, void* info, size_t info_size) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t offset    = 0x%016" PRIx64 "\n"
 	     "\t flags     = 0x%08" PRIx32 "\n"
@@ -2687,7 +2703,7 @@ int KYTY_SYSV_ABI KernelAllocateDirectMemory(int64_t search_start, int64_t searc
                                              int64_t* phys_addr_out) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t search_start = 0x%016" PRIx64 "\n"
 	     "\t search_end   = 0x%016" PRIx64 "\n"
@@ -2720,7 +2736,7 @@ int KYTY_SYSV_ABI KernelAllocateMainDirectMemory(size_t len, size_t alignment, i
                                                  int64_t* phys_addr_out) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t len          = 0x%016" PRIx64 "\n"
 	     "\t alignment    = 0x%016" PRIx64 "\n"
@@ -2732,7 +2748,7 @@ int KYTY_SYSV_ABI KernelAllocateMainDirectMemory(size_t len, size_t alignment, i
 }
 
 static int ReleaseDirectMemoryInternal(int64_t start, size_t len) {
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	if (g_pooled_memory->ReleaseExpansion(static_cast<uint64_t>(start), len)) {
 		if (!g_physical_memory->ReleasePoolExpansion(static_cast<uint64_t>(start), len)) {
@@ -2865,7 +2881,7 @@ int KYTY_SYSV_ABI KernelMapDirectMemory(void** addr, size_t len, int prot, int f
                                         int64_t direct_memory_start, size_t alignment) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	if (addr == nullptr) {
 		return KERNEL_ERROR_EFAULT;
@@ -3043,7 +3059,7 @@ int KYTY_SYSV_ABI KernelMapDirectMemory2(void** addr, size_t len, int type, int 
                                          int64_t direct_memory_start, size_t alignment) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t type = %d\n", type);
 
@@ -3062,7 +3078,7 @@ int KYTY_SYSV_ABI KernelMapNamedDirectMemory(void** addr, size_t len, int prot, 
                                              const char* name) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t name = %s\n", name != nullptr ? name : "(null)");
 
@@ -3092,7 +3108,7 @@ int KYTY_SYSV_ABI KernelIsAddressSanitizerEnabled() {
 int KYTY_SYSV_ABI KernelQueryMemoryProtection(void* addr, void** start, void** end, int* prot) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	EXIT_NOT_IMPLEMENTED(addr == nullptr);
 
@@ -3317,7 +3333,7 @@ static bool ReplaceFixedRangeWithReserved(uint64_t start, uint64_t size) {
 int KYTY_SYSV_ABI KernelReserveVirtualRange(void** addr, size_t len, int flags, size_t alignment) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	const auto in_addr = (addr != nullptr ? reinterpret_cast<uint64_t>(*addr) : 0);
 
@@ -3418,7 +3434,7 @@ bool TestGuestFreeRangeBounds() {
 #endif
 
 bool KernelHandleReservedRangeAccessViolation(uint64_t vaddr) {
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	VirtualRanges::Range range {};
 	if (!g_virtual_ranges->Query(vaddr, 0, &range) ||
@@ -3432,7 +3448,7 @@ int KYTY_SYSV_ABI KernelVirtualQuery(const void* addr, int flags, VirtualQueryIn
                                      uint64_t info_size) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	auto vaddr = reinterpret_cast<uint64_t>(addr);
 
@@ -3485,7 +3501,7 @@ int KYTY_SYSV_ABI KernelVirtualQuery(const void* addr, int flags, VirtualQueryIn
 int KYTY_SYSV_ABI KernelIsStack(void* addr, void** start, void** end) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	auto vaddr = reinterpret_cast<uint64_t>(addr);
 
@@ -3521,7 +3537,7 @@ int KYTY_SYSV_ABI KernelIsStack(void* addr, void** start, void** end) {
 int KYTY_SYSV_ABI KernelAvailableFlexibleMemorySize(size_t* size) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	if (size == nullptr) {
 		return KERNEL_ERROR_EINVAL;
@@ -3572,7 +3588,7 @@ static std::vector<VirtualRanges::Range> RequireGuestRuntimeMemory(uint64_t vadd
 static uint64_t AllocateGuestRuntimeMemory(uint64_t search_addr, uint64_t size,
                                            VirtualMemory::Mode mode, const char* name,
                                            VirtualRangeType type, bool fixed) {
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	constexpr uint64_t GuestPageSize = 0x4000;
 	if (size == 0 || size > UINT64_MAX - (GuestPageSize - 1u) || name == nullptr ||
@@ -3603,7 +3619,7 @@ uint64_t AllocateProgramMemory(uint64_t search_addr, uint64_t size, VirtualMemor
 }
 
 void SetProgramMemoryProtection(uint64_t vaddr, uint64_t size, VirtualMemory::Mode mode) {
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	const auto ranges = RequireGuestRuntimeMemory(vaddr, size);
 	if (std::any_of(ranges.begin(), ranges.end(),
@@ -3637,7 +3653,7 @@ uint64_t AllocateGuestStackMemory(uint64_t search_addr, uint64_t size, VirtualMe
 
 bool ProtectGuestMemory(uint64_t vaddr, uint64_t size, VirtualMemory::Mode mode,
                         VirtualMemory::Mode* old_mode) {
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 	constexpr uint64_t                    GuestPageSize = 0x4000;
 	if (vaddr == 0 || size == 0 || size > UINT64_MAX - (vaddr & (GuestPageSize - 1u))) {
 		return false;
@@ -3663,7 +3679,7 @@ bool ProtectGuestHostMemory(uint64_t vaddr, uint64_t size, VirtualMemory::Mode m
 }
 
 bool FreeGuestMemory(uint64_t vaddr, uint64_t size) {
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	constexpr uint64_t GuestPageSize = 0x4000;
 	if (vaddr == 0 || size == 0 || size > UINT64_MAX - (GuestPageSize - 1u)) {
@@ -3678,7 +3694,7 @@ bool FreeGuestMemory(uint64_t vaddr, uint64_t size) {
 int KYTY_SYSV_ABI KernelMprotect(const void* addr, size_t len, int prot) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	auto vaddr = reinterpret_cast<uint64_t>(addr);
 
@@ -3740,7 +3756,7 @@ int KYTY_SYSV_ABI KernelMprotect(const void* addr, size_t len, int prot) {
 int KYTY_SYSV_ABI KernelMtypeprotect(const void* addr, size_t len, int type, int prot) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t addr = 0x%016" PRIx64 "\n"
 	     "\t len  = 0x%016" PRIx64 "\n"
@@ -3756,7 +3772,7 @@ int KYTY_SYSV_ABI KernelBatchMap2(KernelBatchMapEntry* entries, int num_entries,
                                   int* num_entries_out, int flags) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t entries         = %p\n"
 	     "\t num_entries     = %d\n"
@@ -3861,7 +3877,7 @@ int KYTY_SYSV_ABI KernelMemoryPoolExpand(int64_t search_start, int64_t search_en
                                          size_t alignment, int64_t* phys_addr_out) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	constexpr uint64_t POOL_PAGE_SIZE = 0x10000;
 	if (search_start < 0 || search_end <= search_start || len == 0 ||
@@ -3899,7 +3915,7 @@ int KYTY_SYSV_ABI KernelMemoryPoolReserve(void* addr_in, size_t len, size_t alig
                                           void** addr_out) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t addr_in   = 0x%016" PRIx64 "\n"
 	     "\t len       = 0x%016" PRIx64 "\n"
@@ -3949,7 +3965,7 @@ int KYTY_SYSV_ABI KernelMemoryPoolReserve(void* addr_in, size_t len, size_t alig
 int KYTY_SYSV_ABI KernelMemoryPoolCommit(void* addr, size_t len, int type, int prot, int flags) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t addr  = 0x%016" PRIx64 "\n"
 	     "\t len   = 0x%016" PRIx64 "\n"
@@ -4085,7 +4101,7 @@ static int DecommitMemoryPoolRange(uint64_t vaddr, size_t len) {
 int KYTY_SYSV_ABI KernelMemoryPoolDecommit(void* addr, size_t len, int flags) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	LOGF("\t addr  = 0x%016" PRIx64 "\n"
 	     "\t len   = 0x%016" PRIx64 "\n"
@@ -4127,7 +4143,7 @@ int KYTY_SYSV_ABI KernelMemoryPoolBatch(const KernelMemoryPoolBatchEntry* entrie
                                         int* num_entries_out, int flags) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	if (entries == nullptr || num_entries < 0) {
 		return KERNEL_ERROR_EINVAL;
@@ -4183,7 +4199,7 @@ int KYTY_SYSV_ABI KernelMemoryPoolGetBlockStats(KernelMemoryPoolBlockStats* outp
                                                 size_t                      output_size) {
 	PRINT_NAME();
 
-	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+	MemoryOperationLock memory_operation_lock;
 
 	if (output == nullptr && output_size != 0) {
 		return KERNEL_ERROR_EFAULT;

--- a/src/kernel/pthread.cpp
+++ b/src/kernel/pthread.cpp
@@ -3300,6 +3300,15 @@ bool PthreadHasPendingSignal(Pthread thread, int signum) {
 	return (thread->pending_signal_mask.load(std::memory_order_acquire) & mask) != 0;
 }
 
+// The dispatcher runs on every wait and sleep exit, so keep its common no-signal path to a
+// single atomic load rather than one read-modify-write per signal number.
+bool PthreadHasAnyPendingSignal(Pthread thread) {
+	if (thread == nullptr) {
+		return false;
+	}
+	return thread->pending_signal_mask.load(std::memory_order_acquire) != 0;
+}
+
 bool PthreadTakePendingSignal(Pthread thread, int signum) {
 	if (thread == nullptr || signum < 0 || signum >= 64) {
 		return false;

--- a/src/kernel/pthread.h
+++ b/src/kernel/pthread.h
@@ -111,6 +111,7 @@ uint64_t              PthreadGetHostThreadId(Pthread thread);
 void                  PthreadWakeForSignal(Pthread thread);
 void                  PthreadQueuePendingSignal(Pthread thread, int signum);
 bool                  PthreadHasPendingSignal(Pthread thread, int signum);
+bool                  PthreadHasAnyPendingSignal(Pthread thread);
 bool                  PthreadTakePendingSignal(Pthread thread, int signum);
 bool PthreadGetGuestStack(Pthread thread, uint64_t* stack_addr, uint64_t* stack_size);
 #if defined(KYTY_VIRTUAL_MEMORY_ALLOCATION_TESTS)

--- a/src/libs/libKernel.cpp
+++ b/src/libs/libKernel.cpp
@@ -991,16 +991,30 @@ static void HostSignalDispatchHandler(int /*host_signal*/, siginfo_t* /*info*/,
 
 		auto* handler = reinterpret_cast<exception_handler_func_t>(g_exception_handlers[signum]);
 		if (handler != nullptr) {
-			SignalDispatchScope scope;
-			auto                ctx = CreateSignalUcontextFromHost(host_ctx);
-			if (IsGuestCodeAddress(ctx.uc_mcontext.mc_rip)) {
-				handler(signum, &ctx);
-				ApplySignalUcontextToHost(host_ctx, ctx);
-			} else {
-				// Do not expose or restore a host frame.
-				SanitizeNonGuestSignalUcontext(&ctx, current);
-				handler(signum, &ctx);
+			auto ctx = CreateSignalUcontextFromHost(host_ctx);
+			if (!IsGuestCodeAddress(ctx.uc_mcontext.mc_rip) || Common::InHleCriticalSection()) {
+				// Interrupted inside host code, which for a guest thread means it is parked
+				// in an HLE wait. Running the guest handler here would run it nested inside
+				// that wait, and a handler that blocks (IL2CPP's GC suspend handler waits
+				// on an event flag until the collection ends) then never lets the wait
+				// unwind. That strands the internal state the wait holds: glibc keeps a
+				// group reference on a condition variable for the whole of
+				// pthread_cond_wait, and a stranded one makes every later
+				// pthread_cond_broadcast on that variable block forever, which deadlocks
+				// every thread using it.
+				//
+				// Leave the signal pending instead. The wait-poll callback installed
+				// through CondVar::SetWaitPollCallback, and the sleep paths, dispatch it
+				// from KernelDispatchPendingSignalForCurrentThread once the host frame has
+				// unwound. Nothing depends on delivery being synchronous: the sender's
+				// WaitForSignalDispatch already gives up after DISPATCH_WAIT_MAX.
+				QueuePendingSignal(current, signum);
+				return;
 			}
+
+			SignalDispatchScope scope;
+			handler(signum, &ctx);
+			ApplySignalUcontextToHost(host_ctx, ctx);
 		}
 		return;
 	}
@@ -1077,6 +1091,19 @@ static void SignalApcHandler(void* arg1, void* arg2, void* /*arg3*/, PCONTEXT co
 void KernelDispatchPendingSignalForCurrentThread() {
 	Pthread current = PthreadSelfOrNull();
 	if (current == nullptr) {
+		return;
+	}
+
+	// Called from every wait and sleep exit, so keep the common no-signal case to one load.
+	if (!PthreadHasAnyPendingSignal(current)) {
+		return;
+	}
+
+	// A handler may block for an unbounded time. Running one while this thread holds an
+	// emulator-global lock -- the memory-operation mutex, the GPU submission mutex -- deadlocks
+	// every guest thread that needs it, which is exactly what a stop-the-world collection does.
+	// Leave the signal queued; the next dispatch after the scope unwinds will deliver it.
+	if (Common::InHleCriticalSection()) {
 		return;
 	}
 

--- a/tests/SignalSafetyTests.cpp
+++ b/tests/SignalSafetyTests.cpp
@@ -1,0 +1,200 @@
+// Regression tests for the condition-variable layer that guest signal delivery runs through.
+//
+// Two defects are covered, both of which shipped:
+//
+//   1. CondVar::SignalThread woke its targets while holding the waiter-registry mutex. Waking is
+//      not guaranteed non-blocking, and the waiters it retires leave through
+//      UnregisterCondWaiter, which needs that same mutex, so the waker deadlocked against every
+//      waiter it was trying to wake.
+//   2. Fixing that by collecting the targets and waking with the lock released introduced a
+//      use-after-free: between the two, a waiter can return, unregister, and have its owning
+//      CondVar destroyed. The registry now holds a shared_ptr. Run under ASan to catch a
+//      regression here -- without it the stress cases below are only a no-crash smoke test.
+
+#include "common/threads.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using Common::CondVar;
+using Common::HleCriticalSection;
+using Common::Mutex;
+
+void Check(bool value, const char* text) {
+	if (!value) {
+		std::fprintf(stderr, "SignalSafetyTests: failed: %s\n", text);
+		std::abort();
+	}
+}
+
+// Defect 2. A waiter repeatedly creates a CondVar, parks on it briefly, then destroys it, while a
+// second thread hammers SignalThread against that waiter's id. The destruction races the wake; if
+// SignalThread does not hold the private object alive across the gap, the wake touches freed
+// memory.
+void TestSignalThreadDoesNotOutliveCondVar() {
+	std::atomic_bool  stop {false};
+	std::atomic<int>  waiter_tid {0};
+	std::atomic<bool> waiter_ready {false};
+
+	std::thread waiter([&] {
+		waiter_tid.store(Common::Thread::GetThreadIdUnique(), std::memory_order_release);
+		waiter_ready.store(true, std::memory_order_release);
+		while (!stop.load(std::memory_order_acquire)) {
+			// Fresh objects each round so the destroy lands in the signaller's wake window.
+			auto mutex = std::make_unique<Mutex>();
+			auto cond  = std::make_unique<CondVar>();
+			mutex->Lock();
+			(void)cond->WaitFor(mutex.get(), 200);
+			mutex->Unlock();
+			cond.reset();
+			mutex.reset();
+		}
+	});
+
+	while (!waiter_ready.load(std::memory_order_acquire)) {
+		std::this_thread::yield();
+	}
+	const int target = waiter_tid.load(std::memory_order_acquire);
+	Check(target != 0, "waiter reported a thread id");
+
+	std::thread signaller([&] {
+		while (!stop.load(std::memory_order_acquire)) {
+			CondVar::SignalThread(target);
+		}
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(750));
+	stop.store(true, std::memory_order_release);
+	signaller.join();
+	waiter.join();
+}
+
+// Same defect, wider window: many waiters on distinct condvars, all torn down while a signaller
+// walks the registry.
+void TestSignalThreadWithConcurrentTeardown() {
+	constexpr int WAITER_COUNT = 8;
+
+	std::atomic_bool         stop {false};
+	std::vector<std::thread> waiters;
+	std::atomic<int>         ids[WAITER_COUNT];
+	for (auto& id: ids) {
+		id.store(0, std::memory_order_relaxed);
+	}
+
+	waiters.reserve(WAITER_COUNT);
+	for (int i = 0; i < WAITER_COUNT; i++) {
+		waiters.emplace_back([&, i] {
+			ids[i].store(Common::Thread::GetThreadIdUnique(), std::memory_order_release);
+			while (!stop.load(std::memory_order_acquire)) {
+				Mutex   mutex;
+				CondVar cond;
+				mutex.Lock();
+				(void)cond.WaitFor(&mutex, 100);
+				mutex.Unlock();
+			}
+		});
+	}
+
+	std::thread signaller([&] {
+		while (!stop.load(std::memory_order_acquire)) {
+			for (auto& id: ids) {
+				if (const int target = id.load(std::memory_order_acquire); target != 0) {
+					CondVar::SignalThread(target);
+				}
+			}
+		}
+	});
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(750));
+	stop.store(true, std::memory_order_release);
+	signaller.join();
+	for (auto& thread: waiters) {
+		thread.join();
+	}
+}
+
+// Defect 1, end to end: SignalThread must wake a waiter rather than deadlock against it, and must
+// cut a long wait short instead of letting it time out. A regression here hangs this test rather
+// than failing it, which is the honest shape for a deadlock.
+void TestSignalThreadWakesAWaiter() {
+	Mutex   mutex;
+	CondVar cond;
+
+	std::atomic<int>  waiter_tid {0};
+	std::atomic_bool  waiting {false};
+	std::atomic<bool> returned {false};
+
+	std::thread waiter([&] {
+		waiter_tid.store(Common::Thread::GetThreadIdUnique(), std::memory_order_release);
+		mutex.Lock();
+		waiting.store(true, std::memory_order_release);
+		(void)cond.WaitFor(&mutex, 3000000); // 3 s
+		mutex.Unlock();
+		returned.store(true, std::memory_order_release);
+	});
+
+	while (!waiting.load(std::memory_order_acquire)) {
+		std::this_thread::yield();
+	}
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	const auto start = std::chrono::steady_clock::now();
+	CondVar::SignalThread(waiter_tid.load(std::memory_order_acquire));
+	waiter.join();
+	const auto elapsed = std::chrono::steady_clock::now() - start;
+
+	Check(returned.load(std::memory_order_acquire), "the waiter returned");
+	Check(elapsed < std::chrono::milliseconds(1500),
+	      "SignalThread cuts the wait short rather than letting it time out");
+}
+
+// An unsignalled WaitFor still honours its timeout.
+void TestWaitForTimesOut() {
+	Mutex   mutex;
+	CondVar cond;
+
+	const auto start = std::chrono::steady_clock::now();
+	mutex.Lock();
+	const bool signalled = cond.WaitFor(&mutex, 100000); // 100 ms
+	mutex.Unlock();
+	const auto elapsed = std::chrono::steady_clock::now() - start;
+
+	Check(!signalled, "an unsignalled WaitFor reports a timeout");
+	Check(elapsed >= std::chrono::milliseconds(80), "WaitFor honours its timeout");
+}
+
+// HleCriticalSection is what pending-signal dispatch consults before running a guest handler, so
+// its depth accounting has to survive nesting.
+void TestCriticalSectionNesting() {
+	Check(!Common::InHleCriticalSection(), "not in a critical section to begin with");
+	{
+		HleCriticalSection outer;
+		Check(Common::InHleCriticalSection(), "inside the outer section");
+		{
+			HleCriticalSection inner;
+			Check(Common::InHleCriticalSection(), "inside the nested section");
+		}
+		Check(Common::InHleCriticalSection(), "still inside after the nested section ends");
+	}
+	Check(!Common::InHleCriticalSection(), "outside once the outer section ends");
+}
+
+} // namespace
+
+int main() {
+	TestCriticalSectionNesting();
+	TestWaitForTimesOut();
+	TestSignalThreadWakesAWaiter();
+	TestSignalThreadDoesNotOutliveCondVar();
+	TestSignalThreadWithConcurrentTeardown();
+
+	std::printf("SignalSafetyTests: all passed\n");
+	return 0;
+}


### PR DESCRIPTION
## NOTE

These are commits from PR #156, compressed and cleaned up to be isolated from the rest of the changes that have either a) been committed or b) been identified as hacks/incomplete implementations.

These changes make Subnautica, Powerwash Simulator and cult of the lamb boot and enter in-game. I do not claim that these changes are objectively the correct implementation. This is just a PR separating commits from #156 so that they can be seen in the correct context and provide better insight as to what their purpose is. More details below:

## Summary

  A guest signal handler could run nested inside a host wait, or while the thread held an
  emulator-global lock. Either one deadlocks the emulator: the handler blocks, the frame never
  unwinds, and the state it holds is stranded. This leaves the signal queued in both cases and
  dispatches it once the frame has unwound.

  ## What's included

  ### Guest signal delivery — `libKernel.cpp`, `memory.cpp`, `graphicsRun.cpp`

  - Leave a signal queued when it interrupted host code, and dispatch it from
    `KernelDispatchPendingSignalForCurrentThread` once the frame unwinds. Running IL2CPP's GC-suspend
    handler nested inside a host wait strands glibc's condvar group reference, after which every later
    broadcast on that variable blocks forever — the hard freeze on Subnautica's loading screen.
  - Declare the 33 `g_memory_operation_mutex` sites and the GPU submission lock as critical sections,
    and refuse to dispatch inside one. A handler that blocks while holding either stalls every other
    guest thread; both mutexes were confirmed owned by a single parked thread via `__data.__owner`.
  - Gate the dispatcher on one atomic load. It now runs on every wait and sleep exit, where the
    previous path did a read-modify-write per signal number.

  ### Condition variables — `threads.cpp`, `threads.h`

  - Wake `SignalThread`'s targets with the registry lock released. A broadcast can block until the
    waiters it is retiring have left, and they leave through `UnregisterCondWaiter`, which needs that
    same mutex — so the waker deadlocked against every waiter it was trying to wake. `Signal()` and
    `SignalAll()` already woke without the lock.
  - Hold registered waiters by `shared_ptr`. Between the collect and the wake, a waiter can return,
    unregister and have its owning `CondVar` destroyed, so the wake touched freed memory.
  - Add a dispatch point to `CondVar::WaitFor`. It had none, so a deferred signal sat undelivered for
    the whole of an arbitrarily long timeout.

  ### Build and tests — `CMakeLists.txt`, `tests/SignalSafetyTests.cpp`

  - Add `signal_safety_tests`, covering both the deadlock and the use-after-free. The use-after-free
    oracle is ASan: built with `-fsanitize=address` it reports `heap-use-after-free` in `WakeCondVar`
    reached from `SignalThread`, on memory freed by `~CondVar`, and is clean with the fix. A
    regression in the deadlock hangs the test rather than failing it, which is the honest shape for a
    deadlock.

  ## Platform impact

  - **Windows — changed, and not built or run here.** Two pieces are excluded by existing guards: the
    `CondVar::WaitFor` dispatch point sits in the non-`KYTY_WIN_CS` arm, and the
    `HostSignalDispatchHandler` deferral is inside
    `#if KYTY_PLATFORM != KYTY_PLATFORM_WINDOWS && defined(__x86_64__)`. Windows keeps its own APC
    path (`SignalApcHandler` / `nt_queue_apc_thread_ex`), untouched. Everything else compiles there:
    the `SignalThread` fix, the `shared_ptr` waiter lifetime, `HleCriticalSection`, the 33
    `MemoryOperationLock` sites, and the dispatcher's two new early returns.
  - **macOS** — rides the POSIX arm; compiles, not run.

  ## Testing

  Built on Linux (Clang, Ninja). `ctest` 27/27 including the new `signal_safety`.