### PR TITLE
gpu: preserve sparse and mapped guest memory

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -52,6 +52,27 @@ void BufferCache::Upload(CommandBuffer& command, Buffer& destination, uint64_t d
 	}
 }
 
+void BufferCache::UploadGuestBacking(CommandBuffer& command, Buffer& destination,
+                                     uint64_t destination_offset, uint64_t source_address,
+                                     uint64_t size) {
+	while (size != 0) {
+		const auto chunk = std::min(size, m_staging_buffer.Size());
+		const auto [mapped, stage_offset] = m_staging_buffer.Map(chunk, 4);
+		if (mapped == nullptr ||
+		    !Libs::LibKernel::Memory::TryReadGpuBacking(source_address, mapped, chunk)) {
+			EXIT("BufferCache: guest backing upload failed, addr=0x%016" PRIx64
+			     " size=0x%016" PRIx64 "\n",
+			     source_address, chunk);
+		}
+		m_staging_buffer.Commit();
+		destination.CopyFrom(command, m_staging_buffer, stage_offset, destination_offset, chunk,
+		                     vk::AccessFlagBits::eHostWrite);
+		source_address += chunk;
+		destination_offset += chunk;
+		size -= chunk;
+	}
+}
+
 bool BufferCache::ResolveOverlap(CacheRange& merged, CacheRange candidate) noexcept {
 	if (merged.address == 0 || merged.size == 0 || candidate.address == 0 || candidate.size == 0 ||
 	    merged.size > UINT64_MAX - merged.address ||
@@ -445,8 +466,8 @@ BufferCache::CachedBuffer& BufferCache::GetOrCreateBuffer(CommandBuffer& command
 		    },
 		    [&]() noexcept {
 			    for (const auto& [address, bytes]: uploads) {
-				    Upload(command, *old.buffer, old.buffer->Offset(address),
-				           reinterpret_cast<const void*>(address), bytes);
+				    UploadGuestBacking(command, *old.buffer, old.buffer->Offset(address), address,
+				                       bytes);
 			    }
 		    });
 	}
