### PR TITLE
vulkan: remove validation layer configuration from device creation

### DIFF
--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -607,10 +607,6 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	create_info.flags                = {};
 	create_info.pQueueCreateInfos    = &queue_create_info;
 	create_info.queueCreateInfoCount = 1;
-	create_info.enabledLayerCount =
-	    (r.enable_validation_layers ? static_cast<uint32_t>(r.required_layers.size()) : 0);
-	create_info.ppEnabledLayerNames =
-	    (r.enable_validation_layers ? r.required_layers.data() : nullptr);
 	create_info.enabledExtensionCount   = static_cast<uint32_t>(device_extensions.size());
 	create_info.ppEnabledExtensionNames = device_extensions.data();
 	create_info.pEnabledFeatures        = &device_features;


### PR DESCRIPTION
## Problem

When creating the Vulkan device, the code passed the validation layers
(`VK_LAYER_KHRONOS_validation`) via `VkDeviceCreateInfo.enabledLayerCount` /
`ppEnabledLayerNames`.

Device layers have never been supported since Vulkan 1.0 — layers must be
enabled at instance level only. This triggered a validation error:

vkCreateDevice(): pCreateInfo->enabledLayerCount is 1 (not zero).
The Vulkan spec states: enabledLayerCount must be 0
(VUID-VkDeviceCreateInfo-enabledLayerCount-12384)

## Changes

- Removed `enabledLayerCount` / `ppEnabledLayerNames` from the
  `vk::DeviceCreateInfo` in `src/graphics/presentation/window/vulkanWindow.cpp`.
- The instance-level configuration (where layers belong) is untouched, so
  validation via `VK_LAYER_KHRONOS_validation` still works.
