### PR TITLE
Bringup fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,7 @@ if(BUILD_TESTING)
 		resource_tracking_tests
 		event_queue_lifetime_tests
 		sync_on_address_tests
+		audio_out2_port_tests
 		shader_recompiler_compute_tests
 		virtual_memory_allocation_tests
 	)

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -1688,14 +1688,14 @@ void Gpu::SendCommandSync(Common::UniqueFunction<void>&& command) {
 
 void Gpu::Submit(uint32_t* draw_commands, uint32_t draw_size_dw, uint32_t* constant_commands,
                  uint32_t constant_size_dw, bool trigger_agc_interrupt_on_done) {
-	EXIT_IF(draw_commands == nullptr || draw_size_dw == 0);
+	EXIT_IF(draw_commands == nullptr && draw_size_dw != 0);
 	m_state->Submit(draw_commands, draw_size_dw, constant_commands, constant_size_dw,
 	                trigger_agc_interrupt_on_done);
 }
 
 void Gpu::SubmitCompute(uint32_t queue, uint32_t* commands, uint32_t size_dw,
                         bool trigger_agc_interrupt_on_done) {
-	EXIT_IF(commands == nullptr || size_dw == 0);
+	EXIT_IF(commands == nullptr && size_dw != 0);
 	m_state->SubmitCompute(queue, commands, size_dw, trigger_agc_interrupt_on_done);
 }
 

--- a/src/graphics/host_gpu/graphicContext.h
+++ b/src/graphics/host_gpu/graphicContext.h
@@ -25,7 +25,9 @@ struct GraphicContext: public VulkanInstance {
 	[[nodiscard]] uint64_t GetTotalMemoryBudget() const;
 	void                   CreateBuffer(uint64_t size, VulkanBuffer& buffer);
 	void                   DeleteBuffer(VulkanBuffer& buffer);
-	[[nodiscard]] bool     CreateImage(const vk::ImageCreateInfo& info, VulkanImage& image);
+	[[nodiscard]] bool     CreateImage(const vk::ImageCreateInfo& info, VulkanImage& image,
+	                                   vk::Result* out_result = nullptr);
+	[[nodiscard]] std::string DescribeMemoryBudget() const;
 	void                   DeleteImage(VulkanImage& image);
 	void                   MapMemory(VulkanMemory& memory, void*& data);
 	void                   UnmapMemory(VulkanMemory& memory);

--- a/src/graphics/host_gpu/rangeSet.h
+++ b/src/graphics/host_gpu/rangeSet.h
@@ -59,6 +59,24 @@ public:
 		return result;
 	}
 
+	// Bytes present contiguously from `address`, capped at `size`; 0 if `address` is absent.
+	// Ranges are kept merged, so one lookup already spans the whole extent.
+	[[nodiscard]] uint64_t ContiguousFrom(uint64_t address, uint64_t size) const {
+		if (address == 0 || size == 0 || size > UINT64_MAX - address) {
+			return 0;
+		}
+		const auto end = address + size;
+		auto       it  = m_ranges.upper_bound(address);
+		if (it == m_ranges.begin()) {
+			return 0;
+		}
+		--it;
+		if (it->first > address || it->second <= address) {
+			return 0;
+		}
+		return std::min(it->second, end) - address;
+	}
+
 	[[nodiscard]] bool Contains(uint64_t address, uint64_t size) const {
 		const auto end = End(address, size);
 		auto       it  = m_ranges.upper_bound(address);

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -87,6 +87,7 @@ struct BufferCache::DownloadRange {
 	uint64_t address = 0;
 	uint64_t size    = 0;
 	uint64_t offset  = 0;
+	std::shared_ptr<Buffer> staging;
 };
 
 struct BufferCache::RetiredBuffer {
@@ -131,11 +132,18 @@ BufferCache::RecordDownloads(std::span<const DownloadCopy> copies) {
 		return {};
 	}
 
-	auto& download                   = m_download_buffer;
-	const auto [mapped, base_offset] = download.Map(reservation_size, DOWNLOAD_ALIGNMENT);
+	auto [mapped, base_offset] = m_download_buffer.Map(reservation_size, DOWNLOAD_ALIGNMENT);
+	std::shared_ptr<Buffer> staging;
 	if (mapped == nullptr) {
-		EXIT("BufferCache: download batch could not reserve the shared stream\n");
+		staging = std::make_shared<Buffer>(m_graphics, m_scheduler, MemoryUsage::Download, 0,
+		                                   AllFlags, reservation_size);
+		if (staging->Mapped().empty()) {
+			EXIT("BufferCache: download batch could not reserve %" PRIu64 " bytes of staging\n",
+			     reservation_size);
+		}
+		base_offset = 0;
 	}
+	Buffer& download = staging != nullptr ? *staging : m_download_buffer;
 
 	std::vector<DownloadRange> downloads;
 	downloads.reserve(copies.size());
@@ -147,18 +155,21 @@ BufferCache::RecordDownloads(std::span<const DownloadCopy> copies) {
 		                  envelope_size, vk::AccessFlagBits::eMemoryWrite, vk::AccessFlags {},
 		                  vk::AccessFlagBits::eMemoryRead | vk::AccessFlagBits::eMemoryWrite,
 		                  vk::AccessFlagBits::eHostRead);
-		downloads.push_back({copy.address, copy.size, base_offset + cursor + prefix});
+		downloads.push_back({copy.address, copy.size, base_offset + cursor + prefix, staging});
 		cursor += AlignDownload(envelope_size);
 	}
-	download.Commit();
+	if (staging == nullptr) {
+		m_download_buffer.Commit();
+	}
 	return downloads;
 }
 
 void BufferCache::PublishDownloads(std::span<const DownloadRange> downloads) {
 	for (const auto& range: downloads) {
-		m_download_buffer.Invalidate(range.offset, range.size);
+		Buffer& source = range.staging != nullptr ? *range.staging : m_download_buffer;
+		source.Invalidate(range.offset, range.size);
 		Libs::LibKernel::Memory::WriteBacking(
-		    range.address, m_download_buffer.Mapped().data() + range.offset, range.size);
+		    range.address, source.Mapped().data() + range.offset, range.size);
 	}
 }
 

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -844,6 +844,8 @@ bool BufferCache::IsRegionCpuModified(uint64_t vaddr, uint64_t size) {
 
 void BufferCache::RunGarbageCollector() {
 	const auto tick = m_gc_tick++;
+	// Runs at a submission boundary, the one point where flushing the recorded work is safe.
+	m_scheduler.ThrottleDeviceMemory();
 	if (m_graphics.CanReportMemoryUsage()) {
 		m_total_used_memory = m_graphics.GetDeviceMemoryUsage();
 	}

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -732,13 +732,36 @@ void BufferCache::CopyBuffer(uint64_t dst_vaddr, uint64_t src_vaddr, uint64_t si
                              bool src_gds) {
 	const bool dst_memory = !dst_gds;
 	const bool src_memory = !src_gds;
-	if ((dst_memory && dst_vaddr == 0) || (src_memory && src_vaddr == 0) || size == 0 ||
-	    ((dst_gds || src_gds) && ((dst_vaddr | src_vaddr | size) & 3u) != 0) ||
-	    size > UINT64_MAX - dst_vaddr || size > UINT64_MAX - src_vaddr || (dst_gds && src_gds) ||
-	    (dst_gds == src_gds && src_vaddr < dst_vaddr + size && dst_vaddr < src_vaddr + size) ||
-	    (dst_gds && (dst_vaddr > m_gds_buffer.Size() || size > m_gds_buffer.Size() - dst_vaddr)) ||
+	const auto reject = [&](const char* reason) {
+		EXIT("BufferCache: %s: dst=0x%016" PRIx64 " (gds=%d) src=0x%016" PRIx64
+		     " (gds=%d) size=0x%016" PRIx64 " gds_size=0x%016" PRIx64 "\n",
+		     reason, dst_vaddr, static_cast<int>(dst_gds), src_vaddr, static_cast<int>(src_gds),
+		     size, m_gds_buffer.Size());
+	};
+	if (size == 0) {
+		reject("copy of zero bytes");
+	}
+	if ((dst_memory && dst_vaddr == 0) || (src_memory && src_vaddr == 0)) {
+		reject("copy with a null memory address");
+	}
+	if (size > UINT64_MAX - dst_vaddr || size > UINT64_MAX - src_vaddr) {
+		reject("copy range overflows");
+	}
+	if (dst_gds && src_gds) {
+		reject("GDS-to-GDS copy");
+	}
+	if ((dst_gds || src_gds) && ((dst_vaddr | src_vaddr | size) & 3u) != 0) {
+		reject("GDS copy is not dword aligned");
+	}
+	if ((dst_gds && (dst_vaddr > m_gds_buffer.Size() || size > m_gds_buffer.Size() - dst_vaddr)) ||
 	    (src_gds && (src_vaddr > m_gds_buffer.Size() || size > m_gds_buffer.Size() - src_vaddr))) {
-		EXIT("BufferCache: invalid or overlapping copy range\n");
+		reject("GDS copy is out of bounds");
+	}
+	if (dst_gds == src_gds && src_vaddr < dst_vaddr + size && dst_vaddr < src_vaddr + size) {
+		if (src_vaddr == dst_vaddr) {
+			return;
+		}
+		reject("copy ranges overlap partially");
 	}
 	if (src_memory || dst_memory) {
 		const auto src_region =

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -43,6 +43,15 @@ bool GpuResourceManager::IsMapped(uint64_t vaddr, uint64_t size) const noexcept 
 	return m_mapped_ranges.Contains(vaddr, size);
 }
 
+uint64_t GpuResourceManager::MappedExtent(uint64_t vaddr, uint64_t size) const noexcept {
+	if (vaddr == 0 || size == 0 || vaddr >= TRACKER_ADDRESS_SIZE ||
+	    size > TRACKER_ADDRESS_SIZE - vaddr) {
+		return 0;
+	}
+	std::shared_lock lock(m_mapped_ranges_mutex);
+	return m_mapped_ranges.ContiguousFrom(vaddr, size);
+}
+
 void GpuResourceManager::MapMemory(uint64_t vaddr, uint64_t size) {
 	{
 		std::lock_guard lock(m_mapped_ranges_mutex);

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
@@ -28,6 +28,8 @@ public:
 	[[nodiscard]] bool HandleFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept;
 	[[nodiscard]] bool InvalidateMemory(uint64_t vaddr, uint64_t size);
 	[[nodiscard]] bool IsMapped(uint64_t vaddr, uint64_t size) const noexcept;
+	// Bytes mapped contiguously from `vaddr`, capped at `size`; 0 when `vaddr` is not mapped.
+	[[nodiscard]] uint64_t MappedExtent(uint64_t vaddr, uint64_t size) const noexcept;
 	void               MapMemory(uint64_t vaddr, uint64_t size);
 	void               UnmapMemory(uint64_t vaddr, uint64_t size);
 	void               RunGarbageCollector();

--- a/src/graphics/host_gpu/renderer/cache/streamBuffer.cpp
+++ b/src/graphics/host_gpu/renderer/cache/streamBuffer.cpp
@@ -310,13 +310,13 @@ void StreamBuffer::Commit() {
 	watch.tick        = tick;
 }
 
-void StreamBuffer::Invalidate(uint64_t offset, uint64_t size) {
-	EXIT_IF(Usage() != MemoryUsage::Download || offset > Size() || size > Size() - offset);
-	if (IsCoherent() || size == 0) {
+void Buffer::Invalidate(uint64_t offset, uint64_t size) {
+	EXIT_IF(m_usage != MemoryUsage::Download || offset > m_size || size > m_size - offset);
+	if (m_is_coherent || size == 0) {
 		return;
 	}
-	const auto result = vmaInvalidateAllocation(Graphics().allocator,
-	                                            NativeBuffer().memory.allocation, offset, size);
+	const auto result =
+	    vmaInvalidateAllocation(m_graphics->allocator, m_buffer->memory.allocation, offset, size);
 	EXIT_NOT_IMPLEMENTED(static_cast<vk::Result>(result) != vk::Result::eSuccess);
 }
 

--- a/src/graphics/host_gpu/renderer/cache/streamBuffer.h
+++ b/src/graphics/host_gpu/renderer/cache/streamBuffer.h
@@ -54,6 +54,9 @@ public:
 	[[nodiscard]] bool IsInBounds(uint64_t address, uint64_t size) const noexcept;
 	void               Write(uint64_t offset, const void* source, uint64_t size);
 	void               Flush(uint64_t offset, uint64_t size);
+	// Download mappings become visible to the CPU only after their GPU completion tick is free.
+	// Call this from the scheduler's deferred completion operation before reading Mapped().
+	void Invalidate(uint64_t offset, uint64_t size);
 	void CopyFrom(CommandBuffer& command, const Buffer& source, uint64_t source_offset,
 	              uint64_t destination_offset, uint64_t size,
 	              vk::AccessFlags source_before      = vk::AccessFlagBits::eMemoryWrite,
@@ -93,9 +96,6 @@ public:
 	[[nodiscard]] std::pair<uint8_t*, uint64_t> Map(uint64_t size, uint64_t alignment = 0,
 	                                                bool allow_wait = true);
 	void                                        Commit();
-	// Download mappings become visible to the CPU only after their GPU completion tick is free.
-	// Call this from the scheduler's deferred completion operation before reading Mapped().
-	void                   Invalidate(uint64_t offset, uint64_t size);
 	[[nodiscard]] uint64_t Copy(const void* source, uint64_t size, uint64_t alignment = 0);
 
 private:

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -701,7 +701,14 @@ ImageId TextureCache::ResolveDepthOverlap(const ImageInfo& requested, BindingTyp
 	const bool bpp_match     = requested.bytes_per_block == cached.info.bytes_per_block;
 	bool       recreate      = cached.info.resources < requested.resources;
 	switch (binding) {
-		case BindingType::Texture: recreate |= requested.IsDepth() && !cached.info.IsDepth(); break;
+		case BindingType::Texture:
+			recreate |= requested.IsDepth() && !cached.info.IsDepth();
+			if (!requested.IsDepth() && cached.info.IsDepth() &&
+			    !IsSupportedSampledDepthFormat(cached.info.pixel_format, requested.guest_format,
+			                                   requested.pixel_format)) {
+				return {};
+			}
+			break;
 		case BindingType::Storage: recreate |= cached.info.IsDepth(); break;
 		case BindingType::RenderTarget: recreate |= cached.info.IsDepth(); break;
 		case BindingType::DepthTarget:

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1942,7 +1942,7 @@ void TextureCache::RunGarbageCollector() {
 	const auto collect = [&](bool allow_aggressive) {
 		bool           pressured  = m_total_used_memory >= m_pressure_gc_memory;
 		bool           aggressive = allow_aggressive && m_total_used_memory >= m_critical_gc_memory;
-		const uint64_t age       = std::min<uint64_t>(aggressive ? 160 : pressured ? 80 : 16, tick);
+		const uint64_t age       = std::min<uint64_t>(aggressive ? 16 : pressured ? 80 : 160, tick);
 		size_t         deletions = aggressive ? 40 : pressured ? 20 : 10;
 		std::vector<ImageId> candidates;
 		candidates.reserve(deletions);
@@ -1963,13 +1963,14 @@ void TextureCache::RunGarbageCollector() {
 			}
 			if (owner->IsGpuModified()) {
 				const bool safe = SafeToDownload(*owner);
-				if (safe && owner->info.IsTiled()) {
+				const bool keep_tiled = safe && owner->info.IsTiled();
+				if (keep_tiled && !aggressive) {
 					continue;
 				}
 				if (safe && !pressured) {
 					continue;
 				}
-				if (safe && !TryDownloadImage(id)) {
+				if (safe && !keep_tiled && !TryDownloadImage(id)) {
 					continue;
 				}
 				ClearGpuModified(id);

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1007,7 +1007,7 @@ void TextureCache::UploadImage(Image& image, const ImageDesc& desc, Buffer& sour
 		image.Upload(copies, linear.buffer, linear.offset, linear.size);
 	};
 
-	if (desc.type != BindingType::DepthTarget) {
+	if (!info.IsDepth() && desc.type != BindingType::DepthTarget) {
 		auto plan = BuildColorTransfer(image, desc.type, TransferDirection::Upload);
 		if (!plan.valid) {
 			EXIT("TextureCache: invalid color upload: binding=%u addr=0x%016" PRIx64
@@ -1031,10 +1031,15 @@ void TextureCache::UploadImage(Image& image, const ImageDesc& desc, Buffer& sour
 		return;
 	}
 
-	if (desc.type != BindingType::DepthTarget || info.samples != 1 || image.backing.samples != 1 ||
+	if (!info.IsDepth() || info.samples != 1 || image.backing.samples != 1 ||
 	    info.resources.layers == 0 || info.data.size % info.resources.layers != 0 ||
 	    Prospero::NumBytesPerElement(info.guest_format) != info.bytes_per_block) {
-		EXIT("TextureCache: invalid depth upload\n");
+		EXIT("TextureCache: invalid depth upload: binding=%u format=%u bytes_per_block=%u "
+		     "samples=%u/%u layers=%u addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",
+		     static_cast<uint32_t>(desc.type), static_cast<uint32_t>(info.guest_format),
+		     info.bytes_per_block,
+		     info.samples, image.backing.samples, info.resources.layers, info.data.address,
+		     info.data.size);
 	}
 	TileBlockLayout block {};
 	EXIT_NOT_IMPLEMENTED(

--- a/src/graphics/host_gpu/renderer/commandScheduler.cpp
+++ b/src/graphics/host_gpu/renderer/commandScheduler.cpp
@@ -102,6 +102,9 @@ CommandScheduler::CommandScheduler(RenderContext& context, GraphicContext& graph
       m_priority_thread([this](std::stop_token stop) { PriorityOperationsThread(stop); }) {
 	m_buffers.reserve(CommandBufferGrowStep);
 	m_buffer_ticks.reserve(CommandBufferGrowStep);
+	if (m_graphics.CanReportMemoryUsage()) {
+		m_memory_throttle_bytes = (m_graphics.GetTotalMemoryBudget() / 4) * 3;
+	}
 }
 
 CommandScheduler::~CommandScheduler() {
@@ -238,6 +241,48 @@ void CommandScheduler::PopPendingOperations() {
 	PopPendingOperations(true);
 }
 
+void CommandScheduler::ThrottleDeviceMemory() {
+	// A deferred callback must never block; its caller is the drain loop.
+	if (m_memory_throttle_bytes == 0 || g_deferred_callback_scheduler == this || !Active() ||
+	    !m_recording) {
+		return;
+	}
+	// Bounded so a working set that genuinely exceeds the budget stalls rather than spins.
+	for (int attempt = 0; attempt < 4; attempt++) {
+		if (m_graphics.GetDeviceMemoryUsage() <= m_memory_throttle_bytes) {
+			return;
+		}
+		FinishCurrent();
+	}
+}
+
+void CommandScheduler::ThrottlePendingOperations() {
+	// A deferred callback must never block: the drain loop that would release it is its caller.
+	if (g_deferred_callback_scheduler == this) {
+		return;
+	}
+	for (;;) {
+		uint64_t oldest_tick = 0;
+		size_t   pending     = 0;
+		{
+			std::lock_guard lock(m_operation_mutex);
+			pending = m_pending_operations.size();
+			if (pending <= MaxPendingOperations) {
+				return;
+			}
+			oldest_tick = m_pending_operations.front().tick;
+		}
+		// Must not skip ticks belonging to the buffer still being recorded: a burst queues its
+		// destroys inside one submission, so that is the whole backlog. Wait() submits it first.
+		Wait(oldest_tick);
+		std::lock_guard lock(m_operation_mutex);
+		if (m_pending_operations.size() >= pending) {
+			// No progress; do not spin.
+			return;
+		}
+	}
+}
+
 void CommandScheduler::PopPendingOperations(bool refresh_gpu_tick) {
 	if (refresh_gpu_tick) {
 		m_master.Refresh();
@@ -260,6 +305,7 @@ void CommandScheduler::PopPendingOperations(bool refresh_gpu_tick) {
 void CommandScheduler::DeferOperation(Common::UniqueFunction<void>&& operation) {
 	CheckActive();
 	EXIT_IF(!operation);
+	ThrottlePendingOperations();
 	std::unique_lock lock(m_operation_mutex);
 	if (m_operation_state == OperationState::Open) {
 		m_pending_operations.push({std::move(operation), CurrentTick()});

--- a/src/graphics/host_gpu/renderer/commandScheduler.h
+++ b/src/graphics/host_gpu/renderer/commandScheduler.h
@@ -54,6 +54,7 @@ public:
 	void                      DeferOperation(Common::UniqueFunction<void>&& operation);
 	void                      DeferPriorityOperation(Common::UniqueFunction<void>&& operation);
 	[[nodiscard]] static bool InDeferredOperation() noexcept;
+	void                      ThrottleDeviceMemory();
 
 	[[nodiscard]] bool            Active() const noexcept { return m_current >= 0; }
 	void                          CheckActive() const;
@@ -65,6 +66,16 @@ public:
 
 private:
 	static constexpr size_t CommandBufferGrowStep = 4;
+
+	// Deferred destroys are the only thing releasing device memory, and they run only once the
+	// GPU passes their tick. Unbounded, a streaming burst allocates far past the budget while
+	// nothing can be reclaimed. Measured 0-1 in steady state, 83 at the point of exhaustion.
+	static constexpr size_t MaxPendingOperations = 32;
+
+	void ThrottlePendingOperations();
+
+	// Bytes, not object counts: pinned resources range from kilobytes to tens of megabytes.
+	uint64_t m_memory_throttle_bytes = 0;
 
 	class CommandPool {
 	public:

--- a/src/graphics/host_gpu/renderer/image/image.cpp
+++ b/src/graphics/host_gpu/renderer/image/image.cpp
@@ -10,12 +10,16 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <xxhash.h>
 
 namespace Libs::Graphics {
 
 namespace {
+
+std::atomic<uint64_t> g_live_image_count {0};
+std::atomic<uint64_t> g_live_image_bytes {0};
 
 [[nodiscard]] vk::ImageType HostImageType(Prospero::ImageType type) {
 	switch (type) {
@@ -706,10 +710,23 @@ Image::Image(GraphicContext& graphics, CommandScheduler& scheduler, const ImageI
 	}
 
 	backing.memory.property = vk::MemoryPropertyFlagBits::eDeviceLocal;
-	if (!graphics.CreateImage(create, backing)) {
-		EXIT("failed to create image: extent=%ux%ux%u format=%d layers=%u levels=%u\n",
-		     create.extent.width, create.extent.height, create.extent.depth,
-		     static_cast<int>(create.format), create.arrayLayers, create.mipLevels);
+	vk::Result create_result = vk::Result::eSuccess;
+	if (graphics.CreateImage(create, backing, &create_result)) {
+		g_live_image_count.fetch_add(1, std::memory_order_relaxed);
+		g_live_image_bytes.fetch_add(backing.memory.allocation_info.size,
+		                             std::memory_order_relaxed);
+	} else {
+		const auto budget = graphics.DescribeMemoryBudget();
+		EXIT("failed to create image: %s extent=%ux%ux%u format=%d layers=%u levels=%u "
+		     "usage=0x%x flags=0x%x samples=%u addr=0x%016" PRIx64 " size=0x%016" PRIx64
+		     "\n\tlive images: %" PRIu64 " holding %" PRIu64 " bytes\n\tvma: %s\n",
+		     vk::to_string(create_result).c_str(), create.extent.width, create.extent.height,
+		     create.extent.depth, static_cast<int>(create.format), create.arrayLayers,
+		     create.mipLevels, static_cast<vk::ImageUsageFlags::MaskType>(create.usage),
+		     static_cast<vk::ImageCreateFlags::MaskType>(create.flags), backing.samples,
+		     info.data.address, info.data.size,
+		     g_live_image_count.load(std::memory_order_relaxed),
+		     g_live_image_bytes.load(std::memory_order_relaxed), budget.c_str());
 	}
 }
 
@@ -747,6 +764,9 @@ Image::~Image() {
 		views.views.clear();
 	}
 	if (backing.image != nullptr) {
+		g_live_image_count.fetch_sub(1, std::memory_order_relaxed);
+		g_live_image_bytes.fetch_sub(backing.memory.allocation_info.size,
+		                             std::memory_order_relaxed);
 		m_graphics->DeleteImage(backing);
 	}
 }

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -91,11 +91,25 @@ static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& com
 	if (stride != 0 && records > UINT64_MAX / stride) {
 		EXIT("storage buffer descriptor footprint overflow\n");
 	}
-	const auto size = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
-	if (address == 0 || size == 0) {
+	const auto footprint = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
+	if (address == 0 || footprint == 0) {
 		BindNullStorageBuffer(context, result);
 		return result;
 	}
+
+	uint64_t accessible = 0;
+	if (!HostMemoryQueryRange(address, footprint, HostMemoryAccess::Mapped, accessible)) {
+		static std::atomic_int unmapped_count = 0;
+		if (unmapped_count++ < 32) {
+			LOGF("storage buffer descriptor is not host-accessible: base=0x%016" PRIx64
+			     ", size=0x%016" PRIx64 "\n",
+			     address, footprint);
+		}
+		BindNullStorageBuffer(context, result);
+		return result;
+	}
+	const auto size = std::min(footprint, accessible);
+
 	const auto& graphics  = context.GetGraphics();
 	const auto  alignment = graphics.StorageMinAlignment();
 	if (alignment == 0 ||

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -97,8 +97,13 @@ static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& com
 		return result;
 	}
 
-	uint64_t accessible = 0;
-	if (!HostMemoryQueryRange(address, footprint, HostMemoryAccess::Mapped, accessible)) {
+
+	uint64_t accessible = context.GetGpuResources().MappedExtent(address, footprint);
+	bool     mapped     = accessible != 0;
+	if (accessible < footprint) {
+		mapped = HostMemoryQueryRange(address, footprint, HostMemoryAccess::Mapped, accessible);
+	}
+	if (!mapped) {
 		static std::atomic_int unmapped_count = 0;
 		if (unmapped_count++ < 32) {
 			LOGF("storage buffer descriptor is not host-accessible: base=0x%016" PRIx64

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -713,9 +713,18 @@ RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageResource&   reso
 	                                     ? storage_view_format
 	                                     : pixel_format;
 	const auto block_bytes         = Prospero::BlockCompressedBytesPerBlock(format);
+
+	const auto* depth_policy =
+	    !storage && resource.depth_compare && IsSupportedSampledDepthResource(resource)
+	        ? FindGuestDepthFormatPolicy(format)
+	        : nullptr;
+	if (depth_policy != nullptr && depth_policy->sampled_view_format != pixel_format) {
+		depth_policy = nullptr;
+	}
 	TextureCache::ImageDesc desc {};
-	desc.info.data         = {address, size.size};
-	desc.info.pixel_format = pixel_format;
+	desc.info.data = {address, size.size};
+	desc.info.pixel_format =
+	    depth_policy != nullptr ? depth_policy->depth_attachment_format : pixel_format;
 	desc.info.guest_format = format;
 	desc.info.type         = TextureBaseType(type);
 	desc.info.extent       = {width, height, volume ? depth : 1u};

--- a/src/graphics/host_gpu/vma.cpp
+++ b/src/graphics/host_gpu/vma.cpp
@@ -213,7 +213,34 @@ void GraphicContext::DeleteBuffer(VulkanBuffer& buffer) {
 	buffer.memory.offset          = 0;
 }
 
-bool GraphicContext::CreateImage(const vk::ImageCreateInfo& image_info, VulkanImage& image) {
+std::string GraphicContext::DescribeMemoryBudget() const {
+	if (allocator == nullptr || physical_device == nullptr) {
+		return "unavailable";
+	}
+	const auto& properties = GetPhysicalDeviceMemoryProperties();
+	VmaBudget   budgets[VK_MAX_MEMORY_HEAPS] {};
+	vmaGetHeapBudgets(allocator, budgets);
+	std::string text;
+	for (uint32_t i = 0; i < properties.memoryHeapCount; i++) {
+		text += fmt::format("[heap {} usage={} budget={} allocated={} blocks={}]", i,
+		                    static_cast<uint64_t>(budgets[i].usage),
+		                    static_cast<uint64_t>(budgets[i].budget),
+		                    static_cast<uint64_t>(budgets[i].statistics.allocationBytes),
+		                    static_cast<uint64_t>(budgets[i].statistics.blockBytes));
+	}
+	for (uint32_t i = 0; i < properties.memoryTypeCount; i++) {
+		const auto bytes = g_memory_stats.allocated[i].load(std::memory_order_relaxed);
+		const auto count = g_memory_stats.count[i].load(std::memory_order_relaxed);
+		if (count != 0) {
+			text += fmt::format("[type {} heap {} count={} bytes={}]", i,
+			                    properties.memoryTypes[i].heapIndex, count, bytes);
+		}
+	}
+	return text;
+}
+
+bool GraphicContext::CreateImage(const vk::ImageCreateInfo& image_info, VulkanImage& image,
+                                 vk::Result* out_result) {
 	KYTY_PROFILER_FUNCTION();
 	EXIT_IF(allocator == nullptr || image.image != nullptr || image.memory.allocation != nullptr);
 
@@ -228,6 +255,9 @@ bool GraphicContext::CreateImage(const vk::ImageCreateInfo& image_info, VulkanIm
 	    vmaCreateImage(allocator, static_cast<const vk::ImageCreateInfo::NativeType*>(image_info),
 	                   &alloc_info, &native_image, &memory.allocation, &memory.allocation_info));
 	image.image = native_image;
+	if (out_result != nullptr) {
+		*out_result = result;
+	}
 	if (result != vk::Result::eSuccess) {
 		LogMemoryBudget();
 		return false;

--- a/src/kernel/pthread.cpp
+++ b/src/kernel/pthread.cpp
@@ -1411,7 +1411,13 @@ static int NativeMutexUnlock(PthreadMutexPrivate* mutex, uint32_t* recurse = nul
 	std::unique_lock lock(mutex->m);
 
 	if (mutex->owner != self) {
-		return EPERM;
+		if (mutex->type != KERNEL_PTHREAD_MUTEX_NORMAL || mutex->owner != nullptr) {
+			return EPERM;
+		}
+		if (recurse != nullptr) {
+			*recurse = 0;
+		}
+		return OK;
 	}
 
 	if (recurse != nullptr) {

--- a/src/libs/agc.cpp
+++ b/src/libs/agc.cpp
@@ -3884,6 +3884,9 @@ static bool dcb_has_queued_interrupt(const uint32_t* dcb, uint32_t size_in_dword
 }
 
 static void submit_dcb(uint32_t* dcb, uint32_t size_in_dwords) {
+	if (dcb == nullptr) {
+		return;
+	}
 	GraphicsDbgDumpDcb("d", size_in_dwords, dcb);
 	EXIT_IF(g_renderer == nullptr);
 	g_renderer->GetGpu().Submit(dcb, size_in_dwords, nullptr, 0,

--- a/src/libs/libC.cpp
+++ b/src/libs/libC.cpp
@@ -480,13 +480,14 @@ static KYTY_SYSV_ABI int MtxInit(LibKernel::PthreadMutex* mtx, int type) {
 	}
 
 	constexpr int mtx_recursive = 0x100;
-	if ((type & mtx_recursive) == 0) {
-		return mtx_result(LibKernel::PthreadMutexInit(mtx, nullptr, nullptr));
-	}
+	constexpr int kernel_recursive = 2;
+	constexpr int kernel_normal    = 3;
+
+	const int kernel_type = (type & mtx_recursive) != 0 ? kernel_recursive : kernel_normal;
 
 	LibKernel::PthreadMutexattr attr   = nullptr;
 	int                         result = LibKernel::PthreadMutexattrInit(&attr);
-	result = (result == OK ? LibKernel::PthreadMutexattrSettype(&attr, 2) : result);
+	result = (result == OK ? LibKernel::PthreadMutexattrSettype(&attr, kernel_type) : result);
 	result = (result == OK ? LibKernel::PthreadMutexInit(mtx, &attr, nullptr) : result);
 	(void)LibKernel::PthreadMutexattrDestroy(&attr);
 

--- a/src/libs/libKernel.cpp
+++ b/src/libs/libKernel.cpp
@@ -1542,6 +1542,7 @@ int KYTY_SYSV_ABI KernelGetModuleInfoForUnwind(uint64_t addr, int flags,
 			// TODO(unwind): guest unwinding can reach a Kyty host return address below the guest VA
 			// range. Report a synthetic boundary with no unwind tables so libc stops cleanly
 			// instead of raising.
+			Loader::RecordUnwindHostBoundary(addr);
 			std::memset(info, 0, sizeof(ModuleInfoForUnwind));
 			info->st_size = sizeof(ModuleInfoForUnwind);
 			std::snprintf(info->name, sizeof(info->name), "%s", "KytyHostBoundary");

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -789,6 +789,33 @@ static bool IsDumpableRange(uint64_t addr, uint64_t size) {
 #endif
 }
 
+static std::atomic<uint64_t> g_unwind_boundary_count {0};
+static std::atomic<uint64_t> g_unwind_boundary_last {0};
+
+void RecordUnwindHostBoundary(uint64_t addr) {
+	g_unwind_boundary_count.fetch_add(1, std::memory_order_relaxed);
+	g_unwind_boundary_last.store(addr, std::memory_order_relaxed);
+}
+
+UnwindHostBoundaryStats GetUnwindHostBoundaryStats() {
+	return {g_unwind_boundary_count.load(std::memory_order_relaxed),
+	        g_unwind_boundary_last.load(std::memory_order_relaxed)};
+}
+
+static std::string GuestAddressName(uint64_t addr) {
+	if (addr == 0) {
+		return "0";
+	}
+	const auto* program = Common::Singleton<Loader::RuntimeLinker>::Instance()->FindProgramByAddr(addr);
+	if (program == nullptr || addr < program->base_vaddr) {
+		return fmt::format("{:016x}", addr);
+	}
+	return fmt::format(
+	    "{:016x} {}+0x{:x}", addr,
+	    Common::FilenameWithoutDirectory(Common::PathToGenericString(program->file_name)),
+	    addr - program->base_vaddr);
+}
+
 static bool KytyExceptionHandler(const Common::HostException::ExceptionInfo& exception_info) {
 	const auto* info = &exception_info;
 
@@ -1008,7 +1035,41 @@ static bool KytyExceptionHandler(const Common::HostException::ExceptionInfo& exc
 		return false;
 	}
 
-	EXIT("Unknown exception!!! (%08" PRIx32 ")", info->native_code);
+	std::string bytes;
+	bool        guest_trap = false;
+	if (info->exception_address != 0 && IsReadableRange(info->exception_address, 16)) {
+		const auto* code = reinterpret_cast<const uint8_t*>(info->exception_address);
+		for (uint32_t i = 0; i < 16; i++) {
+			bytes += fmt::format("{:02x} ", code[i]);
+		}
+		guest_trap = code[0] == 0x0f && code[1] == 0x0b;
+	}
+	std::string frames;
+	if (info->rbp != 0) {
+		void*     stack[20];
+		const int depth =
+		    WalkGuestStack(info->rbp, info->rsp, stack, static_cast<int>(std::size(stack)));
+		for (int i = 0; i < depth; i++) {
+			frames += fmt::format("\n\t[{}] {}", i,
+			                      GuestAddressName(reinterpret_cast<uint64_t>(stack[i])));
+		}
+	}
+
+	if (guest_trap) {
+		const auto boundaries = GetUnwindHostBoundaryStats();
+		EXIT("Guest aborted: ud2 at %016" PRIx64
+		     " (%s)\n\ta noreturn abort/terminate returned into the compiler's unreachable "
+		     "marker\n\tunwind host boundaries hit: %" PRIu64 " (last %016" PRIx64
+		     ")\n\tcode: %s\n\tguest stack:%s\n",
+		     info->exception_address, GuestAddressName(info->exception_address).c_str(),
+		     boundaries.count, boundaries.last_addr, bytes.c_str(), frames.c_str());
+		return false;
+	}
+
+	EXIT("Unknown exception!!! (%08" PRIx32 ") at %016" PRIx64 " (%s)\n\tcode: %s\n\tguest "
+	     "stack:%s\n",
+	     info->native_code, info->exception_address,
+	     GuestAddressName(info->exception_address).c_str(), bytes.c_str(), frames.c_str());
 	return false;
 }
 

--- a/src/loader/runtimeLinker.h
+++ b/src/loader/runtimeLinker.h
@@ -209,6 +209,14 @@ private:
 	application_heap_posix_memalign_func_t m_application_heap_posix_memalign = nullptr;
 };
 
+struct UnwindHostBoundaryStats {
+	uint64_t count     = 0;
+	uint64_t last_addr = 0;
+};
+
+void                    RecordUnwindHostBoundary(uint64_t addr);
+UnwindHostBoundaryStats GetUnwindHostBoundaryStats();
+
 #if defined(KYTY_VIRTUAL_MEMORY_ALLOCATION_TESTS)
 bool TestMainEntryUsesGuestStack();
 bool TestModuleRelocationUsesWritableHostMapping();

--- a/src/loader/x64InstructionEmulator.cpp
+++ b/src/loader/x64InstructionEmulator.cpp
@@ -515,7 +515,8 @@ static bool TryEmulateSse4a(PCONTEXT context) {
 		offset++;
 	}
 
-	if (rip[offset] != 0x0f || rip[offset + 1] != 0x78) {
+	const uint8_t opcode = rip[offset + 1];
+	if (rip[offset] != 0x0f || (opcode != 0x78 && opcode != 0x79)) {
 		return false;
 	}
 
@@ -524,13 +525,35 @@ static bool TryEmulateSse4a(PCONTEXT context) {
 		return false;
 	}
 
-	const uint8_t reg    = ((modrm >> 3u) & 0x07u) | ((rex & 0x04u) << 1u);
-	const uint8_t rm     = (modrm & 0x07u) | ((rex & 0x01u) << 3u);
+	const uint8_t reg = ((modrm >> 3u) & 0x07u) | ((rex & 0x04u) << 1u);
+	const uint8_t rm  = (modrm & 0x07u) | ((rex & 0x01u) << 3u);
+
+	// AMD SSE4a EXTRQ/INSERTQ. PS5 code can execute these natively on AMD hardware, while Intel
+	// hosts raise an illegal-instruction exception.
+	if (opcode == 0x79) {
+		auto* dst = GetContextXmm(context, reg);
+		auto* src = GetContextXmm(context, rm);
+		if (dst == nullptr || src == nullptr) {
+			return false;
+		}
+
+		if (prefix == 0x66) {
+			const auto control = static_cast<uint64_t>(src->Low);
+			dst->Low           = ExtractBitField(dst->Low, static_cast<uint32_t>(control),
+			                                     static_cast<uint32_t>(control >> 8u));
+			dst->High          = 0;
+		} else {
+			const auto control = static_cast<uint64_t>(src->High);
+			dst->Low = InsertBitField(dst->Low, src->Low, static_cast<uint32_t>(control),
+			                          static_cast<uint32_t>(control >> 8u));
+		}
+		context->Rip += offset + 3;
+		return true;
+	}
+
 	const uint8_t length = rip[offset + 3];
 	const uint8_t index  = rip[offset + 4];
 
-	// AMD SSE4a immediate-form EXTRQ/INSERTQ. PS5 code can execute these natively on AMD hardware,
-	// while Intel hosts raise an illegal-instruction exception.
 	if (prefix == 0x66) {
 		auto* dst = GetContextXmm(context, rm);
 		if (dst == nullptr) {
@@ -679,6 +702,10 @@ static uint64_t GetXmmLow(const uint32_t* xmm) {
 	return static_cast<uint64_t>(xmm[0]) | (static_cast<uint64_t>(xmm[1]) << 32u);
 }
 
+static uint64_t GetXmmHigh(const uint32_t* xmm) {
+	return static_cast<uint64_t>(xmm[2]) | (static_cast<uint64_t>(xmm[3]) << 32u);
+}
+
 static void SetXmmLow(uint32_t* xmm, uint64_t value) {
 	xmm[0] = static_cast<uint32_t>(value);
 	xmm[1] = static_cast<uint32_t>(value >> 32u);
@@ -710,7 +737,8 @@ static bool TryEmulateSse4a(ucontext_t* context) {
 		offset++;
 	}
 
-	if (rip[offset] != 0x0f || rip[offset + 1] != 0x78) {
+	const uint8_t opcode = rip[offset + 1];
+	if (rip[offset] != 0x0f || (opcode != 0x78 && opcode != 0x79)) {
 		return false;
 	}
 
@@ -719,12 +747,35 @@ static bool TryEmulateSse4a(ucontext_t* context) {
 		return false;
 	}
 
-	const uint8_t reg    = ((modrm >> 3u) & 0x07u) | ((rex & 0x04u) << 1u);
-	const uint8_t rm     = (modrm & 0x07u) | ((rex & 0x01u) << 3u);
+	const uint8_t reg = ((modrm >> 3u) & 0x07u) | ((rex & 0x04u) << 1u);
+	const uint8_t rm  = (modrm & 0x07u) | ((rex & 0x01u) << 3u);
+
+	// AMD SSE4a EXTRQ/INSERTQ.
+	if (opcode == 0x79) {
+		auto* dst = GetContextXmm(context, reg);
+		auto* src = GetContextXmm(context, rm);
+		if (dst == nullptr || src == nullptr) {
+			return false;
+		}
+
+		if (prefix == 0x66) {
+			const auto control = GetXmmLow(src);
+			SetXmmLow(dst, ExtractBitField(GetXmmLow(dst), static_cast<uint32_t>(control),
+			                               static_cast<uint32_t>(control >> 8u)));
+			SetXmmHigh(dst, 0);
+		} else {
+			const auto control = GetXmmHigh(src);
+			SetXmmLow(dst, InsertBitField(GetXmmLow(dst), GetXmmLow(src),
+			                              static_cast<uint32_t>(control),
+			                              static_cast<uint32_t>(control >> 8u)));
+		}
+		rip_reg += static_cast<greg_t>(offset + 3);
+		return true;
+	}
+
 	const uint8_t length = rip[offset + 3];
 	const uint8_t index  = rip[offset + 4];
 
-	// AMD SSE4a immediate-form EXTRQ/INSERTQ.
 	if (prefix == 0x66) {
 		auto* dst = GetContextXmm(context, rm);
 		if (dst == nullptr) {


### PR DESCRIPTION
## Summary

All of these changes were made and discovered when trying to make Beyond Good & Evil 20th Anniversary Edition boot/run. It went from dying on first submit to booting up, starting the game and even rendering/playing the intro cutscene.

- Accept empty DCB submissions instead of aborting.
- Clamp a storage-buffer descriptor to mapped memory.
- Depth compare sampling.
- Emulate SSE4a EXTRQ/INSERTQ register operands.
- C11 plain mutexes now get PTHREAD_MUTEX_NORMAL.
- Texture cache eviction under memory pressure fix.
- Download staging fallback for dowloads bigger than the 32Mib shared stream.
- Split DMA copy rejection into seperate cases and allowed exact self copies.
- Added a fast path for looking up storage buffer mapped ranges from stored
  records. Requests not fully covered by those records fall back to the host
  query as before.
- Added throttling for deferred destroys and device memory in flight, so a
  streaming burst can no longer allocate past the budget while nothing is
  able to be freed.


## Notes for reviewers

- Follows project contributing guidance: focused change, Windows primary build verified.