### PR TITLE
gpu: synchronize buffer and image ownership

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -804,6 +804,29 @@ bool BufferCache::HasGpuDirtyBytes(uint64_t vaddr, uint64_t size) {
 	return !m_gpu_modified_ranges.Intersections(vaddr, size).empty();
 }
 
+void BufferCache::DiscardGpuDirtyBytes(uint64_t vaddr, uint64_t size) {
+	if (vaddr == 0 || size == 0 || vaddr >= TRACKER_ADDRESS_SIZE ||
+	    size > TRACKER_ADDRESS_SIZE - vaddr) {
+		EXIT("BufferCache: invalid GPU-dirty discard range\n");
+	}
+	if (!HasGpuDirtyBytes(vaddr, size)) {
+		return;
+	}
+
+	// The page tracker is conservative, while the range set records exact byte ownership. Remove
+	// the bytes superseded by the image, then rebuild the affected page envelope so unrelated
+	// dirty buffer bytes on either edge remain protected.
+	const auto page_begin = vaddr & ~(TRACKER_PAGE_SIZE - 1u);
+	const auto range_end  = vaddr + size;
+	const auto page_end = std::min<uint64_t>(
+	    (range_end + TRACKER_PAGE_SIZE - 1u) & ~(TRACKER_PAGE_SIZE - 1u), TRACKER_ADDRESS_SIZE);
+	m_gpu_modified_ranges.Subtract(vaddr, size);
+	m_memory_tracker.UnmarkRegionAsGpuModified(page_begin, page_end - page_begin);
+	for (const auto range: m_gpu_modified_ranges.Intersections(page_begin, page_end - page_begin)) {
+		m_memory_tracker.MarkRegionAsGpuModified(range.address, range.size);
+	}
+}
+
 bool BufferCache::IsRegionCpuModified(uint64_t vaddr, uint64_t size) {
 	return m_memory_tracker.IsRegionCpuModified(vaddr, size);
 }

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.h
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.h
@@ -68,6 +68,7 @@ public:
 
 private:
 	friend struct BufferCacheTestAccess;
