### PR TITLE
launcher: keep window open when game folder prompt is dismissed

### DIFF
--- a/src/launcher/src/mainDialog.cpp
+++ b/src/launcher/src/mainDialog.cpp
@@ -180,10 +180,10 @@ void MainDialogPrivate::FindInterpreter() {
 		return;
 	}
 
-	if (!m_ui->widget->EnsureGameDirectory()) {
-		QApplication::quit();
-		return;
-	}
+	// Prompt for a game folder when none are configured, but keep the launcher
+	// open if the user dismisses the dialog (quitting here can segfault during
+	// nested modal shutdown / background compatibility load).
+	m_ui->widget->EnsureGameDirectory();
 
 	m_ui->label_settings_file->setText(tr("Settings file: ") + m_ui->widget->GetSettingsFile());
 


### PR DESCRIPTION
## Summary
- Stop calling `QApplication::quit()` when the first-run game folder dialog is dismissed from `FindInterpreter`.
- Keep the launcher open so settings can still be configured and avoid a segfault during nested modal shutdown.
- Fixes #121.

## Test plan
- [ ] Launch with no game folders configured and dismiss the game folder prompt.
- [ ] Confirm the main window stays open (no quit / no crash).
- [ ] Confirm settings remain usable afterward.
- [ ] Confirm choosing a valid game folder still works as before.