### PR TITLE
gpu: support bindless sampled image resources

### DIFF
--- a/src/graphics/host_gpu/renderer/pipeline/descriptorCache.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptorCache.cpp
@@ -5,6 +5,7 @@
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 
 #include <array>
+#include <algorithm>
 
 namespace Libs::Graphics {
 namespace {
@@ -146,21 +147,35 @@ DescriptorCache::GetDescriptorSetLayoutInternal(Stage                           
 	return layout;
 }
 
-void DescriptorCache::CreatePool() {
+void DescriptorCache::CreatePool(const ShaderRecompiler::IR::Program& program) {
 	KYTY_PROFILER_FUNCTION();
-	constexpr uint32_t           MaxSets = 512;
-	const vk::DescriptorPoolSize sizes[] = {
-	    {vk::DescriptorType::eStorageBuffer,
-	     MaxSets * (ShaderRecompiler::IR::ShaderInfo::MaxBuffers +
-	                ShaderRecompiler::IR::ShaderInfo::MaxAddresses + 3u)},
-	    {vk::DescriptorType::eSampledImage, MaxSets * ShaderRecompiler::IR::ShaderInfo::MaxImages},
-	    {vk::DescriptorType::eStorageImage, MaxSets * ShaderRecompiler::IR::ShaderInfo::MaxImages},
-	    {vk::DescriptorType::eSampler, MaxSets * ShaderRecompiler::IR::ShaderInfo::MaxSamplers},
-	};
+	std::array<uint32_t, 4> per_set {};
+	for (const auto& binding: program.bindings.descriptors) {
+		const auto count = DescriptorCount(binding);
+		switch (DescriptorType(binding.kind)) {
+			case vk::DescriptorType::eStorageBuffer: per_set[0] += count; break;
+			case vk::DescriptorType::eSampledImage: per_set[1] += count; break;
+			case vk::DescriptorType::eStorageImage: per_set[2] += count; break;
+			case vk::DescriptorType::eSampler: per_set[3] += count; break;
+			default: EXIT("unsupported descriptor pool type\n");
+		}
+	}
+	constexpr uint32_t Batch = 32;
+	const uint32_t MaxSets = per_set[1] > ShaderRecompiler::IR::ShaderInfo::MaxImages ? Batch : 512u;
+	const std::array types = {vk::DescriptorType::eStorageBuffer,
+	                          vk::DescriptorType::eSampledImage,
+	                          vk::DescriptorType::eStorageImage,
+	                          vk::DescriptorType::eSampler};
+	std::vector<vk::DescriptorPoolSize> sizes;
+	for (uint32_t i = 0; i < per_set.size(); i++) {
+		if (per_set[i] != 0) {
+			sizes.push_back({types[i], MaxSets * per_set[i]});
+		}
+	}
 	vk::DescriptorPoolCreateInfo info {};
 	info.sType         = vk::StructureType::eDescriptorPoolCreateInfo;
-	info.poolSizeCount = static_cast<uint32_t>(std::size(sizes));
-	info.pPoolSizes    = sizes;
+	info.poolSizeCount = static_cast<uint32_t>(sizes.size());
+	info.pPoolSizes    = sizes.data();
 	info.maxSets       = MaxSets;
 	const auto pool_id = static_cast<int>(m_pools.size());
 	auto&      pool    = m_pools.emplace_back();
@@ -207,7 +222,7 @@ VulkanDescriptorSet* DescriptorCache::Allocate(Stage                            
 			m_first_free_pool = pool.next_free_pool;
 			break;
 		}
-		CreatePool();
+		CreatePool(program);
 	}
 	return nullptr;
 }
@@ -222,15 +237,22 @@ VulkanDescriptorSet& DescriptorCache::GetDescriptor(Stage                       
                                                     const ShaderRecompiler::IR::Program& program,
                                                     const NativeDescriptors&             data) {
 	KYTY_PROFILER_FUNCTION();
+	const auto has_dynamic_images =
+	    std::any_of(program.info.images.begin(), program.info.images.end(), [](const auto& image) {
+		    return image.HasDynamicTable();
+	    });
 	EXIT_IF(data.buffers.size() != program.info.buffers.size() ||
 	        data.images.size() != program.info.images.size() ||
+	        (has_dynamic_images && data.image_tables.size() != program.info.images.size()) ||
 	        data.samplers.size() != program.info.samplers.size() ||
 	        data.addresses.size() != program.info.addresses.size());
 	auto* set = Allocate(stage, program);
 	EXIT_NOT_IMPLEMENTED(set == nullptr);
 
-	const auto descriptor_count = program.info.buffers.size() + program.info.images.size() +
-	                              program.info.samplers.size() + program.info.addresses.size() + 3u;
+	size_t descriptor_count = 0;
+	for (const auto& binding: program.bindings.descriptors) {
+		descriptor_count += DescriptorCount(binding);
+	}
 	std::vector<vk::DescriptorBufferInfo> buffer_infos;
 	std::vector<vk::DescriptorImageInfo>  image_infos;
 	std::vector<vk::WriteDescriptorSet>   writes;
@@ -271,8 +293,12 @@ VulkanDescriptorSet& DescriptorCache::GetDescriptor(Stage                       
 				}
 				break;
 			default: {
+				std::vector<uint32_t> table_indices(data.images.size());
 				for (const auto resource: binding.resources) {
-					const auto& texture = data.images.at(resource);
+					const auto& texture = program.info.images.at(resource).HasDynamicTable()
+					                          ? data.image_tables.at(resource).at(
+					                                table_indices.at(resource)++)
+					                          : data.images.at(resource);
 					image_infos.push_back(MakeImageInfo(texture));
 				}
 				break;

--- a/src/graphics/host_gpu/renderer/pipeline/descriptorCache.h
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptorCache.h
@@ -56,6 +56,7 @@ public:
 	struct NativeDescriptors {
 		std::vector<BufferView>     buffers;
 		std::vector<TextureBinding> images;
+		std::vector<std::vector<TextureBinding>> image_tables;
 		std::vector<vk::Sampler>    samplers;
 		std::vector<BufferView>     addresses;
 		BufferView                  gds;
@@ -95,7 +96,7 @@ private:
 	};
 
 	static vk::DescriptorImageInfo MakeImageInfo(const TextureBinding& texture);
-	void                           CreatePool();
+	void                           CreatePool(const ShaderRecompiler::IR::Program& program);
 	VulkanDescriptorSet* Allocate(Stage stage, const ShaderRecompiler::IR::Program& program);
 	vk::DescriptorSetLayout
 	GetDescriptorSetLayoutInternal(Stage stage, const ShaderRecompiler::IR::Program& program);

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -291,6 +291,14 @@ static void VulkanFindPhysicalDevice(vk::Instance instance, vk::SurfaceKHR surfa
 			LOGF("shaderStorageImageReadWithoutFormat is not supported\n");
 			skip_device = true;
 		}
+		if (features12.shaderSampledImageArrayNonUniformIndexing != VK_TRUE) {
+			LOGF("shaderSampledImageArrayNonUniformIndexing is not supported\n");
+			skip_device = true;
+		}
+		if (device_features2.features.shaderSampledImageArrayDynamicIndexing != VK_TRUE) {
+			LOGF("shaderSampledImageArrayDynamicIndexing is not supported\n");
+			skip_device = true;
+		}
 
 		if (device_features2.features.shaderImageGatherExtended != VK_TRUE) {
 			LOGF("shaderImageGatherExtended is not supported\n");
@@ -553,7 +561,11 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	                     supported_features13.synchronization2 != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(supported_features2.features.sampleRateShading != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(supported_features2.features.depthBiasClamp != VK_TRUE);
+	EXIT_NOT_IMPLEMENTED(
+	    supported_features2.features.shaderSampledImageArrayDynamicIndexing != VK_TRUE);
+	EXIT_NOT_IMPLEMENTED(supported_features12.shaderSampledImageArrayNonUniformIndexing != VK_TRUE);
 	features12.timelineSemaphore = VK_TRUE;
+	features12.shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
 
 	vk::PhysicalDeviceFeatures device_features {};
 	device_features.fragmentStoresAndAtomics = VK_TRUE;
@@ -564,6 +576,7 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 #endif
 	device_features.shaderStorageImageWriteWithoutFormat = VK_TRUE;
 	device_features.shaderStorageImageReadWithoutFormat  = VK_TRUE;
+	device_features.shaderSampledImageArrayDynamicIndexing = VK_TRUE;
 	device_features.shaderImageGatherExtended            = VK_TRUE;
 	device_features.independentBlend                     = VK_TRUE;
 	device_features.tessellationShader                   = VK_TRUE;

--- a/src/graphics/shader/recompiler/emitter/SpirvEmitter.cpp
+++ b/src/graphics/shader/recompiler/emitter/SpirvEmitter.cpp
@@ -249,7 +249,11 @@ bool ValidateNativeProgram(const IR::Program& program, std::string* error) {
 			return Fail(error, "native shader plan has an invalid image class");
 		}
 		present[static_cast<size_t>(kind)] = true;
-		expected[static_cast<size_t>(kind)].push_back(i);
+		auto& resources = expected[static_cast<size_t>(kind)];
+		const auto descriptor_count = program.info.images[i].HasDynamicTable()
+		                                ? program.info.images[i].dynamic_descriptor_count + 1u
+		                                : 1u;
+		resources.insert(resources.end(), descriptor_count, i);
 	}
 	if (!program.info.samplers.empty()) {
 		Expect(Kind::Samplers, Dense(program.info.samplers.size()));
@@ -488,6 +492,10 @@ bool EmitProgram(const IR::Program& program, const IR::ResourceSnapshot& resourc
 	state.needs_subgroup_local_invocation_id = ProgramNeedsSubgroupLocalInvocationId(program);
 	state.needs_compute_derivatives          = ProgramNeedsComputeDerivatives(program);
 	state.needs_image_gather_extended        = ProgramNeedsImageGatherExtended(program);
+	state.needs_sampled_image_nonuniform =
+	    std::any_of(program.info.images.begin(), program.info.images.end(), [](const auto& image) {
+		    return image.HasDynamicTable();
+	    });
 	state.needs_function_lds                 = ProgramNeedsFunctionLds(program);
 	state.needs_pixel_valid_mask             = ProgramNeedsPixelValidMask(program);
 	ComputeReachableBlocks(state, program);

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterAnalysis.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterAnalysis.cpp
@@ -176,6 +176,9 @@ void CollectRegisters(const IR::Program& program, std::vector<RegisterBinding>& 
 					CollectRegister(registers, inst.src[i].reg);
 				}
 			}
+			if (inst.memory.dynamic_resource_offset.kind == IR::OperandKind::Register) {
+				CollectRegister(registers, inst.memory.dynamic_resource_offset.reg);
+			}
 			if (IsPairDwordOpcode(inst.op)) {
 				CollectSequentialRegisters(registers, inst.dst, 2);
 				const uint32_t first_pair_src = inst.op == IR::Opcode::SelectU64 ? 1u : 0u;
@@ -450,12 +453,20 @@ uint32_t DescriptorElementPointer(EmitterState& state, uint32_t result_ptr_type,
                                   uint32_t variable_id, uint32_t array_index,
                                   IR::DescriptorBindingKind kind, uint32_t resource,
                                   const char* variable_name) {
+	return DescriptorElementPointerId(state, result_ptr_type, variable_id,
+	                                  ConstantU32(state, array_index), kind, resource,
+	                                  variable_name);
+}
+
+uint32_t DescriptorElementPointerId(EmitterState& state, uint32_t result_ptr_type,
+	                                uint32_t variable_id, uint32_t array_index_id,
+	                                IR::DescriptorBindingKind kind, uint32_t resource,
+	                                const char* variable_name) {
 	if (variable_id == 0) {
 		ExitDescriptorBindingFailure(state, kind, resource, variable_name);
 	}
 	const auto pointer = state.builder.AllocateId();
-	state.builder.AddFunction(
-	    {OpAccessChain, result_ptr_type, pointer, variable_id, ConstantU32(state, array_index)});
+	state.builder.AddFunction({OpAccessChain, result_ptr_type, pointer, variable_id, array_index_id});
 	return pointer;
 }
 
@@ -548,11 +559,37 @@ uint32_t LoadSampledImageDescriptor(EmitterState& state, const IR::MemoryInfo& m
 	const auto  kind        = SampledBindingKind(integer, view);
 	const auto  binding     = ResourceForDescriptor(state, kind, mem.resource);
 	const auto& descriptors = state.sampled_images[SampledImageIndex(integer, view)];
-	const auto  pointer     = DescriptorElementPointer(
-	    state, descriptors.pointer_type, descriptors.variable, binding.array_index, kind,
+	auto descriptor_index = ConstantU32(state, binding.array_index);
+	const auto& resource   = state.program.info.images.at(mem.resource);
+	const bool dynamic     = resource.HasDynamicTable();
+	if (dynamic) {
+		auto byte_offset = EmitValueLoad(state, mem.dynamic_resource_offset);
+		if (mem.dynamic_resource_base_offset != 0) {
+			byte_offset = EmitAddU32(state, byte_offset,
+			                         ConstantU32(state, mem.dynamic_resource_base_offset));
+		}
+		const auto guest_index = state.builder.AllocateId();
+		state.builder.AddFunction({OpShiftRightLogical, state.uint_type, guest_index, byte_offset,
+		                           ConstantU32(state, 5)});
+		const auto in_bounds = state.builder.AllocateId();
+		state.builder.AddFunction({OpULessThan, state.bool_type, in_bounds, guest_index,
+		                           ConstantU32(state, resource.dynamic_descriptor_count)});
+		const auto safe_index = state.builder.AllocateId();
+		state.builder.AddFunction({OpSelect, state.uint_type, safe_index, in_bounds, guest_index,
+		                           ConstantU32(state, resource.dynamic_descriptor_count)});
+		descriptor_index = EmitAddU32(state, descriptor_index, safe_index);
+	}
+	const auto pointer = DescriptorElementPointerId(
+	    state, descriptors.pointer_type, descriptors.variable, descriptor_index, kind,
 	    mem.resource, "sampled image descriptor array was not emitted");
+	if (dynamic) {
+		state.builder.AddAnnotation({OpDecorate, pointer, DecorationNonUniform});
+	}
 	const auto image = state.builder.AllocateId();
 	state.builder.AddFunction({OpLoad, ImageViewImageType(state, view, integer), image, pointer});
+	if (dynamic) {
+		state.builder.AddAnnotation({OpDecorate, image, DecorationNonUniform});
+	}
 	return image;
 }
 
@@ -581,6 +618,9 @@ uint32_t MakeSampledImage(EmitterState& state, const IR::MemoryInfo& mem, uint32
 	    {OpSampledImage,
 	     ImageViewSampledImageType(state, view, mem.kind == IR::ResourceKind::ImageUint),
 	     sampled_image, image, sampler});
+	if (state.program.info.images.at(mem.resource).HasDynamicTable()) {
+		state.builder.AddAnnotation({OpDecorate, sampled_image, DecorationNonUniform});
+	}
 	return sampled_image;
 }
 

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
@@ -43,6 +43,7 @@ enum : uint32_t {
 	CapabilityGroupNonUniform                = 61,
 	CapabilityGroupNonUniformBallot          = 64,
 	CapabilityGroupNonUniformShuffle         = 65,
+	CapabilitySampledImageArrayNonUniformIndexing = 5307,
 	CapabilityComputeDerivativeGroupQuadsKHR = 5288,
 	StorageClassUniformConstant              = 0,
 	StorageClassInput                        = 1,
@@ -67,6 +68,7 @@ enum : uint32_t {
 	DecorationBinding       = 33,
 	DecorationDescriptorSet = 34,
 	DecorationOffset        = 35,
+	DecorationNonUniform    = 5300,
 };
 
 enum : uint32_t {
@@ -412,6 +414,7 @@ struct EmitterState {
 	bool                                             needs_subgroup_local_invocation_id    = false;
 	bool                                             needs_compute_derivatives             = false;
 	bool                                             needs_image_gather_extended           = false;
+	bool                                             needs_sampled_image_nonuniform        = false;
 	bool                                             needs_function_lds                    = false;
 	bool                                             needs_pixel_valid_mask                = false;
 	bool                                             unsupported_ir_instruction            = false;
@@ -675,6 +678,11 @@ uint32_t DescriptorElementPointer(EmitterState& state, uint32_t result_ptr_type,
                                   uint32_t variable_id, uint32_t array_index,
                                   IR::DescriptorBindingKind kind, uint32_t resource,
                                   const char* variable_name);
+
+uint32_t DescriptorElementPointerId(EmitterState& state, uint32_t result_ptr_type,
+                                    uint32_t variable_id, uint32_t array_index_id,
+                                    IR::DescriptorBindingKind kind, uint32_t resource,
+                                    const char* variable_name);
 
 ImageViewKind SampledImageViewKind(const EmitterState& state, const IR::MemoryInfo& mem,
                                    uint32_t use_pc);

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterModule.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterModule.cpp
@@ -500,6 +500,10 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	if (state.needs_subgroup_shuffle) {
 		state.builder.AddCapability({CapabilityGroupNonUniformShuffle});
 	}
+	if (state.needs_sampled_image_nonuniform) {
+		state.builder.AddCapability({CapabilitySampledImageArrayNonUniformIndexing});
+		state.builder.AddExtension("SPV_EXT_descriptor_indexing");
+	}
 	if (state.needs_compute_derivatives && state.stage == ShaderType::Compute) {
 		state.builder.AddCapability({CapabilityComputeDerivativeGroupQuadsKHR});
 		state.builder.AddExtension("SPV_KHR_compute_shader_derivatives");

--- a/src/graphics/shader/recompiler/ir/BindingLayout.cpp
+++ b/src/graphics/shader/recompiler/ir/BindingLayout.cpp
@@ -269,7 +269,11 @@ bool AllocateBindings(Program& program, const BindingLayoutOptions& options, std
 			}
 			return false;
 		}
-		image_groups[static_cast<size_t>(group - ImageBindingKinds.begin())].push_back(i);
+		auto& resources = image_groups[static_cast<size_t>(group - ImageBindingKinds.begin())];
+		const auto descriptor_count = program.info.images[i].HasDynamicTable()
+		                                ? program.info.images[i].dynamic_descriptor_count + 1u
+		                                : 1u;
+		resources.insert(resources.end(), descriptor_count, i);
 	}
 	for (uint32_t i = 0; i < image_groups.size(); i++) {
 		if (!image_groups[i].empty()) {

--- a/src/graphics/shader/recompiler/ir/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/ResourceMaterialization.cpp
@@ -4,6 +4,7 @@
 #include "graphics/shader/shaderBindings.h"
 
 #include <algorithm>
+#include <cstring>
 #include <fmt/format.h>
 #include <functional>
 
@@ -11,6 +12,8 @@ namespace Libs::Graphics::ShaderRecompiler::IR {
 namespace {
 
 constexpr uint64_t AddressMask = 0x0000ffffffffffffull;
+constexpr uint32_t DynamicImageDescriptorBytes = 8u * sizeof(uint32_t);
+constexpr uint32_t MaxDynamicImageDescriptors  = 65536;
 
 Decoder::ImageDimension DescriptorDimension(const DescriptorValue&  descriptor,
                                             Decoder::ImageDimension requested) {
@@ -62,6 +65,29 @@ bool ValidImageDescriptor(const DescriptorValue& descriptor) {
 	return true;
 }
 
+bool DynamicDescriptorIsTexture(const DescriptorValue& descriptor) {
+	// SCE Agc::Core::ResourceDescriptor stores its two-bit mixed-resource tag in byte 23.
+	// Texture is tag zero; buffers, samplers, and unused slots must not be decoded as images.
+	return descriptor.dword_count == 8 && ((descriptor.dwords[5] >> 27u) & 0x3u) == 0;
+}
+
+bool CompatibleDynamicImageDescriptor(const ImageResource& image,
+	                                  const DescriptorValue& descriptor) {
+	if (!DynamicDescriptorIsTexture(descriptor)) {
+		return false;
+	}
+	if (NullImageDescriptor(descriptor)) {
+		return true;
+	}
+	if (!ValidImageDescriptor(descriptor) ||
+	    DescriptorDimension(descriptor, image.dimension) != image.dimension) {
+		return false;
+	}
+	const auto format = static_cast<Prospero::BufferFormat>((descriptor.dwords[1] >> 20u) & 0x1ffu);
+	const auto integer = image.kind == ResourceKind::ImageUint;
+	return Prospero::IsUintTextureFormat(format) == integer && !(image.depth_compare && integer);
+}
+
 uint32_t DescriptorImageSwizzle(const DescriptorValue& descriptor) {
 	return descriptor.dwords[3] & 0xfffu;
 }
@@ -76,6 +102,136 @@ bool DecodeBufferDescriptor(const DescriptorValue& descriptor, ShaderBufferResou
 		return false;
 	}
 	std::copy_n(descriptor.dwords.begin(), std::size(result.fields), result.fields);
+	return true;
+}
+
+bool ReadRuntimeDword(const SrtRuntime& runtime, uint64_t address, uint32_t& result) {
+	if (runtime.read_memory != nullptr) {
+		return runtime.read_memory(runtime.userdata, address, &result);
+	}
+	std::memcpy(&result, reinterpret_cast<const void*>(address), sizeof(result));
+	return true;
+}
+
+bool MaterializeDynamicImageTable(const ImageResource& image,
+	                              const DescriptorValue& table_value,
+	                              const SrtRuntime& runtime,
+	                              std::vector<DescriptorValue>& result,
+	                              std::string* error) {
+	ShaderBufferResource table;
+	if (!DecodeBufferDescriptor(table_value, table)) {
+		if (error != nullptr) {
+			*error = "dynamic image table has an invalid buffer descriptor";
+		}
+		return false;
+	}
+	const auto stride  = static_cast<uint64_t>(table.Stride());
+	const auto records = static_cast<uint64_t>(table.NumRecords());
+	if (stride != 0 && records > UINT64_MAX / stride) {
+		if (error != nullptr) {
+			*error = "dynamic image table footprint overflows";
+		}
+		return false;
+	}
+	const auto bytes = stride == 0 ? records : stride * records;
+	if (bytes == 0 || bytes % DynamicImageDescriptorBytes != 0) {
+		if (error != nullptr) {
+			*error = fmt::format("dynamic image table has unsupported byte size {}", bytes);
+		}
+		return false;
+	}
+	const auto count = bytes / DynamicImageDescriptorBytes;
+	if (count > MaxDynamicImageDescriptors) {
+		if (error != nullptr) {
+			*error = fmt::format("dynamic image table has {} descriptors; limit is {}", count,
+			                     MaxDynamicImageDescriptors);
+		}
+		return false;
+	}
+	const auto base = table.Base48();
+	if (base == 0 || base > AddressMask - bytes) {
+		if (error != nullptr) {
+			*error = "dynamic image table address is invalid";
+		}
+		return false;
+	}
+	std::vector<DescriptorValue> next;
+	next.reserve(static_cast<size_t>(count) + 1u);
+	for (uint64_t entry = 0; entry < count; entry++) {
+		DescriptorValue descriptor;
+		descriptor.dword_count = 8;
+		for (uint32_t dword = 0; dword < descriptor.dword_count; dword++) {
+			const auto address = base + entry * DynamicImageDescriptorBytes +
+			                     dword * sizeof(uint32_t);
+			if (!ReadRuntimeDword(runtime, address, descriptor.dwords[dword])) {
+				if (error != nullptr) {
+					*error = fmt::format("dynamic image table read failed at 0x{:016x}", address);
+				}
+				return false;
+			}
+		}
+		if (!CompatibleDynamicImageDescriptor(image, descriptor)) {
+			descriptor.dwords.fill(0);
+		}
+		next.push_back(descriptor);
+	}
+	DescriptorValue sentinel;
+	sentinel.dword_count = 8;
+	next.push_back(sentinel);
+	result = std::move(next);
+	return true;
+}
+
+bool MaterializeDynamicImageAddressTable(const ImageResource& image,
+	                                      const DescriptorValue& table_address,
+	                                      const SrtRuntime& runtime,
+	                                      std::vector<DescriptorValue>& result,
+	                                      std::string* error) {
+	if (table_address.dword_count != 2 || image.dynamic_table_address_count == 0) {
+		if (error != nullptr) {
+			*error = "dynamic image address table has invalid metadata";
+		}
+		return false;
+	}
+	const auto pointer = (static_cast<uint64_t>(table_address.dwords[0]) |
+	                      static_cast<uint64_t>(table_address.dwords[1]) << 32u) &
+	                     AddressMask;
+	const auto bytes = static_cast<uint64_t>(image.dynamic_table_address_count) *
+	                   DynamicImageDescriptorBytes;
+	if (pointer == 0 || image.dynamic_table_address_offset > AddressMask - pointer ||
+	    bytes > AddressMask - (pointer + image.dynamic_table_address_offset)) {
+		if (error != nullptr) {
+			*error = "dynamic image address table range is invalid";
+		}
+		return false;
+	}
+	const auto base = pointer + image.dynamic_table_address_offset;
+	std::vector<DescriptorValue> next;
+	next.reserve(static_cast<size_t>(image.dynamic_table_address_count) + 1u);
+	for (uint32_t entry = 0; entry < image.dynamic_table_address_count; entry++) {
+		DescriptorValue descriptor;
+		descriptor.dword_count = 8;
+		for (uint32_t dword = 0; dword < descriptor.dword_count; dword++) {
+			const auto address = base + static_cast<uint64_t>(entry) *
+			                                DynamicImageDescriptorBytes +
+			                     dword * sizeof(uint32_t);
+			if (!ReadRuntimeDword(runtime, address, descriptor.dwords[dword])) {
+				if (error != nullptr) {
+					*error = fmt::format("dynamic image address table read failed at 0x{:016x}",
+					                     address);
+				}
+				return false;
+			}
+		}
+		if (!CompatibleDynamicImageDescriptor(image, descriptor)) {
+			descriptor.dwords.fill(0);
+		}
+		next.push_back(descriptor);
+	}
+	DescriptorValue sentinel;
+	sentinel.dword_count = 8;
+	next.push_back(sentinel);
+	result = std::move(next);
 	return true;
 }
 
@@ -96,8 +252,14 @@ bool ValidateResourceSnapshot(const Program& program, const ResourceSnapshot& sn
 		}
 		return false;
 	}
+	const bool has_dynamic_images =
+	    std::any_of(program.info.images.begin(), program.info.images.end(), [](const auto& image) {
+		    return image.HasDynamicTable();
+	    });
 	if (snapshot.buffers.size() != program.info.buffers.size() ||
 	    snapshot.images.size() != program.info.images.size() ||
+	    (snapshot.image_tables.size() != program.info.images.size() &&
+	     (has_dynamic_images || !snapshot.image_tables.empty())) ||
 	    snapshot.samplers.size() != program.info.samplers.size() ||
 	    snapshot.addresses.size() != program.info.addresses.size()) {
 		if (error != nullptr) {
@@ -129,6 +291,34 @@ bool ValidateResourceSnapshot(const Program& program, const ResourceSnapshot& sn
 				*error = fmt::format("buffer resource {} has invalid image alias {}", i, alias);
 			}
 			return false;
+		}
+	}
+	for (uint32_t i = 0; i < program.info.images.size(); i++) {
+		const auto& image = program.info.images[i];
+		const std::vector<DescriptorValue> empty_table;
+		const auto& table = snapshot.image_tables.empty() ? empty_table : snapshot.image_tables[i];
+		if (!image.HasDynamicTable()) {
+			if (!table.empty()) {
+				if (error != nullptr) {
+					*error = fmt::format("static image resource {} has a dynamic table", i);
+				}
+				return false;
+			}
+		} else if (table.empty() ||
+		           (image.dynamic_descriptor_count != 0 &&
+		            table.size() != static_cast<size_t>(image.dynamic_descriptor_count) + 1u)) {
+			if (error != nullptr) {
+				*error = fmt::format("dynamic image resource {} has an incompatible table size", i);
+			}
+			return false;
+		}
+		for (const auto& descriptor: table) {
+			if (descriptor.dword_count != 8) {
+				if (error != nullptr) {
+					*error = fmt::format("dynamic image resource {} has a malformed descriptor", i);
+				}
+				return false;
+			}
 		}
 	}
 	const auto CheckWidth = [&](const auto& values, uint32_t width, const char* kind) {
@@ -180,6 +370,21 @@ bool ValidateResourceSpecialization(const Program& program, const ResourceSnapsh
 	for (uint32_t i = 0; i < program.info.images.size(); i++) {
 		const auto& image      = program.info.images[i];
 		const auto& descriptor = snapshot.images[i];
+		if (image.HasDynamicTable()) {
+			if (snapshot.image_tables[i].size() !=
+			        static_cast<size_t>(image.dynamic_descriptor_count) + 1u ||
+			    !std::all_of(snapshot.image_tables[i].begin(), snapshot.image_tables[i].end(),
+			                 [&](const auto& value) {
+				                 return CompatibleDynamicImageDescriptor(image, value);
+			                 })) {
+				if (error != nullptr) {
+					*error = fmt::format("dynamic image descriptor table {} no longer matches specialization",
+					                     i);
+				}
+				return false;
+			}
+			continue;
+		}
 		if (NullImageDescriptor(descriptor)) {
 			bool canonical_kind =
 			    image.kind == ResourceKind::Image || image.kind == ResourceKind::StorageImage;
@@ -220,13 +425,13 @@ bool ValidateResourceSpecialization(const Program& program, const ResourceSnapsh
 				}
 				return false;
 			}
-			const auto format =
-			    static_cast<Prospero::BufferFormat>((descriptor.dwords[1] >> 20u) & 0x1ffu);
-			const bool raw_sint_storage = storage && format == Prospero::BufferFormat::k32SInt &&
-			                              !image.read && !image.atomic;
-			const bool uint_descriptor  = Prospero::IsUintTextureFormat(format) || raw_sint_storage;
-			const auto uint_program     = image.kind == ResourceKind::ImageUint ||
-			                              image.kind == ResourceKind::StorageImageUint;
+			const auto format = static_cast<Prospero::BufferFormat>((descriptor.dwords[1] >> 20u) & 0x1ffu);
+			const bool raw_sint_storage =
+			    storage && format == Prospero::BufferFormat::k32SInt &&
+			    !image.read && !image.atomic;
+			const bool uint_descriptor = Prospero::IsUintTextureFormat(format) || raw_sint_storage;
+			const auto uint_program    = image.kind == ResourceKind::ImageUint ||
+			                             image.kind == ResourceKind::StorageImageUint;
 			if (uint_descriptor != uint_program && !(image.atomic && uint_program)) {
 				if (error != nullptr) {
 					*error = fmt::format(
@@ -274,7 +479,11 @@ bool MaterializeResources(const Program& program, const SrtRuntime& runtime,
 		requests.push_back({buffer.source, buffer.first_use_pc});
 	}
 	for (const auto& image: program.info.images) {
-		requests.push_back({image.source, image.first_use_pc});
+		if (image.dynamic_table_address_count != 0) {
+			requests.push_back({image.dynamic_table_source, image.first_use_pc});
+		} else if (!image.HasDynamicTable()) {
+			requests.push_back({image.source, image.first_use_pc});
+		}
 	}
 	for (const auto& sampler: program.info.samplers) {
 		requests.push_back({sampler.source, sampler.first_use_pc});
@@ -301,11 +510,31 @@ bool MaterializeResources(const Program& program, const SrtRuntime& runtime,
 			descriptor.dwords.fill(0);
 		}
 	}
-	next.images.assign(cursor, cursor + program.info.images.size());
-	cursor += program.info.images.size();
-	for (auto& descriptor: next.images) {
-		if (!ValidImageDescriptor(descriptor)) {
-			descriptor.dwords.fill(0);
+	next.images.reserve(program.info.images.size());
+	next.image_tables.resize(program.info.images.size());
+	for (uint32_t i = 0; i < program.info.images.size(); i++) {
+		const auto& image = program.info.images[i];
+		if (image.HasDynamicTable()) {
+			DescriptorValue null_descriptor;
+			null_descriptor.dword_count = 8;
+			next.images.push_back(null_descriptor);
+			if (image.dynamic_table_address_count != 0) {
+				if (!MaterializeDynamicImageAddressTable(image, *cursor++, runtime,
+				                                         next.image_tables[i], error)) {
+					return false;
+				}
+			} else if (image.dynamic_table_buffer >= next.buffers.size() ||
+			           !MaterializeDynamicImageTable(image,
+			                                         next.buffers[image.dynamic_table_buffer], runtime,
+			                                         next.image_tables[i], error)) {
+				return false;
+			}
+		} else {
+			auto descriptor = *cursor++;
+			if (!ValidImageDescriptor(descriptor)) {
+				descriptor.dwords.fill(0);
+			}
+			next.images.push_back(descriptor);
 		}
 	}
 	next.samplers.assign(cursor, cursor + program.info.samplers.size());
@@ -382,6 +611,17 @@ bool SpecializeResources(Program& program, const ResourceSnapshot& snapshot, std
 	for (uint32_t i = 0; i < next.images.size(); i++) {
 		const auto& descriptor = snapshot.images[i];
 		auto&       image      = next.images[i];
+		if (image.HasDynamicTable()) {
+			if (snapshot.image_tables[i].empty()) {
+				if (error != nullptr) {
+					*error = fmt::format("dynamic image resource {} has no table entries", i);
+				}
+				return false;
+			}
+			image.dynamic_descriptor_count =
+			    static_cast<uint32_t>(snapshot.image_tables[i].size() - 1u);
+			continue;
+		}
 		if (NullImageDescriptor(descriptor)) {
 			image.dimension = Decoder::ImageDimension::Dim2D;
 			image.cube      = false;
@@ -415,12 +655,12 @@ bool SpecializeResources(Program& program, const ResourceSnapshot& snapshot, std
 		    image.kind == ResourceKind::StorageImageUint) {
 			image.storage_swizzle = DescriptorImageSwizzle(descriptor);
 		}
-		const auto format =
-		    static_cast<Prospero::BufferFormat>((descriptor.dwords[1] >> 20u) & 0x1ffu);
+		const auto format  = static_cast<Prospero::BufferFormat>((descriptor.dwords[1] >> 20u) & 0x1ffu);
 		const bool storage = image.kind == ResourceKind::StorageImage ||
 		                     image.kind == ResourceKind::StorageImageUint;
 		const bool raw_sint_storage =
-		    storage && format == Prospero::BufferFormat::k32SInt && !image.read && !image.atomic;
+		    storage && format == Prospero::BufferFormat::k32SInt &&
+		    !image.read && !image.atomic;
 		const bool uint_image = Prospero::IsUintTextureFormat(format) || raw_sint_storage;
 		if (uint_image) {
 			switch (image.kind) {

--- a/src/graphics/shader/recompiler/ir/ResourceMaterialization.h
+++ b/src/graphics/shader/recompiler/ir/ResourceMaterialization.h
@@ -17,6 +17,9 @@ struct ResourceSnapshot {
 
 	std::vector<DescriptorValue> buffers;
 	std::vector<DescriptorValue> images;
+	// One entry per dense image resource. Static images keep an empty table. Dynamic images hold
+	// every guest table entry followed by a canonical null sentinel used for out-of-range access.
+	std::vector<std::vector<DescriptorValue>> image_tables;
 	std::vector<DescriptorValue> samplers;
 	std::vector<Address>         addresses;
 	std::vector<uint32_t>        flattened_srt;

--- a/src/graphics/shader/recompiler/ir/ResourceTracking.cpp
+++ b/src/graphics/shader/recompiler/ir/ResourceTracking.cpp
@@ -181,12 +181,17 @@ public:
 				}
 			}
 		}
+		if (!LinkDynamicImageTables(error)) {
+			return false;
+		}
 		LinkImageAliases();
 		m_program.info = std::move(m_info);
 		for (const auto& patch: m_patches) {
 			auto& inst                  = patch.inst.get();
 			inst.memory.resource        = patch.resource;
 			inst.memory.sampler         = patch.sampler;
+			inst.memory.dynamic_resource_offset = patch.dynamic_resource_offset;
+			inst.memory.dynamic_resource_base_offset = patch.dynamic_resource_base_offset;
 			inst.memory.resource_source = ScalarProvenance::Undefined;
 			inst.memory.sampler_source  = ScalarProvenance::Undefined;
 		}
@@ -195,10 +200,20 @@ public:
 	}
 
 private:
+	struct DynamicImagePattern {
+		uint32_t table_source = ScalarProvenance::Undefined;
+		Operand  offset;
+		uint32_t base_offset = 0;
+		uint32_t table_address_offset = 0;
+		uint32_t table_address_count = 0;
+	};
+
 	struct Patch {
 		std::reference_wrapper<Instruction> inst;
 		uint32_t                            resource = 0;
 		uint32_t                            sampler  = 0;
+		Operand                             dynamic_resource_offset;
+		uint32_t                            dynamic_resource_base_offset = 0;
 	};
 
 	bool Fail(uint32_t pc, std::string* error, const std::string& reason) const {
@@ -209,11 +224,211 @@ private:
 		return false;
 	}
 
-	bool ValidateSource(uint32_t source, uint32_t dwords, uint32_t pc, std::string* error) const {
+	uint32_t FindDescriptorSource(const DescriptorValue& descriptor) const {
+		for (uint32_t i = 0; i < m_program.provenance.descriptors.size(); i++) {
+			if (m_program.provenance.descriptors[i] == descriptor) {
+				return i + 2u;
+			}
+		}
+		return ScalarProvenance::Undefined;
+	}
+
+	const Instruction* FindScalarLoadProducer(uint32_t value) const {
+		for (const auto& block: m_program.blocks) {
+			for (const auto& inst: block.instructions) {
+				if ((inst.op == Opcode::SBufferLoadDword || inst.op == Opcode::SLoadDword) &&
+				    inst.scalar_value == value &&
+				    inst.src_count == 1) {
+					return &inst;
+				}
+			}
+		}
+		return nullptr;
+	}
+
+	bool ConstantValue(uint32_t id, uint32_t& result) const {
+		if (id >= m_program.provenance.values.size()) {
+			return false;
+		}
+		const auto& value = m_program.provenance.values[id];
+		if (value.op != ScalarValueOp::Constant) {
+			return false;
+		}
+		result = value.imm;
+		return true;
+	}
+
+	bool DecodeDirectTableOffset(uint32_t id, uint32_t& index, uint32_t& count,
+	                             uint32_t& constant) const {
+		if (id >= m_program.provenance.values.size()) {
+			return false;
+		}
+		const auto& value = m_program.provenance.values[id];
+		if (value.op == ScalarValueOp::Add) {
+			uint32_t folded = 0;
+			if (ConstantValue(value.args[0], folded) &&
+			    DecodeDirectTableOffset(value.args[1], index, count, constant)) {
+				constant += folded;
+				return true;
+			}
+			if (ConstantValue(value.args[1], folded) &&
+			    DecodeDirectTableOffset(value.args[0], index, count, constant)) {
+				constant += folded;
+				return true;
+			}
+			return false;
+		}
+		if (value.op != ScalarValueOp::ShiftLeft) {
+			return false;
+		}
+		uint32_t shift = 0;
+		if (!ConstantValue(value.args[1], shift) || shift != 5u ||
+		    value.args[0] >= m_program.provenance.values.size() ||
+		    m_program.provenance.values[value.args[0]].op != ScalarValueOp::FindLsbU32) {
+			return false;
+		}
+		// The official Prospero ISA operation s_ff1_i32_b32 selects a bit from a
+		// 32-bit source. A non-zero source therefore yields a descriptor index in [0, 31].
+		index    = value.args[0];
+		count    = 32;
+		constant = 0;
+		return true;
+	}
+
+	bool DetectDirectImageTable(const DescriptorValue& descriptor,
+	                            DynamicImagePattern& result) const {
+		if (descriptor.dword_count != 8) {
+			return false;
+		}
+		DescriptorValue table;
+		table.dword_count = 2;
+		uint32_t common_index = ScalarProvenance::Undefined;
+		uint32_t descriptor_count = 0;
+		uint32_t table_offset = 0;
+		Operand  offset_operand;
+		for (uint32_t i = 0; i < descriptor.dword_count; i++) {
+			const auto id = descriptor.dwords[i];
+			if (id >= m_program.provenance.values.size()) {
+				return false;
+			}
+			const auto& value = m_program.provenance.values[id];
+			if (value.op != ScalarValueOp::ReadConst) {
+				return false;
+			}
+			uint32_t index = 0;
+			uint32_t count = 0;
+			uint32_t offset = 0;
+			if (!DecodeDirectTableOffset(value.args[2], index, count, offset)) {
+				return false;
+			}
+			offset += value.imm;
+			const auto* producer = FindScalarLoadProducer(id);
+			if (producer == nullptr || producer->src[0].kind != OperandKind::Register) {
+				return false;
+			}
+			if (i == 0) {
+				table.dwords[0] = value.args[0];
+				table.dwords[1] = value.args[1];
+				common_index     = index;
+				descriptor_count = count;
+				table_offset     = offset;
+				offset_operand   = producer->src[0];
+			} else if (value.args[0] != table.dwords[0] ||
+			           value.args[1] != table.dwords[1] || index != common_index ||
+			           count != descriptor_count || offset != table_offset + i * sizeof(uint32_t)) {
+				return false;
+			}
+		}
+		const auto table_source = FindDescriptorSource(table);
+		if (table_source == ScalarProvenance::Undefined ||
+		    !DescriptorSourceResolved(m_program, table_source)) {
+			return false;
+		}
+		result.table_source         = table_source;
+		result.offset               = offset_operand;
+		result.base_offset          = 0u - table_offset;
+		result.table_address_offset = table_offset;
+		result.table_address_count  = descriptor_count;
+		return true;
+	}
+
+	bool DetectDynamicImageTable(const DescriptorValue& descriptor,
+	                             DynamicImagePattern& result) const {
+		if (DetectDirectImageTable(descriptor, result)) {
+			return true;
+		}
+		if (descriptor.dword_count != 8) {
+			return false;
+		}
+		DescriptorValue table;
+		table.dword_count = 4;
+		uint32_t common_offset = ScalarProvenance::Undefined;
+		Operand  offset_operand;
+		uint32_t base_offset = 0;
+		for (uint32_t i = 0; i < descriptor.dword_count; i++) {
+			const auto id = descriptor.dwords[i];
+			if (id >= m_program.provenance.values.size()) {
+				return false;
+			}
+			const auto& value = m_program.provenance.values[id];
+			if (value.op != ScalarValueOp::ReadConstBuffer) {
+				return false;
+			}
+			if (i == 0) {
+				std::copy_n(value.args.begin(), 4, table.dwords.begin());
+				common_offset = value.args[4];
+				base_offset   = value.imm;
+				const auto* producer = FindScalarLoadProducer(id);
+				if (producer == nullptr) {
+					return false;
+				}
+				offset_operand = producer->src[0];
+			} else {
+				if (!std::equal(value.args.begin(), value.args.begin() + 4,
+				                table.dwords.begin()) || value.args[4] != common_offset ||
+				    value.imm != base_offset + i * sizeof(uint32_t)) {
+					return false;
+				}
+				const auto* producer = FindScalarLoadProducer(id);
+				if (producer == nullptr || producer->src[0] != offset_operand) {
+					return false;
+				}
+			}
+		}
+		if ((base_offset & 31u) != 0 || offset_operand.kind != OperandKind::Register) {
+			return false;
+		}
+		std::vector<uint8_t> visited(m_program.provenance.values.size());
+		std::vector<uint32_t> path;
+		if (!ContainsUnknown(m_program.provenance, common_offset, visited, path)) {
+			return false;
+		}
+		const auto& offset_value = m_program.provenance.values[common_offset];
+		const auto shift_id = offset_value.args[1];
+		if (offset_value.op != ScalarValueOp::ShiftLeft ||
+		    shift_id >= m_program.provenance.values.size() ||
+		    m_program.provenance.values[shift_id].op != ScalarValueOp::Constant ||
+		    m_program.provenance.values[shift_id].imm != 5u) {
+			return false;
+		}
+		const auto table_source = FindDescriptorSource(table);
+		if (table_source == ScalarProvenance::Undefined ||
+		    !DescriptorSourceResolved(m_program, table_source)) {
+			return false;
+		}
+		result = {table_source, offset_operand, base_offset};
+		return true;
+	}
+
+	bool ValidateSource(uint32_t source, uint32_t dwords, uint32_t pc, std::string* error,
+	                    DynamicImagePattern* dynamic_image = nullptr) const {
 		const auto* descriptor = GetDescriptorSource(m_program, source);
 		if (descriptor == nullptr || descriptor->dword_count != dwords) {
 			return Fail(pc, error,
 			            fmt::format("descriptor source {} is missing or has wrong width", source));
+		}
+		if (dynamic_image != nullptr && DetectDynamicImageTable(*descriptor, *dynamic_image)) {
+			return true;
 		}
 		std::vector<uint8_t> visited(m_program.provenance.values.size());
 		for (uint32_t i = 0; i < descriptor->dword_count; i++) {
@@ -311,6 +526,28 @@ private:
 				}
 			}
 		}
+	}
+
+	bool LinkDynamicImageTables(std::string* error) {
+		for (auto& image: m_info.images) {
+			if (image.dynamic_table_source == ScalarProvenance::Undefined) {
+				continue;
+			}
+			if (image.dynamic_table_address_count != 0) {
+				continue;
+			}
+			const auto found = std::find_if(m_info.buffers.begin(), m_info.buffers.end(),
+			                                [&](const auto& buffer) {
+				                                return buffer.source == image.dynamic_table_source;
+			                                });
+			if (found == m_info.buffers.end()) {
+				return Fail(image.first_use_pc, error,
+				            "dynamic image table has no tracked scalar-buffer resource");
+			}
+			image.dynamic_table_buffer =
+			    static_cast<uint32_t>(found - m_info.buffers.begin());
+		}
+		return true;
 	}
 
 	uint32_t AddImage(const Instruction& inst) {
@@ -423,8 +660,9 @@ private:
 		if (!IsBuffer(inst) && !IsImage(inst)) {
 			return true;
 		}
+		DynamicImagePattern dynamic_image;
 		if (!ValidateSource(inst.memory.resource_source, IsBuffer(inst) ? 4u : 8u, inst.pc,
-		                    error)) {
+		                    error, IsImage(inst) ? &dynamic_image : nullptr)) {
 			return false;
 		}
 		const auto resource = IsBuffer(inst) ? AddBuffer(inst) : AddImage(inst);
@@ -432,6 +670,25 @@ private:
 			return Fail(inst.pc, error,
 			            IsBuffer(inst) ? "buffer resource limit exceeded"
 			                           : "image resource limit exceeded");
+		}
+		if (dynamic_image.table_source != ScalarProvenance::Undefined) {
+			auto& image = m_info.images[resource];
+			if (image.written || image.atomic || image.mip_mode != ImageMipMode::None) {
+				return Fail(inst.pc, error,
+				            "GPU-selected storage-image descriptor tables are unsupported");
+			}
+			if (image.dynamic_table_source != ScalarProvenance::Undefined &&
+			    image.dynamic_table_source != dynamic_image.table_source) {
+				return Fail(inst.pc, error, "dynamic image resource changed descriptor table");
+			}
+			if (image.dynamic_table_source != ScalarProvenance::Undefined &&
+			    (image.dynamic_table_address_offset != dynamic_image.table_address_offset ||
+			     image.dynamic_table_address_count != dynamic_image.table_address_count)) {
+				return Fail(inst.pc, error, "dynamic image resource changed descriptor table range");
+			}
+			image.dynamic_table_source = dynamic_image.table_source;
+			image.dynamic_table_address_offset = dynamic_image.table_address_offset;
+			image.dynamic_table_address_count = dynamic_image.table_address_count;
 		}
 		uint32_t sampler = 0;
 		if (NeedsSampler(inst.op)) {
@@ -446,7 +703,8 @@ private:
 				return false;
 			}
 		}
-		m_patches.push_back({std::ref(inst), resource, sampler});
+		m_patches.push_back({std::ref(inst), resource, sampler, dynamic_image.offset,
+		                     dynamic_image.base_offset});
 		return true;
 	}
 

--- a/src/graphics/shader/recompiler/ir/ScalarProvenance.cpp
+++ b/src/graphics/shader/recompiler/ir/ScalarProvenance.cpp
@@ -10,7 +10,8 @@
 namespace Libs::Graphics::ShaderRecompiler::IR {
 uint32_t ScalarValueArgCount(ScalarValueOp op) {
 	switch (op) {
-		case ScalarValueOp::Not: return 1;
+		case ScalarValueOp::Not:
+		case ScalarValueOp::FindLsbU32: return 1;
 		case ScalarValueOp::Add:
 		case ScalarValueOp::Sub:
 		case ScalarValueOp::Mul:
@@ -509,6 +510,7 @@ private:
 			case Opcode::AddShiftLeftU32: return ScalarValueOp::AddShiftLeft;
 			case Opcode::XorAddU32: return ScalarValueOp::XorAdd;
 			case Opcode::ShiftLeftOrU32: return ScalarValueOp::ShiftLeftOr;
+			case Opcode::FindLsbU32: return ScalarValueOp::FindLsbU32;
 			default: return ScalarValueOp::Unknown;
 		}
 	}
@@ -956,6 +958,7 @@ std::string ScalarValueToString(const ScalarProvenance& provenance, uint32_t val
 		case ScalarValueOp::Phi: return fmt::format("phi{}", value);
 		case ScalarValueOp::BitFieldMaskU32:
 			return fmt::format("bfm_u32({}, {})", node.args[0], node.args[1]);
+		case ScalarValueOp::FindLsbU32: return fmt::format("ff1_u32({})", node.args[0]);
 		default: return fmt::format("value{}", value);
 	}
 }

--- a/src/graphics/shader/recompiler/ir/ShaderIR.h
+++ b/src/graphics/shader/recompiler/ir/ShaderIR.h
@@ -127,6 +127,11 @@ struct MemoryInfo {
 	// exact scalar definitions reaching this instruction before that patching step.
 	uint32_t resource_source = 0;
 	uint32_t sampler_source  = 0;
+	// GPU-selected image descriptors are loaded from a guest table with a byte offset. Preserve
+	// the live offset operand after dense resource patching so SPIR-V can index the corresponding
+	// Vulkan descriptor array instead of trying to materialize one descriptor on the CPU.
+	Operand  dynamic_resource_offset;
+	uint32_t dynamic_resource_base_offset = 0;
 	bool     data_signed     = false;
 	bool     typed           = false;
 	bool     formatted       = false;
@@ -224,6 +229,7 @@ enum class ScalarValueOp {
 	AddShiftLeft,
 	XorAdd,
 	ShiftLeftOr,
+	FindLsbU32,
 	ReadConst,
 	ReadConstBuffer,
 	Phi,
@@ -297,17 +303,28 @@ enum class ImageMipMode { None, DynamicStorage };
 constexpr uint32_t StorageImageIdentitySwizzle = 0x00000facu;
 
 struct ImageResource {
+	static constexpr uint32_t NoDynamicTable = UINT32_MAX;
+
 	uint32_t                source          = 0;
 	uint32_t                first_use_pc    = 0;
 	ResourceKind            kind            = ResourceKind::None;
 	Decoder::ImageDimension dimension       = Decoder::ImageDimension::Unknown;
 	ImageMipMode            mip_mode        = ImageMipMode::None;
 	uint32_t                storage_swizzle = StorageImageIdentitySwizzle;
+	uint32_t                dynamic_table_source         = ScalarProvenance::Undefined;
+	uint32_t                dynamic_table_buffer         = NoDynamicTable;
+	uint32_t                dynamic_table_address_offset = 0;
+	uint32_t                dynamic_table_address_count  = 0;
+	uint32_t                dynamic_descriptor_count     = 0;
 	bool                    read            = false;
 	bool                    written         = false;
 	bool                    atomic          = false;
 	bool                    depth_compare   = false;
 	bool                    cube            = false;
+
+	[[nodiscard]] bool HasDynamicTable() const {
+		return dynamic_table_buffer != NoDynamicTable || dynamic_table_address_count != 0;
+	}
 
 	bool operator==(const ImageResource& other) const = default;
 };

--- a/src/graphics/shader/recompiler/ir/SrtWalker.cpp
+++ b/src/graphics/shader/recompiler/ir/SrtWalker.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstring>
 #include <fmt/format.h>
 
@@ -68,6 +69,9 @@ bool ApplyOperation(ScalarValueOp op, const std::array<uint32_t, 3>& args, uint3
 		case ScalarValueOp::OrNot: result = args[0] | ~args[1]; break;
 		case ScalarValueOp::Xor: result = args[0] ^ args[1]; break;
 		case ScalarValueOp::Not: result = ~args[0]; break;
+		case ScalarValueOp::FindLsbU32:
+			result = args[0] == 0 ? UINT32_MAX : std::countr_zero(args[0]);
+			break;
 		case ScalarValueOp::ShiftLeft: result = args[0] << shift; break;
 		case ScalarValueOp::ShiftRight: result = args[0] >> shift; break;
 		case ScalarValueOp::ShiftRightArithmetic:

--- a/tests/ResourceTrackingTests.cpp
+++ b/tests/ResourceTrackingTests.cpp
@@ -120,7 +120,7 @@ Instruction Export(uint32_t pc, ExportTargetKind kind, uint32_t index = 0, uint3
 
 struct TestMemory {
 	uint64_t                base = 0x1000;
-	std::array<uint32_t, 8> words {};
+	std::array<uint32_t, 256> words {};
 	uint32_t                reads      = 0;
 	uint32_t                fail_after = UINT32_MAX;
 };
@@ -1887,6 +1887,164 @@ void TestNativeBindingLayoutHonorsUserDataBase() {
 	      "native binding plan did not retain physical shifted user-SGPR indices");
 }
 
+void TestGpuSelectedImageDescriptorTable() {
+	Program program;
+	program.stage = ShaderType::Compute;
+	program.blocks.resize(1);
+	auto& insts = program.blocks[0].instructions;
+	insts.push_back(MoveImmediate(0x00, 20, 0x1000));
+	insts.push_back(MoveImmediate(0x04, 21, 32u << 16u));
+	insts.push_back(MoveImmediate(0x08, 22, 2));
+	insts.push_back(MoveImmediate(0x0c, 23, 0));
+	Instruction first_lane;
+	first_lane.pc = 0x10;
+	first_lane.op = Opcode::ReadFirstLaneU32;
+	first_lane.dst = Sgpr(26);
+	first_lane.src[0].kind = OperandKind::Register;
+	first_lane.src[0].reg = {RegisterFile::Vector, 0};
+	first_lane.src_count = 1;
+	insts.push_back(first_lane);
+	Instruction offset;
+	offset.pc = 0x14;
+	offset.op = Opcode::ShiftLeftLogicalU32;
+	offset.dst = Sgpr(26);
+	offset.src[0] = Sgpr(26);
+	offset.src[1] = Imm(5);
+	offset.src_count = 2;
+	insts.push_back(offset);
+	for (uint32_t i = 0; i < 8; i++) {
+		auto load = ScalarBufferLoad(0x18, i, 5, i * 4);
+		load.src[0] = Sgpr(26);
+		load.src_count = 1;
+		load.memory.component_index = i;
+		load.memory.component_count = 8;
+		insts.push_back(load);
+	}
+	for (uint32_t i = 0; i < 4; i++) {
+		insts.push_back(MoveImmediate(0x20 + i * 4, 8 + i, 0));
+	}
+	insts.push_back(ImageUse(0x40, Opcode::ImageSample, ResourceKind::Image,
+	                         Decoder::ImageDimension::Dim2D));
+	std::string error;
+	Check(BuildScalarProvenance(program, &error) && BuildSrtPlan(program, &error) &&
+	          PatchSrtReads(program, &error) && TrackResources(program, &error),
+	      error.c_str());
+	Check(program.info.images.size() == 1 && program.info.buffers.size() == 1 &&
+	          program.info.images[0].dynamic_table_buffer == 0 &&
+	          insts.back().memory.dynamic_resource_offset == Sgpr(26),
+	      "GPU-selected image table was not preserved as a dense dynamic resource");
+	TestMemory memory;
+	const std::array<uint32_t, 8> texture = {
+	    0x0294dc00, 0xc4700000, 0x00b3c13f, 0x91b31fac,
+	    0x00000000, 0x00700030, 0xb07b0000, 0x0002ac3c};
+	std::copy(texture.begin(), texture.end(), memory.words.begin());
+	memory.words[13] = 3u << 27u;
+	std::array<uint32_t, 64> user_data {};
+	SrtRuntime runtime {user_data, 0, ReadTestMemory, &memory};
+	ResourceSnapshot snapshot;
+	Check(MaterializeResources(program, runtime, snapshot, &error), error.c_str());
+	Check(snapshot.image_tables.size() == 1 && snapshot.image_tables[0].size() == 3 &&
+	          snapshot.image_tables[0][0].dwords == texture &&
+	          std::all_of(snapshot.image_tables[0][1].dwords.begin(),
+	                      snapshot.image_tables[0][1].dwords.end(),
+	                      [](uint32_t value) { return value == 0; }),
+	      "dynamic image snapshot did not preserve textures and null mixed entries");
+	Check(SpecializeResources(program, snapshot, &error), error.c_str());
+	ShaderComputeInputInfo compute;
+	compute.thread_ids_num = 1;
+	Check(program.info.images[0].dynamic_descriptor_count == 2 &&
+	          CollectShaderInfo(program, {.compute = &compute}, &error) &&
+	          AllocateBindings(program, {}, &error),
+	      error.c_str());
+	const auto* binding = FindBinding(program.bindings, DescriptorBindingKind::Sampled2D);
+	Check(binding != nullptr && binding->resources == std::vector<uint32_t>({0, 0, 0}),
+	      "dynamic image table did not allocate entries plus a null sentinel");
+}
+
+void TestGpuSelectedPointerImageDescriptorTable() {
+	Program program;
+	program.stage = ShaderType::Pixel;
+	program.blocks.resize(1);
+	auto& insts = program.blocks[0].instructions;
+	insts.push_back(MoveImmediate(0x00, 26, 0x1000));
+	insts.push_back(MoveImmediate(0x04, 27, 0));
+	Instruction first_set;
+	first_set.pc = 0x08;
+	first_set.op = Opcode::FindLsbU32;
+	first_set.dst = Sgpr(19);
+	first_set.src[0] = Sgpr(100);
+	first_set.src_count = 1;
+	insts.push_back(first_set);
+	Instruction shift;
+	shift.pc = 0x0c;
+	shift.op = Opcode::ShiftLeftLogicalU32;
+	shift.dst = Sgpr(30);
+	shift.src[0] = Sgpr(19);
+	shift.src[1] = Imm(5);
+	shift.src_count = 2;
+	insts.push_back(shift);
+	Instruction base;
+	base.pc = 0x10;
+	base.op = Opcode::IAddU32;
+	base.dst = Sgpr(30);
+	base.src[0] = Sgpr(30);
+	base.src[1] = Imm(344);
+	base.src_count = 2;
+	insts.push_back(base);
+	Instruction high = base;
+	high.pc = 0x14;
+	high.dst = Sgpr(31);
+	high.src[1] = Imm(16);
+	insts.push_back(high);
+	for (uint32_t i = 0; i < 4; i++) {
+		auto load = ScalarLoad(0x18, 4 + i, 26, i * 4);
+		load.src[0] = Sgpr(30);
+		load.src_count = 1;
+		load.memory.component_index = i;
+		load.memory.component_count = 4;
+		insts.push_back(load);
+	}
+	for (uint32_t i = 0; i < 4; i++) {
+		auto load = ScalarLoad(0x20, 8 + i, 26, i * 4);
+		load.src[0] = Sgpr(31);
+		load.src_count = 1;
+		load.memory.component_index = i;
+		load.memory.component_count = 4;
+		insts.push_back(load);
+	}
+	for (uint32_t i = 0; i < 4; i++) {
+		insts.push_back(MoveImmediate(0x28 + i * 4, 12 + i, 0));
+	}
+	insts.push_back(ImageUse(0x40, Opcode::ImageSample, ResourceKind::Image,
+	                         Decoder::ImageDimension::Dim2D, 1, 3));
+	std::string error;
+	Check(BuildScalarProvenance(program, &error) && BuildSrtPlan(program, &error) &&
+	          PatchSrtReads(program, &error) && TrackResources(program, &error),
+	      error.c_str());
+	Check(program.info.images.size() == 1 && program.info.buffers.empty() &&
+	          program.info.images[0].dynamic_table_buffer == ImageResource::NoDynamicTable &&
+	          program.info.images[0].dynamic_table_address_offset == 344 &&
+	          program.info.images[0].dynamic_table_address_count == 32 &&
+	          insts.back().memory.dynamic_resource_offset == Sgpr(30) &&
+	          insts.back().memory.dynamic_resource_base_offset == 0u - 344u,
+	      "pointer-backed GPU image table was not tracked with its descriptor stride");
+	TestMemory memory;
+	memory.base = 0x1000 + 344;
+	const std::array<uint32_t, 8> texture = {
+	    0x0294dc00, 0xc4700000, 0x00b3c13f, 0x91b31fac,
+	    0x00000000, 0x00700030, 0xb07b0000, 0x0002ac3c};
+	std::copy(texture.begin(), texture.end(), memory.words.begin());
+	std::array<uint32_t, 1> user_data {};
+	SrtRuntime runtime {user_data, 0, ReadTestMemory, &memory};
+	ResourceSnapshot snapshot;
+	Check(MaterializeResources(program, runtime, snapshot, &error) &&
+	          snapshot.image_tables.size() == 1 && snapshot.image_tables[0].size() == 33 &&
+	          snapshot.image_tables[0][0].dwords == texture &&
+	          SpecializeResources(program, snapshot, &error) &&
+	          program.info.images[0].dynamic_descriptor_count == 32,
+	      error.c_str());
+}
+
 void TestTextureNullDescriptorUsesAddressBits() {
 	ShaderTextureResource texture;
 	const uint32_t        captured[8] = {0x00000000, 0xc3800000, 0x0059c09f, 0x91b00fac,
@@ -1947,6 +2105,8 @@ int main() {
 		RUN(TestNativeBindingLayoutUsesExplicitFlatMemory);
 		RUN(TestNativeBindingLayoutHonorsUserDataCount);
 		RUN(TestNativeBindingLayoutHonorsUserDataBase);
+		RUN(TestGpuSelectedImageDescriptorTable);
+		RUN(TestGpuSelectedPointerImageDescriptorTable);
 		RUN(TestTextureNullDescriptorUsesAddressBits);
 		std::cout << "ResourceTrackingTests: all cases passed\n";
 		return 0;


### PR DESCRIPTION
This adds resource tracking, materialization and Vulkan descriptor support for bindless sampled-image tables.

The shader recompiler can now trace dynamically selected image descriptors through the SRT, construct the required descriptor layout and bind the resulting image table at runtime.

Invalid or unsupported table entries remain fail-closed rather than being materialized as arbitrary images.

Testing:
- Built and ran shader_cfg_tests successfully.
- Built and ran resource_tracking_tests successfully.
- Added focused dynamic image-table coverage.