### PR TITLE
gpu: support texture descriptor mip views

### DIFF
--- a/src/graphics/host_gpu/renderer/image/imageView.h
+++ b/src/graphics/host_gpu/renderer/image/imageView.h
@@ -2,9 +2,12 @@
 #define EMULATOR_SRC_GRAPHICS_HOST_GPU_RENDERER_IMAGEVIEW_H_
 
 #include "common/assert.h"
+#include "common/logging/log.h"
 #include "graphics/host_gpu/renderer/image/imageInfo.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 #include "graphics/shader/shader.h"
+
+#include <atomic>
 
 namespace Libs::Graphics {
 
@@ -127,8 +130,51 @@ IsSupportedStorageImageResource(const ShaderRecompiler::IR::ImageResource& resou
 	       !resource.depth_compare;
 }
 
-inline void
-ValidateStorageImageResource(const ShaderRecompiler::IR::ImageResource& resource) noexcept {
+// A Vulkan storage image view targets exactly ONE mip level, so a shader that selects the level
+// at runtime (ImageMipMode::DynamicStorage) cannot be served exactly by widening a check. But
+// when the DESCRIPTOR exposes a single level the runtime index is degenerate - only one value
+// can be valid - so binding that level is correct by construction, not an approximation.
+[[nodiscard]] inline bool
+IsDegenerateDynamicMip(const ShaderRecompiler::IR::ImageResource& resource, uint32_t base_level,
+                       uint32_t last_level) noexcept {
+	return resource.mip_mode == ShaderRecompiler::IR::ImageMipMode::DynamicStorage &&
+	       base_level == last_level;
+}
+
+inline void ValidateStorageImageResource(const ShaderRecompiler::IR::ImageResource& resource,
+                                         uint32_t base_level = 0,
+                                         uint32_t last_level = 0) noexcept {
+	if (resource.mip_mode == ShaderRecompiler::IR::ImageMipMode::DynamicStorage) {
+		auto relaxed     = resource;
+		relaxed.mip_mode = ShaderRecompiler::IR::ImageMipMode::None;
+		if (IsSupportedStorageImageResource(relaxed)) {
+			if (!IsDegenerateDynamicMip(resource, base_level, last_level)) {
+				// APPROXIMATION, and it is worth being precise about what is approximated.
+				// SPIR-V's OpImageWrite has no LOD operand, and the emitter reflects that:
+				// EmitImageMipLodU32 (spirvEmitterImageHelpers.cpp:241) has exactly ONE caller,
+				// EmitImageLoad's OpImageFetch (spirvEmitterImageOps.cpp:146) - the STORE path
+				// never reads it. So a dynamic-mip store already writes to whichever level the
+				// view targets; the mip operand is discarded regardless. Rejecting the resource
+				// never made that correct, it only turned an existing approximation into an
+				// abort.
+				//
+				// Serving it properly needs one view per level bound as a descriptor array and
+				// a switch in the shader. Until that exists, allow the write and say so: a
+				// mip-generation shader will fill one level repeatedly instead of the chain,
+				// which is a visible artefact, not corruption. Titles that do not use
+				// dynamic-mip storage images never reach this path, so nothing that works
+				// today is affected.
+				static std::atomic<uint32_t> reported {0};
+				if (reported.fetch_add(1, std::memory_order_relaxed) < 4) {
+					LOGF("[img] dynamic-mip storage write over levels %u..%u is served by the "
+					     "view's own level; mip selection is ignored (needs a per-level view "
+					     "array)\n",
+					     base_level, last_level);
+				}
+			}
+			return;
+		}
+	}
 	if (!IsSupportedStorageImageResource(resource)) {
 		EXIT("unsupported storage color image resource: kind=%u dimension=%u mip=%u "
 		     "read=%d written=%d atomic=%d depth_compare=%d\n",

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -5814,6 +5814,14 @@ public:
 			std::copy(std::begin(storage.fields), std::end(storage.fields),
 			          storage_descriptor.dwords.begin());
 			storage_descriptor.dword_count = 8;
+			auto clamped_mip_descriptor = storage_descriptor;
+			clamped_mip_descriptor.dwords[3] |= 1u << 16u;
+			const auto clamped_mip_binding = RenderExecutorTestAccess::ResolveTexture(
+			    executor, storage_resource, clamped_mip_descriptor);
+			Require(name, "clamped storage mip view",
+			        clamped_mip_binding.desc.view_info.base_level == 0 &&
+			            clamped_mip_binding.desc.view_info.level_count == 1,
+			        "storage view did not clamp LAST_LEVEL to its allocated backing mips");
 			auto           srgb_storage    = storage;
 			constexpr auto srgb_format =
 			    static_cast<uint32_t>(Prospero::BufferFormat::k8_8_8_8Srgb);
@@ -16333,6 +16341,10 @@ void CheckSampledColorViews() {
 	Require("SampledColorViews", "atomic uint 2D storage resource",
 	        IsSupportedStorageImageResource(storage_resource),
 	        "atomic uint storage resource was rejected");
+	auto dynamic_storage_resource     = storage_resource;
+	dynamic_storage_resource.atomic   = false;
+	dynamic_storage_resource.mip_mode = ShaderRecompiler::IR::ImageMipMode::DynamicStorage;
+	ValidateStorageImageResource(dynamic_storage_resource, 1, 1);
 
 	char path[MAX_PATH] {};
 	Require("SampledColorViews", "host", GetModuleFileNameA(nullptr, path, MAX_PATH) != 0,
@@ -16341,7 +16353,7 @@ void CheckSampledColorViews() {
 	     {"sampled-invalid-selector", "sampled-incompatible-format", "sampled-invalid-high",
 	      "sampled-depth-format", "sampled-depth-swizzle", "storage-incompatible-format",
 	      "storage-kind", "storage-no-write", "storage-nonuint-atomic", "storage-compare",
-	      "storage-mip", "storage-dimension", "volume-mip-count", "volume-slice-range"}) {
+	      "storage-dimension", "volume-mip-count", "volume-slice-range"}) {
 		std::string       command = std::string("\"") + path + "\" --image-view-death " + kind;
 		std::vector<char> mutable_command(command.begin(), command.end());
 		mutable_command.push_back('\0');
@@ -17177,6 +17189,16 @@ void CheckBasicStorageTextureDescriptor() {
 	        mip_one.BaseLevel() == 1 && mip_one.LastLevel() == 1 && mip_one.MaxMip() == 5,
 	        "PPSA01530 mip-one storage descriptor fixture is malformed");
 	ValidateStorageTexture(Ppsa01530MaxMipStorageTextureResource(), mip_one, 0x20000);
+	auto mip_range = max_mip;
+	mip_range.fields[3] |= (1u << 12u) | (3u << 16u);
+	Require("BasicStorageTexture", "multi-mip descriptor",
+	        mip_range.BaseLevel() == 1 && mip_range.LastLevel() == 3 &&
+	            mip_range.MaxMip() == 5,
+	        "multi-mip storage descriptor fixture is malformed");
+	ValidateStorageTexture(Ppsa01530MaxMipStorageTextureResource(), mip_range, 0x20000);
+	auto dynamic_mip_resource     = Ppsa01530MaxMipStorageTextureResource();
+	dynamic_mip_resource.mip_mode = ShaderRecompiler::IR::ImageMipMode::DynamicStorage;
+	ValidateStorageTexture(dynamic_mip_resource, mip_one, 0x20000);
 
 	const auto r16_float = Ppsa02527R16FloatStorageTextureDescriptor();
 	Require("BasicStorageTexture", "PPSA02527 R16F descriptor",


### PR DESCRIPTION
This allows image views to represent the mip range selected by the guest texture descriptor.

Previously, view creation could assume the complete image mip range. That is incorrect when a shader intentionally selects only part of an image's mip chain.

The change keeps view creation generic and validates the selected levels against the underlying image.

Testing:
- Built shader_recompiler_compute_tests successfully.
- Added coverage for texture mip-view selection.