### PR TITLE
window: toggle borderless fullscreen with F11 and Alt+Enter

### DIFF
--- a/src/graphics/presentation/window/hostInput.cpp
+++ b/src/graphics/presentation/window/hostInput.cpp
@@ -119,7 +119,8 @@ public:
 			}
 
 			const bool reserved =
-			    binding.key == SDLK_ESCAPE || binding.key == SDLK_SPACE || binding.key == SDLK_F1;
+			    binding.key == SDLK_ESCAPE || binding.key == SDLK_SPACE || binding.key == SDLK_F1 ||
+			    binding.key == SDLK_F11;
 			if (binding.control == INVALID_CONTROL || reserved ||
 			    (binding.key == SDLK_UNKNOWN && binding.mouse_button == 0)) {
 				EXIT("Invalid input mapping: %s\n", value.c_str());

--- a/src/graphics/presentation/window/window.cpp
+++ b/src/graphics/presentation/window/window.cpp
@@ -219,6 +219,21 @@ static void GameEventTerminate(WindowLoopState& game) {
 	game.need_exit = true;
 }
 
+static void ToggleDesktopFullscreen() {
+	if (g_window == nullptr || g_window->window == nullptr) {
+		return;
+	}
+
+	const auto flags = static_cast<uint32_t>(SDL_GetWindowFlags(g_window->window));
+	const bool fullscreen =
+	    (flags & static_cast<uint32_t>(SDL_WINDOW_FULLSCREEN_DESKTOP)) != 0u;
+	const auto mode =
+	    fullscreen ? 0u : static_cast<uint32_t>(SDL_WINDOW_FULLSCREEN_DESKTOP);
+	if (SDL_SetWindowFullscreen(g_window->window, mode) != 0) {
+		LOGF("Toggle fullscreen failed: %s\n", SDL_GetError());
+	}
+}
+
 static void GameEventKeyboard(WindowLoopState& game, const EventKeyboard& key) {
 #ifdef KYTY_DBG_INPUT
 	LOGF("Key: time = %.04f, %s%s, %s%s, %s, scan = %d, key = %d, mod = %04" PRIx16 "\n",
@@ -235,6 +250,17 @@ static void GameEventKeyboard(WindowLoopState& game, const EventKeyboard& key) {
 			case SDLK_F1:
 				if (!key.repeat) {
 					RenderDocRequestCapture();
+				}
+				break;
+			case SDLK_F11:
+				if (!key.repeat) {
+					ToggleDesktopFullscreen();
+				}
+				break;
+			case SDLK_RETURN:
+			case SDLK_KP_ENTER:
+				if (!key.repeat && (key.mod & KMOD_ALT) != 0) {
+					ToggleDesktopFullscreen();
 				}
 				break;
 			default: break;

--- a/src/graphics/presentation/window/window.cpp
+++ b/src/graphics/presentation/window/window.cpp
@@ -235,6 +235,8 @@ static void ToggleDesktopFullscreen() {
 }
 
 static void GameEventKeyboard(WindowLoopState& game, const EventKeyboard& key) {
+	static SDL_Keycode fullscreen_key = SDLK_UNKNOWN;
+
 #ifdef KYTY_DBG_INPUT
 	LOGF("Key: time = %.04f, %s%s, %s%s, %s, scan = %d, key = %d, mod = %04" PRIx16 "\n",
 	     key.timestamp_seconds, (key.down ? "down" : ""), (key.up ? "up" : ""),
@@ -261,6 +263,7 @@ static void GameEventKeyboard(WindowLoopState& game, const EventKeyboard& key) {
 			case SDLK_KP_ENTER:
 				if (!key.repeat && (key.mod & KMOD_ALT) != 0) {
 					ToggleDesktopFullscreen();
+					fullscreen_key = key.key_code;
 				}
 				break;
 			default: break;
@@ -269,7 +272,12 @@ static void GameEventKeyboard(WindowLoopState& game, const EventKeyboard& key) {
 
 #endif
 
-	if ((key.down || key.up) && !key.repeat) {
+	const bool fullscreen_key_event =
+	    fullscreen_key != SDLK_UNKNOWN && key.key_code == fullscreen_key;
+	if (fullscreen_key_event && key.up) {
+		fullscreen_key = SDLK_UNKNOWN;
+	}
+	if ((key.down || key.up) && !key.repeat && !fullscreen_key_event) {
 		HostInputKey(key.key_code, key.down);
 	}
 }


### PR DESCRIPTION
## Summary
- Add runtime toggle for borderless desktop fullscreen with F11 and Alt+Enter via `SDL_SetWindowFullscreen(SDL_WINDOW_FULLSCREEN_DESKTOP)`, matching the existing startup fullscreen path.
- Reserve `SDLK_F11` in host input mappings so it cannot be rebound over the toggle.

Fixes #217.

## Test plan
- [ ] Start with windowed mode, press F11, confirm borderless desktop fullscreen.
- [ ] Press F11 again, confirm return to windowed.
- [ ] Repeat with Alt+Enter (and keypad Enter with Alt).
- [ ] Confirm Escape / Space / F1 behavior is unchanged.
- [ ] Confirm F11 cannot be assigned as a host input binding.