@@ -486,14 +507,14 @@ BufferBinding BufferCache::ObtainBuffer(CommandBuffer& command, uint64_t vaddr, 
 		    m_graphics.physical_device_properties.limits.minUniformBufferOffsetAlignment, 1);
 		if (auto [mapped, offset] = m_stream_buffer.Map(size, alignment, false);
 		    mapped != nullptr) {
-			if (Libs::LibKernel::Memory::TryReadBacking(vaddr, mapped, size)) {
+			if (Libs::LibKernel::Memory::TryReadGpuBacking(vaddr, mapped, size)) {
 				m_stream_buffer.Commit();
 				return {{}, m_stream_buffer.Handle(), offset};
 			}
 		} else {
 			auto owner = std::make_shared<Buffer>(m_graphics, m_scheduler, MemoryUsage::Upload, 0,
 			                                      AllFlags, size);
-			if (Libs::LibKernel::Memory::TryReadBacking(vaddr, owner->Mapped().data(), size)) {
+			if (Libs::LibKernel::Memory::TryReadGpuBacking(vaddr, owner->Mapped().data(), size)) {
 				owner->Flush(0, size);
 				return {owner, owner->Handle(), 0};
 			}
@@ -511,8 +532,8 @@ BufferBinding BufferCache::ObtainBuffer(CommandBuffer& command, uint64_t vaddr, 
 	    [&](uint64_t address, uint64_t bytes) noexcept { uploads.emplace_back(address, bytes); },
 	    [&]() noexcept {
 		    for (const auto& [address, bytes]: uploads) {
-			    Upload(command, *cached.buffer, cached.buffer->Offset(address),
-			           reinterpret_cast<const void*>(address), bytes);
+			    UploadGuestBacking(command, *cached.buffer, cached.buffer->Offset(address), address,
+			                       bytes);
 		    }
 	    });
 	if (is_written) {
@@ -621,8 +642,15 @@ ImageBufferSource BufferCache::ObtainBufferForImage(uint64_t vaddr, uint64_t siz
 	}
 
 	auto [staging, stage_offset] = m_staging_buffer.Map(size, 16);
-	if (staging == nullptr || !Libs::LibKernel::Memory::TryReadBacking(vaddr, staging, size)) {
-		EXIT("BufferCache: failed to read mapped guest image backing\n");
+	if (staging == nullptr) {
+		EXIT("BufferCache: failed to allocate image staging range: addr=0x%016" PRIx64
+		     " size=0x%016" PRIx64 "\n",
+		     vaddr, size);
+	}
+	if (!Libs::LibKernel::Memory::TryReadGpuBacking(vaddr, staging, size)) {
+		EXIT("BufferCache: failed to read mapped guest image backing: addr=0x%016" PRIx64
+		     " size=0x%016" PRIx64 "\n",
+		     vaddr, size);
 	}
 	m_staging_buffer.Commit();
 

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.h
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.h
@@ -87,6 +87,8 @@ private:
 	[[nodiscard]] static bool ResolveOverlap(CacheRange& merged, CacheRange candidate) noexcept;
 	void Upload(CommandBuffer& command, Buffer& destination, uint64_t destination_offset,
 	            const void* source, uint64_t size);
+	void UploadGuestBacking(CommandBuffer& command, Buffer& destination,
+	                        uint64_t destination_offset, uint64_t source_address, uint64_t size);
 	[[nodiscard]] CachedBuffer& GetOrCreateBuffer(CommandBuffer& command, uint64_t vaddr,
 	                                              uint64_t size);
 	[[nodiscard]] bool SynchronizeBufferFromImage(Buffer& buffer, uint64_t vaddr, uint64_t size);

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -7,6 +7,7 @@
 #include "common/threads.h"
 #include "common/virtualMemory.h"
 #include "graphics/guest_gpu/graphicsRun.h"
+#include "graphics/host_gpu/hostMemory.h"
 #include "graphics/host_gpu/renderer/cache/gpuResourceManager.h"
 #include "libs/errno.h"
 #include "libs/libs.h"
@@ -931,6 +932,65 @@ static bool IsInPrtAperture(uint64_t address) {
 	}
 
 	return false;
+}
+
+static bool IsInPrtAperture(uint64_t address, uint64_t size) {
+	if (size == 0 || size > UINT64_MAX - address) {
+		return false;
+	}
+
+	Common::LockGuard lock(g_prt_aperture_mutex);
+	for (const auto& aperture: g_prt_apertures) {
+		if (aperture.size != 0 && address >= aperture.address &&
+		    size <= aperture.address + aperture.size - address) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool TryReadGpuBacking(uint64_t vaddr, void* data, uint64_t size) {
+	if (g_guest_address_space == nullptr || g_virtual_ranges == nullptr || data == nullptr ||
+	    size == 0 || size > UINT64_MAX - vaddr) {
+		return false;
+	}
+
+	// Do not take g_memory_operation_mutex here. Guest map/unmap calls can hold it while waiting
+	// synchronously for the GPU command lane. The range and backing stores synchronize their own
+	// queries, while GPU unmapping is serialized behind the active command.
+	std::vector<VirtualRanges::Range> ranges;
+	if (!g_virtual_ranges->QuerySpan(vaddr, size, &ranges)) {
+		return false;
+	}
+
+	const bool sparse = IsInPrtAperture(vaddr, size);
+	if (!sparse && std::any_of(ranges.begin(), ranges.end(),
+	                          [](const auto& range) { return !IsCommittedRangeType(range.type); })) {
+		return false;
+	}
+
+	// PS5 PRT reads preserve resident spans and define unresident spans as zero for the GPU.
+	// Direct/flexible mappings use shared backing; private committed runtime mappings are read
+	// from their validated guest virtual addresses.
+	auto* destination = static_cast<uint8_t*>(data);
+	if (sparse) {
+		std::memset(destination, 0, static_cast<size_t>(size));
+	}
+	for (const auto& range: ranges) {
+		if (!IsCommittedRangeType(range.type)) {
+			continue;
+		}
+		auto* range_destination = destination + range.start - vaddr;
+		if (g_guest_address_space->TryReadBacking(range.start, range_destination, range.size)) {
+			continue;
+		}
+		if (!Graphics::HostMemoryRangeIsReadable(range.start, range.size)) {
+			return false;
+		}
+		std::memcpy(range_destination, reinterpret_cast<const void*>(range.start),
+		            static_cast<size_t>(range.size));
+	}
+	return true;
 }
 
 static bool SelfTestSub64SharedPlaceholderAlias() {

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -109,6 +109,7 @@ void                   RegisterCallbacks(callback_func_t alloc_func, callback_fu
 void                   SetFlexibleMemorySize(uint64_t size);
 bool                   TryWriteBacking(uint64_t vaddr, const void* data, uint64_t size);
 bool                   TryReadBacking(uint64_t vaddr, void* data, uint64_t size);
+bool                   TryReadGpuBacking(uint64_t vaddr, void* data, uint64_t size);
 [[nodiscard]] uint64_t ClampRangeSize(uint64_t vaddr, uint64_t size);
 void                   WriteBacking(uint64_t vaddr, const void* data, uint64_t size) noexcept;
 void                   InvalidateMemory(uint64_t vaddr, uint64_t size);

--- a/tests/VirtualMemoryAllocationTests.cpp
+++ b/tests/VirtualMemoryAllocationTests.cpp
@@ -752,7 +752,15 @@ void TestRuntimeMemoryOwnerLifecycle() {
 	Check(test, base != 0, "runtime allocation failed");
 	Check(test, Libs::LibKernel::Memory::TestGuestAddressRangeIsOwned(base, SceKernelPageSize * 2),
 	      "runtime allocation is outside the owner");
-	*reinterpret_cast<uint64_t*>(base) = 0x52554e54494d454full; // "RUNTIMEO"
+	constexpr uint64_t runtime_value = 0x52554e54494d454full; // "RUNTIMEO"
+	*reinterpret_cast<uint64_t*>(base) = runtime_value;
+	uint64_t gpu_read = 0;
+	Check(test, !Libs::LibKernel::Memory::TryReadBacking(base, &gpu_read, sizeof(gpu_read)),
+	      "private runtime allocation unexpectedly used shared backing");
+	Check(test,
+	      Libs::LibKernel::Memory::TryReadGpuBacking(base, &gpu_read, sizeof(gpu_read)) &&
+	          gpu_read == runtime_value,
+	      "GPU read did not resolve private committed runtime memory");
 	Check(test,
 	      Libs::LibKernel::Memory::ProtectGuestMemory(base, SceKernelPageSize,
 	                                                  Common::VirtualMemory::Mode::Read),
@@ -2002,6 +2010,53 @@ void TestLargeHintedReserveHostsSmallDirectMap() {
 	std::printf("[host]    %-48s ok\n", test);
 }
 
+void TestGpuPrtBackingReadZeroFillsUnresidentPages() {
+	const char*        test          = "GpuPrtBackingReadZeroFillsUnresidentPages";
+	constexpr uint64_t aperture_hint = 0x2000000000ull;
+	constexpr uint64_t total_size    = SceKernelPageSize * 3;
+
+	void* reserve = reinterpret_cast<void*>(aperture_hint);
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelReserveVirtualRange(&reserve, total_size, 0,
+	                                                           SceKernelPageSize),
+	        "KernelReserveVirtualRange");
+	const auto base = reinterpret_cast<uint64_t>(reserve);
+	CheckOk(test, Libs::LibKernel::Memory::KernelSetPrtAperture(0, reserve, total_size),
+	        "KernelSetPrtAperture");
+
+	void* mapped = reserve;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelMapNamedFlexibleMemory(
+	            &mapped, SceKernelPageSize, SceKernelProtCpuRw,
+	            SceKernelMapFixed | SceKernelMapNoCoalesce, "prt_resident"),
+	        "KernelMapNamedFlexibleMemory");
+	Check(test, mapped == reserve, "fixed PRT mapping moved");
+	std::memset(mapped, 0x5a, SceKernelPageSize);
+
+	std::vector<uint8_t> strict(total_size, 0xa5);
+	Check(test, !Libs::LibKernel::Memory::TryReadBacking(base, strict.data(), strict.size()),
+	      "strict backing read accepted unresident PRT pages");
+	Check(test, strict.front() == 0xa5 && strict.back() == 0xa5,
+	      "failed strict read modified its destination");
+
+	std::vector<uint8_t> sparse(total_size, 0xa5);
+	Check(test, Libs::LibKernel::Memory::TryReadGpuBacking(base, sparse.data(), sparse.size()),
+	      "GPU PRT backing read failed");
+	Check(test,
+	      std::all_of(sparse.begin(), sparse.begin() + SceKernelPageSize,
+	                  [](uint8_t value) { return value == 0x5a; }),
+	      "GPU PRT backing read lost resident bytes");
+	Check(test,
+	      std::all_of(sparse.begin() + SceKernelPageSize, sparse.end(),
+	                  [](uint8_t value) { return value == 0; }),
+	      "GPU PRT backing read did not zero unresident pages");
+
+	CheckOk(test, Libs::LibKernel::Memory::KernelMunmap(base, total_size), "KernelMunmap");
+	CheckOk(test, Libs::LibKernel::Memory::KernelSetPrtAperture(0, nullptr, 0),
+	        "KernelSetPrtAperture(clear)");
+	std::printf("[host]    %-48s ok\n", test);
+}
+
 void TestMemoryPoolAlignmentContracts() {
 	const char* test = "MemoryPoolAlignmentContracts";
 	void*       addr = nullptr;
@@ -2477,6 +2532,7 @@ int main(int argc, char** argv) {
 	RunTest(TestFixedReserveRollbackSkipsUntouchedChunks);
 	RunTest(TestFixedReserveRangeAddRollbackKeepsPlaceholder);
 	RunTest(TestLargeHintedReserveHostsSmallDirectMap);
+	RunTest(TestGpuPrtBackingReadZeroFillsUnresidentPages);
 	RunTest(TestMemoryPoolAlignmentContracts);
 	RunTest(TestProsperoSampleMemoryPoolExpandCommit);
 	RunTest(TestFragmentedMemoryPoolBacking);


### PR DESCRIPTION
This improves the lifetime and synchronization of sparse or partially mapped guest memory.

Buffer cache entries are updated when guest mappings change, while valid mapped regions and their contents are preserved. This avoids stale native resources and incorrect assumptions about contiguous guest allocations.

The behavior is implemented at the memory and buffer-cache level and benefits any workload using sparse GPU mappings.

Testing:
- Built virtual_memory_allocation_tests and shader_recompiler_compute_tests.
- Ran virtual_memory_allocation_tests successfully.
- Helped DS compile more shaders
- Afaik no regression on other titles

Note: 
My commits had stacked dependency's, had AI to help me to rewrite them so they could be merged independent of eachother.  