### PR TITLE
fix: SAMPLE_C color sampling, GPU write-watch, and Windows CET guest stacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,7 @@ set(KYTY_EMULATOR_PDB_LINK_PATH "${CMAKE_CURRENT_BINARY_DIR}/kyty_emulator.pdb")
 if(KYTY_CLANG_CL)
 	target_link_options(kyty_emulator PRIVATE
 		"/DYNAMICBASE:NO"
+		"/CETCOMPAT:NO"
 		"/DEBUG:FULL"
 		"/PDB:${KYTY_EMULATOR_PDB_LINK_PATH}"
 		"/lldmap:${KYTY_EMULATOR_MAP_LINK_PATH}"

--- a/src/common/hostException.cpp
+++ b/src/common/hostException.cpp
@@ -79,7 +79,8 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 	auto* exception_record = exception->ExceptionRecord;
 
 	if (exception_record->ExceptionCode == DBG_PRINTEXCEPTION_C ||
-	    exception_record->ExceptionCode == DBG_PRINTEXCEPTION_WIDE_C) {
+	    exception_record->ExceptionCode == DBG_PRINTEXCEPTION_WIDE_C ||
+	    exception_record->ExceptionCode == 0xE06D7363) {
 		return EXCEPTION_CONTINUE_SEARCH;
 	}
 

--- a/src/common/hostException.cpp
+++ b/src/common/hostException.cpp
@@ -73,6 +73,42 @@ static Handler LoadInstalledHandler() noexcept {
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 
+// ntdll!RtlRestoreContext __fastfail(0xD) unless Context.Rsp is inside
+// TEB.StackLimit..StackBase. Guest threads run with RSP on a PS5 stack, while the
+// VEH frame itself also lives on that stack — so a "host" local is not in the TEB
+// range either. Widen the TEB bounds to the guest stack allocation instead.
+static void ExpandTebStackToInclude(uint64_t rsp) noexcept {
+	auto*          teb         = reinterpret_cast<uint8_t*>(NtCurrentTeb());
+	auto*          stack_base  = reinterpret_cast<uint64_t*>(teb + 0x08);
+	auto*          stack_limit = reinterpret_cast<uint64_t*>(teb + 0x10);
+	auto*          dealloc     = reinterpret_cast<uint64_t*>(teb + 0x1478);
+	const uint64_t base        = *stack_base;
+	const uint64_t limit       = *stack_limit;
+	if (rsp >= limit && rsp <= base) {
+		return;
+	}
+
+	uint64_t low  = rsp & ~0xFFFull;
+	uint64_t high = low + 0x1000u;
+	MEMORY_BASIC_INFORMATION mbi {};
+	if (VirtualQuery(reinterpret_cast<void*>(rsp), &mbi, sizeof(mbi)) != 0 &&
+	    mbi.State != MEM_FREE && mbi.AllocationBase != nullptr) {
+		low  = reinterpret_cast<uint64_t>(mbi.AllocationBase);
+		high = reinterpret_cast<uint64_t>(mbi.BaseAddress) + mbi.RegionSize;
+		MEMORY_BASIC_INFORMATION next {};
+		while (VirtualQuery(reinterpret_cast<void*>(high), &next, sizeof(next)) != 0 &&
+		       next.AllocationBase == mbi.AllocationBase) {
+			high = reinterpret_cast<uint64_t>(next.BaseAddress) + next.RegionSize;
+		}
+	}
+	if (high <= low) {
+		high = low + 0x1000u;
+	}
+	*stack_limit = low;
+	*stack_base  = high;
+	*dealloc     = low;
+}
+
 static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 	FilterScope filter_scope;
 
@@ -80,7 +116,13 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 
 	if (exception_record->ExceptionCode == DBG_PRINTEXCEPTION_C ||
 	    exception_record->ExceptionCode == DBG_PRINTEXCEPTION_WIDE_C ||
-	    exception_record->ExceptionCode == 0xE06D7363) {
+	    exception_record->ExceptionCode == 0xE06D7363 ||
+	    exception_record->ExceptionCode == EXCEPTION_BREAKPOINT ||
+	    exception_record->ExceptionCode == EXCEPTION_SINGLE_STEP ||
+	    exception_record->ExceptionCode == EXCEPTION_NONCONTINUABLE_EXCEPTION ||
+	    exception_record->ExceptionCode == 0xC0000409) {
+		// 0xC0000409 = STATUS_STACK_BUFFER_OVERRUN / __fastfail (int $0x29).
+		// Continuing that exception is itself a fast-fail under a debugger.
 		return EXCEPTION_CONTINUE_SEARCH;
 	}
 
@@ -134,7 +176,12 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 
 	const auto handler = LoadInstalledHandler();
 
-	return handler(info) ? EXCEPTION_CONTINUE_EXECUTION : EXCEPTION_CONTINUE_SEARCH;
+	if (!handler(info)) {
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	ExpandTebStackToInclude(exception->ContextRecord->Rsp);
+	return EXCEPTION_CONTINUE_EXECUTION;
 }
 
 #elif defined(__APPLE__)

--- a/src/common/platform/sysWindowsVirtual.cpp
+++ b/src/common/platform/sysWindowsVirtual.cpp
@@ -57,7 +57,21 @@ static VirtualMemory::Mode GetProtectionFlag(DWORD mode) {
 	}
 }
 
-void SysVirtualInit() {}
+void SysVirtualInit() {
+	// Windows 11 RtlRestoreContext validates CONTEXT.Rip after a VEH CONTINUE_EXECUTION.
+	// Guest code lives in MEM_PRIVATE mappings, so enable the documented JIT relaxed mode
+	// instead of redirecting RIP (that is itself FAST_FAIL_INVALID_SET_OF_CONTEXT).
+	PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY ssp {};
+	GetProcessMitigationPolicy(GetCurrentProcess(), ProcessUserShadowStackPolicy, &ssp,
+	                           sizeof(ssp));
+	ssp.SetContextIpValidation            = 1;
+	ssp.SetContextIpValidationRelaxedMode = 1;
+	if (SetProcessMitigationPolicy(ProcessUserShadowStackPolicy, &ssp, sizeof(ssp)) == 0) {
+		PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY relaxed {};
+		relaxed.SetContextIpValidationRelaxedMode = 1;
+		(void)SetProcessMitigationPolicy(ProcessUserShadowStackPolicy, &relaxed, sizeof(relaxed));
+	}
+}
 
 uint64_t SysVirtualAlloc(uint64_t address, uint64_t size, VirtualMemory::Mode mode) {
 	auto ptr = (address == 0 ? SysVirtualAllocAligned(address, size, mode, 1)

--- a/src/graphics/host_gpu/pageManager.cpp
+++ b/src/graphics/host_gpu/pageManager.cpp
@@ -375,4 +375,66 @@ void PageManager::OnGpuMap(uint64_t, uint64_t) {}
 
 void PageManager::OnGpuUnmap(uint64_t, uint64_t) {}
 
+bool PageManager::HasWatchers(uint64_t vaddr) const {
+	if (vaddr == 0 || vaddr >= ADDRESS_SIZE) {
+		return false;
+	}
+	auto* region = m_impl->FindRegion(vaddr);
+	if (region == nullptr) {
+		return false;
+	}
+	SpinGuard lock(region->lock);
+	const auto page_index = static_cast<size_t>((vaddr % REGION_SIZE) / PAGE_SIZE);
+	const auto& page      = region->pages[page_index];
+	return page.write_watchers != 0 || page.access_watchers != 0;
+}
+
+void PageManager::ReapplyProtection(uint64_t vaddr, uint64_t size) {
+	if (vaddr == 0 || size == 0 || vaddr >= ADDRESS_SIZE || size > ADDRESS_SIZE - vaddr) {
+		return;
+	}
+	const auto begin = PageStart(vaddr);
+	const auto end   = PageEnd(vaddr, size);
+	for (auto chunk_begin = begin; chunk_begin < end;) {
+		const auto chunk_end   = std::min(end, (chunk_begin / REGION_SIZE + 1) * REGION_SIZE);
+		const auto region_base = chunk_begin / REGION_SIZE * REGION_SIZE;
+		auto*      region      = m_impl->FindRegion(chunk_begin);
+		if (region == nullptr) {
+			chunk_begin = chunk_end;
+			continue;
+		}
+		SpinGuard lock(region->lock);
+		const auto first = static_cast<size_t>((chunk_begin - region_base) / PAGE_SIZE);
+		const auto last  = static_cast<size_t>((chunk_end - region_base) / PAGE_SIZE);
+		uint32_t   perms = region->pages[first].Perms();
+		uint64_t   range_begin = first;
+		uint64_t   range_bytes = 0;
+		const auto flush       = [&] {
+			if (range_bytes != 0) {
+				m_impl->Protect(region_base + range_begin * PAGE_SIZE, range_bytes, perms);
+				range_bytes = 0;
+			}
+		};
+		for (size_t page_index = first; page_index < last; page_index++) {
+			const auto page_perms = region->pages[page_index].Perms();
+			if (range_bytes == 0) {
+				perms       = page_perms;
+				range_begin = page_index;
+				range_bytes = PAGE_SIZE;
+				continue;
+			}
+			if (page_perms != perms) {
+				flush();
+				perms       = page_perms;
+				range_begin = page_index;
+				range_bytes = PAGE_SIZE;
+				continue;
+			}
+			range_bytes += PAGE_SIZE;
+		}
+		flush();
+		chunk_begin = chunk_end;
+	}
+}
+
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/pageManager.h
+++ b/src/graphics/host_gpu/pageManager.h
@@ -24,8 +24,10 @@ public:
 	void UpdatePageWatchers(uint64_t vaddr, uint64_t size);
 	template <bool track, bool is_read = false>
 	void UpdatePageWatchersForRegion(uint64_t base_addr, RegionBits& mask);
-	void OnGpuMap(uint64_t vaddr, uint64_t size);
-	void OnGpuUnmap(uint64_t vaddr, uint64_t size);
+	[[nodiscard]] bool HasWatchers(uint64_t vaddr) const;
+	void               ReapplyProtection(uint64_t vaddr, uint64_t size);
+	void               OnGpuMap(uint64_t vaddr, uint64_t size);
+	void               OnGpuUnmap(uint64_t vaddr, uint64_t size);
 
 private:
 	struct Impl;

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -3,6 +3,7 @@
 #include "common/assert.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/host_gpu/renderer/commandScheduler.h"
+
 namespace Libs::Graphics {
 
 GpuResourceManager::GpuResourceManager(GraphicContext& graphics, CommandScheduler& scheduler)
@@ -12,17 +13,26 @@ GpuResourceManager::GpuResourceManager(GraphicContext& graphics, CommandSchedule
 GpuResourceManager::~GpuResourceManager() = default;
 
 bool GpuResourceManager::HandleFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept {
-	constexpr uint64_t fault_size = 8;
-	if (!IsMapped(fault_vaddr, fault_size)) {
+	try {
+		constexpr uint64_t fault_size = 8;
+		const bool mapped  = IsMapped(fault_vaddr, fault_size);
+		const bool watched = m_page_manager.HasWatchers(fault_vaddr);
+		if (!mapped && !watched) {
+			return false;
+		}
+		if (access == PageFaultAccess::Write) {
+			m_buffer_cache.InvalidateMemory(fault_vaddr, fault_size);
+			m_texture_cache.InvalidateMemory(fault_vaddr, fault_size);
+		} else {
+			if (!mapped) {
+				return false;
+			}
+			m_buffer_cache.ReadMemory(fault_vaddr, fault_size);
+		}
+		return true;
+	} catch (...) {
 		return false;
 	}
-	if (access == PageFaultAccess::Write) {
-		m_buffer_cache.InvalidateMemory(fault_vaddr, fault_size);
-		m_texture_cache.InvalidateMemory(fault_vaddr, fault_size);
-	} else {
-		m_buffer_cache.ReadMemory(fault_vaddr, fault_size);
-	}
-	return true;
 }
 
 bool GpuResourceManager::InvalidateMemory(uint64_t vaddr, uint64_t size) {
@@ -32,6 +42,14 @@ bool GpuResourceManager::InvalidateMemory(uint64_t vaddr, uint64_t size) {
 	m_buffer_cache.InvalidateMemory(vaddr, size);
 	m_texture_cache.InvalidateMemory(vaddr, size);
 	return true;
+}
+
+void GpuResourceManager::ReapplyPageProtection(uint64_t vaddr, uint64_t size) {
+	if (vaddr == 0 || size == 0 || vaddr >= TRACKER_ADDRESS_SIZE ||
+	    size > TRACKER_ADDRESS_SIZE - vaddr) {
+		return;
+	}
+	m_page_manager.ReapplyProtection(vaddr, size);
 }
 
 bool GpuResourceManager::IsMapped(uint64_t vaddr, uint64_t size) const noexcept {

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
@@ -27,6 +27,7 @@ public:
 
 	[[nodiscard]] bool HandleFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept;
 	[[nodiscard]] bool InvalidateMemory(uint64_t vaddr, uint64_t size);
+	void               ReapplyPageProtection(uint64_t vaddr, uint64_t size);
 	[[nodiscard]] bool IsMapped(uint64_t vaddr, uint64_t size) const noexcept;
 	void               MapMemory(uint64_t vaddr, uint64_t size);
 	void               UnmapMemory(uint64_t vaddr, uint64_t size);

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -742,20 +742,13 @@ RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageResource&   reso
 	return {id, nullptr, std::move(desc)};
 }
 
-static vk::Sampler NativeSampler(RenderContext&                       context,
-                                 const ShaderRecompiler::IR::Program& program, uint32_t index,
-                                 const ShaderRecompiler::IR::DescriptorValue& value) {
+static vk::Sampler NativeSampler(RenderContext& context, const ShaderRecompiler::IR::Program&,
+                                 uint32_t, const ShaderRecompiler::IR::DescriptorValue& value) {
 	ShaderSamplerResource descriptor;
 	CopyNativeDescriptor(value, descriptor.fields);
-	const bool depth_compare = std::any_of(program.info.sampled_pairs.begin(),
-	                                       program.info.sampled_pairs.end(), [&](const auto& pair) {
-		                                       return pair.sampler == index &&
-		                                              pair.image < program.info.images.size() &&
-		                                              program.info.images[pair.image].depth_compare;
-	                                       });
-	if (!depth_compare) {
-		descriptor.fields[0] &= ~(0x7u << 12u);
-	}
+	// SAMPLE_C is lowered to a regular sample plus an ALU compare. A comparison sampler is
+	// illegal with non-Dref SPIR-V, and host sampled views are color formats anyway.
+	descriptor.fields[0] &= ~(0x7u << 12u);
 	return context.GetSamplerCache().GetSampler(descriptor);
 }
 

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterImageOps.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterImageOps.cpp
@@ -45,6 +45,63 @@ uint32_t LoadStorageImageDescriptorAtIndex(EmitterState& state, uint32_t resourc
 	return image;
 }
 
+uint32_t SamplerCompareFunc(const EmitterState& state, const IR::Instruction& inst) {
+	if (inst.memory.sampler >= state.resources.samplers.size()) {
+		return 3u;
+	}
+	const auto& sampler = state.resources.samplers[inst.memory.sampler];
+	if (sampler.dword_count == 0) {
+		return 3u;
+	}
+	return (sampler.dwords[0] >> 12u) & 0x7u;
+}
+
+bool ImageUsesAluDepthCompare(const EmitterState& state, const IR::Instruction& inst) {
+	if (inst.memory.resource < state.program.info.images.size() &&
+	    state.program.info.images[inst.memory.resource].alu_depth_compare) {
+		return true;
+	}
+	// Color SAMPLE_C: only compare when the guest sampler actually has a depth-compare op.
+	// zfunc 0 (Never) is treated as a regular color sample — bitmap fonts use SAMPLE_C with
+	// a non-comparison sampler and expect the texel, not 0/1 coverage.
+	if (inst.memory.sampler >= state.resources.samplers.size()) {
+		return false;
+	}
+	const auto& sampler = state.resources.samplers[inst.memory.sampler];
+	if (sampler.dword_count == 0) {
+		return false;
+	}
+	return ((sampler.dwords[0] >> 12u) & 0x7u) != 0u;
+}
+
+uint32_t EmitAluDepthCompareF32(EmitterState& state, uint32_t sampled, uint32_t dref,
+                                uint32_t compare_func) {
+	const auto one  = ConstantF32Value(state, 1.0f);
+	const auto zero = EmitZeroF32(state);
+	switch (compare_func) {
+		case 0: return zero;
+		case 7: return one;
+		default: break;
+	}
+
+	uint32_t opcode = OpFOrdLessThanEqual;
+	switch (compare_func) {
+		case 1: opcode = OpFOrdLessThan; break;
+		case 2: opcode = OpFOrdEqual; break;
+		case 3: opcode = OpFOrdLessThanEqual; break;
+		case 4: opcode = OpFOrdGreaterThan; break;
+		case 5: opcode = OpFOrdNotEqual; break;
+		case 6: opcode = OpFOrdGreaterThanEqual; break;
+		default: break;
+	}
+
+	const auto pass = state.builder.AllocateId();
+	state.builder.AddFunction({opcode, state.bool_type, pass, sampled, dref});
+	const auto result = state.builder.AllocateId();
+	state.builder.AddFunction({OpSelect, state.float_type, result, pass, one, zero});
+	return result;
+}
+
 } // namespace
 
 uint32_t EmitImageGetResinfoComponent(EmitterState& state, uint32_t image, uint32_t size,
@@ -245,39 +302,42 @@ void AddImageSampleOperands(EmitterState& state, const IR::Instruction& inst,
 }
 
 uint32_t ImageSampleOpcode(const EmitterState& state, const IR::Instruction& inst) {
-	const auto flags        = inst.memory.image_sample_flags;
-	const bool dref         = (flags & Decoder::ImageSampleFlagCompare) != 0;
-	const bool explicit_lod = ImageSampleNeedsExplicitLod(state, inst);
-	if (explicit_lod) {
-		return dref ? OpImageSampleDrefExplicitLod : OpImageSampleExplicitLod;
-	}
-	return dref ? OpImageSampleDrefImplicitLod : OpImageSampleImplicitLod;
+	// GCN IMAGE_SAMPLE_C compares the sampled red/depth channel in the shader. Host sampled
+	// views are color formats (including depth sampled as R16/R32), which do not support
+	// VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT, so Vulkan Dref ops are illegal.
+	return ImageSampleNeedsExplicitLod(state, inst) ? OpImageSampleExplicitLod
+	                                                : OpImageSampleImplicitLod;
 }
 
 void EmitImageSample(EmitterState& state, const IR::Instruction& inst) {
 	const auto view          = SampledImageViewKind(state, inst.memory, inst.pc);
 	const auto sampled_image = MakeSampledImage(state, inst.memory, inst.pc, view);
 
-	const auto layout      = MakeImageSampleLayout(inst, view);
-	const auto base_coord  = EmitImageCoordF32(state, inst, layout, view);
-	const auto sample      = state.builder.AllocateId();
-	const auto dref        = HasImageSampleFlag(inst, Decoder::ImageSampleFlagCompare);
-	const bool integer     = inst.memory.kind == IR::ResourceKind::ImageUint;
-	uint32_t   result_type = state.vec4_float_type;
-	if (dref) {
-		result_type = state.float_type;
-	} else if (integer) {
-		result_type = state.vec4_uint_type;
-	}
+	const auto            layout       = MakeImageSampleLayout(inst, view);
+	const auto            base_coord   = EmitImageCoordF32(state, inst, layout, view);
+	const auto            sample       = state.builder.AllocateId();
+	const auto            dref         = HasImageSampleFlag(inst, Decoder::ImageSampleFlagCompare);
+	const bool            integer      = inst.memory.kind == IR::ResourceKind::ImageUint;
+	const auto            result_type  = integer ? state.vec4_uint_type : state.vec4_float_type;
 	const auto            explicit_lod = ImageSampleNeedsExplicitLod(state, inst);
 	const auto            opcode       = ImageSampleOpcode(state, inst);
 	std::vector<uint32_t> words        = {opcode, result_type, sample, sampled_image, base_coord};
-	if (dref) {
-		words.push_back(EmitImageDrefF32(state, inst, layout));
-	}
 	AddImageSampleOperands(state, inst, layout, explicit_lod, words);
 	state.builder.AddFunction(words);
-	EmitImageSampleResult(state, inst, sample, dref, integer);
+
+	const bool alu_compare =
+	    dref && !integer && ImageUsesAluDepthCompare(state, inst);
+	if (!alu_compare) {
+		EmitImageSampleResult(state, inst, sample, false, integer);
+		return;
+	}
+
+	const auto red = state.builder.AllocateId();
+	state.builder.AddFunction({OpCompositeExtract, state.float_type, red, sample, 0});
+	const auto compared =
+	    EmitAluDepthCompareF32(state, red, EmitImageDrefF32(state, inst, layout),
+	                           SamplerCompareFunc(state, inst));
+	EmitImageSampleResult(state, inst, compared, true, false);
 }
 
 uint32_t ImageGatherComponent(uint32_t dmask) {
@@ -307,33 +367,34 @@ void EmitImageGather4(EmitterState& state, const IR::Instruction& inst) {
 	const auto view          = SampledImageViewKind(state, inst.memory, inst.pc);
 	const auto sampled_image = MakeSampledImage(state, inst.memory, inst.pc, view);
 
-	const auto            layout      = MakeImageSampleLayout(inst, view);
-	const auto            coord       = EmitImageCoordF32(state, inst, layout, view);
-	const auto            texels      = state.builder.AllocateId();
-	const auto            dref        = HasImageSampleFlag(inst, Decoder::ImageSampleFlagCompare);
-	const bool            integer     = inst.memory.kind == IR::ResourceKind::ImageUint;
-	const auto            result_type = integer ? state.vec4_uint_type : state.vec4_float_type;
-	std::vector<uint32_t> words =
-	    dref ? std::vector<uint32_t> {OpImageDrefGather,
-	                                  state.vec4_float_type,
-	                                  texels,
-	                                  sampled_image,
-	                                  coord,
-	                                  EmitImageDrefF32(state, inst, layout)}
-	         : std::vector<uint32_t> {
-	               OpImageGather, result_type,
-	               texels,        sampled_image,
-	               coord,         ConstantU32(state, ImageGatherComponent(inst.memory.dmask))};
+	const auto            layout       = MakeImageSampleLayout(inst, view);
+	const auto            coord        = EmitImageCoordF32(state, inst, layout, view);
+	const auto            texels       = state.builder.AllocateId();
+	const auto            dref         = HasImageSampleFlag(inst, Decoder::ImageSampleFlagCompare);
+	const bool            integer      = inst.memory.kind == IR::ResourceKind::ImageUint;
+	const auto            result_type  = integer ? state.vec4_uint_type : state.vec4_float_type;
+	const auto            component    = dref && ImageUsesAluDepthCompare(state, inst)
+	                                         ? 0u
+	                                         : ImageGatherComponent(inst.memory.dmask);
+	std::vector<uint32_t> words = {OpImageGather, result_type, texels, sampled_image, coord,
+	                               ConstantU32(state, component)};
 	AddImageGatherOperands(state, inst, layout, view, words);
 	state.builder.AddFunction(words);
 
+	const bool alu_compare =
+	    dref && !integer && ImageUsesAluDepthCompare(state, inst);
+	const auto dref_value   = alu_compare ? EmitImageDrefF32(state, inst, layout) : 0;
+	const auto compare_func = alu_compare ? SamplerCompareFunc(state, inst) : 0;
 	for (uint32_t i = 0; i < inst.memory.data_dwords; i++) {
-		const auto component = state.builder.AllocateId();
+		const auto gathered = state.builder.AllocateId();
 		state.builder.AddFunction({OpCompositeExtract, integer ? state.uint_type : state.float_type,
-		                           component, texels, i});
-		const auto bits = integer ? component : state.builder.AllocateId();
+		                           gathered, texels, i});
+		const auto compared =
+		    alu_compare ? EmitAluDepthCompareF32(state, gathered, dref_value, compare_func)
+		                : gathered;
+		const auto bits = integer ? compared : state.builder.AllocateId();
 		if (!integer) {
-			state.builder.AddFunction({OpBitcast, state.uint_type, bits, component});
+			state.builder.AddFunction({OpBitcast, state.uint_type, bits, compared});
 		}
 		EmitStoreU32(state, OffsetRegisterOperand(inst.dst, i), bits);
 	}

--- a/src/graphics/shader/recompiler/ir/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/ResourceMaterialization.cpp
@@ -42,6 +42,14 @@ Decoder::ImageDimension DescriptorDimension(const DescriptorValue&  descriptor,
 	}
 }
 
+bool GuestFormatUsesAluDepthCompare(Prospero::BufferFormat format) {
+	switch (format) {
+		case Prospero::BufferFormat::k16UNorm:
+		case Prospero::BufferFormat::k32Float: return true;
+		default: return false;
+	}
+}
+
 bool NullImageDescriptor(const DescriptorValue& descriptor) {
 	return descriptor.dwords[0] == 0 && (descriptor.dwords[1] & 0xffu) == 0;
 }
@@ -244,6 +252,14 @@ bool ValidateResourceSpecialization(const Program& program, const ResourceSnapsh
 				}
 				return false;
 			}
+			if (image.alu_depth_compare !=
+			    (image.depth_compare && GuestFormatUsesAluDepthCompare(format))) {
+				if (error != nullptr) {
+					*error = fmt::format(
+					    "image descriptor {} no longer matches depth-compare specialization", i);
+				}
+				return false;
+			}
 		}
 	}
 	for (uint32_t i = 0; i < program.info.addresses.size(); i++) {
@@ -385,6 +401,7 @@ bool SpecializeResources(Program& program, const ResourceSnapshot& snapshot, std
 		if (NullImageDescriptor(descriptor)) {
 			image.dimension = Decoder::ImageDimension::Dim2D;
 			image.cube      = false;
+			image.alu_depth_compare = false;
 			switch (image.kind) {
 				case ResourceKind::ImageUint: image.kind = ResourceKind::Image; break;
 				case ResourceKind::StorageImageUint:
@@ -429,6 +446,8 @@ bool SpecializeResources(Program& program, const ResourceSnapshot& snapshot, std
 				default: break;
 			}
 		}
+		image.alu_depth_compare =
+		    image.depth_compare && GuestFormatUsesAluDepthCompare(format);
 	}
 	struct ImagePatch {
 		std::reference_wrapper<Instruction> inst;

--- a/src/graphics/shader/recompiler/ir/ShaderIR.h
+++ b/src/graphics/shader/recompiler/ir/ShaderIR.h
@@ -305,9 +305,10 @@ struct ImageResource {
 	uint32_t                storage_swizzle = StorageImageIdentitySwizzle;
 	bool                    read            = false;
 	bool                    written         = false;
-	bool                    atomic          = false;
-	bool                    depth_compare   = false;
-	bool                    cube            = false;
+	bool                    atomic             = false;
+	bool                    depth_compare      = false;
+	bool                    alu_depth_compare  = false;
+	bool                    cube               = false;
 
 	bool operator==(const ImageResource& other) const = default;
 };

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -1073,7 +1073,9 @@ static std::span<const uint32_t> AddShaderProgramPermutation(const char* stage,
                                                              ShaderProgramPermutation permutation) {
 	static std::atomic<int> compiled {0};
 	const auto              compiled_count = compiled.fetch_add(1, std::memory_order_relaxed) + 1;
-	std::printf("Num compiled %d shaders\n", compiled_count);
+	if (compiled_count <= 8 || (compiled_count & 31) == 0) {
+		LOGF("Num compiled %d shaders\n", compiled_count);
+	}
 
 	std::scoped_lock lock(g_shader_program_cache_mutex);
 	auto&            permutations = g_shader_program_cache[key];

--- a/src/kernel/fileSystem.cpp
+++ b/src/kernel/fileSystem.cpp
@@ -574,21 +574,19 @@ int64_t KYTY_SYSV_ABI KernelRead(int d, void* buf, size_t nbytes) {
 	if (file->special == SpecialFile::Random) {
 		FillRandomBuffer(buf, nbytes);
 
-		LOGF("\tRead %" PRIu64 " random bytes from: %s\n", static_cast<uint64_t>(nbytes),
-		     Common::PathToString(file->real_name).c_str());
+		if (PRINT_NAME_ENABLED) {
+			LOGF("\tRead %" PRIu64 " random bytes from: %s\n", static_cast<uint64_t>(nbytes),
+			     Common::PathToString(file->real_name).c_str());
+		}
 
 		return static_cast<int64_t>(nbytes);
 	}
 
 	file->mutex.Lock();
 
-	bool       is_invalid = file->f.IsInvalid();
-	const auto pos        = file->f.Tell();
-	const auto file_size  = file->f.Size();
-	const auto remaining  = pos < file_size ? file_size - pos : 0;
-	Memory::InvalidateMemory(reinterpret_cast<uint64_t>(buf),
-	                         std::min<uint64_t>(nbytes, remaining));
+	bool     is_invalid = file->f.IsInvalid();
 	uint32_t bytes_read = 0;
+	Memory::InvalidateMemory(reinterpret_cast<uint64_t>(buf), nbytes);
 	file->f.Read(buf, static_cast<uint32_t>(nbytes), &bytes_read);
 
 	file->mutex.Unlock();
@@ -598,7 +596,9 @@ int64_t KYTY_SYSV_ABI KernelRead(int d, void* buf, size_t nbytes) {
 		return KERNEL_ERROR_EIO;
 	}
 
-	LOGF("\tRead %u bytes from: %s\n", bytes_read, Common::PathToString(file->real_name).c_str());
+	if (PRINT_NAME_ENABLED) {
+		LOGF("\tRead %u bytes from: %s\n", bytes_read, Common::PathToString(file->real_name).c_str());
+	}
 
 	return bytes_read;
 }
@@ -663,7 +663,9 @@ int64_t KYTY_SYSV_ABI KernelWrite(int d, const void* buf, size_t nbytes) {
 		return KERNEL_ERROR_EIO;
 	}
 
-	LOGF("\tWrite %u bytes to: %s\n", bytes_written, Common::PathToString(file->real_name).c_str());
+	if (PRINT_NAME_ENABLED) {
+		LOGF("\tWrite %u bytes to: %s\n", bytes_written, Common::PathToString(file->real_name).c_str());
+	}
 
 	return bytes_written;
 }
@@ -698,22 +700,21 @@ int64_t KYTY_SYSV_ABI KernelPread(int d, void* buf, size_t nbytes, int64_t offse
 	if (file->special == SpecialFile::Random) {
 		FillRandomBuffer(buf, nbytes);
 
-		LOGF("\tRead %" PRIu64 " random bytes (pos = %" PRId64 ") from: %s\n",
-		     static_cast<uint64_t>(nbytes), offset, Common::PathToString(file->real_name).c_str());
+		if (PRINT_NAME_ENABLED) {
+			LOGF("\tRead %" PRIu64 " random bytes (pos = %" PRId64 ") from: %s\n",
+			     static_cast<uint64_t>(nbytes), offset,
+			     Common::PathToString(file->real_name).c_str());
+		}
 
 		return static_cast<int64_t>(nbytes);
 	}
 
 	file->mutex.Lock();
 
-	bool       is_invalid = file->f.IsInvalid();
-	auto       pos        = file->f.Tell();
-	const auto file_size  = file->f.Size();
-	const auto remaining =
-	    static_cast<uint64_t>(offset) < file_size ? file_size - static_cast<uint64_t>(offset) : 0;
-	Memory::InvalidateMemory(reinterpret_cast<uint64_t>(buf),
-	                         std::min<uint64_t>(nbytes, remaining));
+	bool     is_invalid = file->f.IsInvalid();
+	auto     pos        = file->f.Tell();
 	uint32_t bytes_read = 0;
+	Memory::InvalidateMemory(reinterpret_cast<uint64_t>(buf), nbytes);
 	file->f.Seek(offset);
 	file->f.Read(buf, static_cast<uint32_t>(nbytes), &bytes_read);
 	file->f.Seek(pos);
@@ -725,8 +726,10 @@ int64_t KYTY_SYSV_ABI KernelPread(int d, void* buf, size_t nbytes, int64_t offse
 		return KERNEL_ERROR_EIO;
 	}
 
-	LOGF("\tRead %u bytes (pos = %" PRId64 ") from: %s\n", bytes_read, offset,
-	     Common::PathToString(file->real_name).c_str());
+	if (PRINT_NAME_ENABLED) {
+		LOGF("\tRead %u bytes (pos = %" PRId64 ") from: %s\n", bytes_read, offset,
+		     Common::PathToString(file->real_name).c_str());
+	}
 
 	return bytes_read;
 }
@@ -778,8 +781,10 @@ int64_t KYTY_SYSV_ABI KernelPwrite(int d, const void* buf, size_t nbytes, int64_
 		return KERNEL_ERROR_EIO;
 	}
 
-	LOGF("\tWrite %u bytes (pos = %" PRId64 ") to: %s\n", bytes_written, offset,
-	     Common::PathToString(file->real_name).c_str());
+	if (PRINT_NAME_ENABLED) {
+		LOGF("\tWrite %u bytes (pos = %" PRId64 ") to: %s\n", bytes_written, offset,
+		     Common::PathToString(file->real_name).c_str());
+	}
 
 	return bytes_written;
 }

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -905,7 +905,11 @@ void InstallGpuResources(Graphics::GpuResourceManager* resources) noexcept {
 }
 
 bool HandleGpuFault(Graphics::PageFaultAccess access, uint64_t fault_vaddr) noexcept {
-	return g_gpu_resources != nullptr && g_gpu_resources->HandleFault(access, fault_vaddr);
+	try {
+		return g_gpu_resources != nullptr && g_gpu_resources->HandleFault(access, fault_vaddr);
+	} catch (...) {
+		return false;
+	}
 }
 
 struct PrtAperture {
@@ -3419,11 +3423,69 @@ bool KernelHandleReservedRangeAccessViolation(uint64_t vaddr) {
 	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
 
 	VirtualRanges::Range range {};
-	if (!g_virtual_ranges->Query(vaddr, 0, &range) ||
-	    std::strncmp(range.name, "AMM", KERNEL_MAXIMUM_NAME_LENGTH) != 0) {
+	if (!g_virtual_ranges->Query(vaddr, 0, &range)) {
 		return false;
 	}
-	EXIT("AMM virtual-memory unmap is unsupported: addr=0x%016" PRIx64 "\n", vaddr);
+
+	if (std::strncmp(range.name, "AMM", KERNEL_MAXIMUM_NAME_LENGTH) == 0) {
+		EXIT("AMM virtual-memory unmap is unsupported: addr=0x%016" PRIx64 "\n", vaddr);
+		return false;
+	}
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	if (range.type == VirtualRangeType::PoolReserved ||
+	    range.type == VirtualRangeType::Reserved) {
+		return false;
+	}
+
+	constexpr uint64_t page_size     = 0x4000;
+	constexpr uint64_t commit_window = 0x800000; // 8 MiB per fault during large asset loads
+	const uint64_t     page_addr     = vaddr & ~(page_size - 1);
+	const uint64_t     range_end     = range.start + range.size;
+	uint64_t           commit_end    = page_addr + commit_window;
+	if (commit_end > range_end) {
+		commit_end = range_end;
+	}
+	uint64_t commit_size = commit_end > page_addr ? commit_end - page_addr : page_size;
+	if (commit_size < page_size) {
+		commit_size = page_size;
+	}
+
+	MEMORY_BASIC_INFORMATION info {};
+	if (VirtualQuery(reinterpret_cast<void*>(page_addr), &info, sizeof(info)) != 0 &&
+	    info.State == MEM_COMMIT) {
+		// Already committed: this is a GPU write-watch / no-access fault, not demand-paging.
+		// VirtualProtect(PAGE_READWRITE) would permanently drop tracker protections and leave
+		// font atlases / streamed textures stale.
+		return false;
+	}
+
+	DWORD protect = PAGE_READWRITE;
+	if ((range.protection & PROT_CPU_EXEC) != 0) {
+		protect = PAGE_EXECUTE_READWRITE;
+	} else if ((range.protection & PROT_CPU_WRITE) == 0 && (range.protection & PROT_CPU_READ) != 0) {
+		protect = PAGE_READONLY;
+	}
+
+	void* committed_ptr = ::VirtualAlloc(reinterpret_cast<void*>(page_addr), commit_size,
+	                                     MEM_COMMIT, protect);
+	if (committed_ptr == nullptr) {
+		committed_ptr = ::VirtualAlloc(reinterpret_cast<void*>(page_addr), page_size, MEM_COMMIT,
+		                               protect);
+		commit_size   = page_size;
+	}
+	if (committed_ptr == nullptr) {
+		return false;
+	}
+	if (g_gpu_resources != nullptr) {
+		// MEM_COMMIT with an explicit protect resets nearby write-watchers in the 8 MiB window.
+		GetGpuResources().ReapplyPageProtection(page_addr, commit_size);
+	}
+	return true;
+#else
+	(void)vaddr;
+	return false;
+#endif
 }
 
 int KYTY_SYSV_ABI KernelVirtualQuery(const void* addr, int flags, VirtualQueryInfo* info,

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -23,7 +23,10 @@
 #include "loader/symbolDatabase.h"
 #include "loader/x64InstructionEmulator.h"
 
+#include <Zydis/Zydis.h>
+
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstdio>
 #include <cstdlib>
@@ -806,11 +809,9 @@ static bool KytyExceptionHandler(const Common::HostException::ExceptionInfo& exc
 				case CoreAccess::Write: return GpuAccess::Write;
 				case CoreAccess::Execute: return GpuAccess::Execute;
 				case CoreAccess::Unknown:
-					EXIT("unknown access type for page fault at 0x%016" PRIx64 "\n",
-					     info->access_violation_vaddr);
+					return GpuAccess::Read;
 			}
-			EXIT("invalid access type for page fault at 0x%016" PRIx64 "\n",
-			     info->access_violation_vaddr);
+			return GpuAccess::Read;
 		}();
 		if (Libs::LibKernel::Memory::HandleGpuFault(access, info->access_violation_vaddr)) {
 			return true;
@@ -1002,13 +1003,15 @@ static bool KytyExceptionHandler(const Common::HostException::ExceptionInfo& exc
 			dump_guest_qwords("vorbis len", info->rcx);
 		}
 
-		EXIT("Access violation: %s [%016" PRIx64 "] %s\n",
-		     Common::EnumName(info->access_violation_type).c_str(), info->access_violation_vaddr,
-		     (info->access_violation_vaddr == g_invalid_memory ? "(Unpatched object)" : ""));
+		LOGF_COLOR(Log::Color::BrightRed,
+		           "Access violation: %s [%016" PRIx64 "] %s\n",
+		           Common::EnumName(info->access_violation_type).c_str(),
+		           info->access_violation_vaddr,
+		           (info->access_violation_vaddr == g_invalid_memory ? "(Unpatched object)" : ""));
 		return false;
 	}
 
-	EXIT("Unknown exception!!! (%08" PRIx32 ")", info->native_code);
+	LOGF("Unknown exception!!! (%08" PRIx32 ")\n", info->native_code);
 	return false;
 }
 
@@ -1345,6 +1348,47 @@ static void PatchProgram(Program* program, uint64_t address, uint64_t size) {
 					std::memset(ptr, 0x90, 12);
 				}
 			}
+		}
+	}
+
+	if (size >= 2) {
+		// Only patch real `int $0x29` instructions. A byte scan false-positives inside
+		// immediates/displacements (e.g. `mov rax, [rip+0x0529CD48]` contains CD 29).
+		static ZydisDecoder decoder = [] {
+			ZydisDecoder value {};
+			ZydisDecoderInit(&value, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
+			return value;
+		}();
+
+		auto* const start_ptr = reinterpret_cast<uint8_t*>(address);
+		auto*       ptr       = start_ptr;
+		auto* const end_ptr   = start_ptr + size;
+		while (ptr + 2 <= end_ptr) {
+			ZydisDecodedInstruction                                  instruction {};
+			std::array<ZydisDecodedOperand, ZYDIS_MAX_OPERAND_COUNT> operands {};
+			if (!ZYAN_SUCCESS(ZydisDecoderDecodeFull(
+			        &decoder, ptr, static_cast<ZyanUSize>(end_ptr - ptr), &instruction,
+			        operands.data())) ||
+			    instruction.length == 0) {
+				ptr++;
+				continue;
+			}
+
+			if (instruction.mnemonic == ZYDIS_MNEMONIC_INT &&
+			    instruction.operand_count_visible >= 1 &&
+			    operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE &&
+			    operands[0].imm.value.u == 0x29) {
+				LOGF("Patch int $0x29 at addr: [%016" PRIx64 "]\n",
+				     reinterpret_cast<uint64_t>(ptr));
+				if (ptr >= start_ptr + 5 && ptr[-5] == 0xb9 && ptr[-4] == 0x0d &&
+				    ptr[-3] == 0x00 && ptr[-2] == 0x00 && ptr[-1] == 0x00) {
+					ptr[-5] = 0xc3;
+					std::memset(ptr - 4, 0x90, 4 + instruction.length);
+				} else {
+					std::memset(ptr, 0x90, instruction.length);
+				}
+			}
+			ptr += instruction.length;
 		}
 	}
 

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -14944,7 +14944,7 @@ TestCase ImageSampleA16CompareBiasRdna2AddressOrder() {
 	test.name           = "ImageSampleA16CompareBiasRdna2AddressOrder";
 	test.code           = code;
 	test.opcodes        = {O::VMovB32, O::ImageSample, O::SEndpgm};
-	test.required_spirv = {"OpImageSampleDrefExplicitLod", "UnpackHalf2x16"};
+	test.required_spirv = {"OpImageSampleExplicitLod", "UnpackHalf2x16"};
 	test.compile_only   = true;
 	return test;
 }
@@ -14982,7 +14982,7 @@ TestCase ImageGatherCompareOpcodes() {
 	test.code           = code;
 	test.opcodes        = {O::VMovB32,        O::ImageGather4C,    O::ImageGather4CLz,
 	                       O::ImageGather4CO, O::ImageGather4CLzO, O::SEndpgm};
-	test.required_spirv = {"OpImageDrefGather", "OpBitFieldSExtract"};
+	test.required_spirv = {"OpImageGather", "OpBitFieldSExtract"};
 	test.compile_only   = true;
 	return test;
 }

--- a/tests/shaderCfgTests.cpp
+++ b/tests/shaderCfgTests.cpp
@@ -3209,8 +3209,8 @@ void TestNewShaderRecompilerImageSampleVariants() {
 	      "MIMG A16 bit did not survive into IR memory metadata");
 	Check(SpirvContainsOpcode(result.spirv, 88),
 	      "SPIR-V binary does not contain shared OpImageSampleExplicitLod emission");
-	Check(SpirvContainsOpcode(result.spirv, 90),
-	      "SPIR-V binary does not contain shared OpImageSampleDrefExplicitLod emission");
+	Check(SpirvInstructionOpcodeCount(result.spirv, 90) == 0,
+	      "IMAGE_SAMPLE_C must not emit OpImageSampleDrefExplicitLod on color sampled views");
 	Check(SpirvContainsOpcode(result.spirv, 80),
 	      "SPIR-V binary does not contain coordinate/gradient composite construction");
 	Check(SpirvContainsExtInst(result.spirv, 62),
@@ -3326,8 +3326,10 @@ void TestNewShaderRecompilerImageSampleA16ExceptionComponents() {
 		    "A16 IMAGE_SAMPLE_C did not preserve compare+A16 metadata");
 		Check(Common::ContainsStr(result.ir_dump, "image_flags=0x88"),
 		      "A16 IMAGE_SAMPLE_C did not preserve compare+A16 IR flags");
-		Check(SpirvInstructionOpcodeCount(result.spirv, 90) == 1,
-		      "A16 IMAGE_SAMPLE_C should emit one dref sample");
+		Check(SpirvInstructionOpcodeCount(result.spirv, 88) == 1,
+		      "A16 IMAGE_SAMPLE_C should emit one explicit-lod sample");
+		Check(SpirvInstructionOpcodeCount(result.spirv, 90) == 0,
+		      "A16 IMAGE_SAMPLE_C must not emit Vulkan Dref sampling");
 		Check(SpirvExtInstCount(result.spirv, 62) == 2,
 		      "PCF reference must remain 32-bit while only xy sampler coords use A16");
 	}
@@ -3494,15 +3496,19 @@ void TestNewShaderRecompilerPixelImageSampleLodSelection() {
 	}
 	{
 		const auto result = compile(0x28, 0x1); // image_sample_c
-		Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleDrefImplicitLod) == 1,
-		      "pixel IMAGE_SAMPLE_C must use OpImageSampleDrefImplicitLod");
+		Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleImplicitLod) == 1,
+		      "pixel IMAGE_SAMPLE_C must use OpImageSampleImplicitLod");
+		Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleDrefImplicitLod) == 0,
+		      "pixel IMAGE_SAMPLE_C must not use Vulkan Dref sampling");
 		Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleDrefExplicitLod) == 0,
 		      "pixel IMAGE_SAMPLE_C unexpectedly used explicit dref lod");
 	}
 	{
 		const auto result = compile(0x2f, 0x1); // image_sample_c_lz
-		Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleDrefExplicitLod) == 1,
-		      "pixel IMAGE_SAMPLE_C_LZ must use explicit dref lod");
+		Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleExplicitLod) == 1,
+		      "pixel IMAGE_SAMPLE_C_LZ must use explicit lod");
+		Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleDrefExplicitLod) == 0,
+		      "pixel IMAGE_SAMPLE_C_LZ must not use Vulkan Dref sampling");
 	}
 }
 
