### PR TITLE
common: Ignore C++ EH exceptions (0xE06D7363) in VectoredExceptionHandler

### DIFF
--- a/src/common/hostException.cpp
+++ b/src/common/hostException.cpp
@@ -79,7 +79,8 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 	auto* exception_record = exception->ExceptionRecord;
 
 	if (exception_record->ExceptionCode == DBG_PRINTEXCEPTION_C ||
-	    exception_record->ExceptionCode == DBG_PRINTEXCEPTION_WIDE_C) {
+	    exception_record->ExceptionCode == DBG_PRINTEXCEPTION_WIDE_C ||
+	    exception_record->ExceptionCode == 0xE06D7363) {
 		return EXCEPTION_CONTINUE_SEARCH;
 	}
 


### PR DESCRIPTION
### Summary of Changes

- **Filter MSVC C++ Exception Code (`0xE06D7363`) in SEH Handler**:
  `0xE06D7363` (`STATUS_CPP_EH_EXCEPTION`) is the standard exception code raised by MSVC / Clang-CL whenever a C++ `throw` statement is executed.
  
  Previously, `VectoredExceptionHandler` in `src/common/hostException.cpp` caught all unhandled SEH exception codes and logged them as:
  ```text
  Unhandled win exception: code=0xe06d7363, addr=...
