### PR TITLE
Windows11 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ build/
 _Build/vscode-clang/
 _Build/
 cmake-build-debug/
+
+# Emulator runtime data
+_DownloadData/
+_Shaders/
+_TempData/
+_Textures/
+*.pdb

--- a/scripts/build-windows.bat
+++ b/scripts/build-windows.bat
@@ -1,0 +1,18 @@
+@echo off
+rem Generic Windows build for KytyPS5. Run scripts\configure-windows.bat first.
+rem
+rem Optional overrides (must match configure):
+rem   BUILD_DIR  output directory, defaults to build
+
+setlocal
+
+if not defined BUILD_DIR set "BUILD_DIR=build"
+
+cd /d "%~dp0.."
+cmake --build "%BUILD_DIR%" --target launcher --parallel %*
+if errorlevel 1 exit /b 1
+cmake --install "%BUILD_DIR%" --prefix "%BUILD_DIR%/install"
+if errorlevel 1 exit /b 1
+
+echo.
+echo Build complete: %BUILD_DIR%\install

--- a/scripts/configure-windows.bat
+++ b/scripts/configure-windows.bat
@@ -1,0 +1,55 @@
+@echo off
+rem Generic Windows configuration for KytyPS5 (clang-cl + Ninja + Qt 6 + Vulkan).
+rem
+rem Requirements:
+rem   - Visual Studio or Build Tools 2017+ with the C++ toolset installed
+rem   - clang-cl, cmake and ninja on PATH (LLVM, CMake, Ninja)
+rem   - Qt 6 built for MSVC x64 (auto-detected under C:\Qt, override with QT_DIR)
+rem   - Vulkan SDK (VULKAN_SDK set by its installer; optional for configure)
+rem
+rem Optional overrides (set before running):
+rem   QT_DIR     path to the Qt MSVC tree, e.g. C:\Qt\6.8.2\msvc2022_64
+rem   BUILD_DIR  output directory, defaults to build
+
+setlocal
+
+if not defined BUILD_DIR set "BUILD_DIR=build"
+
+if not defined QT_DIR (
+  for /d %%d in ("C:\Qt\6.*") do set "QT_DIR=%%d\msvc2022_64"
+)
+if not defined QT_DIR (
+  echo ERROR: Qt 6 not found under C:\Qt. Set QT_DIR, e.g. C:\Qt\6.8.2\msvc2022_64.
+  exit /b 1
+)
+
+for %%t in (cmake ninja clang-cl) do (
+  where %%t >nul 2>nul
+  if errorlevel 1 (
+    echo ERROR: %%t not found on PATH.
+    exit /b 1
+  )
+)
+
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+  echo ERROR: vswhere.exe not found - install Visual Studio or Build Tools with the C++ workload.
+  exit /b 1
+)
+set "VCTOOLSDIR="
+for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VCTOOLSDIR=%%i"
+if not defined VCTOOLSDIR (
+  echo ERROR: no Visual Studio installation with the VC C++ tools found.
+  exit /b 1
+)
+call "%VCTOOLSDIR%\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 exit /b 1
+
+cd /d "%~dp0.."
+cmake -S . -B "%BUILD_DIR%" -G Ninja -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl ^
+  -DCMAKE_PREFIX_PATH=%QT_DIR% %*
+if errorlevel 1 exit /b 1
+
+echo.
+echo Configured into %BUILD_DIR%. Use scripts\build-windows.bat to compile.

--- a/scripts/fix-submodules.bat
+++ b/scripts/fix-submodules.bat
@@ -1,0 +1,16 @@
+@echo off
+rem Reset every git submodule to the exact commit recorded in the index, using a
+rem shallow fetch. Useful when a submodule directory exists but is empty, or
+rem ends up on the wrong commit (e.g. after switching branches).
+
+cd /d "%~dp0.."
+
+for /f "tokens=2,4" %%a in ('git ls-files -s ^| findstr /b "160000"') do (
+  echo Checking out %%b @ %%a
+  git -C "%%b" fetch --depth 1 origin %%a 2>nul
+  if errorlevel 1 (
+    echo   fetch failed for %%b
+  ) else (
+    git -C "%%b" checkout %%a
+  )
+)

