### PR TITLE
Build audio_out2_port_tests with kyty_tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,7 @@ if(BUILD_TESTING)
 		sync_on_address_tests
 		shader_recompiler_compute_tests
 		virtual_memory_allocation_tests
+		audio_out2_port_tests
 	)
 endif()
 


### PR DESCRIPTION
## Summary

Add `audio_out2_port_tests` to the `kyty_tests` custom target dependencies.

`audio_out2_port` is registered with CTest, but its executable was not built by `kyty_tests`, so running the documented regression-test workflow could leave the test as `Not Run` because `audio_out2_port_tests.exe` was missing.

## Testing

- Removed `_Build/windows/audio_out2_port_tests.exe`
- Ran: `cmake --build _Build/windows --target kyty_tests --parallel`
- Confirmed `audio_out2_port_tests.exe` was rebuilt
- Ran: `ctest --test-dir _Build/windows --output-on-failure -R "^audio_out2_port$"`
- Result: `1/1` test passed