### PR TITLE
shader: use Prospero compute metadata

### DIFF
--- a/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
@@ -1367,10 +1367,6 @@ static void HwShSetCsRegister(CommandProcessor& cp, uint32_t cmd_offset, uint32_
 			                         Pm4::COMPUTE_PGM_RSRC1_BULKY_MASK) != 0u;
 			cs_regs.threadgroup_configuration = ((value >> Pm4::COMPUTE_PGM_RSRC1_WGP_MODE_SHIFT) &
 			                                     Pm4::COMPUTE_PGM_RSRC1_WGP_MODE_MASK) != 0u;
-			cs_regs.wave_size                 = (((value >> Pm4::COMPUTE_PGM_RSRC1_W32_EN_SHIFT) &
-			                                      Pm4::COMPUTE_PGM_RSRC1_W32_EN_MASK) != 0u)
-			                                        ? 32u
-			                                        : 64u;
 			break;
 		case Pm4::COMPUTE_PGM_RSRC2:
 			cs_regs.scratch_en     = ((value >> Pm4::COMPUTE_PGM_RSRC2_SCRATCH_EN_SHIFT) &

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -1182,7 +1182,8 @@ void CommandProcessor::DispatchDirect(uint32_t thread_group_x, uint32_t thread_g
 				     "\n",
 				     frame_num, m_submit_id, thread_group_x, thread_group_y, thread_group_z,
 				     std::max(cs.num_thread_x, 1u), std::max(cs.num_thread_y, 1u),
-				     std::max(cs.num_thread_z, 1u), mode, static_cast<uint32_t>(cs.wave_size),
+				     std::max(cs.num_thread_z, 1u), mode,
+				     Pm4::GetComputeWaveSizeFromDispatchModifier(mode),
 				     cs.data_addr, m_ucfg.GetGdsOaState().GetIndex(),
 				     oa.IsCounterEnabled() ? "true" : "false", oa.GetAddressBytes(),
 				     oa.GetSpaceAvailable());
@@ -1193,7 +1194,7 @@ void CommandProcessor::DispatchDirect(uint32_t thread_group_x, uint32_t thread_g
 		// local_x        = std::max(cs.num_thread_x, 1u);
 		// local_y        = std::max(cs.num_thread_y, 1u);
 		// local_z        = std::max(cs.num_thread_z, 1u);
-		if (cs.wave_size == 64u) {
+		if (Pm4::GetComputeWaveSizeFromDispatchModifier(mode) == 64u) {
 			static std::atomic_bool logged_wave64_shader {false};
 			if (!logged_wave64_shader.exchange(true, std::memory_order_relaxed)) {
 				LOGF("warning: executing wave64 compute shader cs=0x%016" PRIx64 "\n",

--- a/src/graphics/guest_gpu/hardwareContext.h
+++ b/src/graphics/guest_gpu/hardwareContext.h
@@ -555,7 +555,6 @@ struct CsStageRegisters {
 	bool     fp16_overflow             = false;
 	bool     bulky                     = false;
 	bool     threadgroup_configuration = false;
-	uint8_t  wave_size                 = 64;
 	bool     scratch_en                = false;
 	uint8_t  user_sgpr                 = 0;
 	bool     tgid_x_en                 = false;

--- a/src/graphics/guest_gpu/pm4.h
+++ b/src/graphics/guest_gpu/pm4.h
@@ -25,6 +25,13 @@ constexpr uint32_t IT_CLEAR_STATE               = 0x12;
 constexpr uint32_t IT_INDEX_BUFFER_SIZE         = 0x13;
 constexpr uint32_t IT_DISPATCH_DIRECT           = 0x15;
 constexpr uint32_t IT_DISPATCH_INDIRECT         = 0x16;
+// Prospero AGC encodes the compute wave mode in DispatchModifier, not in
+// COMPUTE_PGM_RSRC1. Bit 15 set selects wave32; clear selects wave64.
+constexpr uint32_t DISPATCH_MODIFIER_WAVE32_EN = 1u << 15u;
+
+constexpr uint32_t GetComputeWaveSizeFromDispatchModifier(uint32_t dispatch_modifier) {
+	return (dispatch_modifier & DISPATCH_MODIFIER_WAVE32_EN) != 0u ? 32u : 64u;
+}
 constexpr uint32_t IT_SET_PREDICATION           = 0x20;
 constexpr uint32_t IT_COND_EXEC                 = 0x22;
 constexpr uint32_t IT_DRAW_INDIRECT             = 0x24;
@@ -984,8 +991,6 @@ constexpr uint32_t COMPUTE_PGM_RSRC1_FP16_OVFL_SHIFT  = 26;
 constexpr uint32_t COMPUTE_PGM_RSRC1_FP16_OVFL_MASK   = 0x1;
 constexpr uint32_t COMPUTE_PGM_RSRC1_WGP_MODE_SHIFT   = 29;
 constexpr uint32_t COMPUTE_PGM_RSRC1_WGP_MODE_MASK    = 0x1;
-constexpr uint32_t COMPUTE_PGM_RSRC1_W32_EN_SHIFT     = 30;
-constexpr uint32_t COMPUTE_PGM_RSRC1_W32_EN_MASK      = 0x1;
 
 constexpr uint32_t COMPUTE_PGM_RSRC2                      = 0x213;
 constexpr uint32_t COMPUTE_PGM_RSRC2_SCRATCH_EN_SHIFT     = 0;

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -9,6 +9,7 @@
 #include "graphics/guest_gpu/gpu_defs.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/guest_gpu/hardwareContext.h"
+#include "graphics/guest_gpu/pm4.h"
 #include "graphics/host_gpu/graphicContext.h"
 #include "graphics/host_gpu/renderer/image/imageInfo.h"
 #include "graphics/host_gpu/renderer/pipeline/descriptorCache.h"
@@ -193,10 +194,11 @@ void RenderExecutor::DispatchDirect(uint64_t submit_id, RenderCommandBuffer& buf
 
 	const auto& cs_regs = sh_ctx.GetCs();
 	const auto& sh_regs = ctx.GetShaderRegisters();
+	const uint32_t guest_wave_size = Pm4::GetComputeWaveSizeFromDispatchModifier(mode);
 
 	ShaderComputeInputInfo    input_info {};
 	std::span<const uint32_t> cs_shader;
-	if (!ShaderCompileInfoCS(cs_regs, sh_regs, input_info, cs_shader)) {
+	if (!ShaderCompileInfoCS(cs_regs, sh_regs, guest_wave_size, input_info, cs_shader)) {
 		EXIT("ShaderCompileInfoCS failed for dispatch with CS shader 0x%016" PRIx64 "\n",
 		     cs_regs.cs_regs.data_addr);
 	}

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
@@ -428,6 +428,18 @@ struct EmitterState {
 	std::map<uint32_t, uint32_t>                     float_constants;
 };
 
+inline uint32_t GetLdsDwordCount(const EmitterState& state) {
+	if (state.needs_function_lds) {
+		return 8192u;
+	}
+	if (state.stage == ShaderType::Compute && state.compute_input_info != nullptr) {
+		// SPIR-V does not permit a zero-length OpTypeArray.
+		return std::max(state.compute_input_info->lds_size_dwords, 1u);
+	}
+	// Preserve the standalone recompiler default when no hardware state was supplied.
+	return 1024u;
+}
+
 enum class VertexInputScalarKind { Float, Sint, Uint };
 
 constexpr uint32_t NoImageComponent = 0xffffffffu;

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterMemory.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterMemory.cpp
@@ -482,7 +482,7 @@ uint32_t EmitLdsElementPointer(EmitterState& state, uint32_t index) {
 
 uint32_t EmitLdsElementInBounds(EmitterState& state, uint32_t index) {
 	const auto in_bounds = state.builder.AllocateId();
-	const auto dwords    = state.needs_function_lds ? 8192u : 1024u;
+	const auto dwords    = GetLdsDwordCount(state);
 	state.builder.AddFunction(
 	    {OpULessThan, state.bool_type, in_bounds, index, ConstantU32(state, dwords)});
 	return in_bounds;

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterModule.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterModule.cpp
@@ -12,6 +12,24 @@ uint32_t DescriptorCount(const EmitterState& state, IR::DescriptorBindingKind ki
 	return binding != nullptr ? static_cast<uint32_t>(binding->resources.size()) : 0;
 }
 
+static bool StorageImageClassUsesAtomics(const EmitterState& state, bool integer,
+	                                     ImageViewKind view) {
+	const auto* binding = DescriptorBinding(state, StorageBindingKind(integer, view));
+	if (binding == nullptr) {
+		return false;
+	}
+	return std::any_of(binding->resources.begin(), binding->resources.end(), [&](uint32_t resource) {
+		return resource < state.program.info.images.size() &&
+		       state.program.info.images[resource].atomic;
+	});
+}
+
+static bool StorageImageClassIsFormatless(const EmitterState& state, uint32_t index) {
+	const auto view    = static_cast<ImageViewKind>(index % StorageImageViewKindCount);
+	const bool integer = index >= StorageImageViewKindCount;
+	return !integer || !StorageImageClassUsesAtomics(state, true, view);
+}
+
 uint32_t ConstantU32(EmitterState& state, uint32_t value) {
 	if (auto it = state.constants.find(value); it != state.constants.end()) {
 		return it->second;
@@ -484,9 +502,12 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	if (state.needs_image_gather_extended) {
 		state.builder.AddCapability({CapabilityImageGatherExtended});
 	}
-	if (std::any_of(state.storage_images.begin(),
-	                state.storage_images.begin() + StorageImageViewKindCount,
-	                [](const auto& image) { return image.variable != 0; })) {
+	if (std::any_of(state.storage_images.begin(), state.storage_images.end(),
+	                [&](const auto& image) {
+		                const auto index =
+		                    static_cast<uint32_t>(&image - state.storage_images.data());
+		                return image.variable != 0 && StorageImageClassIsFormatless(state, index);
+	                })) {
 		state.builder.AddCapability({CapabilityStorageImageReadWithoutFormat});
 		state.builder.AddCapability({CapabilityStorageImageWriteWithoutFormat});
 	}
@@ -716,7 +737,7 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	if (state.stage == ShaderType::Compute || state.needs_function_lds) {
 		const auto storage_class =
 		    state.needs_function_lds ? StorageClassFunction : StorageClassWorkgroup;
-		const auto lds_size = ConstantU32(state, state.needs_function_lds ? 8192u : 1024u);
+		const auto lds_size = ConstantU32(state, GetLdsDwordCount(state));
 		state.builder.AddType({OpTypeArray, state.lds_array_type, state.uint_type, lds_size});
 		state.builder.AddType(
 		    {OpTypePointer, state.ptr_workgroup_array, storage_class, state.lds_array_type});
@@ -765,7 +786,8 @@ void EmitHeaderAndTypes(EmitterState& state) {
 		const auto view      = static_cast<ImageViewKind>(i % StorageImageViewKindCount);
 		const bool integer   = i >= StorageImageViewKindCount;
 		const auto component = integer ? state.uint_type : state.float_type;
-		const auto format    = integer ? ImageFormatR32ui : ImageFormatUnknown;
+		const auto format = StorageImageClassIsFormatless(state, i) ? ImageFormatUnknown
+		                                                             : ImageFormatR32ui;
 		state.builder.AddType({OpTypeImage, image.image_type, component, ImageSpirvDimension(view),
 		                       0, ImageSpirvArrayed(view), 0, 2, format});
 		state.builder.AddType(

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -884,7 +884,9 @@ static void ShaderGetStaticInputInfoPS(
 
 static void ShaderGetStaticInputInfoCS(const HW::ComputeShaderInfo& regs,
                                        const HW::ShaderRegisters& /*sh*/,
+	                                   uint32_t guest_wave_size,
                                        ShaderComputeInputInfo& info) {
+	EXIT_NOT_IMPLEMENTED(guest_wave_size != 32u && guest_wave_size != 64u);
 	info = {};
 
 	info.threads_num[0] = regs.cs_regs.num_thread_x;
@@ -893,9 +895,11 @@ static void ShaderGetStaticInputInfoCS(const HW::ComputeShaderInfo& regs,
 	info.group_id[0]    = regs.cs_regs.tgid_x_en != 0;
 	info.group_id[1]    = regs.cs_regs.tgid_y_en != 0;
 	info.group_id[2]    = regs.cs_regs.tgid_z_en != 0;
-	info.wave_size      = regs.cs_regs.wave_size;
+	info.wave_size      = guest_wave_size;
 	info.thread_ids_num = regs.cs_regs.tidig_comp_cnt + 1;
 	info.tg_size_en     = regs.cs_regs.tg_size_en != 0;
+	// COMPUTE_PGM_RSRC2 encodes LDS_SIZE in 512-byte (128-dword) units.
+	info.lds_size_dwords = static_cast<uint32_t>(regs.cs_regs.lds_size) * 128u;
 
 	info.workgroup_register = regs.cs_regs.user_sgpr;
 }
@@ -1182,10 +1186,11 @@ bool ShaderCompileInfoPS(const HW::PixelShaderInfo& regs, const HW::ShaderRegist
 }
 
 bool ShaderCompileInfoCS(const HW::ComputeShaderInfo& regs, const HW::ShaderRegisters& sh,
-                         ShaderComputeInputInfo& info, std::span<const uint32_t>& spirv) {
+	                     uint32_t guest_wave_size, ShaderComputeInputInfo& info,
+	                     std::span<const uint32_t>& spirv) {
 	spirv = {};
 
-	ShaderGetStaticInputInfoCS(regs, sh, info);
+	ShaderGetStaticInputInfoCS(regs, sh, guest_wave_size, info);
 	const auto shader_hash = regs.cs_regs.data_addr;
 	const auto program_id  = ShaderGetIdCS(regs, info, false);
 	const auto key         = MakeShaderStageProgramKey(ShaderType::Compute, shader_hash, program_id,
@@ -1701,6 +1706,7 @@ ShaderId ShaderGetIdCS(const HW::ComputeShaderInfo& regs, const ShaderComputeInp
 	ret.ids.push_back(input_info.workgroup_register);
 	ret.ids.push_back(input_info.wave_size);
 	ret.ids.push_back(input_info.thread_ids_num);
+	ret.ids.push_back(input_info.lds_size_dwords);
 
 	for (int i = 0; i < 3; i++) {
 		ret.ids.push_back(input_info.threads_num[i]);

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -86,6 +86,7 @@ struct ShaderVertexInputInfo {
 struct ShaderComputeInputInfo {
 	uint32_t           threads_num[3]             = {0, 0, 0};
 	uint32_t           dispatch_threads_num[3]    = {0, 0, 0};
+	uint32_t           lds_size_dwords            = 0;
 	bool               group_id[3]                = {false, false, false};
 	bool               dispatch_thread_dimensions = false;
 	uint32_t           wave_size                  = 64;
@@ -240,7 +241,8 @@ bool ShaderCompileInfoPS(const HW::PixelShaderInfo& regs, const HW::ShaderRegist
                          std::span<const Prospero::ColorComponentMapping, 8> target_export_mapping,
                          ShaderPixelInputInfo& input_info, std::span<const uint32_t>& spirv);
 bool ShaderCompileInfoCS(const HW::ComputeShaderInfo& regs, const HW::ShaderRegisters& sh,
-                         ShaderComputeInputInfo& input_info, std::span<const uint32_t>& spirv);
+	                     uint32_t guest_wave_size, ShaderComputeInputInfo& input_info,
+	                     std::span<const uint32_t>& spirv);
 bool ShaderCompileSpirvVS(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
                           ShaderLaneMaskMode lane_mask_mode, ShaderVertexInputInfo& input_info,
                           std::vector<uint32_t>& spirv);

--- a/tests/shaderCfgTests.cpp
+++ b/tests/shaderCfgTests.cpp
@@ -121,6 +121,36 @@ bool SpirvContainsOpcode(const std::vector<uint32_t>& binary, uint32_t opcode) {
 	return false;
 }
 
+bool SpirvContainsArrayLength(const std::vector<uint32_t>& binary, uint32_t length) {
+	std::vector<uint32_t> length_ids;
+	for (size_t i = 5; i < binary.size();) {
+		const uint32_t word       = binary[i];
+		const uint32_t opcode     = word & 0xffffu;
+		const uint32_t word_count = word >> 16u;
+		if (word_count == 0 || i + word_count > binary.size()) {
+			return false;
+		}
+		if (opcode == 43u && word_count == 4u && binary[i + 3] == length) {
+			length_ids.push_back(binary[i + 2]);
+		}
+		i += word_count;
+	}
+	for (size_t i = 5; i < binary.size();) {
+		const uint32_t word       = binary[i];
+		const uint32_t opcode     = word & 0xffffu;
+		const uint32_t word_count = word >> 16u;
+		if (word_count == 0 || i + word_count > binary.size()) {
+			return false;
+		}
+		if (opcode == 28u && word_count == 4u &&
+		    std::find(length_ids.begin(), length_ids.end(), binary[i + 3]) != length_ids.end()) {
+			return true;
+		}
+		i += word_count;
+	}
+	return false;
+}
+
 uint32_t SpirvInstructionOpcodeCount(const std::vector<uint32_t>& binary, uint32_t opcode) {
 	uint32_t count = 0;
 	for (size_t i = 5; i < binary.size();) {
@@ -5995,22 +6025,45 @@ void TestNewShaderRecompilerExecMaskHelpers() {
 }
 
 void TestComputeShaderInputWaveSize() {
-	const auto decode_wave_size = [](uint32_t rsrc1) {
-		const bool wave32 = (((rsrc1 >> Pm4::COMPUTE_PGM_RSRC1_W32_EN_SHIFT) &
-		                      Pm4::COMPUTE_PGM_RSRC1_W32_EN_MASK) != 0u);
-		return wave32 ? 32u : 64u;
+	Check(Pm4::GetComputeWaveSizeFromDispatchModifier(0x00000001u) == 64u,
+	      "DispatchModifier without bit 15 did not select wave64");
+	Check(Pm4::GetComputeWaveSizeFromDispatchModifier(0x00000041u) == 64u,
+	      "DispatchModifier base flags changed wave64 selection");
+	Check(Pm4::GetComputeWaveSizeFromDispatchModifier(0x00008001u) == 32u,
+	      "DispatchModifier bit 15 did not select wave32");
+	Check(Pm4::GetComputeWaveSizeFromDispatchModifier(0x00008041u) == 32u,
+	      "DispatchModifier flags changed wave32 selection");
+	Check(Pm4::GetComputeWaveSizeFromDispatchModifier(0x80000041u) == 64u,
+	      "unrelated DispatchModifier high bit changed wave selection");
+}
+
+void TestComputeShaderInputLdsReservation() {
+	const uint32_t shader[] = {
+	    EncodeDs0(0x0d), EncodeDs1(0, 0, 1), // ds_write_b32 v0, v1
+	    0xbf810000u,
 	};
 
-	constexpr uint32_t observed_wave32_rsrc1_a = 0x402c0146u;
-	constexpr uint32_t observed_wave32_rsrc1_b = 0x402c00c1u;
-	Check(decode_wave_size(observed_wave32_rsrc1_a) == 32u,
-	      "COMPUTE_PGM_RSRC1 W32_EN bit did not match observed PS5 value A");
-	Check(decode_wave_size(observed_wave32_rsrc1_b) == 32u,
-	      "COMPUTE_PGM_RSRC1 W32_EN bit did not match observed PS5 value B");
+	ShaderComputeInputInfo input_info = RegressionComputeInputInfo();
+	input_info.lds_size_dwords        = 9u * 128u;
 
-	constexpr uint32_t w32_en_bit = 1u << Pm4::COMPUTE_PGM_RSRC1_W32_EN_SHIFT;
-	Check(decode_wave_size(observed_wave32_rsrc1_a & ~w32_en_bit) == 64u,
-	      "cleared COMPUTE_PGM_RSRC1 W32_EN bit did not decode as wave64");
+	ShaderRecompiler::CompileOptions options;
+	options.stage              = ShaderType::Compute;
+	options.compute_input_info = &input_info;
+
+	ShaderRecompiler::CompileResult result;
+	std::string                     error;
+	Check(ShaderRecompiler::TryRecompile(shader, options, result, &error), error.c_str());
+	Check(SpirvContainsArrayLength(result.spirv, 1152u),
+	      "compute SPIR-V LDS array did not use the hardware reservation size");
+	CheckSpirvBinaryValidates(result.spirv);
+
+	std::array<uint32_t, 1> shader_id_code {};
+	HW::ComputeShaderInfo   regs {};
+	regs.cs_regs.data_addr = reinterpret_cast<uint64_t>(shader_id_code.data());
+	auto smaller_info       = input_info;
+	smaller_info.lds_size_dwords = 5u * 128u;
+	Check(ShaderGetIdCS(regs, input_info, false) != ShaderGetIdCS(regs, smaller_info, false),
+	      "compute shaders with different LDS reservations shared a shader cache ID");
 }
 
 void TestNewShaderRecompilerWave32MasksExecHighStores() {
@@ -7740,6 +7793,7 @@ int main() {
 	TestNewShaderRecompilerCfgIrreducibleDispatcher();
 	TestNewShaderRecompilerExecMaskHelpers();
 	TestComputeShaderInputWaveSize();
+	TestComputeShaderInputLdsReservation();
 	TestNewShaderRecompilerWave32MasksExecHighStores();
 	TestNewShaderRecompilerWave32VccHighScalarStores();
 	TestNewShaderRecompilerCompareMaskIsFullWaveBallot();


### PR DESCRIPTION
This derives compute wave size and related shader metadata from the Prospero dispatch information instead of using the older register interpretation.

In particular, wave32 versus wave64 is taken from the dispatch modifier. The compute local size and workgroup inputs are then propagated through compilation consistently.

This follows the Prospero documentation metadata model and removes an incorrect assumption inherited from older GPU register layouts.

Testing:
- Built and ran shader_cfg_tests successfully.
- Added tests for wave-size decoding and compute metadata propagation.