### PR TITLE
gpu: support required render states

### DIFF
--- a/src/graphics/host_gpu/renderer/debug.cpp
+++ b/src/graphics/host_gpu/renderer/debug.cpp
@@ -614,9 +614,22 @@ static void ClipPrint(const char* func, const HW::ClipControl& c) {
 static void ClipCheck(const HW::ClipControl& c) {
 	// dx_linear_attr_clip_enable preserves linear (noperspective) attributes at clip-generated
 	// vertices, which Vulkan provides as part of clipping and interpolation.
+	//
+	// A split Z clip mode - near and far clipped differently - has no single-boolean Vulkan
+	// equivalent, so it is approximated rather than fatal; see where depth_clip_enable is
+	// chosen in PipelineCache. Report the actual pair once so the approximation can be judged
+	// against what the title asked for.
+	if (!c.IsZClipModeRepresentable()) {
+		static std::atomic<bool> reported {false};
+		if (!reported.exchange(true)) {
+			LOGF("clip control: split z clip mode (min_disable=%d max_disable=%d); Vulkan has "
+			     "one depthClipEnable for both planes, approximating with the near plane "
+			     "setting\n",
+			     static_cast<int>(c.min_z_clip_disable), static_cast<int>(c.max_z_clip_disable));
+		}
+	}
 	EXIT_NOT_IMPLEMENTED(c.user_clip_planes != 0 || c.user_clip_plane_mode != 0 ||
-	                     c.vertex_kill_any || !c.IsZClipModeRepresentable() ||
-	                     c.user_clip_plane_negate_y || c.clip_disable ||
+	                     c.vertex_kill_any || c.user_clip_plane_negate_y || c.clip_disable ||
 	                     c.user_clip_plane_cull_only || c.cull_on_clipping_error_disable ||
 	                     c.force_viewport_index_from_vs_enable);
 }

--- a/src/graphics/host_gpu/renderer/depthRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/depthRenderTarget.cpp
@@ -166,21 +166,65 @@ void RenderExecutor::ResolveRenderDepthTarget(uint64_t submit_id, RenderCommandB
 			DepthFatal("invalid depth view: base=%u last=%u", z.depth_view.slice_start,
 			           z.depth_view.slice_max);
 	}
-	if (rc.resummarize_enable || rc.copy_centroid || rc.copy_sample != 0 ||
-	    z.z_info.expclear_enabled || z.stencil_info.expclear_enabled ||
-	    z.z_info.partially_resident || z.stencil_info.partially_resident ||
-	    z.z_info.max_mip_level != 0 || z.depth_view.current_mip_level != 0 ||
-	    z.depth_info.addr5_swizzle_mask != 0 || z.depth_info.array_mode != 0 ||
-	    z.depth_info.pipe_config != 0 || z.depth_info.bank_width != 0 ||
-	    z.depth_info.bank_height != 0 || z.depth_info.macro_tile_aspect != 0 ||
-	    z.depth_info.num_banks != 0 || z.htile_surface.linear != 0 ||
-	    z.htile_surface.full_cache != 0 || z.htile_surface.htile_uses_preload_win != 0 ||
-	    z.htile_surface.preload != 0 || z.htile_surface.prefetch_width != 0 ||
-	    z.htile_surface.prefetch_height != 0 || z.htile_surface.dst_outside_zero_to_one != 0 ||
-	    z.z_read_base_addr == 0 || z.z_write_base_addr != z.z_read_base_addr ||
-	    (z.z_read_base_addr & 0xffffu) != 0 ||
-	    dc.zfunc > static_cast<uint8_t>(vk::CompareOp::eAlways)) {
-		DepthFatal("unsupported depth register state");
+	// Twenty-five independent conditions collapsed into one message that named none of them,
+	// which made every abort here a research project. Report the first offender.
+	struct DepthReject {
+		const char* name;
+		bool        hit;
+	};
+	const DepthReject rejects[] = {
+	    // resummarize_enable is deliberately absent: it asks the hardware to recompute HTILE's
+	    // min/max depth metadata after a direct depth write. This emulator never emulates
+	    // HTILE - the clear mask is fixed at zero and htile_acceleration is only read for
+	    // compatibility checks - so depth is stored uncompressed and there is neither metadata
+	    // to recompute nor a consumer that would read it. Ignoring the request is correct
+	    // here rather than merely convenient.
+	    {"copy_centroid", rc.copy_centroid},
+	    {"copy_sample", rc.copy_sample != 0},
+	    {"z expclear_enabled", z.z_info.expclear_enabled},
+	    {"stencil expclear_enabled", z.stencil_info.expclear_enabled},
+	    {"z partially_resident", z.z_info.partially_resident},
+	    {"stencil partially_resident", z.stencil_info.partially_resident},
+	    {"z max_mip_level != 0", z.z_info.max_mip_level != 0},
+	    {"depth_view current_mip_level != 0", z.depth_view.current_mip_level != 0},
+	    {"addr5_swizzle_mask", z.depth_info.addr5_swizzle_mask != 0},
+	    {"array_mode", z.depth_info.array_mode != 0},
+	    {"pipe_config", z.depth_info.pipe_config != 0},
+	    {"bank_width", z.depth_info.bank_width != 0},
+	    {"bank_height", z.depth_info.bank_height != 0},
+	    {"macro_tile_aspect", z.depth_info.macro_tile_aspect != 0},
+	    {"num_banks", z.depth_info.num_banks != 0},
+	    {"htile linear", z.htile_surface.linear != 0},
+	    {"htile full_cache", z.htile_surface.full_cache != 0},
+	    {"htile uses_preload_win", z.htile_surface.htile_uses_preload_win != 0},
+	    {"htile preload", z.htile_surface.preload != 0},
+	    {"htile prefetch_width", z.htile_surface.prefetch_width != 0},
+	    {"htile prefetch_height", z.htile_surface.prefetch_height != 0},
+	    {"htile dst_outside_zero_to_one", z.htile_surface.dst_outside_zero_to_one != 0},
+	    {"z_read_base_addr is zero", z.z_read_base_addr == 0},
+	    {"z write and read base addresses differ", z.z_write_base_addr != z.z_read_base_addr},
+	    {"z_read_base_addr is not 64K aligned", (z.z_read_base_addr & 0xffffu) != 0},
+	    {"zfunc out of range", dc.zfunc > static_cast<uint8_t>(vk::CompareOp::eAlways)},
+	};
+	if (rc.resummarize_enable) {
+		static std::atomic<bool> resummarize_reported {false};
+		if (!resummarize_reported.exchange(true)) {
+			LOGF("DepthTarget: ignoring HTILE resummarize request; depth is stored uncompressed "
+			     "and no HTILE metadata is emulated\n");
+		}
+	}
+	const char* depth_offender = nullptr;
+	for (const auto& r: rejects) {
+		if (r.hit) {
+			depth_offender = r.name;
+			break;
+		}
+	}
+	if (depth_offender != nullptr) {
+		DepthFatal("%s (z_read=0x%016" PRIx64 " z_write=0x%016" PRIx64 " zfunc=%u "
+		           "has_stencil=%d)",
+		           depth_offender, z.z_read_base_addr, z.z_write_base_addr,
+		           static_cast<uint32_t>(dc.zfunc), static_cast<int>(has_stencil));
 	}
 	if (has_stencil) {
 		if (z.stencil_info.format != Prospero::StencilFormat::k8UInt || !htile_stencil_compat ||

--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
@@ -131,7 +131,13 @@ PipelineCache::GraphicsPipeline& PipelineCache::CreateGraphicsPipeline(
 	}
 
 	const auto& clip_control = ctx.GetClipControl();
-	EXIT_NOT_IMPLEMENTED(!clip_control.IsZClipModeRepresentable());
+	// A split z clip mode - near and far clipped differently - used to abort here. Vulkan
+	// exposes a single depthClipEnable (via VK_EXT_depth_clip_enable) covering both planes,
+	// so the split case cannot be expressed exactly without emitting a clip distance from the
+	// shader. IsZClipEnabled() already reads only the near plane, so approximating with it
+	// leaves every representable case bit-identical and costs accuracy only on the far plane
+	// of titles that split them. Aborting was strictly worse than approximating. ClipCheck
+	// logs the pair once.
 	static_params.negative_one_to_one = !clip_control.dx_clip_space;
 	static_params.depth_clip_enable   = clip_control.IsZClipEnabled();
 	static_params.topology            = topology;

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -659,16 +659,24 @@ static bool DrawHasActivePixelShader(const RenderCommandBuffer& buffer,
 	const auto& ctx    = buffer.GetRegisters();
 	const auto& sh_ctx = buffer.GetShaders();
 
+	const auto& sh_regs = ctx.GetShaderRegisters();
+	const auto& ps      = sh_ctx.GetPs();
+
+	// A pixel shader that is not bound cannot be active, whatever the render targets are.
+	// This was checked only on the depth-only path below, so a draw with colour targets and
+	// no pixel shader reported active and then aborted looking up shader address 0 in the
+	// ShaderMap. Double Dragon Gaiden issues exactly that.
+	if (!ShaderAddressValid(ps.ps_regs.data_addr)) {
+		return false;
+	}
+
 	const bool with_depth = (state.depth_info.format != vk::Format::eUndefined &&
 	                         static_cast<bool>(state.depth_info.image_id));
 	if (state.color_count != 0 || !with_depth) {
 		return true;
 	}
 
-	const auto& sh_regs = ctx.GetShaderRegisters();
-	const auto& ps      = sh_ctx.GetPs();
-	return ShaderAddressValid(ps.ps_regs.data_addr) &&
-	       PixelShaderHasDepthOrCoverageSideEffects(sh_regs);
+	return PixelShaderHasDepthOrCoverageSideEffects(sh_regs);
 }
 
 enum class CbColorMode : uint8_t {


### PR DESCRIPTION
This adds handling for several rendering states currently needed by more demanding PS5 workloads.

The changes improve depth render-target setup, pipeline state selection and draw-state handling. Unsupported combinations remain guarded instead of silently producing an invalid pipeline.

The implementation is generic and does not contain any title-specific checks.


Note:
This is based on the work to make Demon's Souls to boot. 