+	friend class TextureCache;
 
 	struct CacheRange {
 		uint64_t address = 0;
@@ -95,6 +96,7 @@ private:
 	void QueueGarbageDownload(std::span<const DownloadCopy> copies, RetiredBuffer retire);
 	void WriteHostMemory(uint64_t vaddr, std::span<const uint8_t> data);
 	void ReadMemoryOnGpu(uint64_t vaddr, uint64_t size, bool is_write);
+	void DiscardGpuDirtyBytes(uint64_t vaddr, uint64_t size);
 
 	GraphicContext&                                   m_graphics;
 	CommandScheduler&                                 m_scheduler;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1409,6 +1409,12 @@ void TextureCache::CommitGpuWrite(Image& image) {
 	if (image.IsCpuDirty()) {
 		image.RefreshComplete();
 	}
+	if (!image.info.data.Empty()) {
+		// Render and storage writes make the image the newest representation of these guest bytes.
+		// Keeping an older overlapping buffer dirty would later resurrect stale data when the
+		// allocation is read through another image interpretation.
+		m_buffer_cache.DiscardGpuDirtyBytes(image.info.data.address, image.info.data.size);
+	}
 	image.MarkGpuModified();
 }
 

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -141,6 +141,10 @@ struct BufferCacheTestAccess {
 	                                       uint64_t size) {
 		return cache.SynchronizeBufferFromImage(buffer, address, size);
 	}
+
+	static void DiscardGpuDirtyBytes(BufferCache& cache, uint64_t address, uint64_t size) {
+		cache.DiscardGpuDirtyBytes(address, size);
+	}
 };
 
 struct StreamBufferTestAccess {
@@ -2490,6 +2494,22 @@ public:
 			Require(name, "registered-range removal",
 			        !cache.IsRegionRegistered(index_begin, index_span),
 			        "unmapped Buffer owner remained in the registered-range index");
+
+			constexpr uint64_t ownership_offset = 0x400000;
+			const uint64_t     image_bytes      = base + ownership_offset + 0x100;
+			const uint64_t     sibling_bytes    = base + ownership_offset + 0x200;
+			auto ownership = cache.ObtainBuffer(scheduler.Current(), image_bytes, 0x104, true, false);
+			Require(name, "image/buffer ownership setup", ownership.owner != nullptr,
+			        "failed to create overlapping dirty buffer ranges");
+			scheduler.Current().RetainResourceUntilFence(ownership.owner);
+			cache.FillBuffer(image_bytes, sizeof(uint32_t), 0x11223344u);
+			cache.FillBuffer(sibling_bytes, sizeof(uint32_t), 0x55667788u);
+			BufferCacheTestAccess::DiscardGpuDirtyBytes(cache, image_bytes, sizeof(uint32_t));
+			Require(name, "image supersedes exact buffer bytes",
+			        !cache.HasGpuDirtyBytes(image_bytes, sizeof(uint32_t)) &&
+			            cache.HasGpuDirtyBytes(sibling_bytes, sizeof(uint32_t)) &&
+			            cache.IsRegionGpuModified(sibling_bytes, sizeof(uint32_t)),
+			        "image ownership discarded a dirty sibling or retained stale exact bytes");
 
 			MarkGpuWrite(base + first_offset, sizeof(first_value));
 			MarkGpuWrite(base + second_offset, sizeof(second_value));
@@ -15208,7 +15228,58 @@ TestCase ImageStoreR32UintUsesUintStorageImage() {
 	test.storage_image_rgba           = MakeRgbaImage(4, 4);
 	test.storage_image_r32ui          = std::vector<u32>(16, 0);
 	test.expected_storage_image_r32ui = expected_image;
-	test.required_spirv               = {"R32ui", "storage_uint_2d"};
+	test.required_spirv = {"OpCapability StorageImageReadWithoutFormat",
+	                       "OpCapability StorageImageWriteWithoutFormat", "storage_uint_2d"};
+	test.forbidden_spirv = {"R32ui"};
+	return test;
+}
+
+TestCase ImageStoreR8UintUsesFormatlessStorageImage() {
+	using O = ShaderOpcode;
+
+	std::vector<u32> code;
+	AppendVMovU32(&code, 20, 2);
+	AppendVMovU32(&code, 21, 1);
+	AppendVMovU32(&code, 22, 0);
+	AppendVMovU32(&code, 0, 0x7fu);
+	code.push_back(EncodeMimg0(0x08, 0x1));
+	code.push_back(EncodeMimg1(0, 20));
+	AppendEnd(&code);
+
+	TestCase test;
+	test.name          = "ImageStoreR8UintUsesFormatlessStorageImage";
+	test.code          = code;
+	test.opcodes       = {O::VMovB32, O::ImageStore, O::SEndpgm};
+	test.user_data     = MakeStorageTextureData(Prospero::BufferFormat::k8UInt);
+	test.has_user_data = true;
+	test.compile_only  = true;
+	test.required_spirv = {"OpCapability StorageImageWriteWithoutFormat", "storage_uint_2d"};
+	test.forbidden_spirv = {"R32ui"};
+	return test;
+}
+
+TestCase ImageStoreR8G8UintUsesFormatlessStorageImage() {
+	using O = ShaderOpcode;
+
+	std::vector<u32> code;
+	AppendVMovU32(&code, 20, 2);
+	AppendVMovU32(&code, 21, 1);
+	AppendVMovU32(&code, 22, 0);
+	AppendVMovU32(&code, 0, 0x7fu);
+	AppendVMovU32(&code, 1, 0x80u);
+	code.push_back(EncodeMimg0(0x08, 0x3));
+	code.push_back(EncodeMimg1(0, 20));
+	AppendEnd(&code);
+
+	TestCase test;
+	test.name          = "ImageStoreR8G8UintUsesFormatlessStorageImage";
+	test.code          = code;
+	test.opcodes       = {O::VMovB32, O::ImageStore, O::SEndpgm};
+	test.user_data     = MakeStorageTextureData(Prospero::BufferFormat::k8_8UInt);
+	test.has_user_data = true;
+	test.compile_only  = true;
+	test.required_spirv = {"OpCapability StorageImageWriteWithoutFormat", "storage_uint_2d"};
+	test.forbidden_spirv = {"R32ui"};
 	return test;
 }
 
@@ -15774,6 +15845,8 @@ std::vector<TestCase> MakeCases() {
 	AddCase(ImageStoreR32FloatUsesFormatlessStorageImage);
 	AddCase(ImageStoreR32SintUsesRawUintView);
 	AddCase(ImageStoreR32UintUsesUintStorageImage);
+	AddCase(ImageStoreR8UintUsesFormatlessStorageImage);
+	AddCase(ImageStoreR8G8UintUsesFormatlessStorageImage);
 	AddCase(ComputeTgSizeSgprUsesWaveMetadata);
 	AddCase(ImageAtomicVariants);
 	AddCase(ImageAtomicGlc0DoesNotReturnOldValue);


### PR DESCRIPTION
This improves synchronization when the same guest memory is accessed through both buffer and image resources.

When an image becomes the authoritative GPU representation, only the corresponding buffer bytes are discarded. Unrelated dirty bytes belonging to the same native allocation remain preserved.

The patch also enables formatless storage-image access for narrow integer formats where the Vulkan view format cannot be represented directly in SPIR-V.

Testing:
- Built shader_recompiler_compute_tests successfully.
- The new ownership and formatless-storage cases pass.