### PR TITLE
logging: rotate printf log files to cap report size

### DIFF
--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -12,12 +12,16 @@
 #include <mutex>
 #include <spdlog/formatter.h>
 #include <spdlog/logger.h>
-#include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/null_sink.h>
+#include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_sinks.h>
 #include <string_view>
 
 namespace {
+
+// Cap printf log growth so reports stay usable (see issue #200).
+constexpr std::size_t kMaxLogFileSize = 64ull * 1024 * 1024;
+constexpr std::size_t kMaxLogFiles    = 3;
 
 class RawFormatter final: public spdlog::formatter {
 public:
@@ -46,8 +50,9 @@ std::shared_ptr<spdlog::logger> MakeFileLogger(std::string                  name
 		std::filesystem::create_directories(parent);
 	}
 
-	auto sink =
-	    std::make_shared<spdlog::sinks::basic_file_sink_mt>(Common::PathToString(path), true);
+	// rotate_on_open matches the old truncate-on-open "fresh file each run" behavior.
+	auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+	    Common::PathToString(path), kMaxLogFileSize, kMaxLogFiles, true);
 	return MakeLogger(std::move(name), std::move(sink));
 }
 


### PR DESCRIPTION
## Summary
- Replace unbounded `basic_file_sink_mt` with `rotating_file_sink_mt` for printf logs.
- Cap each file at 64 MiB with 3 rotated files and `rotate_on_open=true` so verbose titles cannot grow multi-GB logs that are useless for bug reports.

Fixes #200.

## Test plan
- [ ] Build with the logging change and start a title that previously produced a huge printf log.
- [ ] Confirm a fresh log file is opened on run and that size stays within the 64 MiB x 3 rotation policy.
- [ ] Confirm existing log viewers still open the active printf log path.