@@ -3780,8 +3786,8 @@ void TestNewShaderRecompilerImageGatherVariants() {
 	Check(SpirvContainsCapability(result.spirv, 25),
 	      "SPIR-V binary does not request ImageGatherExtended");
 	Check(SpirvContainsOpcode(result.spirv, 96), "SPIR-V binary does not contain OpImageGather");
-	Check(SpirvContainsOpcode(result.spirv, 97),
-	      "SPIR-V binary does not contain OpImageDrefGather");
+	Check(SpirvInstructionOpcodeCount(result.spirv, 97) == 0,
+	      "IMAGE_GATHER4_C must not emit OpImageDrefGather on color sampled views");
 	Check(SpirvContainsOpcode(result.spirv, 202),
 	      "SPIR-V binary does not contain packed gather offset extraction");
 	Check(SpirvContainsOpcode(result.spirv, 81),


### PR DESCRIPTION
## Summary

Minecraft Legends (PPSA05510) **crashed on startup** when this work started. With a debugger it died on `0xC0000409` / `int $0x29` (`RtlRestoreContext` CET fast-fail). Without a debugger, Vulkan aborted on an illegal depth-compare sample (`vkCmdDrawIndexed-None-06479`).

After those two crashes were unblocked, the title actually launched - then showed broken UI text in the menu and couldnt get iname, after some fix i was able to get ~3 FPS as soon as i moved. This PR is that whole path: boot, then the remaining text/cache bugs.

Current numbers on RTX 4080 Laptop / i9-13900HX (Release, no debugger): about **16 FPS peak idle**, **2–9 FPS when moving**.

## Why it crashed under a debugger (`0xC0000409`)

Guest threads run with RSP on a PS5 stack. After VEH `CONTINUE_EXECUTION`, `RtlRestoreContext` **__fastfail(0xD)** unless `Context.Rsp` is inside `TEB.StackLimit..StackBase`. The VEH frame itself also lives on that guest stack, so a host local is not in the TEB range either.

CET IP validation then rejects the restored RIP because guest code is `MEM_PRIVATE`, not a JIT image. A naive byte scan for `CD 29` also false-positived inside immediates (`mov rax, [rip+disp32]`).

**Fix:** widen the TEB stack bounds to the guest allocation before continuing; enable `SetContextIpValidationRelaxedMode`; `/CETCOMPAT:NO`; skip `STATUS_STACK_BUFFER_OVERRUN` in the filter (continuing it is itself a fast-fail); patch only real `int $0x29` via Zydis, and turn `mov ecx, 0xD; int 0x29` into a ret/nop.

## Why it crashed without a debugger (Vulkan Dref)

GCN `IMAGE_SAMPLE_C` compares the sampled red/depth channel against a reference. The recompiler was emitting Vulkan `OpImageSampleDref*` / `OpImageDrefGather` for that.

That is illegal on the host: sampled views are color formats (`VK_FORMAT_R8G8B8A8_UNORM`, etc.) and do **not** support `SAMPLED_IMAGE_DEPTH_COMPARISON`. NVIDIA's validation layer aborted on the first UI/font draw. Without the layer, the driver either crashed or ignored the Dref and returned the color texel.

## Why SAMPLE_C then ate the UI

A first workaround did the compare in ALU on every SAMPLE_C. That is correct for real depth (`k16UNorm` / `k32Float`), but bitmap fonts use SAMPLE_C on a **color** atlas with compare-func 0 (Never). The ALU path then replaced every texel with 0/1, so subtitles came out as `TION: I` / `FORE IGHT: T k v I F`.

**Fix:** never emit Dref. Sample as RGBA. Run the ALU compare only for true depth formats, or for a color SAMPLE_C whose guest sampler actually has a nonzero zfunc (SDF / shadow). zfunc 0 stays a regular color sample. Comparison bits are stripped from the Vulkan sampler so it stays legal next to non-Dref SPIR-V.

## Why glyphs appeared then vanished, and FPS fell when moving

Font atlases and streamed world textures are write-watched: pages go `PAGE_READONLY` so a CPU write faults, the texture cache is marked dirty, and the next bind re-uploads.

Demand-paging treated those faults as “not committed yet” and called `VirtualAlloc(MEM_COMMIT, PAGE_READWRITE)` on an **8 MiB** window. On Windows that resets protection for every already-committed page in the window, including pages the GPU tracker still thought were watched.

After that:
- later CPU writes to the atlas no longer faulted → GPU kept the old upload → some glyphs stayed, new ones never showed up
- the same 8 MiB invalidate forced huge buffer/texture re-uploads whenever the world streamed → ~3 FPS, then 0–7 FPS while moving

**Fix:**
- a page that is already `MEM_COMMIT` is a write-watch / no-access fault, not paging — leave it to `HandleGpuFault`
- `HandleFault` also runs when the page has watchers even if it is missing from `m_mapped_ranges` (CPU-only heaps used as textures)
- after a real 8 MiB commit, re-apply tracker protections instead of invalidating the whole window
- stop `printf("Num compiled %d shaders")` on every permutation (console I/O during shader storm) and gate filesystem read/write logs behind `PRINT_NAME`