--- a/src/common/hostException.cpp
+++ b/src/common/hostException.cpp
@@ -1,8 +1,10 @@
 #include "common/hostException.h"
 
 #include <atomic>
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
+#include <mutex>
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 #include <windows.h> // IWYU pragma: keep
@@ -73,6 +75,63 @@ static Handler LoadInstalledHandler() noexcept {
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 
+// Resume trampoline for guest-mode continuations. The Windows 11 24H2 guarded
+// context-restore path validates the continuation RSP against the thread's
+// stack, so a guest RSP fail-fasts before the resume. The exception filter
+// instead gives the dispatcher a host-stack RSP and this trampoline address
+// (both valid), then the trampoline swaps in the guest RSP and jumps to the
+// guest RIP without touching any general-purpose register:
+//   +0x00: xchg rsp, [rip+0x08]   ; 48 87 24 25 08 00 00 00
+//   +0x08: jmp  [rip+0x0a]        ; ff 25 0a 00 00 00
+//   +0x10: rsp_slot (guest RSP)
+//   +0x18: rip_slot (guest RIP)
+struct Trampoline {
+	alignas(8) uint8_t code[16] {};
+	uint64_t            rsp_slot = 0;
+	uint64_t            rip_slot = 0;
+};
+
+static constexpr uint32_t kTrampolineCount = 64;
+static std::mutex         g_trampoline_mutex;
+static Trampoline*        g_trampolines[kTrampolineCount] {};
+static uint32_t           g_trampoline_threads[kTrampolineCount] {};
+
+static Trampoline* AcquireTrampoline() {
+	const auto thread_id = static_cast<uint32_t>(GetCurrentThreadId());
+	std::lock_guard lock(g_trampoline_mutex);
+
+	uint32_t free_slot = kTrampolineCount;
+	for (uint32_t i = 0; i < kTrampolineCount; i++) {
+		if (g_trampolines[i] != nullptr) {
+			if (g_trampoline_threads[i] == thread_id) {
+				return g_trampolines[i];
+			}
+		} else if (free_slot == kTrampolineCount) {
+			free_slot = i;
+		}
+	}
+	if (free_slot == kTrampolineCount) {
+		return nullptr;
+	}
+
+	auto* tramp = static_cast<Trampoline*>(VirtualAlloc(nullptr, sizeof(Trampoline),
+	                                                    MEM_COMMIT | MEM_RESERVE,
+	                                                    PAGE_EXECUTE_READWRITE));
+	if (tramp == nullptr) {
+		return nullptr;
+	}
+
+	const uint8_t bytes[16] = {0x48, 0x87, 0x24, 0x25, 0x08, 0x00, 0x00, 0x00,
+	                           0xFF, 0x25, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00};
+	for (uint32_t i = 0; i < sizeof(bytes); i++) {
+		tramp->code[i] = bytes[i];
+	}
+
+	g_trampolines[free_slot]        = tramp;
+	g_trampoline_threads[free_slot] = thread_id;
+	return tramp;
+}
+
 static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 	FilterScope filter_scope;
 
@@ -133,7 +192,48 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 
 	const auto handler = LoadInstalledHandler();
 
-	return handler(info) ? EXCEPTION_CONTINUE_EXECUTION : EXCEPTION_CONTINUE_SEARCH;
+	if (!handler(info)) {
+		std::fprintf(stderr,
+		             "HOST EXCEPTION **unresolved**: type=%s addr=0x%016" PRIx64
+		             " fault_ip=0x%016" PRIx64 "\n",
+		             info.type == ExceptionType::IllegalInstruction ? "illegal_instruction"
+		                                                            : "access_violation",
+		             info.access_violation_vaddr, info.exception_address);
+		std::fprintf(stderr,
+		             "  regs: rax=%016" PRIx64 " rbx=%016" PRIx64 " rcx=%016" PRIx64
+		             " rdx=%016" PRIx64 " rsi=%016" PRIx64 " rdi=%016" PRIx64 " rbp=%016" PRIx64
+		             " rsp=%016" PRIx64 " r8=%016" PRIx64 " r9=%016" PRIx64 " r10=%016" PRIx64
+		             " r11=%016" PRIx64 " r12=%016" PRIx64 " r13=%016" PRIx64 " r14=%016" PRIx64
+		             " r15=%016" PRIx64 "\n",
+		             info.rax, info.rbx, info.rcx, info.rdx, info.rsi, info.rdi, info.rbp,
+		             info.rsp, info.r8, info.r9, info.r10, info.r11, info.r12, info.r13,
+		             info.r14, info.r15);
+		std::fflush(stderr);
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	// Windows 11 24H2 dispatches EXCEPTION_CONTINUE_EXECUTION through
+	// ntdll!RtlGuardRestoreContext, which fail-fasts (0xc0000409,
+	// FAST_FAIL_INVALID_SET_OF_CONTEXT) when the continuation RSP is not
+	// within the current thread's stack. Guest code resumes with a guest-mode
+	// RSP, so the resume is redirected through a per-thread trampoline: the
+	// dispatcher is given a host-stack RSP (valid) and the trampoline address
+	// (module code, valid), and the trampoline itself swaps in the guest RSP
+	// and jumps to the guest RIP using only the RSP register, preserving all
+	// guest general-purpose registers.
+	if (auto* trampoline = AcquireTrampoline(); trampoline != nullptr) {
+		auto* const context = exception->ContextRecord;
+		trampoline->rsp_slot = context->Rsp;
+		trampoline->rip_slot = context->Rip;
+		context->Rip         = reinterpret_cast<uintptr_t>(trampoline->code);
+		context->Rsp         = reinterpret_cast<uintptr_t>(&context);
+		context->ContextFlags = (context->ContextFlags & ~0x50u) | 0x100000Fu;
+		return EXCEPTION_CONTINUE_EXECUTION;
+	}
+#endif
+
+	return EXCEPTION_CONTINUE_EXECUTION;
 }
 
 #elif defined(__APPLE__)
@@ -313,6 +413,34 @@ bool InstallHandler(Handler handler) {
 	g_handler.store(handler, std::memory_order_release);
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	// Windows 11 24H2 dispatches a vectored-handler continuation through
+	// ntdll!RtlGuardRestoreContext, which validates the continuation RSP by
+	// calling RtlGuardIsValidStackPointer.  That validator reads the current
+	// thread's TEB stack bounds, and guest threads (which run with a guest
+	// RSP and a guest-mode TEB) never pass it, so the dispatcher fail-fasts
+	// (0xc0000409, FAST_FAIL_INVALID_SET_OF_CONTEXT) before resuming guest
+	// code.  The validation block is skipped when the process shadow-stack
+	// policy byte at LdrSystemDllInitBlock+0x9c has bit 0 set; set it so the
+	// dispatcher restores the continuation context as-is (the guest resume
+	// itself is handled by the trampoline below).
+	HMODULE ntdll_module = GetModuleHandleW(L"ntdll.dll");
+	uint8_t* guard_policy =
+	    (ntdll_module != nullptr)
+	        ? reinterpret_cast<uint8_t*>(GetProcAddress(ntdll_module, "LdrSystemDllInitBlock"))
+	        : nullptr;
+	if (guard_policy != nullptr) {
+		DWORD old_protect = 0;
+		if (VirtualProtect(guard_policy + 0x9c, 1, PAGE_READWRITE, &old_protect) != 0) {
+			guard_policy[0x9c] |= 0x01u;
+			VirtualProtect(guard_policy + 0x9c, 1, old_protect, &old_protect);
+			printf("host_exception: guarded-restore RSP validation disabled (policy byte=0x%02x)\n",
+			       guard_policy[0x9c]);
+		} else {
+			printf("host_exception: guarded-restore RSP validation patch failed (error=%lu)\n",
+			       static_cast<unsigned long>(GetLastError()));
+		}
+	}
+
 	if (AddVectoredExceptionHandler(1, ExceptionFilter) == nullptr) {
 		g_handler.store(nullptr, std::memory_order_release);
 		g_install_state.store(0, std::memory_order_release);

--- a/src/graphics/host_gpu/rangeSet.h
+++ b/src/graphics/host_gpu/rangeSet.h
@@ -59,6 +59,25 @@ public:
 		return result;
 	}
 
+	// How many bytes from `address` fall inside a single tracked range, capped at `max_size`, or
+	// zero when the address is not tracked at all. Add coalesces overlapping and adjacent ranges, so
+	// one entry spans an entire contiguous run and a nonzero result really is contiguous.
+	[[nodiscard]] uint64_t ContiguousExtent(uint64_t address, uint64_t max_size) const {
+		if (address == 0 || max_size == 0) {
+			return 0;
+		}
+		auto it = m_ranges.upper_bound(address);
+		if (it == m_ranges.begin()) {
+			return 0;
+		}
+		--it;
+		// Entries are half-open [first, second).
+		if (address < it->first || address >= it->second) {
+			return 0;
+		}
+		return std::min(it->second - address, max_size);
+	}
+
 	[[nodiscard]] bool Contains(uint64_t address, uint64_t size) const {
 		const auto end = End(address, size);
 		auto       it  = m_ranges.upper_bound(address);

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -3,6 +3,8 @@
 #include "common/assert.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/host_gpu/renderer/commandScheduler.h"
+
+#include <algorithm>
 namespace Libs::Graphics {
 
 GpuResourceManager::GpuResourceManager(GraphicContext& graphics, CommandScheduler& scheduler)
@@ -41,6 +43,17 @@ bool GpuResourceManager::IsMapped(uint64_t vaddr, uint64_t size) const noexcept 
 	}
 	std::shared_lock lock(m_mapped_ranges_mutex);
 	return m_mapped_ranges.Contains(vaddr, size);
+}
+
+uint64_t GpuResourceManager::MappedExtent(uint64_t vaddr, uint64_t max_size) const noexcept {
+	if (vaddr == 0 || max_size == 0 || vaddr >= TRACKER_ADDRESS_SIZE) {
+		return 0;
+	}
+	// Clip before vaddr + max_size could leave the tracker's address space, so a descriptor that
+	// nominally spans terabytes cannot produce a range the tracker would later reject outright.
+	const auto       limit = std::min(max_size, TRACKER_ADDRESS_SIZE - vaddr);
+	std::shared_lock lock(m_mapped_ranges_mutex);
+	return m_mapped_ranges.ContiguousExtent(vaddr, limit);
 }
 
 void GpuResourceManager::MapMemory(uint64_t vaddr, uint64_t size) {

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
@@ -28,6 +28,10 @@ public:
 	[[nodiscard]] bool HandleFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept;
 	[[nodiscard]] bool InvalidateMemory(uint64_t vaddr, uint64_t size);
 	[[nodiscard]] bool IsMapped(uint64_t vaddr, uint64_t size) const noexcept;
+	// Contiguous mapped bytes starting at `vaddr`, capped at `max_size` and at the tracker's address
+	// space. Zero when nothing is mapped there. Lets a caller bind what the guest actually mapped
+	// rather than what a descriptor nominally claims.
+	[[nodiscard]] uint64_t MappedExtent(uint64_t vaddr, uint64_t max_size) const noexcept;
 	void               MapMemory(uint64_t vaddr, uint64_t size);
 	void               UnmapMemory(uint64_t vaddr, uint64_t size);
 	void               RunGarbageCollector();

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -91,30 +91,57 @@ static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& com
 	if (stride != 0 && records > UINT64_MAX / stride) {
 		EXIT("storage buffer descriptor footprint overflow\n");
 	}
-	const auto size = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
-	if (address == 0 || size == 0) {
+	const auto nominal = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
+	if (address == 0 || nominal == 0) {
 		BindNullStorageBuffer(context, result);
 		return result;
 	}
 	const auto& graphics  = context.GetGraphics();
 	const auto  alignment = graphics.StorageMinAlignment();
-	if (alignment == 0 ||
-	    size > graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange) {
-		EXIT("storage buffer range or device alignment is unsupported\n");
+	const auto  max_range =
+	    static_cast<uint64_t>(graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange);
+	if (alignment == 0) {
+		EXIT("storage buffer device alignment is unsupported\n");
 	}
+
+	// A GNM descriptor's num_records is routinely over-provisioned - commonly close to UINT32_MAX -
+	// because the shader bounds-checks its own accesses. The nominal footprint is therefore not a
+	// claim that any of it is resident, and binding it whole asks the buffer cache to stage, track
+	// and map memory the guest never mapped: that faults inside the staging copy or fails the memory
+	// tracker's range validation, depending on where the descriptor happens to point.
+	//
+	// Bind the contiguous mapped extent instead. Vulkan robust buffer access returns zero past the
+	// end, which is exactly what the guest's own bounds checks already assume. The extent comes from
+	// the ranges the guest mapped for GPU access rather than from host commit state: that is the
+	// question actually being asked, it costs a map probe instead of a kernel transition on a path
+	// that runs for every buffer of every draw, and it does not mistake a GPU-owned page for an
+	// absent one.
+	const auto requested = std::min(nominal, max_range);
+	const auto size      = context.GetGpuResources().MappedExtent(address, requested);
+
+	// A base that maps nothing binds the null buffer rather than faulting; reads then return zero,
+	// which is the same answer robust access gives past the end of a short binding.
+	if (size == 0) {
+		BindNullStorageBuffer(context, result);
+		return result;
+	}
+
 	auto binding = context.GetBufferCache().ObtainBuffer(
 	    command_buffer, address, size, resource.written, resource.read, resource.formatted);
 	const auto aligned_offset = binding.offset - binding.offset % alignment;
 	const auto adjustment     = binding.offset - aligned_offset;
-	const auto max_range      = graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange;
-	if (adjustment % sizeof(uint32_t) != 0 || adjustment >= 256 || size > max_range - adjustment) {
+	if (adjustment % sizeof(uint32_t) != 0 || adjustment >= 256) {
 		EXIT("storage buffer offset adjustment is unsupported\n");
 	}
-	buffer_offset = static_cast<uint32_t>(adjustment);
-	result.owner  = std::move(binding.owner);
-	result.buffer = binding.buffer;
-	result.offset = aligned_offset;
-	result.range  = static_cast<vk::DeviceSize>(size + adjustment);
+	// Aligning the offset down puts `adjustment` bytes in front of the binding, so the described
+	// range has to leave room for them inside the device limit. Trimming the tail is safe for the
+	// same reason the clamp above is.
+	const auto bound_size = std::min(size, max_range - adjustment);
+	buffer_offset         = static_cast<uint32_t>(adjustment);
+	result.owner          = std::move(binding.owner);
+	result.buffer         = binding.buffer;
+	result.offset         = aligned_offset;
+	result.range          = static_cast<vk::DeviceSize>(bound_size + adjustment);
 	return result;
 }
 

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -141,6 +141,10 @@ static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& com
 	// the resource needs puts unrelated game data behind that protection, which is a good deal worse
 	// than a short binding. Sixty-four kilobytes is a thousand-odd matrices - far past any real mesh -
 	// while staying inside a handful of the buffer cache's own pages.
+	//
+	// Compute is deliberately included. Skinning does not only happen in the draw path - a skin-cache
+	// pass reads the same bone matrices in compute and writes the posed vertices out - so excluding
+	// it puts that pass straight back on the short binding and the tear returns.
 	constexpr uint64_t IndexedFetchCap = 64ull * 1024ull;
 	const auto         read_extent     = std::min(max_range, IndexedFetchCap);
 	const auto requested =
@@ -927,8 +931,8 @@ void RenderExecutor::RebindBuffers(CommandBuffer&                     buffer,
 		ShaderBufferResource descriptor;
 		CopyNativeDescriptor(snapshot.buffers[i], descriptor.fields);
 		uint32_t buffer_offset = 0;
-		resources.buffers.push_back(NativeStorageBuffer(m_context, buffer, descriptor,
-		                                                program.info.buffers[i], buffer_offset));
+		resources.buffers.push_back(NativeStorageBuffer(
+		    m_context, buffer, descriptor, program.info.buffers[i], buffer_offset));
 		const auto dword = layout.buffer_offset_dword + i / 4u;
 		const auto shift = (i % 4u) * 8u;
 		prepared.user_data[dword] |= buffer_offset << shift;

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -110,14 +110,37 @@ static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& com
 	// and map memory the guest never mapped: that faults inside the staging copy or fails the memory
 	// tracker's range validation, depending on where the descriptor happens to point.
 	//
-	// Bind the contiguous mapped extent instead. Vulkan robust buffer access returns zero past the
-	// end, which is exactly what the guest's own bounds checks already assume. The extent comes from
-	// the ranges the guest mapped for GPU access rather than from host commit state: that is the
-	// question actually being asked, it costs a map probe instead of a kernel transition on a path
-	// that runs for every buffer of every draw, and it does not mistake a GPU-owned page for an
-	// absent one.
-	const auto requested = std::min(nominal, max_range);
-	const auto size      = context.GetGpuResources().MappedExtent(address, requested);
+	// Bind the contiguous mapped extent instead. The extent comes from the ranges the guest mapped for
+	// GPU access rather than from host commit state: that is the question actually being asked, it
+	// costs a map probe instead of a kernel transition on a path that runs for every buffer of every
+	// draw, and it does not mistake a GPU-owned page for an absent one.
+	//
+	// num_records is likewise not a reliable *lower* bound on what a shader reads. A skinned mesh
+	// fetches its bone matrices through one formatted descriptor indexed by bone number, and the
+	// descriptor it is given routinely describes fewer records than the mesh indexes - so binding
+	// exactly stride * num_records leaves every bone past the end reading zero under robust access.
+	// Zero matrices collapse their vertices onto the origin while the rest stay correctly posed,
+	// which is a mesh torn between two positions rather than one that is simply missing.
+	//
+	// So such a descriptor is given the mapped extent even when its record footprint is smaller. This
+	// can only grow the binding, never shrink it, and it stays inside memory the guest mapped for the
+	// GPU.
+	//
+	// Kept as narrow as the symptom allows, on two axes. Only a read-only descriptor with a stride
+	// qualifies - a stride is what makes a fetch indexed by record, which is the shape the bound bites
+	// on - so raw byte buffers and every written buffer keep the footprint they ask for. Whether the
+	// fetch is format-converted makes no difference to the bound and is deliberately not part of the
+	// test. And the growth is capped well below the mapping, because ObtainBuffer does not merely bind
+	// this range: it tracks it, which write-protects the guest pages underneath. Reaching further than
+	// the resource needs puts unrelated game data behind that protection, which is a good deal worse
+	// than a short binding. Sixty-four kilobytes is a thousand-odd matrices - far past any real mesh -
+	// while staying inside a handful of the buffer cache's own pages.
+	constexpr uint64_t IndexedFetchCap = 64ull * 1024ull;
+	const bool         indexed_fetch   = resource.read && !resource.written && stride != 0;
+	const auto read_extent = std::min(max_range, IndexedFetchCap);
+	const auto requested =
+	    indexed_fetch && nominal < read_extent ? read_extent : std::min(nominal, max_range);
+	const auto size = context.GetGpuResources().MappedExtent(address, requested);
 
 	// A base that maps nothing binds the null buffer rather than faulting; reads then return zero,
 	// which is the same answer robust access gives past the end of a short binding.

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -92,7 +92,13 @@ static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& com
 		EXIT("storage buffer descriptor footprint overflow\n");
 	}
 	const auto nominal = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
-	if (address == 0 || nominal == 0) {
+	// An indexed read-only fetch is exempt from the empty-footprint shortcut. num_records is the field
+	// the extension below exists because it under-reports, and zero is that same under-reporting at
+	// its limit: taking it at face value binds nothing at all, so every index reads zero and the whole
+	// mesh collapses rather than part of it. A base that genuinely maps nothing still lands on the
+	// null buffer a few lines down, once the mapping has been asked rather than the descriptor.
+	const bool indexed_fetch = resource.read && !resource.written && stride != 0;
+	if (address == 0 || (nominal == 0 && !indexed_fetch)) {
 		BindNullStorageBuffer(context, result);
 		return result;
 	}
@@ -136,8 +142,7 @@ static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& com
 	// than a short binding. Sixty-four kilobytes is a thousand-odd matrices - far past any real mesh -
 	// while staying inside a handful of the buffer cache's own pages.
 	constexpr uint64_t IndexedFetchCap = 64ull * 1024ull;
-	const bool         indexed_fetch   = resource.read && !resource.written && stride != 0;
-	const auto read_extent = std::min(max_range, IndexedFetchCap);
+	const auto         read_extent     = std::min(max_range, IndexedFetchCap);
 	const auto requested =
 	    indexed_fetch && nominal < read_extent ? read_extent : std::min(nominal, max_range);
 	const auto size = context.GetGpuResources().MappedExtent(address, requested);

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -3569,6 +3569,39 @@ static std::vector<VirtualRanges::Range> RequireGuestRuntimeMemory(uint64_t vadd
 	return ranges;
 }
 
+static void RegisterCETCompatibleDynamicRange(uint64_t vaddr, uint64_t size) {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	using SetProcessDynamicEnforcedCetCompatibleRanges_t = BOOL(WINAPI*)(
+	    HANDLE, USHORT, const PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE*);
+	static const auto func = [] {
+		const auto kernel32 = GetModuleHandleW(L"kernel32.dll");
+		return kernel32 == nullptr
+		           ? static_cast<SetProcessDynamicEnforcedCetCompatibleRanges_t>(nullptr)
+		           : reinterpret_cast<SetProcessDynamicEnforcedCetCompatibleRanges_t>(
+		                 GetProcAddress(kernel32, "SetProcessDynamicEnforcedCetCompatibleRanges"));
+	}();
+	static bool error_logged = false;
+	if (func == nullptr || vaddr == 0 || size == 0) {
+		return;
+	}
+	PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE range{};
+	range.BaseAddress = static_cast<UINT_PTR>(vaddr);
+	range.Size        = static_cast<SIZE_T>(size);
+	range.Flags       = DYNAMIC_ENFORCED_ADDRESS_RANGE_ADD;
+	const auto ok = func(GetCurrentProcess(), 1, &range);
+	if ((!ok || (range.Flags & DYNAMIC_ENFORCED_ADDRESS_RANGE_PROCESSED) == 0) &&
+	    !error_logged) {
+		error_logged = true;
+		LOGF("SetProcessDynamicEnforcedCetCompatibleRanges(0x%016" PRIx64 ", 0x%016" PRIx64
+		     ") failed: %u\n",
+		     vaddr, size, static_cast<uint32_t>(GetLastError()));
+	}
+#else
+	(void)vaddr;
+	(void)size;
+#endif
+}
+
 static uint64_t AllocateGuestRuntimeMemory(uint64_t search_addr, uint64_t size,
                                            VirtualMemory::Mode mode, const char* name,
                                            VirtualRangeType type, bool fixed) {
@@ -3594,6 +3627,9 @@ static uint64_t AllocateGuestRuntimeMemory(uint64_t search_addr, uint64_t size,
 		return 0;
 	}
 	MapGpuRange(vaddr, mapped_size);
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	RegisterCETCompatibleDynamicRange(vaddr, mapped_size);
+#endif
 	return vaddr;
 }
 

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -829,6 +829,21 @@ static bool KytyExceptionHandler(const Common::HostException::ExceptionInfo& exc
 		        info->access_violation_vaddr)) {
 			return true;
 		}
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+		MEMORY_BASIC_INFORMATION fault_mbi = {};
+		if (VirtualQuery(reinterpret_cast<const void*>(info->access_violation_vaddr), &fault_mbi,
+		                 sizeof(fault_mbi)) != 0) {
+			LOGF("fault-va: state=%u protect=0x%08" PRIx32 " type=%u base=0x%016" PRIx64
+			     " size=0x%016" PRIx64 "\n",
+			     static_cast<uint32_t>(fault_mbi.State),
+			     static_cast<uint32_t>(fault_mbi.Protect), static_cast<uint32_t>(fault_mbi.Type),
+			     reinterpret_cast<uint64_t>(fault_mbi.BaseAddress),
+			     reinterpret_cast<uint64_t>(fault_mbi.RegionSize));
+		} else {
+			LOGF("fault-va: VirtualQuery failed\n");
+		}
+#endif
 	}
 
 	LOGF("kyty_exception_handler: %016" PRIx64 "\n", info->exception_address);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,10 +12,31 @@
 
 #include <charconv>
 #include <cstdio>
+#include <exception>
 #include <fmt/format.h>
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+#include <windows.h>
+#endif
 
 using namespace Common;
 using namespace Emulator;
+
+static void TerminateHandler() {
+	std::printf("[TERM-MARK] std::terminate: unhandled exception\n");
+	fflush(stdout);
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	void*      frames[48] {};
+	const auto frame_count =
+	    CaptureStackBackTrace(0, static_cast<DWORD>(std::size(frames)), frames, nullptr);
+	for (uint16_t i = 0; i < frame_count; i++) {
+		const auto address = reinterpret_cast<uintptr_t>(frames[i]);
+		std::printf("[TERM-MARK]   frame[%u]=0x%016" PRIxPTR "\n", i, address);
+	}
+	fflush(stdout);
+#endif
+	std::_Exit(9);
+}
 
 static std::string GetBuildString() {
 	Date date = Date::FromMacros(std::string(__DATE__));
@@ -278,6 +299,8 @@ int main(int argc, char* argv[]) {
 	auto& slist = *SubsystemsList::Instance();
 
 	slist.SetArgs(argc, argv);
+
+	std::set_terminate(TerminateHandler);
 
 	auto* core    = CommonSubsystem::Instance();
 	auto* threads = ThreadsSubsystem::Instance();


### PR DESCRIPTION
### Summary

Includes several fixes from @Almo7aya (I was working on his branch trying to
understand why some titles wouldn't work for me), plus the Windows 11 24H2
crash fix I found along the way and some build/diagnostic housekeeping.

---

#### Commit per commit

**gpu: bind storage buffers to the mapped extent** (from @Almo7aya)
GNM buffer descriptors routinely over-provision `num_records` (often ~UINT32_MAX),
but the nominal footprint was handed straight to the buffer cache, which tried to
stage/track/map memory the guest never mapped. Depending on where it landed it
caused random-looking access violations or invalid tracker ranges. Now binds the
contiguous mapped extent instead (with `RangeSet::ContiguousExtent` +
`MappedExtent`), clamps when the footprint exceeds `maxStorageBufferRange` instead
of failing hard, and reports once on stdout. Vulkan robust buffer access returns
zeros past the end, which is what the guest's own bounds checks already assume.

**fix(gpu): bind an indexed fetch past its record count** (from @Almo7aya)
Skinned meshes rendered torn: part posed correctly, rest collapsed onto the
origin. The bone-matrix descriptor described fewer records than the mesh
indexed, so bones past the end read zero matrices. Read-only stride-bearing
descriptors now get the mapped extent instead of exactly `stride * num_records`,
capped at 64 KB (a thousand-odd matrices, well past any real mesh, and bounded so
the buffer cache's write-protection doesn't reach unrelated game data).

**fix(gpu): do not let a zero record count bind nothing at all** (from @Almo7aya)
`num_records = 0` hit the empty-footprint shortcut and bound the null buffer, so
the whole mesh collapsed. The indexed read-only fetch is now exempt from that
shortcut and the mapping is asked for instead of taking the descriptor at its
word. Removes the last of the skinned-mesh deformation.

**fix(gpu): keep the indexed-fetch binding on compute too** (from @Almo7aya)
Skinning also happens in a compute skin-cache pass that reads the same bone
matrices, so excluding compute brought the tear straight back. Compute included.

**fix(win): resume guest continuations on Windows 11 24H2** (mine)
On Win11 24H2, `EXCEPTION_CONTINUE_EXECUTION` is dispatched through
`ntdll!RtlGuardRestoreContext`, which validates the continuation RSP against the
thread's TEB stack bounds (`RtlGuardIsValidStackPointer`) and fail-fasts the
process with `0xc0000409 / FAST_FAIL_INVALID_SET_OF_CONTEXT` for any guest-mode
RSP. The fix sets the process shadow-stack policy byte (`LdrSystemDllInitBlock+0x9c`)
so the validation is skipped, redirects the resume through a per-thread
trampoline (host RSP given to the dispatcher, guest RSP swapped back in before
jumping to the guest RIP, without touching any GPR), normalizes `ContextFlags` so
the restore takes the pure user-mode path instead of `NtContinue`, and registers
the dynamic guest ranges as CET-compatible (best-effort, log-only on failure).

**fix: surface unhandled host exceptions with more context** (mine)
Added a `std::terminate` handler that prints a backtrace and exits with a
distinct code instead of the default abort, and on an unresolved access
violation the faulting region's state/protection is logged via `VirtualQuery`
so crashes are easier to diagnose remotely.

**build: add generic Windows build scripts** (mine)
Replaced machine-specific scripts with generic ones that work for anyone:
`configure-windows.bat` finds the MSVC environment via `vswhere` and
auto-detects Qt under `C:\Qt`, `build-windows.bat` builds/installs the launcher,
`fix-submodules.bat` re-checks-out every submodule at the committed SHA.

**chore: ignore emulator runtime data** (mine)
`.gitignore` now covers the download cache, shader cache, misc runtime dirs and
PDB files.