### PR TITLE
shader: experimental support Prospero wave64 execution

### DIFF
--- a/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
@@ -1367,10 +1367,6 @@ static void HwShSetCsRegister(CommandProcessor& cp, uint32_t cmd_offset, uint32_
 			                         Pm4::COMPUTE_PGM_RSRC1_BULKY_MASK) != 0u;
 			cs_regs.threadgroup_configuration = ((value >> Pm4::COMPUTE_PGM_RSRC1_WGP_MODE_SHIFT) &
 			                                     Pm4::COMPUTE_PGM_RSRC1_WGP_MODE_MASK) != 0u;
-			cs_regs.wave_size                 = (((value >> Pm4::COMPUTE_PGM_RSRC1_W32_EN_SHIFT) &
-			                                      Pm4::COMPUTE_PGM_RSRC1_W32_EN_MASK) != 0u)
-			                                        ? 32u
-			                                        : 64u;
 			break;
 		case Pm4::COMPUTE_PGM_RSRC2:
 			cs_regs.scratch_en     = ((value >> Pm4::COMPUTE_PGM_RSRC2_SCRATCH_EN_SHIFT) &

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <atomic>
 #include <cstdio>
+#include <cstdlib>
 #include <deque>
 #include <memory>
 #include <semaphore>
@@ -1163,10 +1164,32 @@ void CommandProcessor::DrawIndirectMulti(uint32_t data_offset, uint32_t max_coun
 
 void CommandProcessor::DispatchDirect(uint32_t thread_group_x, uint32_t thread_group_y,
                                       uint32_t thread_group_z, uint32_t mode) {
+	static const bool isolate_compute_dispatch = [] {
+		const char* const value = std::getenv("KYTY_DEBUG_ISOLATE_COMPUTE_DISPATCH");
+		return value != nullptr && value[0] == '1' && value[1] == '\0';
+	}();
+	static std::atomic<uint64_t> isolate_dispatch_sequence {0};
+	uint64_t isolate_sequence = 0;
+	if (isolate_compute_dispatch) {
+		isolate_sequence = isolate_dispatch_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+	}
 	uint32_t frame_num = 0;
 	// uint32_t local_x   = 1;
 	// uint32_t local_y   = 1;
 	// uint32_t local_z   = 1;
+
+	if (isolate_compute_dispatch) {
+		LOGF("Compute dispatch isolation: #%-6" PRIu64 " pre-wait submit=%" PRIu64
+		     " groups=%ux%ux%u mode=0x%08" PRIx32 " cs=0x%016" PRIx64 "\n",
+		     isolate_sequence, m_submit_id, thread_group_x, thread_group_y, thread_group_z, mode,
+		     m_sh_ctx.GetCs().cs_regs.data_addr);
+		std::printf("Compute dispatch isolation: #%-6" PRIu64 " pre-wait submit=%" PRIu64
+		            " groups=%ux%ux%u mode=0x%08" PRIx32 " cs=0x%016" PRIx64 "\n",
+		            isolate_sequence, m_submit_id, thread_group_x, thread_group_y, thread_group_z,
+		            mode, m_sh_ctx.GetCs().cs_regs.data_addr);
+		std::fflush(stdout);
+		BufferFlushAndWait();
+	}
 
 	{
 		CheckBuffer();
@@ -1176,13 +1199,14 @@ void CommandProcessor::DispatchDirect(uint32_t thread_group_x, uint32_t thread_g
 			if (log_count.fetch_add(1, std::memory_order_relaxed) < 1024) {
 				const auto& cs = m_sh_ctx.GetCs().cs_regs;
 				const auto& oa = m_ucfg.GetGdsOaCounter(m_ucfg.GetGdsOaState().GetIndex());
+				const auto  wave_size = Pm4::GetComputeWaveSizeFromDispatchModifier(mode);
 				LOGF("QueuePoint DispatchDirect: frame=%u submit=%" PRIu64
 				     " groups=%ux%ux%u local=%ux%ux%u mode=0x%08" PRIx32 " wave=%u cs=0x%016" PRIx64
 				     " oa_index=%u oa_enabled=%s oa_addr=0x%04" PRIx32 " oa_space=0x%08" PRIx32
 				     "\n",
 				     frame_num, m_submit_id, thread_group_x, thread_group_y, thread_group_z,
 				     std::max(cs.num_thread_x, 1u), std::max(cs.num_thread_y, 1u),
-				     std::max(cs.num_thread_z, 1u), mode, static_cast<uint32_t>(cs.wave_size),
+				     std::max(cs.num_thread_z, 1u), mode, wave_size,
 				     cs.data_addr, m_ucfg.GetGdsOaState().GetIndex(),
 				     oa.IsCounterEnabled() ? "true" : "false", oa.GetAddressBytes(),
 				     oa.GetSpaceAvailable());
@@ -1193,7 +1217,7 @@ void CommandProcessor::DispatchDirect(uint32_t thread_group_x, uint32_t thread_g
 		// local_x        = std::max(cs.num_thread_x, 1u);
 		// local_y        = std::max(cs.num_thread_y, 1u);
 		// local_z        = std::max(cs.num_thread_z, 1u);
-		if (cs.wave_size == 64u) {
+		if (Pm4::GetComputeWaveSizeFromDispatchModifier(mode) == 64u) {
 			static std::atomic_bool logged_wave64_shader {false};
 			if (!logged_wave64_shader.exchange(true, std::memory_order_relaxed)) {
 				LOGF("warning: executing wave64 compute shader cs=0x%016" PRIx64 "\n",
@@ -1206,6 +1230,19 @@ void CommandProcessor::DispatchDirect(uint32_t thread_group_x, uint32_t thread_g
 
 		m_renderer.GetRenderExecutor().DispatchDirect(m_submit_id, CurrentBuffer(), thread_group_x,
 		                                              thread_group_y, thread_group_z, mode);
+	}
+
+	if (isolate_compute_dispatch) {
+		BufferFlushAndWait();
+		LOGF("Compute dispatch isolation: #%-6" PRIu64 " completed submit=%" PRIu64
+		     " groups=%ux%ux%u mode=0x%08" PRIx32 " cs=0x%016" PRIx64 "\n",
+		     isolate_sequence, m_submit_id, thread_group_x, thread_group_y, thread_group_z, mode,
+		     m_sh_ctx.GetCs().cs_regs.data_addr);
+		std::printf("Compute dispatch isolation: #%-6" PRIu64 " completed submit=%" PRIu64
+		            " groups=%ux%ux%u mode=0x%08" PRIx32 " cs=0x%016" PRIx64 "\n",
+		            isolate_sequence, m_submit_id, thread_group_x, thread_group_y, thread_group_z,
+		            mode, m_sh_ctx.GetCs().cs_regs.data_addr);
+		std::fflush(stdout);
 	}
 
 	/*constexpr uint32_t DispatchInitiatorUseThreadDimensions = 1u << 5u;

--- a/src/graphics/guest_gpu/hardwareContext.h
+++ b/src/graphics/guest_gpu/hardwareContext.h
@@ -555,7 +555,6 @@ struct CsStageRegisters {
 	bool     fp16_overflow             = false;
 	bool     bulky                     = false;
 	bool     threadgroup_configuration = false;
-	uint8_t  wave_size                 = 64;
 	bool     scratch_en                = false;
 	uint8_t  user_sgpr                 = 0;
 	bool     tgid_x_en                 = false;

--- a/src/graphics/guest_gpu/pm4.h
+++ b/src/graphics/guest_gpu/pm4.h
@@ -25,6 +25,13 @@ constexpr uint32_t IT_CLEAR_STATE               = 0x12;
 constexpr uint32_t IT_INDEX_BUFFER_SIZE         = 0x13;
 constexpr uint32_t IT_DISPATCH_DIRECT           = 0x15;
 constexpr uint32_t IT_DISPATCH_INDIRECT         = 0x16;
+// Prospero AGC encodes the compute wave mode in DispatchModifier, not in
+// COMPUTE_PGM_RSRC1. Bit 15 set selects wave32; clear selects wave64.
+constexpr uint32_t DISPATCH_MODIFIER_WAVE32_EN = 1u << 15u;
+
+constexpr uint32_t GetComputeWaveSizeFromDispatchModifier(uint32_t dispatch_modifier) {
+	return (dispatch_modifier & DISPATCH_MODIFIER_WAVE32_EN) != 0u ? 32u : 64u;
+}
 constexpr uint32_t IT_SET_PREDICATION           = 0x20;
 constexpr uint32_t IT_COND_EXEC                 = 0x22;
 constexpr uint32_t IT_DRAW_INDIRECT             = 0x24;
@@ -984,8 +991,6 @@ constexpr uint32_t COMPUTE_PGM_RSRC1_FP16_OVFL_SHIFT  = 26;
 constexpr uint32_t COMPUTE_PGM_RSRC1_FP16_OVFL_MASK   = 0x1;
 constexpr uint32_t COMPUTE_PGM_RSRC1_WGP_MODE_SHIFT   = 29;
 constexpr uint32_t COMPUTE_PGM_RSRC1_WGP_MODE_MASK    = 0x1;
-constexpr uint32_t COMPUTE_PGM_RSRC1_W32_EN_SHIFT     = 30;
-constexpr uint32_t COMPUTE_PGM_RSRC1_W32_EN_MASK      = 0x1;
 
 constexpr uint32_t COMPUTE_PGM_RSRC2                      = 0x213;
 constexpr uint32_t COMPUTE_PGM_RSRC2_SCRATCH_EN_SHIFT     = 0;

--- a/src/graphics/host_gpu/renderer/pipeline/shaderSubgroup.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaderSubgroup.cpp
@@ -21,9 +21,58 @@ ShaderLaneMaskMode SelectGraphicsLaneMaskMode(uint32_t guest_wave_size) {
 	return ShaderLaneMaskMode::NativeWave;
 }
 
+ShaderLaneMaskMode SelectComputeLaneMaskMode(const ShaderSubgroupCapabilities& capabilities,
+                                             uint32_t guest_wave_size,
+                                             uint32_t local_threads) {
+	if (guest_wave_size != 64u || local_threads < guest_wave_size) {
+		return ShaderLaneMaskMode::NativeWave;
+	}
+	if (capabilities.subgroup_size == guest_wave_size) {
+		return ShaderLaneMaskMode::NativeWave;
+	}
+	const auto compute_stage = vk::ShaderStageFlagBits::eCompute;
+	const bool controlled64 = capabilities.subgroup_size_control_enabled &&
+	                          (capabilities.required_subgroup_size_stages & compute_stage) &&
+	                          guest_wave_size >= capabilities.min_subgroup_size &&
+	                          guest_wave_size <= capabilities.max_subgroup_size;
+	return controlled64 ? ShaderLaneMaskMode::NativeWave : ShaderLaneMaskMode::PerInvocation;
+}
+
+ShaderLaneMaskMode SelectComputeProgramLaneMaskMode(
+    const ShaderSubgroupCapabilities& capabilities, uint32_t guest_wave_size,
+    uint32_t local_threads, const ShaderRecompiler::IR::Program& native_program) {
+	// Compile and analyze native IR first. Most compute programs do not consume
+	// whole-wave masks or subgroup ordering, and remain correct in the existing
+	// FlattenedMasks path even when one guest wave spans two host subgroups.
+	// Per-invocation lowering changes the representation of EXEC/VCC, so only
+	// select it for programs which actually require exact guest-wave semantics.
+	if (SelectComputeLaneMaskMode(capabilities, guest_wave_size, local_threads) !=
+	        ShaderLaneMaskMode::PerInvocation ||
+	    !ShaderRecompiler::Spirv::ProgramRequiresExactSubgroupSize(native_program)) {
+		return ShaderLaneMaskMode::NativeWave;
+	}
+	if (guest_wave_size == 64u && capabilities.subgroup_size == 32u &&
+	    local_threads == guest_wave_size &&
+	    ShaderRecompiler::Spirv::ProgramSupportsHalfWaveSeparable(native_program)) {
+		return ShaderLaneMaskMode::NativeWave;
+	}
+	auto logical_program           = native_program;
+	logical_program.lane_mask_mode = ShaderLaneMaskMode::PerInvocation;
+	const bool supported =
+	    local_threads == guest_wave_size
+	        ? ShaderRecompiler::Spirv::ProgramSupportsLogicalSingleWaveWorkgroup(logical_program)
+	        : local_threads > guest_wave_size && local_threads % guest_wave_size == 0u &&
+	              ShaderRecompiler::Spirv::ProgramSupportsLogicalMultiWaveWorkgroup(logical_program);
+	if (!supported) {
+		return ShaderLaneMaskMode::NativeWave;
+	}
+	return ShaderLaneMaskMode::PerInvocation;
+}
+
 ShaderSubgroupConfiguration ConfigureShaderSubgroup(const ShaderSubgroupCapabilities& capabilities,
                                                     vk::ShaderStageFlagBits           stage,
-                                                    const ShaderRecompiler::IR::Program& program) {
+                                                    const ShaderRecompiler::IR::Program& program,
+                                                    uint32_t local_threads) {
 	const auto guest_wave_size = program.wave_size;
 	if (guest_wave_size != 32u && guest_wave_size != 64u) {
 		return {};
@@ -39,11 +88,29 @@ ShaderSubgroupConfiguration ConfigureShaderSubgroup(const ShaderSubgroupCapabili
 		            : ShaderSubgroupMode::PerInvocationGraphics,
 		        0};
 	}
+	if (program.lane_mask_mode == ShaderLaneMaskMode::PerInvocation) {
+		if (local_threads == guest_wave_size &&
+		    ShaderRecompiler::Spirv::ProgramSupportsLogicalSingleWaveWorkgroup(program)) {
+			return {ShaderSubgroupMode::LogicalSingleWaveWorkgroup, 0};
+		}
+		if (local_threads > guest_wave_size && local_threads % guest_wave_size == 0u &&
+		    ShaderRecompiler::Spirv::ProgramSupportsLogicalMultiWaveWorkgroup(program)) {
+			return {ShaderSubgroupMode::LogicalMultiWaveWorkgroup, 0};
+		}
+		return {};
+	}
 	if (program.lane_mask_mode != ShaderLaneMaskMode::NativeWave) {
 		return {};
 	}
 	if (capabilities.subgroup_size == guest_wave_size) {
 		return {ShaderSubgroupMode::Natural, 0};
+	}
+	// A workgroup smaller than one guest wave is a single partial wave. The
+	// inactive guest lanes have no invocations, so native subgroup operations
+	// are exact when every live lane fits in one host subgroup.
+	if (local_threads != 0u && local_threads < guest_wave_size &&
+	    local_threads <= capabilities.subgroup_size) {
+		return {ShaderSubgroupMode::PartialWave, 0};
 	}
 	if (capabilities.subgroup_size_control_enabled &&
 	    (capabilities.required_subgroup_size_stages & stage) &&
@@ -51,10 +118,47 @@ ShaderSubgroupConfiguration ConfigureShaderSubgroup(const ShaderSubgroupCapabili
 	    guest_wave_size <= capabilities.max_subgroup_size) {
 		return {ShaderSubgroupMode::Controlled, guest_wave_size};
 	}
+	if (guest_wave_size == 64u && capabilities.subgroup_size == 32u &&
+	    local_threads == guest_wave_size &&
+	    ShaderRecompiler::Spirv::ProgramSupportsHalfWaveSeparable(program)) {
+		return {ShaderSubgroupMode::HalfWaveIndependent, 0};
+	}
 	if (!ShaderRecompiler::Spirv::ProgramRequiresExactSubgroupSize(program)) {
 		return {ShaderSubgroupMode::FlattenedMasks, 0};
 	}
 	return {};
+}
+
+bool ComputeProgramWave64Supported(const ShaderSubgroupCapabilities& capabilities,
+                                   uint32_t local_threads,
+                                   const ShaderRecompiler::IR::Program& native_program) {
+	if (native_program.wave_size != 64u ||
+	    native_program.lane_mask_mode != ShaderLaneMaskMode::NativeWave) {
+		return false;
+	}
+	const auto selected = SelectComputeProgramLaneMaskMode(
+	    capabilities, native_program.wave_size, local_threads, native_program);
+	if (selected == ShaderLaneMaskMode::PerInvocation) {
+		// Selection already cloned and certified the logical representation. The
+		// caller will perform the actual PerInvocation recompile afterwards.
+		return true;
+	}
+	return ConfigureShaderSubgroup(capabilities, vk::ShaderStageFlagBits::eCompute,
+	                               native_program, local_threads)
+	           .mode != ShaderSubgroupMode::Unsupported;
+}
+
+uint32_t SelectComputeExecutionWaveSize(const ShaderSubgroupCapabilities& capabilities,
+                                        uint32_t local_threads,
+                                        const ShaderRecompiler::IR::Program& native_program) {
+	if (native_program.wave_size != 64u ||
+	    ComputeProgramWave64Supported(capabilities, local_threads, native_program)) {
+		return native_program.wave_size;
+	}
+	// Older hosts cannot always expose a 64-lane subgroup, and not every shader
+	// can be represented by the exact logical-wave lowering yet. Keep such
+	// programs runnable with the established wave32 compatibility lowering.
+	return 32u;
 }
 
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/pipeline/shaderSubgroup.h
+++ b/src/graphics/host_gpu/renderer/pipeline/shaderSubgroup.h
@@ -9,7 +9,11 @@ namespace Libs::Graphics {
 enum class ShaderSubgroupMode {
 	Natural,
 	Controlled,
+	PartialWave,
 	PerInvocationGraphics,
+	LogicalSingleWaveWorkgroup,
+	LogicalMultiWaveWorkgroup,
+	HalfWaveIndependent,
 	FlattenedMasks,
 	Unsupported
 };
@@ -31,9 +35,26 @@ struct ShaderSubgroupCapabilities {
 
 ShaderLaneMaskMode SelectGraphicsLaneMaskMode(uint32_t guest_wave_size);
 
+ShaderLaneMaskMode SelectComputeLaneMaskMode(const ShaderSubgroupCapabilities& capabilities,
+	                                         uint32_t guest_wave_size,
+	                                         uint32_t local_threads);
+
+ShaderLaneMaskMode SelectComputeProgramLaneMaskMode(
+    const ShaderSubgroupCapabilities& capabilities, uint32_t guest_wave_size,
+    uint32_t local_threads, const ShaderRecompiler::IR::Program& native_program);
+
 ShaderSubgroupConfiguration ConfigureShaderSubgroup(const ShaderSubgroupCapabilities& capabilities,
                                                     vk::ShaderStageFlagBits           stage,
-                                                    const ShaderRecompiler::IR::Program& program);
+                                                    const ShaderRecompiler::IR::Program& program,
+                                                    uint32_t local_threads = 0);
+
+bool ComputeProgramWave64Supported(const ShaderSubgroupCapabilities& capabilities,
+                                   uint32_t local_threads,
+                                   const ShaderRecompiler::IR::Program& native_program);
+
+uint32_t SelectComputeExecutionWaveSize(const ShaderSubgroupCapabilities& capabilities,
+	                                    uint32_t local_threads,
+	                                    const ShaderRecompiler::IR::Program& native_program);
 
 } // namespace Libs::Graphics
 

--- a/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
@@ -18,6 +18,7 @@
 #include "graphics/shader/shader.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <limits>
 #include <span>
 
@@ -418,17 +419,64 @@ static void CreateLayout(DescriptorCache&                   descriptor_cache,
 static void ConfigureSubgroupSize(const GraphicContext& graphics, vk::ShaderStageFlagBits vk_stage,
                                   const ShaderRecompiler::IR::Program&                   program,
                                   vk::PipelineShaderStageRequiredSubgroupSizeCreateInfo& required,
-                                  vk::PipelineShaderStageCreateInfo&                     stage) {
-	const auto config =
-	    ConfigureShaderSubgroup(ShaderSubgroupCapabilities {graphics}, vk_stage, program);
+                                  vk::PipelineShaderStageCreateInfo&                     stage,
+                                  uint32_t local_threads = 0) {
+	auto config =
+	    ConfigureShaderSubgroup(ShaderSubgroupCapabilities {graphics}, vk_stage, program,
+	                            local_threads);
+	if (config.mode == ShaderSubgroupMode::Unsupported &&
+	    vk_stage == vk::ShaderStageFlagBits::eCompute && program.wave_size == 64u &&
+	    program.lane_mask_mode == ShaderLaneMaskMode::NativeWave &&
+	    local_threads > program.wave_size) {
+		const char* fallback = std::getenv("KYTY_DEBUG_ALLOW_SPLIT_WAVE64");
+		if (fallback != nullptr && fallback[0] == '1' && fallback[1] == '\0') {
+			static std::atomic<uint32_t> log_count {0};
+			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
+				LOGF("DEBUG ONLY: splitting %u-lane compute shader 0x%016" PRIx64
+				     " across subgroup32 for a %u-thread workgroup\n",
+				     program.wave_size, program.shader_hash, local_threads);
+			}
+			return;
+		}
+	}
 	switch (config.mode) {
 		case ShaderSubgroupMode::Natural: return;
+		case ShaderSubgroupMode::PartialWave: {
+			static std::atomic<uint32_t> log_count {0};
+			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
+				LOGF("Vulkan running %u active lanes of a %u-lane guest compute wave "
+				     "inside one %u-lane host subgroup\n",
+				     local_threads, program.wave_size, graphics.subgroup_size);
+			}
+			return;
+		}
 		case ShaderSubgroupMode::PerInvocationGraphics: {
 			static std::atomic<uint32_t> log_count {0};
 			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
 				LOGF("Vulkan running %u-lane graphics shader stage 0x%08x with per-invocation "
 				     "EXEC/VCC on the host-native subgroup\n",
 				     program.wave_size, static_cast<uint32_t>(vk_stage));
+			}
+			return;
+		}
+		case ShaderSubgroupMode::LogicalSingleWaveWorkgroup: {
+			static std::atomic<uint32_t> log_count {0};
+			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
+				LOGF("Vulkan running one %u-lane guest compute wave as a full workgroup "
+				     "with per-invocation EXEC/VCC\n",
+				     program.wave_size);
+			}
+			return;
+		}
+		case ShaderSubgroupMode::LogicalMultiWaveWorkgroup: {
+			// The emitter represents each guest wave with per-invocation masks and
+			// workgroup-indexed summaries. It does not require a host subgroup size.
+			return;
+		}
+		case ShaderSubgroupMode::HalfWaveIndependent: {
+			static std::atomic<uint32_t> log_count {0};
+			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
+				LOGF("Vulkan running one separable wave64 as two independent subgroup32 halves\n");
 			}
 			return;
 		}
@@ -444,9 +492,12 @@ static void ConfigureSubgroupSize(const GraphicContext& graphics, vk::ShaderStag
 		case ShaderSubgroupMode::Controlled: break;
 		case ShaderSubgroupMode::Unsupported:
 		default:
-			EXIT("Vulkan cannot run %u-lane shader stage 0x%08x: default=%u min=%u max=%u "
+			EXIT("Vulkan cannot run shader 0x%016" PRIx64
+			     " (%u-lane, mask_mode=%u) stage 0x%08x: default=%u min=%u max=%u "
 			     "controlled_stages=0x%08x\n",
-			     program.wave_size, static_cast<uint32_t>(vk_stage), graphics.subgroup_size,
+			     program.shader_hash, program.wave_size,
+			     static_cast<uint32_t>(program.lane_mask_mode),
+			     static_cast<uint32_t>(vk_stage), graphics.subgroup_size,
 			     graphics.min_subgroup_size, graphics.max_subgroup_size,
 			     static_cast<vk::ShaderStageFlags::MaskType>(
 			         graphics.required_subgroup_size_stages));
@@ -530,7 +581,6 @@ void CreatePipelineInternal(
 
 	vk::PipelineShaderStageCreateInfo                     vert_shader_stage_info {};
 	vk::PipelineShaderStageRequiredSubgroupSizeCreateInfo vert_subgroup_size {};
-
 	vert_shader_stage_info.sType               = vk::StructureType::ePipelineShaderStageCreateInfo;
 	vert_shader_stage_info.pNext               = nullptr;
 	vert_shader_stage_info.flags               = {};
@@ -1046,7 +1096,6 @@ void CreatePipelineInternal(GraphicContext& graphics, DescriptorCache& descripto
                             const ShaderComputeInputInfo&   input_info,
                             std::span<const uint32_t>       cs_shader) {
 	vk::ShaderModule comp_shader_module = nullptr;
-
 	vk::ShaderModuleCreateInfo create_info {};
 
 	create_info.sType    = vk::StructureType::eShaderModuleCreateInfo;
@@ -1073,8 +1122,11 @@ void CreatePipelineInternal(GraphicContext& graphics, DescriptorCache& descripto
 	comp_shader_stage_info.pName               = "main";
 	comp_shader_stage_info.pSpecializationInfo = nullptr;
 	EXIT_IF(!input_info.stage);
+	const auto local_threads = std::max(input_info.threads_num[0], 1u) *
+	                           std::max(input_info.threads_num[1], 1u) *
+	                           std::max(input_info.threads_num[2], 1u);
 	ConfigureSubgroupSize(graphics, vk::ShaderStageFlagBits::eCompute, *input_info.stage.program,
-	                      comp_subgroup_size, comp_shader_stage_info);
+	                      comp_subgroup_size, comp_shader_stage_info, local_threads);
 
 	vk::DescriptorSetLayout set_layouts[1]  = {};
 	uint32_t                set_layouts_num = 0;

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -9,6 +9,7 @@
 #include "graphics/guest_gpu/gpu_defs.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/guest_gpu/hardwareContext.h"
+#include "graphics/guest_gpu/pm4.h"
 #include "graphics/host_gpu/graphicContext.h"
 #include "graphics/host_gpu/renderer/image/imageInfo.h"
 #include "graphics/host_gpu/renderer/pipeline/descriptorCache.h"
@@ -115,7 +116,7 @@ bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t grou
 	    group_z == 1 && input.dispatch_threads_num[0] == group_x &&
 	    input.dispatch_threads_num[1] == 1 && input.dispatch_threads_num[2] == 1 &&
 	    input.group_id[0] && !input.group_id[1] && !input.group_id[2] &&
-	    input.thread_ids_num == 1 && input.wave_size == 32 && !input.tg_size_en && mode == 0x61u &&
+	    input.thread_ids_num == 1 && input.wave_size == 64 && !input.tg_size_en && mode == 0x61u &&
 	    group_x % input.threads_num[0] == 0 && descriptor.NumRecords() == group_x;
 	const auto size = BufferDescriptorSize(descriptor);
 	if (!full_dispatch || size == 0) {
@@ -193,12 +194,44 @@ void RenderExecutor::DispatchDirect(uint64_t submit_id, RenderCommandBuffer& buf
 
 	const auto& cs_regs = sh_ctx.GetCs();
 	const auto& sh_regs = ctx.GetShaderRegisters();
+	const uint32_t sdk_guest_wave_size = Pm4::GetComputeWaveSizeFromDispatchModifier(mode);
+	const uint32_t local_threads = std::max(cs_regs.cs_regs.num_thread_x, 1u) *
+	                               std::max(cs_regs.cs_regs.num_thread_y, 1u) *
+	                               std::max(cs_regs.cs_regs.num_thread_z, 1u);
+	uint32_t guest_wave_size = sdk_guest_wave_size;
+	const ShaderSubgroupCapabilities subgroup_caps {m_context.GetGraphics()};
 
 	ShaderComputeInputInfo    input_info {};
 	std::span<const uint32_t> cs_shader;
-	if (!ShaderCompileInfoCS(cs_regs, sh_regs, input_info, cs_shader)) {
+	if (!ShaderCompileInfoCS(cs_regs, sh_regs, guest_wave_size,
+	                         ShaderLaneMaskMode::NativeWave, input_info, cs_shader)) {
 		EXIT("ShaderCompileInfoCS failed for dispatch with CS shader 0x%016" PRIx64 "\n",
 		     cs_regs.cs_regs.data_addr);
+	}
+	auto lane_mask_mode = SelectComputeProgramLaneMaskMode(
+	    subgroup_caps, guest_wave_size, local_threads, *input_info.stage.program);
+	const uint32_t execution_wave_size = SelectComputeExecutionWaveSize(
+	    subgroup_caps, local_threads, *input_info.stage.program);
+	if (execution_wave_size != guest_wave_size) {
+		guest_wave_size = execution_wave_size;
+		if (!ShaderCompileInfoCS(cs_regs, sh_regs, guest_wave_size,
+		                         ShaderLaneMaskMode::NativeWave, input_info, cs_shader)) {
+			EXIT("ShaderCompileInfoCS wave32 compatibility fallback failed for CS shader "
+			     "0x%016" PRIx64 "\n",
+			     cs_regs.cs_regs.data_addr);
+		}
+		lane_mask_mode = SelectComputeProgramLaneMaskMode(
+		    subgroup_caps, guest_wave_size, local_threads, *input_info.stage.program);
+	}
+	if (lane_mask_mode == ShaderLaneMaskMode::PerInvocation) {
+		ShaderComputeInputInfo logical_info {};
+		if (!ShaderCompileInfoCS(cs_regs, sh_regs, guest_wave_size, lane_mask_mode, logical_info,
+		                         cs_shader)) {
+			EXIT("ShaderCompileInfoCS logical wave64 recompile failed for CS shader 0x%016" PRIx64
+			     "\n",
+			     cs_regs.cs_regs.data_addr);
+		}
+		input_info = std::move(logical_info);
 	}
 
 	const bool use_thread_dimensions = (mode & DISPATCH_INITIATOR_USE_THREAD_DIMENSIONS) != 0;

--- a/src/graphics/shader/recompiler/ShaderRecompiler.cpp
+++ b/src/graphics/shader/recompiler/ShaderRecompiler.cpp
@@ -18,8 +18,11 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
 #include <fmt/format.h>
 #include <map>
+#include <mutex>
 #include <span>
 #include <utility>
 
@@ -832,6 +835,13 @@ bool TryRecompile(std::span<const uint32_t> code, const CompileOptions& options,
 	    options.pixel_input_info != nullptr ? options.pixel_input_info : &default_pixel;
 	info_options.compute =
 	    options.compute_input_info != nullptr ? options.compute_input_info : &default_compute;
+	ir.compute_linear_local64 =
+	    ir.stage == ShaderType::Compute && info_options.compute->threads_num[0] == 64u &&
+	    info_options.compute->threads_num[1] == 1u &&
+	    info_options.compute->threads_num[2] == 1u && info_options.compute->group_id[0] &&
+	    info_options.compute->thread_ids_num >= 1;
+	ir.compute_workgroup_register = info_options.compute->workgroup_register;
+	ir.compute_thread_ids_num     = info_options.compute->thread_ids_num;
 	if (!IR::CollectShaderInfo(ir, info_options, error)) {
 		return false;
 	}

--- a/src/graphics/shader/recompiler/decompiler/VectorAluOps.cpp
+++ b/src/graphics/shader/recompiler/decompiler/VectorAluOps.cpp
@@ -48,7 +48,7 @@ constexpr Vop2OpcodeInfo VOP2_OPS[] = {
     {0x15u, Opcode::VLshrB32},
     {0x16u, Opcode::VLshrrevB32, Vop2SdwaProfile::ReverseLogicalRight},
     {0x17u, Opcode::VAshrI32},
-    {0x18u, Opcode::VAshrrevI32},
+    {0x18u, Opcode::VAshrrevI32, Vop2SdwaProfile::ReverseLogicalRight},
     {0x19u, Opcode::VLshlB32},
     {0x1au, Opcode::VLshlrevB32, Vop2SdwaProfile::ReverseLogicalLeft},
     {0x1bu, Opcode::VAndB32, Vop2SdwaProfile::Bitwise},
@@ -61,7 +61,7 @@ constexpr Vop2OpcodeInfo VOP2_OPS[] = {
     {0x22u, Opcode::VBcntU32B32},
     {0x23u, Opcode::VMbcntLoU32B32},
     {0x24u, Opcode::VMbcntHiU32B32},
-    {0x25u, Opcode::VAddNcU32, Vop2SdwaProfile::IntegerFullDestination},
+    {0x25u, Opcode::VAddNcU32, Vop2SdwaProfile::IntegerPartialDestination},
     {0x28u, Opcode::VAddcU32},
     {0x26u, Opcode::VSubNcU32, Vop2SdwaProfile::IntegerPartialDestination},
     {0x27u, Opcode::VSubrevNcU32, Vop2SdwaProfile::IntegerFullDestination},
@@ -267,7 +267,8 @@ constexpr OpcodeMap VOP3_OPS[] = {
     {0x363u, Opcode::VBfmB32},          {0x364u, Opcode::VBcntU32B32},
     {0x365u, Opcode::VMbcntLoU32B32},   {0x366u, Opcode::VMbcntHiU32B32},
     {0x368u, Opcode::VCvtPknormI16F32}, {0x369u, Opcode::VCvtPknormU16F32},
-    {0x36au, Opcode::VCvtPkU16U32},     {0x36fu, Opcode::VLshlOrB32},
+    {0x36au, Opcode::VCvtPkU16U32},
+    {0x36fu, Opcode::VLshlOrB32},
     {0x371u, Opcode::VAndOrB32},        {0x372u, Opcode::VOr3B32},
     {0x377u, Opcode::VPermlane16B32},   {0x378u, Opcode::VPermlanex16B32},
     {0x34bu, Opcode::VFmaF16},          {0x36du, Opcode::VAdd3U32},
@@ -446,6 +447,10 @@ constexpr Vop1SdwaRule VOP1_SDWA_RULES[] = {
      SdwaSelWords() | SdwaSelFull(), false},
     {Opcode::VCvtF32U32, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
     {Opcode::VCvtF32I32, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
+    {Opcode::VCvtF32Ubyte0, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
+    {Opcode::VCvtF32Ubyte1, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
+    {Opcode::VCvtF32Ubyte2, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
+    {Opcode::VCvtF32Ubyte3, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
     {Opcode::VCvtF32F16, SdwaSelWords() | SdwaSelFull(), 0, 0, true},
     {Opcode::VCvtF16F32, SdwaSelFull(), SdwaSelWords(), SdwaSelFull(), false},
     {Opcode::VCvtF16U16, SdwaSelWords() | SdwaSelFull(), SdwaSelWords(),
@@ -478,6 +483,8 @@ constexpr Vop1SdwaRule VOP1_SDWA_RULES[] = {
     {Opcode::VCvtI32F32, SdwaSelFull(), SdwaSelBytes() | SdwaSelWords(), SdwaSelFull(), false},
     {Opcode::VCvtRpiI32F32, SdwaSelFull(), SdwaSelBytes() | SdwaSelWords(), SdwaSelFull(), false},
     {Opcode::VCvtFlrI32F32, SdwaSelFull(), SdwaSelBytes() | SdwaSelWords(), SdwaSelFull(), false},
+    {Opcode::VNotB32, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
+    {Opcode::VFfblB32, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
 };
 
 const Vop1SdwaRule* FindVop1SdwaRule(Opcode opcode) {
@@ -870,8 +877,8 @@ constexpr Vop2SdwaRule VOP2_SDWA_RULES[] = {
      true, true},
     {SdwaSelFull(), SdwaSelAll(), SdwaSelAll(), false, false},
     {SdwaSelAll(), SdwaSelAll(), SdwaSelAll(), true, false},
-    {SdwaSelFull(), SdwaSelFull(), SdwaSelWords() | SdwaSelFull(), false, false},
-    {SdwaSelFull(), SdwaSelFull(), SdwaSelAll(), false, false},
+    {SdwaSelFull(), SdwaSelAll(), SdwaSelWords() | SdwaSelFull(), false, false},
+    {SdwaSelFull(), SdwaSelAll(), SdwaSelAll(), false, false},
     {SdwaSelWords() | SdwaSelFull(), SdwaSelAll(), SdwaSelAll(), true, false},
 };
 static_assert(sizeof(VOP2_SDWA_RULES) / sizeof(VOP2_SDWA_RULES[0]) ==
@@ -1221,7 +1228,7 @@ uint32_t NativeVop3SourceCount(Opcode opcode) {
 		case Opcode::VBcntU32B32:
 		case Opcode::VCvtPknormI16F32:
 		case Opcode::VCvtPknormU16F32:
-		case Opcode::VCvtPkU16U32: return 2;
+		case Opcode::VCvtPkU16U32:
 		default: return 3;
 	}
 }

--- a/src/graphics/shader/recompiler/emitter/SpirvEmitter.cpp
+++ b/src/graphics/shader/recompiler/emitter/SpirvEmitter.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cinttypes>
 #include <cstdio>
+#include <cstdlib>
 
 namespace Libs::Graphics::ShaderRecompiler::Spirv {
 
@@ -17,6 +18,12 @@ bool Fail(std::string* error, const std::string& message) {
 		*error = message;
 	}
 	return false;
+}
+
+bool UsesBinkDiagnosticTrace(const IR::Program& program) {
+	const char* const enabled = std::getenv("KYTY_BINK_TRACE_DIR");
+	return enabled != nullptr && enabled[0] != '\0' &&
+	       program.shader_hash == 0x0000000208a64d00ULL;
 }
 
 bool ImageBinding(const IR::ImageResource& image, IR::DescriptorBindingKind& kind) {
@@ -212,7 +219,8 @@ bool ValidateInstructionContract(const IR::Instruction& inst, std::string* error
 		return Fail(error, "floating-point atomic instruction must target a buffer");
 	}
 	if (IsAtomic(inst.op) &&
-	    !((kind == IR::ResourceKind::Buffer && inst.src_count == buffer_address_count + 1u) ||
+	    !((kind == IR::ResourceKind::Buffer &&
+	       inst.src_count == buffer_address_count + 1u) ||
 	      ((kind == IR::ResourceKind::Lds || kind == IR::ResourceKind::Gds) &&
 	       inst.memory.resource == 0 && inst.src_count == 2 &&
 	       (inst.dst.kind == IR::OperandKind::Null ||
@@ -254,7 +262,7 @@ bool ValidateNativeProgram(const IR::Program& program, std::string* error) {
 	if (!program.info.samplers.empty()) {
 		Expect(Kind::Samplers, Dense(program.info.samplers.size()));
 	}
-	const auto uses_gds =
+	const auto uses_gds = UsesBinkDiagnosticTrace(program) ||
 	    std::any_of(program.blocks.begin(), program.blocks.end(), [](const auto& block) {
 		    return std::any_of(
 		        block.instructions.begin(), block.instructions.end(),
@@ -417,6 +425,39 @@ bool ProgramRequiresExactSubgroupSize(const IR::Program& program) {
 				return true;
 			}
 			switch (inst.op) {
+				case IR::Opcode::DsReadUbyte:
+				case IR::Opcode::DsReadSbyte:
+				case IR::Opcode::DsReadUshort:
+				case IR::Opcode::DsReadSshort:
+				case IR::Opcode::DsReadB32:
+				case IR::Opcode::DsReadAddtidB32:
+					// LDS read visibility uses a subgroup control barrier. It is only
+					// correct when one host subgroup represents one complete guest wave.
+					if (program.stage == ShaderType::Compute &&
+					    inst.memory.kind == IR::ResourceKind::Lds) {
+						return true;
+					}
+					break;
+				case IR::Opcode::AtomicSwapU32:
+				case IR::Opcode::AtomicAddU32:
+				case IR::Opcode::AtomicSubU32:
+				case IR::Opcode::AtomicSMinI32:
+				case IR::Opcode::AtomicUMinU32:
+				case IR::Opcode::AtomicSMaxI32:
+				case IR::Opcode::AtomicUMaxU32:
+				case IR::Opcode::AtomicAndU32:
+				case IR::Opcode::AtomicOrU32:
+				case IR::Opcode::AtomicXorU32:
+				case IR::Opcode::AtomicFMinF32:
+				case IR::Opcode::AtomicFMaxF32:
+				case IR::Opcode::DsMinF32:
+				case IR::Opcode::DsMaxF32:
+					// Compute LDS atomics use a subgroup phase barrier outside EXEC.
+					if (program.stage == ShaderType::Compute &&
+					    inst.memory.kind == IR::ResourceKind::Lds) {
+						return true;
+					}
+					break;
 				case IR::Opcode::WqmB64:
 					if (inst.dst.kind == IR::OperandKind::Register &&
 					    inst.dst.reg.file != IR::RegisterFile::Scalar) {
@@ -438,6 +479,724 @@ bool ProgramRequiresExactSubgroupSize(const IR::Program& program) {
 		}
 	}
 	return false;
+}
+
+bool ProgramSupportsHalfWaveSeparable(const IR::Program& program) {
+	if (program.stage != ShaderType::Compute || program.wave_size != 64u ||
+	    program.lane_mask_mode != ShaderLaneMaskMode::NativeWave || program.blocks.empty() ||
+	    !program.compute_linear_local64 || !ProgramRequiresExactSubgroupSize(program)) {
+		return false;
+	}
+
+	auto find_block = [&](uint32_t id) -> const IR::BasicBlock* {
+		const auto it = std::find_if(program.blocks.begin(), program.blocks.end(),
+		                             [id](const auto& block) { return block.id == id; });
+		return it == program.blocks.end() ? nullptr : &*it;
+	};
+	const IR::BasicBlock* branch_header = nullptr;
+	for (const auto& block: program.blocks) {
+		const auto& term = block.terminator;
+		if (term.kind == CFG::TerminatorKind::IndirectBranch ||
+		    term.kind == CFG::TerminatorKind::Unsupported || term.loop_header) {
+			return false;
+		}
+		if (term.kind == CFG::TerminatorKind::ConditionalBranch) {
+			if (branch_header != nullptr ||
+			    (term.condition != CFG::BranchCondition::ExecZero &&
+			     term.condition != CFG::BranchCondition::ExecNonZero)) {
+				return false;
+			}
+			branch_header = &block;
+		}
+	}
+	if (branch_header == nullptr) {
+		return false;
+	}
+
+	// Accept only an acyclic inactive-half bypass: EXECZ jumps directly to merge,
+	// while the active half executes one straight-line block and then merges.
+	const auto& branch = branch_header->terminator;
+	if (branch.merge_block == UINT32_MAX || branch_header->successors.size() != 2u) {
+		return false;
+	}
+	const auto bypass_id = branch.condition == CFG::BranchCondition::ExecZero
+	                           ? branch.true_block
+	                           : branch.false_block;
+	const auto active_id = branch.condition == CFG::BranchCondition::ExecZero
+	                           ? branch.false_block
+	                           : branch.true_block;
+	const auto* active_block = find_block(active_id);
+	if (bypass_id != branch.merge_block || active_block == nullptr ||
+	    active_block->successors.size() != 1u ||
+	    active_block->successors[0] != branch.merge_block ||
+	    active_block->terminator.kind != CFG::TerminatorKind::Branch) {
+		return false;
+	}
+	std::vector<uint32_t> tail_blocks;
+	const auto*           tail = find_block(branch.merge_block);
+	while (tail != nullptr) {
+		if (!tail->instructions.empty() ||
+		    std::find(tail_blocks.begin(), tail_blocks.end(), tail->id) != tail_blocks.end()) {
+			return false;
+		}
+		tail_blocks.push_back(tail->id);
+		if (tail->terminator.kind == CFG::TerminatorKind::Return) {
+			break;
+		}
+		if (tail->terminator.kind != CFG::TerminatorKind::Branch ||
+		    tail->successors.size() != 1u) {
+			return false;
+		}
+		tail = find_block(tail->successors[0]);
+	}
+	if (tail == nullptr || tail->terminator.kind != CFG::TerminatorKind::Return) {
+		return false;
+	}
+	for (const auto& block: program.blocks) {
+		if (block.id != branch_header->id && block.id != active_id &&
+		    std::find(tail_blocks.begin(), tail_blocks.end(), block.id) == tail_blocks.end()) {
+			return false;
+		}
+	}
+
+	auto is_register_file = [](const IR::Operand& operand, IR::RegisterFile file) {
+		return operand.kind == IR::OperandKind::Register && operand.reg.file == file;
+	};
+	auto is_scalar_register = [](const IR::Operand& operand) {
+		return operand.kind == IR::OperandKind::Register &&
+		       operand.reg.file != IR::RegisterFile::Vector &&
+		       operand.reg.file != IR::RegisterFile::Exec;
+	};
+	uint32_t     exec_compare_count = 0;
+	IR::Register gating_lane {};
+	bool         has_gating_lane = false;
+	uint32_t     guarded_store_count = 0;
+	for (const auto& block: program.blocks) {
+		const bool in_active_block = block.id == active_id;
+		for (const auto& inst: block.instructions) {
+			if (inst.memory.kind == IR::ResourceKind::Lds ||
+			    inst.memory.kind == IR::ResourceKind::Gds ||
+			    Emitter::InstructionHasDppSource(inst) || IsAtomic(inst.op) ||
+			    inst.op == IR::Opcode::ImageStore || inst.op == IR::Opcode::FlatStoreByte ||
+			    inst.op == IR::Opcode::FlatStoreShort || inst.op == IR::Opcode::FlatStoreDword ||
+			    inst.op == IR::Opcode::Export) {
+				return false;
+			}
+			for (uint32_t source = 0; source < inst.src_count; source++) {
+				if (is_register_file(inst.src[source], IR::RegisterFile::Exec)) {
+					return false;
+				}
+			}
+			if (is_register_file(inst.dst2, IR::RegisterFile::Exec) || ProducesLaneMask(inst) ||
+			    inst.op == IR::Opcode::SelectMaskU32 ||
+			    inst.op == IR::Opcode::SelectMaskF32Bits ||
+			    inst.op == IR::Opcode::SaveexecB32 || inst.op == IR::Opcode::SaveexecB64) {
+				return false;
+			}
+			if (is_register_file(inst.dst, IR::RegisterFile::Exec)) {
+				if (&block != branch_header || !IR::IsCompareOpcode(inst.op)) {
+					return false;
+				}
+				exec_compare_count++;
+				for (uint32_t source = 0; source < inst.src_count; source++) {
+					if (is_register_file(inst.src[source], IR::RegisterFile::Vector)) {
+						if (has_gating_lane) {
+							return false;
+						}
+						gating_lane     = inst.src[source].reg;
+						has_gating_lane = true;
+					}
+				}
+			} else if (IR::IsCompareOpcode(inst.op) && !Emitter::IsSccOperand(inst.dst)) {
+				return false;
+			}
+
+			switch (inst.op) {
+				case IR::Opcode::Barrier:
+				case IR::Opcode::WqmB64:
+				case IR::Opcode::MaskedBitCountLowU32:
+				case IR::Opcode::MaskedBitCountHighU32:
+				case IR::Opcode::ReadFirstLaneU32:
+				case IR::Opcode::ReadLaneU32:
+				case IR::Opcode::WriteLaneU32:
+				case IR::Opcode::Permlane16B32:
+				case IR::Opcode::Permlanex16B32:
+				case IR::Opcode::DsSwizzleB32:
+				case IR::Opcode::DsConsume:
+				case IR::Opcode::DsAppend:
+				case IR::Opcode::ImageGetLod: return false;
+				default: break;
+			}
+
+			const bool buffer_store = inst.op == IR::Opcode::BufferStoreByte ||
+			                          inst.op == IR::Opcode::BufferStoreShort ||
+			                          inst.op == IR::Opcode::BufferStoreDword;
+			if (buffer_store) {
+				if (!in_active_block || !has_gating_lane || !inst.memory.idxen ||
+				    inst.memory.offen || inst.src_count < 2u ||
+				    inst.src[1].kind != IR::OperandKind::Register ||
+				    inst.src[1].reg != gating_lane ||
+				    inst.memory.resource >= program.info.buffers.size() ||
+				    (program.info.buffers[inst.memory.resource].packed_stride & 0x3fffu) == 0u) {
+					return false;
+				}
+				guarded_store_count++;
+			}
+
+			if (in_active_block && is_scalar_register(inst.dst)) {
+				for (uint32_t source = 0; source < inst.src_count; source++) {
+					if (is_register_file(inst.src[source], IR::RegisterFile::Vector)) {
+						return false;
+					}
+				}
+			}
+		}
+	}
+	if (exec_compare_count != 1u || !has_gating_lane || guarded_store_count != 1u) {
+		return false;
+	}
+	if (branch_header->instructions.empty() ||
+	    !is_register_file(branch_header->instructions.back().dst, IR::RegisterFile::Exec)) {
+		return false;
+	}
+	uint32_t               index_definition_count = 0;
+	const IR::Instruction* index_definition       = nullptr;
+	IR::Register           workgroup_register {};
+	for (const auto& block: program.blocks) {
+		for (const auto& inst: block.instructions) {
+			const bool defines_gate =
+			    (inst.dst.kind == IR::OperandKind::Register && inst.dst.reg == gating_lane) ||
+			    (inst.dst2.kind == IR::OperandKind::Register && inst.dst2.reg == gating_lane);
+			if (!defines_gate) {
+				continue;
+			}
+			if (&block != branch_header || inst.op != IR::Opcode::ShiftLeftAddU32 ||
+			    inst.src_count != 3u ||
+			    !is_register_file(inst.src[0], IR::RegisterFile::Scalar) ||
+			    inst.src[1].kind != IR::OperandKind::ImmediateU32 || inst.src[1].imm != 6u ||
+			    inst.src[2].kind != IR::OperandKind::Register || inst.src[2].reg != gating_lane) {
+				return false;
+			}
+			index_definition_count++;
+			index_definition = &inst;
+			workgroup_register = inst.src[0].reg;
+		}
+	}
+	if (index_definition_count != 1u || gating_lane.index != 0u ||
+	    program.compute_thread_ids_num < 1 || program.compute_workgroup_register < 0 ||
+	    workgroup_register.index != static_cast<uint32_t>(program.compute_workgroup_register)) {
+		return false;
+	}
+	const auto has_input = [&](IR::StageInputKind kind) {
+		return std::any_of(program.info.inputs.begin(), program.info.inputs.end(),
+		                   [kind](const auto& input) { return input.kind == kind; });
+	};
+	if (!has_input(IR::StageInputKind::WorkgroupId) ||
+	    !has_input(IR::StageInputKind::LocalInvocationId)) {
+		return false;
+	}
+	for (const auto& block: program.blocks) {
+		for (const auto& inst: block.instructions) {
+			if (&inst == index_definition) {
+				continue;
+			}
+			if ((inst.dst.kind == IR::OperandKind::Register &&
+			     inst.dst.reg == workgroup_register) ||
+			    (inst.dst2.kind == IR::OperandKind::Register &&
+			     inst.dst2.reg == workgroup_register)) {
+				return false;
+			}
+		}
+	}
+
+	// The merge tail is instruction-free, so active-half scalar definitions cannot
+	// be observed after reconvergence. Scalar defs are still required to be uniform
+	// within the active block above.
+	return true;
+}
+
+namespace {
+
+struct LogicalMaskTaint {
+	std::array<bool, 256> scalar {};
+	std::array<bool, 2>   vcc {};
+	std::array<bool, 2>   exec {};
+
+	bool operator==(const LogicalMaskTaint&) const = default;
+};
+
+bool LogicalMaskPairOpcode(IR::Opcode op) {
+	switch (op) {
+		case IR::Opcode::MoveU64:
+		case IR::Opcode::SaveexecB64:
+		case IR::Opcode::BitwiseAndU64:
+		case IR::Opcode::BitwiseAndNotU64:
+		case IR::Opcode::BitwiseOrU64:
+		case IR::Opcode::BitwiseOrNotU64:
+		case IR::Opcode::BitwiseXorU64:
+		case IR::Opcode::BitwiseNandU64:
+		case IR::Opcode::BitwiseNorU64:
+		case IR::Opcode::BitwiseXnorU64:
+		case IR::Opcode::BitwiseNotU64:
+		case IR::Opcode::SelectU64: return true;
+		default: return false;
+	}
+}
+
+bool LogicalMaskPointwiseConsumer(IR::Opcode op) {
+	switch (op) {
+		case IR::Opcode::MoveU32:
+		case IR::Opcode::MoveU64:
+		case IR::Opcode::SaveexecB32:
+		case IR::Opcode::SaveexecB64:
+		case IR::Opcode::BitwiseAndU32:
+		case IR::Opcode::BitwiseAndU64:
+		case IR::Opcode::BitwiseAndNotU32:
+		case IR::Opcode::BitwiseAndNotU64:
+		case IR::Opcode::BitwiseOrU32:
+		case IR::Opcode::BitwiseOrU64:
+		case IR::Opcode::BitwiseOrNotU32:
+		case IR::Opcode::BitwiseOrNotU64:
+		case IR::Opcode::BitwiseXorU32:
+		case IR::Opcode::BitwiseXorU64:
+		case IR::Opcode::BitwiseNandU32:
+		case IR::Opcode::BitwiseNandU64:
+		case IR::Opcode::BitwiseNorU32:
+		case IR::Opcode::BitwiseNorU64:
+		case IR::Opcode::BitwiseXnorU32:
+		case IR::Opcode::BitwiseXnorU64:
+		case IR::Opcode::BitwiseNotU32:
+		case IR::Opcode::BitwiseNotU64:
+		case IR::Opcode::SelectU32:
+		case IR::Opcode::SelectU64:
+		case IR::Opcode::SelectMaskU32:
+		case IR::Opcode::SelectMaskF32Bits:
+			return true;
+		// A per-lane nonzero test followed by the logical SCC reduction exactly
+		// implements "any bit set". Equality of one numeric mask dword does not.
+		case IR::Opcode::CompareNeU32:
+		case IR::Opcode::CompareNeU64:
+		case IR::Opcode::CompareEqU64: return true;
+		default: return false;
+	}
+}
+
+bool LogicalMaskRegisterTainted(const LogicalMaskTaint& taint, IR::Register reg,
+	                              bool pair) {
+	auto part = [&](uint32_t offset) {
+		switch (reg.file) {
+			case IR::RegisterFile::Scalar:
+				return reg.index + offset < taint.scalar.size() &&
+			       taint.scalar[reg.index + offset];
+			case IR::RegisterFile::Vcc:
+				return reg.index + offset < taint.vcc.size() && taint.vcc[reg.index + offset];
+			case IR::RegisterFile::Exec:
+				return reg.index + offset < taint.exec.size() &&
+			       taint.exec[reg.index + offset];
+			default: return false;
+		}
+	};
+	return part(0) || (pair && part(1));
+}
+
+void SetLogicalMaskRegisterTaint(LogicalMaskTaint& taint, const IR::Operand& operand,
+	                               bool pair, bool value) {
+	if (operand.kind != IR::OperandKind::Register) {
+		return;
+	}
+	auto set_part = [&](uint32_t offset) {
+		const auto index = operand.reg.index + offset;
+		switch (operand.reg.file) {
+			case IR::RegisterFile::Scalar:
+				if (index < taint.scalar.size()) taint.scalar[index] = value;
+				break;
+			case IR::RegisterFile::Vcc:
+				if (index < taint.vcc.size()) taint.vcc[index] = value;
+				break;
+			case IR::RegisterFile::Exec:
+				if (index < taint.exec.size()) taint.exec[index] = true;
+				break;
+			default: break;
+		}
+	};
+	set_part(0);
+	if (pair) set_part(1);
+}
+
+bool LogicalMaskInstructionSourceTainted(const LogicalMaskTaint& taint,
+	                                       const IR::Instruction& inst) {
+	const bool pair = LogicalMaskPairOpcode(inst.op) || IR::IsCompare64Opcode(inst.op);
+	for (uint32_t i = 0; i < inst.src_count; i++) {
+		if (inst.src[i].kind == IR::OperandKind::Register &&
+		    LogicalMaskRegisterTainted(taint, inst.src[i].reg, pair)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool LogicalMaskTaintTransfer(const IR::Instruction& inst, LogicalMaskTaint& taint) {
+	const bool source_tainted = LogicalMaskInstructionSourceTainted(taint, inst);
+	if (source_tainted && !LogicalMaskPointwiseConsumer(inst.op)) {
+		return false;
+	}
+
+	const bool compare_mask = IR::IsCompareOpcode(inst.op) && !Emitter::IsSccOperand(inst.dst);
+	const bool pair         = compare_mask || LogicalMaskPairOpcode(inst.op);
+	if (inst.op == IR::Opcode::SaveexecB32 || inst.op == IR::Opcode::SaveexecB64) {
+		SetLogicalMaskRegisterTaint(taint, inst.dst, pair, true);
+		return true;
+	}
+	SetLogicalMaskRegisterTaint(taint, inst.dst, pair, compare_mask || source_tainted);
+	SetLogicalMaskRegisterTaint(taint, inst.dst2, false,
+	                           ProducesLaneMask(inst) || source_tainted);
+	return true;
+}
+
+bool ProgramPreservesLogicalScalarMasks(const IR::Program& program) {
+	if (program.blocks.empty()) {
+		return true;
+	}
+	const auto block_index = [&](uint32_t id) {
+		const auto it = std::find_if(program.blocks.begin(), program.blocks.end(),
+		                             [id](const auto& block) { return block.id == id; });
+		return it == program.blocks.end() ? program.blocks.size()
+		                                  : static_cast<size_t>(it - program.blocks.begin());
+	};
+	std::vector<LogicalMaskTaint> input(program.blocks.size());
+	std::vector<bool>             reachable(program.blocks.size(), false);
+	reachable[0]       = true;
+	input[0].exec[0]  = true;
+	input[0].exec[1]  = true;
+	bool changed       = true;
+	while (changed) {
+		changed = false;
+		for (size_t i = 0; i < program.blocks.size(); i++) {
+			if (!reachable[i]) continue;
+			auto output = input[i];
+			for (const auto& inst: program.blocks[i].instructions) {
+				if (!LogicalMaskTaintTransfer(inst, output)) return false;
+			}
+			for (const auto successor: program.blocks[i].successors) {
+				const auto target = block_index(successor);
+				if (target == program.blocks.size()) return false;
+				if (!reachable[target]) {
+					reachable[target] = true;
+					input[target]     = output;
+					changed           = true;
+					continue;
+				}
+				auto merged = input[target];
+				for (size_t reg = 0; reg < merged.scalar.size(); reg++)
+					merged.scalar[reg] = merged.scalar[reg] || output.scalar[reg];
+				for (size_t part = 0; part < 2; part++) {
+					merged.vcc[part]  = merged.vcc[part] || output.vcc[part];
+					merged.exec[part] = merged.exec[part] || output.exec[part];
+				}
+				if (!(merged == input[target])) {
+					input[target] = merged;
+					changed       = true;
+				}
+			}
+		}
+	}
+	return true;
+}
+
+} // namespace
+
+bool ProgramSupportsLogicalSingleWaveWorkgroup(const IR::Program& program) {
+	if (program.stage != ShaderType::Compute || program.wave_size != 64u ||
+	    program.lane_mask_mode != ShaderLaneMaskMode::PerInvocation) {
+		return false;
+	}
+	if (!ProgramPreservesLogicalScalarMasks(program)) {
+		return false;
+	}
+	for (const auto& block: program.blocks) {
+		for (const auto& inst: block.instructions) {
+				auto safe_dpp = [](const IR::Operand& operand) {
+				if (!operand.dpp) {
+					return true;
+				}
+				const auto control = operand.dpp_ctrl;
+				return control <= 0xffu || (control >= 0x101u && control <= 0x10fu) ||
+				       (control >= 0x111u && control <= 0x11fu) ||
+				       (control >= 0x121u && control <= 0x12fu) || control == 0x140u ||
+				       control == 0x141u || (control >= 0x160u && control <= 0x16fu);
+			};
+			if (!safe_dpp(inst.dst) || !safe_dpp(inst.dst2)) {
+				return false;
+			}
+			for (uint32_t source = 0; source < inst.src_count; source++) {
+				if (!safe_dpp(inst.src[source])) {
+					return false;
+				}
+			}
+			if ((inst.op == IR::Opcode::MaskedBitCountLowU32 ||
+			     inst.op == IR::Opcode::MaskedBitCountHighU32) &&
+			    inst.src_count != 0u && inst.src[0].kind == IR::OperandKind::Register &&
+			    (inst.src[0].reg.file == IR::RegisterFile::Exec ||
+			     inst.src[0].reg.file == IR::RegisterFile::Vcc)) {
+				// Logical masks are stored as one Boolean per invocation, not as the
+				// numeric 32-bit mask half required by V_MBCNT.
+				return false;
+			}
+			switch (inst.op) {
+				// These operations still use host subgroup collectives/shuffles. Their
+				// source lane may live in the other subgroup32 half, so accepting them
+				// would silently produce a wrong wave64 result.
+				case IR::Opcode::WqmB64:
+				case IR::Opcode::DsSwizzleB32:
+				case IR::Opcode::DsConsume:
+				case IR::Opcode::DsAppend:
+				case IR::Opcode::ImageGetLod: return false;
+				default: break;
+			}
+		}
+	}
+	return true;
+}
+
+namespace {
+
+bool OperandIsScc(const IR::Operand& operand) {
+	return operand.kind == IR::OperandKind::Register &&
+	       operand.reg.file == IR::RegisterFile::Scc;
+}
+
+std::array<bool, 256> FindNonUniformScalarRegisters(const IR::Program& program) {
+	std::array<bool, 256> nonuniform {};
+	bool                  changed = true;
+	while (changed) {
+		changed = false;
+		for (const auto& block: program.blocks) {
+			for (const auto& inst: block.instructions) {
+				auto source_nonuniform = [&](const IR::Operand& source) {
+					if (source.kind != IR::OperandKind::Register) {
+						return false;
+					}
+					if (source.reg.file != IR::RegisterFile::Scalar) {
+						return true;
+					}
+					return source.reg.index < nonuniform.size() && nonuniform[source.reg.index];
+				};
+				bool tainted = false;
+				for (uint32_t i = 0; i < inst.src_count; i++) {
+					tainted = tainted || source_nonuniform(inst.src[i]);
+				}
+				auto taint_destination = [&](const IR::Operand& destination) {
+					if (!tainted || destination.kind != IR::OperandKind::Register ||
+					    destination.reg.file != IR::RegisterFile::Scalar ||
+					    destination.reg.index >= nonuniform.size() ||
+					    nonuniform[destination.reg.index]) {
+						return;
+					}
+					nonuniform[destination.reg.index] = true;
+					changed                               = true;
+				};
+				taint_destination(inst.dst);
+				taint_destination(inst.dst2);
+			}
+		}
+	}
+	return nonuniform;
+}
+
+bool SccBranchIsWorkgroupUniform(const IR::BasicBlock& block,
+	                              const std::array<bool, 256>& nonuniform_scalar) {
+	for (auto it = block.instructions.rbegin(); it != block.instructions.rend(); ++it) {
+		const auto& inst = *it;
+		if (!Emitter::IsSccOperand(inst.dst)) {
+			continue;
+		}
+		for (uint32_t i = 0; i < inst.src_count; i++) {
+			const auto& source = inst.src[i];
+			if (source.kind != IR::OperandKind::Register) {
+				continue;
+			}
+			if (source.reg.file != IR::RegisterFile::Scalar ||
+			    source.reg.index >= nonuniform_scalar.size() ||
+			    nonuniform_scalar[source.reg.index]) {
+				return false;
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
+const IR::BasicBlock* FindIrBlock(const IR::Program& program, uint32_t id) {
+	const auto it = std::find_if(program.blocks.begin(), program.blocks.end(),
+	                             [id](const auto& block) { return block.id == id; });
+	return it == program.blocks.end() ? nullptr : &*it;
+}
+
+bool ReachesByStraightLine(const IR::Program& program, uint32_t from, uint32_t target) {
+	std::vector<uint32_t> seen;
+	while (from != UINT32_MAX && from != target && seen.size() <= program.blocks.size()) {
+		if (std::find(seen.begin(), seen.end(), from) != seen.end()) {
+			return false;
+		}
+		seen.push_back(from);
+		const auto* block = FindIrBlock(program, from);
+		if (block == nullptr || block->successors.size() != 1u) {
+			return false;
+		}
+		from = block->successors[0];
+	}
+	return from == target;
+}
+
+bool InstructionNeedsLogicalWorkgroupCollective(const IR::Instruction& inst) {
+	if (inst.op == IR::Opcode::Barrier || inst.op == IR::Opcode::ReadLaneU32 ||
+	    inst.op == IR::Opcode::ReadFirstLaneU32 ||
+	    (inst.op == IR::Opcode::CompareEqU64 && Emitter::IsSccOperand(inst.dst))) {
+		return true;
+	}
+	for (uint32_t i = 0; i < inst.src_count; i++) {
+		if (OperandIsScc(inst.src[i])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool ProgramHasUnsynchronizedLogicalLdsRead(const IR::Program& program) {
+	std::vector<bool> dirty_in(program.blocks.size(), false);
+	std::vector<bool> reachable(program.blocks.size(), false);
+	if (!program.blocks.empty()) {
+		reachable[0] = true;
+	}
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		for (size_t i = 0; i < program.blocks.size(); i++) {
+			if (!reachable[i]) {
+				continue;
+			}
+			bool dirty = dirty_in[i];
+			for (const auto& inst: program.blocks[i].instructions) {
+				if (inst.op == IR::Opcode::Barrier) {
+					dirty = false;
+					continue;
+				}
+				if (inst.memory.kind != IR::ResourceKind::Lds) {
+					continue;
+				}
+				if (IsDsRead(inst.op) && dirty) {
+					return true;
+				}
+				if (IsDsWrite(inst.op) || IsAtomic(inst.op)) {
+					dirty = true;
+				}
+			}
+			for (const auto successor: program.blocks[i].successors) {
+				const auto index = std::find_if(
+				    program.blocks.begin(), program.blocks.end(),
+				    [successor](const auto& block) { return block.id == successor; });
+				if (index == program.blocks.end()) {
+					return true;
+				}
+				const auto target = static_cast<size_t>(index - program.blocks.begin());
+				if (!reachable[target] || (dirty && !dirty_in[target])) {
+					reachable[target] = true;
+					dirty_in[target]  = dirty_in[target] || dirty;
+					changed           = true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+} // namespace
+
+bool ProgramSupportsLogicalMultiWaveWorkgroup(const IR::Program& program) {
+	if (!ProgramSupportsLogicalSingleWaveWorkgroup(program) || program.blocks.empty()) {
+		return false;
+	}
+	if (ProgramHasUnsynchronizedLogicalLdsRead(program)) {
+		return false;
+	}
+
+	const auto nonuniform_scalar = FindNonUniformScalarRegisters(program);
+	std::vector<bool> nonuniform_control(program.blocks.size(), false);
+	auto block_index = [&](uint32_t id) -> size_t {
+		const auto it = std::find_if(program.blocks.begin(), program.blocks.end(),
+		                             [id](const auto& block) { return block.id == id; });
+		return it == program.blocks.end() ? program.blocks.size()
+		                                  : static_cast<size_t>(it - program.blocks.begin());
+	};
+
+	for (const auto& block: program.blocks) {
+		const auto& term = block.terminator;
+		if (term.kind == CFG::TerminatorKind::IndirectBranch ||
+		    term.kind == CFG::TerminatorKind::Unsupported) {
+			return false;
+		}
+		if (term.kind != CFG::TerminatorKind::ConditionalBranch) {
+			continue;
+		}
+		bool uniform = false;
+		switch (term.condition) {
+			case CFG::BranchCondition::SccZero:
+			case CFG::BranchCondition::SccNonZero:
+				uniform = SccBranchIsWorkgroupUniform(block, nonuniform_scalar);
+				break;
+			default: break;
+		}
+		if (uniform) {
+			continue;
+		}
+		if (term.loop_header) {
+			return false;
+		}
+		uint32_t merge_block = term.merge_block;
+		if (merge_block == UINT32_MAX) {
+			if (ReachesByStraightLine(program, term.false_block, term.true_block)) {
+				merge_block = term.true_block;
+			} else if (ReachesByStraightLine(program, term.true_block, term.false_block)) {
+				merge_block = term.false_block;
+			} else {
+				return false;
+			}
+		}
+		std::vector<uint32_t> pending {term.true_block, term.false_block};
+		std::vector<uint32_t> seen;
+		while (!pending.empty()) {
+			const auto id = pending.back();
+			pending.pop_back();
+			if (id == merge_block ||
+			    std::find(seen.begin(), seen.end(), id) != seen.end()) {
+				continue;
+			}
+			seen.push_back(id);
+			const auto index = block_index(id);
+			if (index == program.blocks.size()) {
+				return false;
+			}
+			nonuniform_control[index] = true;
+			const auto* region_block  = FindIrBlock(program, id);
+			pending.insert(pending.end(), region_block->successors.begin(),
+			               region_block->successors.end());
+		}
+	}
+
+	for (size_t i = 0; i < program.blocks.size(); i++) {
+		if (!nonuniform_control[i]) {
+			continue;
+		}
+		const auto& block = program.blocks[i];
+		if (block.terminator.kind == CFG::TerminatorKind::ConditionalBranch) {
+			return false;
+		}
+		if (std::any_of(block.instructions.begin(), block.instructions.end(),
+		                InstructionNeedsLogicalWorkgroupCollective)) {
+			return false;
+		}
+	}
+	return true;
 }
 
 bool EmitProgram(const IR::Program& program, const IR::ResourceSnapshot& resources,
@@ -474,6 +1233,24 @@ bool EmitProgram(const IR::Program& program, const IR::ResourceSnapshot& resourc
 	state.stage                = program.stage;
 	state.wave_size            = program.wave_size;
 	state.per_invocation_masks = program.lane_mask_mode == ShaderLaneMaskMode::PerInvocation;
+	if (program.stage == ShaderType::Compute && state.per_invocation_masks &&
+	    program.wave_size == 64u && compute_input_info != nullptr) {
+		const auto local_threads =
+		    std::max(compute_input_info->threads_num[0], 1u) *
+		    std::max(compute_input_info->threads_num[1], 1u) *
+		    std::max(compute_input_info->threads_num[2], 1u);
+		state.logical_local_threads         = local_threads;
+		state.logical_wave_count            = (local_threads + program.wave_size - 1u) /
+		                                      program.wave_size;
+		state.logical_single_wave_workgroup = local_threads == program.wave_size;
+		state.logical_multi_wave_workgroup  = local_threads > program.wave_size &&
+		                                         local_threads % program.wave_size == 0u &&
+		                                         ProgramSupportsLogicalMultiWaveWorkgroup(program);
+		if (local_threads > program.wave_size && !state.logical_multi_wave_workgroup) {
+			return Fail(error,
+			            "logical multi-wave workgroup contains a non-uniform collective site");
+		}
+	}
 	state.exact_subgroup_operations =
 	    !state.per_invocation_masks && ProgramRequiresExactSubgroupSize(program);
 	state.registers.reserve(InitialEmitterVectorReserve);
@@ -488,6 +1265,7 @@ bool EmitProgram(const IR::Program& program, const IR::ResourceSnapshot& resourc
 	state.needs_subgroup_local_invocation_id = ProgramNeedsSubgroupLocalInvocationId(program);
 	state.needs_compute_derivatives          = ProgramNeedsComputeDerivatives(program);
 	state.needs_image_gather_extended        = ProgramNeedsImageGatherExtended(program);
+	state.needs_sampled_image_nonuniform = false;
 	state.needs_function_lds                 = ProgramNeedsFunctionLds(program);
 	state.needs_pixel_valid_mask             = ProgramNeedsPixelValidMask(program);
 	ComputeReachableBlocks(state, program);

--- a/src/graphics/shader/recompiler/emitter/SpirvEmitter.h
+++ b/src/graphics/shader/recompiler/emitter/SpirvEmitter.h
@@ -11,6 +11,12 @@ namespace Libs::Graphics::ShaderRecompiler::Spirv {
 
 bool ProgramRequiresExactSubgroupSize(const IR::Program& program);
 
+bool ProgramSupportsHalfWaveSeparable(const IR::Program& program);
+
+bool ProgramSupportsLogicalSingleWaveWorkgroup(const IR::Program& program);
+
+bool ProgramSupportsLogicalMultiWaveWorkgroup(const IR::Program& program);
+
 bool EmitProgram(const IR::Program& program, const IR::ResourceSnapshot& resources,
                  const ShaderVertexInputInfo*  vertex_input_info,
                  const ShaderPixelInputInfo*   pixel_input_info,

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterAluOps.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterAluOps.cpp
@@ -308,6 +308,13 @@ uint32_t EmitSelectValueU32(EmitterState& state, uint32_t cond, uint32_t true_va
 }
 
 void EmitStoreSccBool(EmitterState& state, uint32_t cond) {
+	// Per-invocation logical masks keep the lane predicate until SCC is consumed.
+	// Reducing here would introduce a workgroup barrier for dead SCC definitions,
+	// including definitions reached by only some guest waves. A semantic SCC read
+	// performs the per-wave reduction instead.
+	if (!IsLogicalWaveWorkgroup(state)) {
+		cond = EmitLogicalWaveAnyBool(state, cond);
+	}
 	const auto value =
 	    EmitSelectValueU32(state, cond, ConstantU32(state, 1), ConstantU32(state, 0));
 	EmitStoreU32(state, SccOperand(), value);
@@ -870,9 +877,12 @@ uint32_t EmitRightAlignedMaskU32(EmitterState& state, uint32_t count) {
 void EmitBitFieldMaskU32(EmitterState& state, const IR::Instruction& inst) {
 	const auto count  = EmitAndConstant(state, EmitValueLoad(state, inst.src[0]), 31u);
 	const auto offset = EmitAndConstant(state, EmitValueLoad(state, inst.src[1]), 31u);
+	const auto mask   = EmitRightAlignedMaskU32(state, count);
 	const auto ret    = state.builder.AllocateId();
-	state.builder.AddFunction({OpBitFieldInsert, state.uint_type, ret, ConstantU32(state, 0),
-	                           ConstantU32(state, 0xffffffffu), offset, count});
+	// Prospero defines V_BFM_B32 as ((1 << size[4:0]) - 1) << offset[4:0].
+	// OpBitFieldInsert is undefined when offset + count exceeds 32, while the native
+	// operation deliberately permits that case and truncates the shifted result.
+	state.builder.AddFunction({OpShiftLeftLogical, state.uint_type, ret, mask, offset});
 	EmitStoreU32(state, inst.dst, ret);
 }
 
@@ -958,19 +968,39 @@ void EmitBitFieldExtractU32(EmitterState& state, const IR::Instruction& inst) {
 }
 
 void EmitBitFieldExtract3U32(EmitterState& state, const IR::Instruction& inst, bool signed_value) {
-	const auto src    = EmitValueLoad(state, inst.src[0]);
-	const auto offset = EmitAndConstant(state, EmitValueLoad(state, inst.src[1]), 31u);
-	const auto count  = EmitAndConstant(state, EmitValueLoad(state, inst.src[2]), 31u);
-	const auto ret    = state.builder.AllocateId();
-	if (signed_value) {
-		const auto shifted = state.builder.AllocateId();
-		const auto mask    = EmitRightAlignedMaskU32(state, count);
-		state.builder.AddFunction({OpShiftRightArithmetic, state.uint_type, shifted, src, offset});
-		state.builder.AddFunction({OpBitwiseAnd, state.uint_type, ret, shifted, mask});
-		EmitStoreU32(state, inst.dst, ret);
+	const auto src     = EmitValueLoad(state, inst.src[0]);
+	const auto offset  = EmitAndConstant(state, EmitValueLoad(state, inst.src[1]), 31u);
+	const auto count   = EmitAndConstant(state, EmitValueLoad(state, inst.src[2]), 31u);
+	const auto shifted = state.builder.AllocateId();
+	const auto mask    = EmitRightAlignedMaskU32(state, count);
+	const auto field   = state.builder.AllocateId();
+	state.builder.AddFunction({OpShiftRightLogical, state.uint_type, shifted, src, offset});
+	state.builder.AddFunction({OpBitwiseAnd, state.uint_type, field, shifted, mask});
+	if (!signed_value) {
+		EmitStoreU32(state, inst.dst, field);
 		return;
 	}
-	state.builder.AddFunction({OpBitFieldUExtract, state.uint_type, ret, src, offset, count});
+
+	// The SCE ISA sign-extends the field selected by size[4:0]. It does not clamp
+	// that size to 32 - offset. Clamping changes crossing fields such as offset=28,
+	// size=8 from +15 into -1. Explicit shifts also define the architectural size=0
+	// result without relying on SPIR-V's bit-field edge-case restrictions.
+	const auto extension_shift     = state.builder.AllocateId();
+	const auto extension_shift_mod = state.builder.AllocateId();
+	const auto left                = state.builder.AllocateId();
+	const auto left_i32            = state.builder.AllocateId();
+	const auto extended_i32        = state.builder.AllocateId();
+	const auto ret                 = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpISub, state.uint_type, extension_shift, ConstantU32(state, 32), count});
+	state.builder.AddFunction({OpBitwiseAnd, state.uint_type, extension_shift_mod, extension_shift,
+	                           ConstantU32(state, 31)});
+	state.builder.AddFunction(
+	    {OpShiftLeftLogical, state.uint_type, left, field, extension_shift_mod});
+	state.builder.AddFunction({OpBitcast, state.int_type, left_i32, left});
+	state.builder.AddFunction(
+	    {OpShiftRightArithmetic, state.int_type, extended_i32, left_i32, extension_shift_mod});
+	state.builder.AddFunction({OpBitcast, state.uint_type, ret, extended_i32});
 	EmitStoreU32(state, inst.dst, ret);
 }
 
@@ -1374,7 +1404,7 @@ uint32_t EmitClassMaskF32(EmitterState& state, uint32_t value, uint32_t mask) {
 	uint32_t match = EmitClassMaskBitMatch(state, mask, 0, snan);
 	match          = EmitLogicalOrBool(state, match, EmitClassMaskBitMatch(state, mask, 1, qnan));
 	match          = EmitLogicalOrBool(
-	    state, match, EmitClassMaskBitMatch(state, mask, 2, EmitLogicalAndBool(state, inf, sign)));
+        state, match, EmitClassMaskBitMatch(state, mask, 2, EmitLogicalAndBool(state, inf, sign)));
 	match = EmitLogicalOrBool(
 	    state, match,
 	    EmitClassMaskBitMatch(state, mask, 3, EmitLogicalAndBool(state, normal, sign)));
@@ -1435,10 +1465,7 @@ void EmitMinMaxF32(EmitterState& state, const IR::Instruction& inst, bool max_va
 
 void EmitCompareResult(EmitterState& state, const IR::Operand& dst, uint32_t cond) {
 	if (IsSccOperand(dst)) {
-		const auto ret = state.builder.AllocateId();
-		state.builder.AddFunction(
-		    {OpSelect, state.uint_type, ret, cond, ConstantU32(state, 1), ConstantU32(state, 0)});
-		EmitStoreU32(state, dst, ret);
+		EmitStoreSccBool(state, cond);
 		return;
 	}
 
@@ -1500,6 +1527,19 @@ void EmitCompareU64(EmitterState& state, const IR::Instruction& inst) {
 	state.builder.AddFunction({compare_op, state.bool_type, high, lhs_high, rhs_high});
 	state.builder.AddFunction(
 	    {equal ? OpLogicalAnd : OpLogicalOr, state.bool_type, cond, low, high});
+	if (equal && IsLogicalWaveWorkgroup(state) && IsSccOperand(inst.dst)) {
+		// Per-invocation EXEC/VCC represents one bit of a guest 64-bit mask in
+		// each invocation. S_CMP_EQ_U64 is true only if every guest bit is equal;
+		// reducing the local equality with Any would incorrectly accept a single
+		// matching lane. Express All(equal) as !Any(!equal) across the workgroup.
+		const auto different = state.builder.AllocateId();
+		const auto all_equal = state.builder.AllocateId();
+		state.builder.AddFunction({OpLogicalNot, state.bool_type, different, cond});
+		const auto any_different = EmitLogicalWaveAnyBool(state, different);
+		state.builder.AddFunction({OpLogicalNot, state.bool_type, all_equal, any_different});
+		EmitCompareResult(state, inst.dst, all_equal);
+		return;
+	}
 	EmitCompareResult(state, inst.dst, cond);
 }
 

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterControlFlow.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterControlFlow.cpp
@@ -1,5 +1,7 @@
 #include "graphics/shader/recompiler/emitter/spirvEmitterInternal.h"
 
+#include <cstdlib>
+
 namespace Libs::Graphics::ShaderRecompiler::Spirv::Emitter {
 
 void ComputeReachableBlocks(EmitterState& state, const IR::Program& program) {
@@ -160,6 +162,22 @@ uint32_t InitialRegisterValue(const EmitterState& state, IR::Register reg) {
 	if (reg.file == IR::RegisterFile::Exec) {
 		if (state.per_invocation_masks) {
 			return reg.index == 0 ? 1u : 0u;
+		}
+		if (state.stage == ShaderType::Compute && state.compute_input_info != nullptr) {
+			const auto local_threads =
+			    std::max(state.compute_input_info->threads_num[0], 1u) *
+			    std::max(state.compute_input_info->threads_num[1], 1u) *
+			    std::max(state.compute_input_info->threads_num[2], 1u);
+			if (local_threads < state.wave_size) {
+				const auto active_bits = reg.index == 0
+				                             ? std::min(local_threads, 32u)
+				                             : (local_threads > 32u
+				                                    ? std::min(local_threads - 32u, 32u)
+				                                    : 0u);
+				return active_bits == 32u
+				           ? 0xffffffffu
+				           : (active_bits == 0u ? 0u : (1u << active_bits) - 1u);
+			}
 		}
 		if (reg.index == 0) {
 			return 0xffffffffu;
@@ -746,39 +764,51 @@ void EmitInstruction(EmitterState& state, const IR::Instruction& inst) {
 			EmitGuardedByExec(state, [&]() { EmitBufferStoreDword(state, inst); });
 			break;
 		case IR::Opcode::AtomicSwapU32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicExchange); });
 			break;
 		case IR::Opcode::AtomicAddU32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicIAdd); });
 			break;
 		case IR::Opcode::AtomicSubU32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicISub); });
 			break;
 		case IR::Opcode::AtomicSMinI32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicSMin); });
 			break;
 		case IR::Opcode::AtomicUMinU32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicUMin); });
 			break;
 		case IR::Opcode::AtomicSMaxI32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicSMax); });
 			break;
 		case IR::Opcode::AtomicUMaxU32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicUMax); });
 			break;
 		case IR::Opcode::AtomicAndU32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicAnd); });
 			break;
 		case IR::Opcode::AtomicOrU32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicOr); });
 			break;
 		case IR::Opcode::AtomicXorU32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicU32(state, inst, OpAtomicXor); });
 			break;
 		case IR::Opcode::AtomicFMinF32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicFMinF32(state, inst); });
 			break;
 		case IR::Opcode::AtomicFMaxF32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitAtomicFMaxF32(state, inst); });
 			break;
 		case IR::Opcode::FlatLoadUbyte: EmitFlatLoadUbyte(state, inst); break;
@@ -804,26 +834,41 @@ void EmitInstruction(EmitterState& state, const IR::Instruction& inst) {
 			});
 			break;
 		case IR::Opcode::DsReadUbyte:
+			EmitDsReadVisibilityBarrier(state, inst.memory.kind, inst.pc);
 			EmitMemoryLoadSubDwordU32(state, inst, inst.memory.kind, 0, 1, 8, false);
 			break;
 		case IR::Opcode::DsReadSbyte:
+			EmitDsReadVisibilityBarrier(state, inst.memory.kind, inst.pc);
 			EmitMemoryLoadSubDwordU32(state, inst, inst.memory.kind, 0, 1, 8, true);
 			break;
 		case IR::Opcode::DsReadUshort:
+			EmitDsReadVisibilityBarrier(state, inst.memory.kind, inst.pc);
 			EmitMemoryLoadSubDwordU32(state, inst, inst.memory.kind, 0, 1, 16, false);
 			break;
 		case IR::Opcode::DsReadSshort:
+			EmitDsReadVisibilityBarrier(state, inst.memory.kind, inst.pc);
 			EmitMemoryLoadSubDwordU32(state, inst, inst.memory.kind, 0, 1, 16, true);
 			break;
-		case IR::Opcode::DsReadB32: EmitMemoryLoadU32(state, inst, inst.memory.kind, 0, 1); break;
+		case IR::Opcode::DsReadB32:
+			EmitDsReadVisibilityBarrier(state, inst.memory.kind, inst.pc);
+			EmitMemoryLoadU32(state, inst, inst.memory.kind, 0, 1);
+			break;
 		case IR::Opcode::DsSwizzleB32: EmitDsSwizzleB32(state, inst); break;
-		case IR::Opcode::DsConsume: EmitDsAppendConsume(state, inst, OpAtomicISub); break;
-		case IR::Opcode::DsAppend: EmitDsAppendConsume(state, inst, OpAtomicIAdd); break;
+		case IR::Opcode::DsConsume:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
+			EmitDsAppendConsume(state, inst, OpAtomicISub);
+			break;
+		case IR::Opcode::DsAppend:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
+			EmitDsAppendConsume(state, inst, OpAtomicIAdd);
+			break;
 		case IR::Opcode::DsReadAddtidB32: EmitDsReadAddtidB32(state, inst); break;
 		case IR::Opcode::DsMinF32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitDsFloatMinMaxF32(state, inst, false); });
 			break;
 		case IR::Opcode::DsMaxF32:
+			EmitDsAtomicPhaseBarrier(state, inst.memory.kind);
 			EmitGuardedByExec(state, [&]() { EmitDsFloatMinMaxF32(state, inst, true); });
 			break;
 		case IR::Opcode::DsWriteByte:
@@ -1038,9 +1083,10 @@ void EmitDispatcherSwitch(EmitterState& state, const IR::Program& program) {
 	EmitDispatcherExit(state);
 }
 
-size_t BufferLoadGroupSize(const IR::BasicBlock& block, size_t first_index) {
+size_t SplitLoadGroupSize(const IR::BasicBlock& block, size_t first_index,
+                          IR::Opcode expected_opcode) {
 	const auto& first = block.instructions[first_index];
-	if (first.op != IR::Opcode::BufferLoadDword || first.memory.component_index != 0u ||
+	if (first.op != expected_opcode || first.memory.component_index != 0u ||
 	    first.memory.component_count <= 1u) {
 		return 1u;
 	}
@@ -1049,9 +1095,10 @@ size_t BufferLoadGroupSize(const IR::BasicBlock& block, size_t first_index) {
 	while (first_index + count < block.instructions.size() &&
 	       count < first.memory.component_count) {
 		const auto& next = block.instructions[first_index + count];
-		if (next.op != IR::Opcode::BufferLoadDword || next.pc != first.pc ||
+		if (next.op != expected_opcode || next.pc != first.pc ||
 		    next.memory.component_index != count ||
-		    next.memory.component_count != first.memory.component_count) {
+		    next.memory.component_count != first.memory.component_count ||
+		    next.memory.kind != first.memory.kind) {
 			break;
 		}
 		count++;
@@ -1061,12 +1108,51 @@ size_t BufferLoadGroupSize(const IR::BasicBlock& block, size_t first_index) {
 
 void EmitBlockInstructions(EmitterState& state, const IR::BasicBlock& block) {
 	for (size_t i = 0; i < block.instructions.size();) {
-		const auto count = BufferLoadGroupSize(block, i);
-		if (count > 1u) {
+		const auto& instruction = block.instructions[i];
+		EmitLogicalWaveLdsInstructionBarrier(state, instruction);
+		if (std::getenv("KYTY_BINK_WORKGROUP_LDS_BARRIER") != nullptr &&
+		    state.program.shader_hash == 0x0000000208a63b00ULL &&
+		    (instruction.pc == 0x000001d4u || instruction.pc == 0x0000092cu)) {
+			// Diagnostic wave64 phase boundary: all 64 invocations have reconverged
+			// before a new decode-loop iteration or the second transform partition.
+			const auto semantics = MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
+			state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+			                           ConstantU32(state, ScopeWorkgroup),
+			                           ConstantU32(state, semantics)});
+		}
+		const char* const trace_pc_text = std::getenv("KYTY_BINK_TRACE_PC");
+		const bool trace_instruction =
+		    BinkTraceEnabled(state) && trace_pc_text != nullptr &&
+		    static_cast<uint32_t>(std::strtoul(trace_pc_text, nullptr, 0)) == instruction.pc &&
+		    instruction.dst.kind == IR::OperandKind::Register;
+		uint32_t trace_old  = 0;
+		uint32_t trace_src0 = 0;
+		uint32_t trace_src1 = 0;
+		if (trace_instruction) {
+			trace_old  = EmitRegisterLoad(state, instruction.dst.reg);
+			trace_src0 = instruction.src_count > 0u ? EmitValueLoad(state, instruction.src[0])
+			                                            : ConstantU32(state, 0);
+			trace_src1 = instruction.src_count > 1u ? EmitValueLoad(state, instruction.src[1])
+			                                            : ConstantU32(state, 0);
+		}
+		const auto buffer_count =
+		    SplitLoadGroupSize(block, i, IR::Opcode::BufferLoadDword);
+		const auto ds_count = buffer_count == 1u
+		                          ? SplitLoadGroupSize(block, i, IR::Opcode::DsReadB32)
+		                          : 1u;
+		const auto count = std::max(buffer_count, ds_count);
+		if (buffer_count > 1u) {
 			EmitBufferLoadDwordGroup(state, block.instructions.data() + i,
 			                         static_cast<uint32_t>(count));
+		} else if (ds_count > 1u) {
+			EmitDsReadB32Group(state, block.instructions.data() + i,
+			                   static_cast<uint32_t>(count));
 		} else {
-			EmitInstruction(state, block.instructions[i]);
+			EmitInstruction(state, instruction);
+		}
+		if (trace_instruction) {
+			EmitBinkTraceRecord(state, 6u, instruction.pc, trace_old, trace_src0, trace_src1,
+			                    EmitRegisterLoad(state, instruction.dst.reg));
 		}
 		i += count;
 	}
@@ -1100,6 +1186,52 @@ void EmitDispatcherFunction(EmitterState& state, const IR::Program& program) {
 	EmitDispatcherLoopTail(state);
 }
 
+bool EmitConditionalLoopBlock(EmitterState& state, const IR::BasicBlock& block) {
+	const auto& term = block.terminator;
+	if (!term.loop_header || term.kind != CFG::TerminatorKind::ConditionalBranch) {
+		return false;
+	}
+
+	const auto header_label = BlockLabel(state, block.id);
+	const auto merge_label  = BlockLabel(state, term.merge_block);
+	const auto cfg_continue = BlockLabel(state, term.continue_block);
+	const auto cfg_true     = BlockLabel(state, term.true_block);
+	const auto cfg_false    = BlockLabel(state, term.false_block);
+	if (header_label == 0 || merge_label == 0 || cfg_continue == 0 || cfg_true == 0 ||
+	    cfg_false == 0) {
+		EmitReturn(state);
+		return true;
+	}
+
+	// Branch conditions may lower to a small structured selection (for example,
+	// a logical-wave EXEC/VCC reduction). Keep all such lowering in a loop-body
+	// block so the original CFG label remains the SPIR-V loop header and owns
+	// OpLoopMerge. A self-loop additionally needs a dedicated continue block:
+	// making the conditional block itself the back-edge violates the rule that
+	// the continue construct is structurally post-dominated by its back-edge.
+	const bool self_continue = term.continue_block == block.id;
+	const auto body_label    = state.builder.AllocateId();
+	const auto continue_label =
+	    self_continue ? state.builder.AllocateId() : cfg_continue;
+	state.builder.AddFunction({OpLoopMerge, merge_label, continue_label, LoopControlNone});
+	state.builder.AddFunction({OpBranch, body_label});
+	state.builder.AddFunction({OpLabel, body_label});
+	EmitBlockInstructions(state, block);
+
+	const auto condition = EmitBranchCondition(state, term.condition);
+	const auto true_label =
+	    self_continue && term.true_block == block.id ? continue_label : cfg_true;
+	const auto false_label =
+	    self_continue && term.false_block == block.id ? continue_label : cfg_false;
+	state.builder.AddFunction({OpBranchConditional, condition, true_label, false_label});
+
+	if (self_continue) {
+		state.builder.AddFunction({OpLabel, continue_label});
+		state.builder.AddFunction({OpBranch, header_label});
+	}
+	return true;
+}
+
 void EmitFunction(EmitterState& state, const IR::Program& program) {
 	state.builder.AddFunction(
 	    {OpFunction, state.void_type, state.main_func, FunctionControlNone, state.func_type});
@@ -1128,6 +1260,9 @@ void EmitFunction(EmitterState& state, const IR::Program& program) {
 			continue;
 		}
 		state.builder.AddFunction({OpLabel, BlockLabel(state, block.id)});
+		if (EmitConditionalLoopBlock(state, block)) {
+			continue;
+		}
 		EmitBlockInstructions(state, block);
 		EmitTerminator(state, block.terminator);
 	}

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterFlowOps.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterFlowOps.cpp
@@ -176,7 +176,10 @@ void EmitSaveexecPerInvocation(EmitterState& state, const IR::Instruction& inst)
 	const auto result =
 	    use_or ? EmitLogicalOrBool(state, lhs, rhs) : EmitLogicalAndBool(state, lhs, rhs);
 	EmitPerInvocationMask(state, MakeRegisterOperand(IR::RegisterFile::Exec, 0), result);
-	EmitStoreSccBool(state, result);
+	// SAVEEXEC reports whether the saved (old) EXEC was non-zero. In logical
+	// single-wave mode that is a workgroup-wide property; preserve the established
+	// graphics PerInvocation behavior until that path is migrated separately.
+	EmitStoreSccBool(state, IsLogicalWaveWorkgroup(state) ? old_exec : result);
 }
 
 void EmitSaveexecB32(EmitterState& state, const IR::Instruction& inst) {
@@ -205,7 +208,8 @@ void EmitSaveexecB32(EmitterState& state, const IR::Instruction& inst) {
 
 	const auto cond = state.builder.AllocateId();
 	const auto scc  = state.builder.AllocateId();
-	state.builder.AddFunction({OpINotEqual, state.bool_type, cond, new_low, ConstantU32(state, 0)});
+	// Prospero SAVEEXEC sets SCC from the saved old EXEC, not the updated mask.
+	state.builder.AddFunction({OpINotEqual, state.bool_type, cond, old_low, ConstantU32(state, 0)});
 	state.builder.AddFunction(
 	    {OpSelect, state.uint_type, scc, cond, ConstantU32(state, 1), ConstantU32(state, 0)});
 	EmitStoreU32(state, SccOperand(), scc);
@@ -250,11 +254,12 @@ void EmitSaveexecB64(EmitterState& state, const IR::Instruction& inst) {
 	EmitStoreU32(state, MakeRegisterOperand(IR::RegisterFile::Exec, 0), new_low);
 	EmitStoreU32(state, MakeRegisterOperand(IR::RegisterFile::Exec, 1), new_high);
 
-	const auto active_new_high = state.wave_size == 32u ? ConstantU32(state, 0) : new_high;
+	const auto active_old_high = state.wave_size == 32u ? ConstantU32(state, 0) : old_high;
 	const auto mask            = state.builder.AllocateId();
 	const auto cond            = state.builder.AllocateId();
 	const auto scc             = state.builder.AllocateId();
-	state.builder.AddFunction({OpBitwiseOr, state.uint_type, mask, new_low, active_new_high});
+	// Prospero SAVEEXEC sets SCC from SDST (the saved old EXEC).
+	state.builder.AddFunction({OpBitwiseOr, state.uint_type, mask, old_low, active_old_high});
 	state.builder.AddFunction({OpINotEqual, state.bool_type, cond, mask, ConstantU32(state, 0)});
 	state.builder.AddFunction(
 	    {OpSelect, state.uint_type, scc, cond, ConstantU32(state, 1), ConstantU32(state, 0)});
@@ -264,6 +269,61 @@ void EmitSaveexecB64(EmitterState& state, const IR::Instruction& inst) {
 void EmitReadFirstLaneU32(EmitterState& state, const IR::Instruction& inst) {
 	const auto src         = EmitValueLoad(state, inst.src[0]);
 	const auto active      = EmitExecActiveBool(state);
+	if (IsLogicalWaveWorkgroup(state) && state.logical_wave_lane_variable != 0 &&
+	    state.logical_wave_summary_variable != 0) {
+		// V_READFIRSTLANE selects the lowest active guest lane. A logical wave64
+		// spans two host subgroup32 waves, so snapshot all values and reduce the
+		// active guest lane index through workgroup memory.
+		const auto local_id = EmitLocalInvocationIndex(state);
+		const auto guest_lane = EmitLogicalWaveLaneIndex(state);
+		const auto summary_pointer = EmitLogicalWaveSummaryPointer(state);
+		const auto own_ptr  = state.builder.AllocateId();
+		const auto semantics =
+		    MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
+		state.builder.AddFunction({OpAccessChain, state.ptr_workgroup_uint, own_ptr,
+		                           state.logical_wave_lane_variable, local_id});
+		state.builder.AddFunction({OpStore, own_ptr, src});
+		const auto ignored_reset = state.builder.AllocateId();
+		state.builder.AddFunction({OpAtomicExchange, state.uint_type, ignored_reset,
+		                           summary_pointer,
+		                           ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, MemorySemanticsNone),
+		                           ConstantU32(state, 64)});
+		state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, semantics)});
+		const auto candidate = state.builder.AllocateId();
+		state.builder.AddFunction({OpSelect, state.uint_type, candidate, active, guest_lane,
+		                           ConstantU32(state, 64)});
+		const auto ignored_min = state.builder.AllocateId();
+		state.builder.AddFunction({OpAtomicUMin, state.uint_type, ignored_min,
+		                           summary_pointer,
+		                           ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, MemorySemanticsNone), candidate});
+		state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, semantics)});
+		const auto first_lane  = state.builder.AllocateId();
+		const auto has_lane    = state.builder.AllocateId();
+		const auto safe_lane   = state.builder.AllocateId();
+		const auto lane_ptr    = state.builder.AllocateId();
+		const auto first_value = state.builder.AllocateId();
+		state.builder.AddFunction(
+		    {OpLoad, state.uint_type, first_lane, summary_pointer});
+		state.builder.AddFunction({OpULessThan, state.bool_type, has_lane, first_lane,
+		                           ConstantU32(state, 64)});
+		state.builder.AddFunction({OpSelect, state.uint_type, safe_lane, has_lane, first_lane,
+		                           ConstantU32(state, 0)});
+		state.builder.AddFunction({OpAccessChain, state.ptr_workgroup_uint, lane_ptr,
+		                           state.logical_wave_lane_variable,
+		                           EmitLogicalWaveLaneArrayIndex(state, safe_lane)});
+		state.builder.AddFunction({OpLoad, state.uint_type, first_value, lane_ptr});
+		state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, semantics)});
+		EmitStoreU32(state, inst.dst, first_value);
+		return;
+	}
 	const auto ballot      = state.builder.AllocateId();
 	const auto first_lane  = state.builder.AllocateId();
 	const auto first_value = state.builder.AllocateId();
@@ -287,6 +347,34 @@ uint32_t EmitLaneIndex(EmitterState& state, const IR::Operand& operand) {
 void EmitReadLaneU32(EmitterState& state, const IR::Instruction& inst) {
 	const auto src   = EmitValueLoad(state, inst.src[0]);
 	const auto lane  = EmitLaneIndex(state, inst.src[1]);
+	if (IsLogicalWaveWorkgroup(state) && state.logical_wave_lane_variable != 0) {
+		// A Prospero wave64 read may select lane 32..63, which cannot be reached
+		// by a host subgroup32 shuffle. Snapshot every guest lane in a dedicated
+		// workgroup array, rendezvous the two host subgroups, then broadcast the
+		// selected guest lane. Scalar lane reads are reached uniformly by the one
+		// logical-wave workgroup, so these barriers are dynamically uniform.
+		const auto local_id = EmitLocalInvocationIndex(state);
+		const auto own_ptr  = state.builder.AllocateId();
+		const auto lane_ptr = state.builder.AllocateId();
+		const auto value    = state.builder.AllocateId();
+		const auto semantics =
+		    MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
+		state.builder.AddFunction({OpAccessChain, state.ptr_workgroup_uint, own_ptr,
+		                           state.logical_wave_lane_variable, local_id});
+		state.builder.AddFunction({OpStore, own_ptr, src});
+		state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, semantics)});
+		state.builder.AddFunction({OpAccessChain, state.ptr_workgroup_uint, lane_ptr,
+		                           state.logical_wave_lane_variable,
+		                           EmitLogicalWaveLaneArrayIndex(state, lane)});
+		state.builder.AddFunction({OpLoad, state.uint_type, value, lane_ptr});
+		state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, ScopeWorkgroup),
+		                           ConstantU32(state, semantics)});
+		EmitStoreU32(state, inst.dst, value);
+		return;
+	}
 	const auto value = state.builder.AllocateId();
 	state.builder.AddFunction({OpGroupNonUniformShuffle, state.uint_type, value,
 	                           ConstantU32(state, ScopeSubgroup), src, lane});
@@ -347,11 +435,20 @@ void EmitPermlaneB32(EmitterState& state, const IR::Instruction& inst, bool x16)
 	state.builder.AddFunction(
 	    {OpBitwiseAnd, state.uint_type, index1, index0, ConstantU32(state, 15)});
 	state.builder.AddFunction({OpBitwiseOr, state.uint_type, target, row_value, index1});
+	uint32_t host_target = target;
+	if (IsLogicalWaveWorkgroup(state)) {
+		// Both lane16 operations stay within one 32-lane row pair. LocalInvocationIndex
+		// is the guest lane, while OpGroupNonUniformShuffle expects the host-subgroup
+		// lane number for the second half of the guest wave.
+		host_target = state.builder.AllocateId();
+		state.builder.AddFunction({OpBitwiseAnd, state.uint_type, host_target, target,
+		                           ConstantU32(state, 31u)});
+	}
 	state.builder.AddFunction({OpGroupNonUniformShuffle, state.uint_type, shuffled,
-	                           ConstantU32(state, ScopeSubgroup), value, target});
+	                           ConstantU32(state, ScopeSubgroup), value, host_target});
 	uint32_t ret = shuffled;
 	if (!inst.dst.op_sel) {
-		const auto source_active = EmitLaneIndexActiveBool(state, target);
+		const auto source_active = EmitLaneIndexActiveBool(state, host_target);
 		ret                      = state.builder.AllocateId();
 		state.builder.AddFunction(
 		    {OpSelect, state.uint_type, ret, source_active, shuffled, ConstantU32(state, 0)});

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
@@ -38,12 +38,15 @@ enum : uint32_t {
 	CapabilitySampled1D                      = 43,
 	CapabilityImage1D                        = 44,
 	CapabilityImageQuery                     = 50,
+	CapabilityClipDistance                   = 32,
 	CapabilityStorageImageReadWithoutFormat  = 55,
 	CapabilityStorageImageWriteWithoutFormat = 56,
 	CapabilityGroupNonUniform                = 61,
 	CapabilityGroupNonUniformBallot          = 64,
 	CapabilityGroupNonUniformShuffle         = 65,
+	CapabilitySampledImageArrayNonUniformIndexing = 5307,
 	CapabilityComputeDerivativeGroupQuadsKHR = 5288,
+	CapabilityFragmentBarycentricKHR          = 5284,
 	StorageClassUniformConstant              = 0,
 	StorageClassInput                        = 1,
 	StorageClassOutput                       = 3,
@@ -59,6 +62,7 @@ enum : uint32_t {
 
 enum : uint32_t {
 	DecorationBlock         = 2,
+	DecorationSpecId        = 1,
 	DecorationBuiltIn       = 11,
 	DecorationNoPerspective = 13,
 	DecorationFlat          = 14,
@@ -67,10 +71,13 @@ enum : uint32_t {
 	DecorationBinding       = 33,
 	DecorationDescriptorSet = 34,
 	DecorationOffset        = 35,
+	DecorationNonUniform    = 5300,
+	DecorationPerVertexKHR  = 5285,
 };
 
 enum : uint32_t {
 	BuiltInPosition                  = 0,
+	BuiltInClipDistance              = 3,
 	BuiltInFragCoord                 = 15,
 	BuiltInFrontFacing               = 17,
 	BuiltInSampleMask                = 20,
@@ -82,6 +89,8 @@ enum : uint32_t {
 	BuiltInSubgroupLocalInvocationId = 41,
 	BuiltInVertexIndex               = 42,
 	BuiltInInstanceIndex             = 43,
+	BuiltInBaryCoordKHR              = 5286,
+	BuiltInBaryCoordNoPerspKHR       = 5287,
 };
 
 enum : uint32_t {
@@ -129,6 +138,7 @@ enum : uint32_t {
 	OpTypeFunction                 = 33,
 	OpConstant                     = 43,
 	OpConstantComposite            = 44,
+	OpSpecConstant                 = 50,
 	OpFunction                     = 54,
 	OpFunctionEnd                  = 56,
 	OpVariable                     = 59,
@@ -276,6 +286,7 @@ struct InputBinding {
 	uint32_t           component_count = 1;
 	uint32_t           variable_id     = 0;
 	std::string        debug_name;
+	bool               per_vertex = false;
 };
 
 struct OutputBinding {
@@ -322,6 +333,17 @@ struct EmitterState {
 	uint32_t                                         wave_size          = 64;
 	bool                                             exact_subgroup_operations    = false;
 	bool                                             per_invocation_masks         = false;
+	// A single 64-lane guest compute wave can be represented by all 64
+	// invocations of one host workgroup when the host cannot provide subgroup64.
+	// This is deliberately narrower than general per-invocation mask lowering:
+	// workgroup collectives are only valid when the complete workgroup is one
+	// guest wave.
+	bool                                             logical_single_wave_workgroup = false;
+	// Multiple guest wave64s may share a workgroup when every workgroup
+	// collective is proven to occur in dynamically uniform control flow.
+	bool                                             logical_multi_wave_workgroup  = false;
+	uint32_t                                         logical_wave_count            = 0;
+	uint32_t                                         logical_local_threads         = 0;
 	uint32_t                                         void_type                    = 0;
 	uint32_t                                         bool_type                    = 0;
 	uint32_t                                         uint_type                    = 0;
@@ -352,6 +374,10 @@ struct EmitterState {
 	uint32_t                                         ptr_input_vec3_uint          = 0;
 	uint32_t                                         ptr_input_vec4_uint          = 0;
 	uint32_t                                         ptr_input_vec4_float         = 0;
+	uint32_t                                         per_vertex_input_array_type  = 0;
+	uint32_t                                         ptr_input_per_vertex_array   = 0;
+	uint32_t                                         bary_coord_variable          = 0;
+	uint32_t                                         bary_coord_no_persp_variable = 0;
 	uint32_t                                         sample_mask_array_type       = 0;
 	uint32_t                                         ptr_output_int               = 0;
 	uint32_t                                         ptr_output_sample_mask_array = 0;
@@ -359,6 +385,8 @@ struct EmitterState {
 	uint32_t                                         ptr_output_vec4_float        = 0;
 	uint32_t                                         per_vertex_type              = 0;
 	uint32_t                                         ptr_output_per_vertex        = 0;
+	uint32_t                                         clip_distance_array_type     = 0;
+	uint32_t                                         synthetic_depth_clip         = 0;
 	uint32_t                                         storage_runtime_array_type   = 0;
 	uint32_t                                         storage_buffer_type          = 0;
 	uint32_t                                         ptr_storage_buffer           = 0;
@@ -382,6 +410,12 @@ struct EmitterState {
 	uint32_t                                         ptr_workgroup_array       = 0;
 	uint32_t                                         ptr_workgroup_uint        = 0;
 	uint32_t                                         lds_variable              = 0;
+	uint32_t                                         logical_wave_summary_variable = 0;
+	uint32_t                                         logical_wave_summary_array_type = 0;
+	uint32_t                                         ptr_logical_wave_summary_array  = 0;
+	uint32_t                                         logical_wave_lane_array_type  = 0;
+	uint32_t                                         ptr_logical_wave_lane_array   = 0;
+	uint32_t                                         logical_wave_lane_variable    = 0;
 	std::array<SampledImageDescriptors, 14>          sampled_images;
 	std::array<StorageImageDescriptors, 10>          storage_images;
 	uint32_t                                         sampler_type                          = 0;
@@ -412,6 +446,7 @@ struct EmitterState {
 	bool                                             needs_subgroup_local_invocation_id    = false;
 	bool                                             needs_compute_derivatives             = false;
 	bool                                             needs_image_gather_extended           = false;
+	bool                                             needs_sampled_image_nonuniform        = false;
 	bool                                             needs_function_lds                    = false;
 	bool                                             needs_pixel_valid_mask                = false;
 	bool                                             unsupported_ir_instruction            = false;
@@ -427,6 +462,24 @@ struct EmitterState {
 	std::map<uint32_t, uint32_t>                     signed_constants;
 	std::map<uint32_t, uint32_t>                     float_constants;
 };
+
+inline bool IsLogicalWaveWorkgroup(const EmitterState& state) {
+	return state.logical_single_wave_workgroup || state.logical_multi_wave_workgroup;
+}
+
+inline uint32_t GetLdsDwordCount(const EmitterState& state) {
+	if (state.needs_function_lds) {
+		return 8192u;
+	}
+	if (state.stage == ShaderType::Compute && state.compute_input_info != nullptr) {
+		// SPIR-V does not permit a zero-length OpTypeArray. A one-dword declaration is
+		// harmless for compute programs whose hardware LDS reservation is zero.
+		return std::max(state.compute_input_info->lds_size_dwords, 1u);
+	}
+	// Preserve the standalone recompiler's historical default when no hardware state
+	// was supplied by a caller (primarily decoder/emitter unit tests).
+	return 1024u;
+}
 
 enum class VertexInputScalarKind { Float, Sint, Uint };
 
@@ -676,6 +729,11 @@ uint32_t DescriptorElementPointer(EmitterState& state, uint32_t result_ptr_type,
                                   IR::DescriptorBindingKind kind, uint32_t resource,
                                   const char* variable_name);
 
+uint32_t DescriptorElementPointerId(EmitterState& state, uint32_t result_ptr_type,
+                                    uint32_t variable_id, uint32_t array_index_id,
+                                    IR::DescriptorBindingKind kind, uint32_t resource,
+                                    const char* variable_name);
+
 ImageViewKind SampledImageViewKind(const EmitterState& state, const IR::MemoryInfo& mem,
                                    uint32_t use_pc);
 
@@ -774,6 +832,16 @@ uint32_t EmitMaskActiveBool(EmitterState& state, IR::RegisterFile file);
 uint32_t EmitMaskZeroBool(EmitterState& state, IR::RegisterFile file, bool zero);
 
 uint32_t EmitMaskSummaryZeroBool(EmitterState& state, IR::RegisterFile file, bool zero);
+
+uint32_t EmitLogicalWaveAnyBool(EmitterState& state, uint32_t value_bool);
+
+uint32_t EmitLogicalWaveIndex(EmitterState& state);
+
+uint32_t EmitLogicalWaveLaneIndex(EmitterState& state);
+
+uint32_t EmitLogicalWaveSummaryPointer(EmitterState& state);
+
+uint32_t EmitLogicalWaveLaneArrayIndex(EmitterState& state, uint32_t guest_lane);
 
 uint32_t EmitExecActiveBool(EmitterState& state);
 
@@ -940,6 +1008,11 @@ uint32_t EmitGdsElementInBounds(EmitterState& state, uint32_t index);
 
 uint32_t EmitGdsElementPointer(EmitterState& state, uint32_t index);
 
+bool BinkTraceEnabled(const EmitterState& state);
+
+void EmitBinkTraceRecord(EmitterState& state, uint32_t site, uint32_t pc, uint32_t value0,
+	                     uint32_t value1, uint32_t value2, uint32_t value3);
+
 uint32_t EmitMemoryElementPointer(EmitterState& state, const IR::MemoryInfo& mem, uint32_t index,
                                   uint32_t use_pc);
 
@@ -1014,7 +1087,6 @@ uint32_t EmitAtomicPointer(EmitterState& state, const IR::Instruction& inst);
 void EmitDeviceAtomicMemoryBarrier(EmitterState& state);
 
 void EmitAtomicU32(EmitterState& state, const IR::Instruction& inst, uint32_t opcode);
-
 void EmitAtomicFMinF32(EmitterState& state, const IR::Instruction& inst);
 void EmitAtomicFMaxF32(EmitterState& state, const IR::Instruction& inst);
 
@@ -1034,6 +1106,15 @@ void EmitBufferLoadDword(EmitterState& state, const IR::Instruction& inst);
 
 void EmitBufferLoadDwordGroup(EmitterState& state, const IR::Instruction* instructions,
                               uint32_t count);
+
+void EmitDsReadVisibilityBarrier(EmitterState& state, IR::ResourceKind kind,
+                                 uint32_t guest_pc = UINT32_MAX);
+void EmitDsAtomicPhaseBarrier(EmitterState& state, IR::ResourceKind kind);
+
+void EmitLogicalWaveLdsInstructionBarrier(EmitterState& state,
+                                          const IR::Instruction& inst);
+
+void EmitDsReadB32Group(EmitterState& state, const IR::Instruction* instructions, uint32_t count);
 
 void EmitBufferStoreDword(EmitterState& state, const IR::Instruction& inst);
 

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterMemory.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterMemory.cpp
@@ -1,6 +1,83 @@
 #include "graphics/shader/recompiler/emitter/spirvEmitterInternal.h"
 
+#include <cstdio>
+#include <cstdlib>
+
 namespace Libs::Graphics::ShaderRecompiler::Spirv::Emitter {
+
+bool BinkTraceEnabled(const EmitterState& state) {
+	const char* const directory = std::getenv("KYTY_BINK_TRACE_DIR");
+	return directory != nullptr && directory[0] != '\0' && state.gds_variable != 0 &&
+	       state.program.shader_hash == 0x0000000208a64d00ULL;
+}
+
+void EmitBinkTraceRecord(EmitterState& state, uint32_t site, uint32_t pc, uint32_t value0,
+	                     uint32_t value1, uint32_t value2, uint32_t value3) {
+	if (!BinkTraceEnabled(state)) {
+		return;
+	}
+	const char* const requested_site_text = std::getenv("KYTY_BINK_TRACE_SITE");
+	const auto requested_site = requested_site_text != nullptr
+	                                ? static_cast<uint32_t>(std::strtoul(
+	                                      requested_site_text, nullptr, 10))
+	                                : 2u;
+	if (site != requested_site) {
+		return;
+	}
+
+	uint32_t selected_x = 60;
+	uint32_t selected_y = 34;
+	uint32_t selected_z = 0;
+	if (const char* const text = std::getenv("KYTY_BINK_TRACE_GROUP"); text != nullptr) {
+		(void)std::sscanf(text, "%u,%u,%u", &selected_x, &selected_y, &selected_z);
+	}
+	const auto group_x = EmitInputComponentU32(state, IR::StageInputKind::WorkgroupId, 0);
+	const auto group_y = EmitInputComponentU32(state, IR::StageInputKind::WorkgroupId, 1);
+	const auto group_z = EmitInputComponentU32(state, IR::StageInputKind::WorkgroupId, 2);
+	const auto equals = [&](uint32_t value, uint32_t expected) {
+		const auto result = state.builder.AllocateId();
+		state.builder.AddFunction(
+		    {OpIEqual, state.bool_type, result, value, ConstantU32(state, expected)});
+		return result;
+	};
+	const auto xy = state.builder.AllocateId();
+	const auto xyz = state.builder.AllocateId();
+	const auto selected = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpLogicalAnd, state.bool_type, xy, equals(group_x, selected_x), equals(group_y, selected_y)});
+	state.builder.AddFunction(
+	    {OpLogicalAnd, state.bool_type, xyz, xy, equals(group_z, selected_z)});
+	state.builder.AddFunction(
+	    {OpLogicalAnd, state.bool_type, selected, xyz, EmitExecActiveBool(state)});
+
+	const auto write_label = state.builder.AllocateId();
+	const auto merge_label = state.builder.AllocateId();
+	state.builder.AddFunction({OpSelectionMerge, merge_label, SelectionControlNone});
+	state.builder.AddFunction({OpBranchConditional, selected, write_label, merge_label});
+	state.builder.AddFunction({OpLabel, write_label});
+
+	const auto local = EmitBinaryU32(state, OpBitwiseAnd, EmitLocalInvocationIndex(state),
+	                                ConstantU32(state, 63u));
+	const auto iteration = EmitBinaryU32(
+	    state, OpBitwiseAnd, EmitRegisterLoad(state, {IR::RegisterFile::Scalar, 41}),
+	    ConstantU32(state, 3u));
+	const auto site_iteration = EmitAddU32(
+	    state, ConstantU32(state, site * 4u), iteration);
+	const auto record = EmitAddU32(
+	    state,
+	    EmitBinaryU32(state, OpShiftLeftLogical, site_iteration, ConstantU32(state, 6u)), local);
+	const auto base =
+	    EmitBinaryU32(state, OpShiftLeftLogical, record, ConstantU32(state, 3u));
+	const uint32_t values[] = {ConstantU32(state, 0xb17c0000u | site),
+	                           ConstantU32(state, pc), local, iteration,
+	                           value0, value1, value2, value3};
+	for (uint32_t i = 0; i < std::size(values); i++) {
+		const auto index = EmitAddU32(state, base, ConstantU32(state, i));
+		state.builder.AddFunction({OpStore, EmitGdsElementPointer(state, index), values[i]});
+	}
+	state.builder.AddFunction({OpBranch, merge_label});
+	state.builder.AddFunction({OpLabel, merge_label});
+}
 
 uint32_t EmitDppWriteActiveBool(EmitterState& state, const IR::Operand& dst) {
 	const auto exec_active = EmitExecActiveBool(state);
@@ -269,10 +346,10 @@ uint32_t EmitBufferByteAddress(EmitterState& state, const IR::Instruction& inst,
 	const auto end               = first_src + src_count;
 	auto       cursor            = first_src;
 	auto       LoadAddressSource = [&]() {
-		if (cursor >= end) {
-			return ConstantU32(state, 0);
-		}
-		return EmitValueLoad(state, inst.src[cursor++]);
+        if (cursor >= end) {
+            return ConstantU32(state, 0);
+        }
+        return EmitValueLoad(state, inst.src[cursor++]);
 	};
 
 	uint32_t index = ConstantU32(state, 0);
@@ -506,9 +583,9 @@ uint32_t EmitMemoryLoadDwordValueU32(EmitterState& state, const IR::Instruction&
 	mem.kind                   = kind;
 	const auto index           = EmitMemoryDwordIndex(state, inst, mem, first_src, src_count);
 	auto       LoadFromPointer = [&](uint32_t pointer) {
-		const auto value = state.builder.AllocateId();
-		state.builder.AddFunction({OpLoad, state.uint_type, value, pointer});
-		return value;
+        const auto value = state.builder.AllocateId();
+        state.builder.AddFunction({OpLoad, state.uint_type, value, pointer});
+        return value;
 	};
 	if (mem.kind == IR::ResourceKind::Lds) {
 		return LoadFromPointer(EmitLdsElementPointer(state, index));
@@ -641,7 +718,7 @@ void EmitMemoryStoreU32(EmitterState& state, const IR::Instruction& inst, IR::Re
 
 template <typename Fn>
 uint32_t EmitAtomicUpdateU32(EmitterState& state, uint32_t pointer, IR::ResourceKind kind,
-                             Fn&& desired_value) {
+                             Fn&& desired_value, bool emit_memory_barrier = true) {
 	const auto scope          = kind == IR::ResourceKind::Lds ? ScopeWorkgroup : ScopeDevice;
 	const auto memory         = kind == IR::ResourceKind::Lds ? MemorySemanticsWorkgroupMemory
 	                                                          : MemorySemanticsUniformMemory;
@@ -672,9 +749,11 @@ uint32_t EmitAtomicUpdateU32(EmitterState& state, uint32_t pointer, IR::Resource
 	state.builder.AddFunction({OpLabel, continue_label});
 	state.builder.AddFunction({OpBranch, header});
 	state.builder.AddFunction({OpLabel, merge});
-	const auto semantics = MemorySemanticsAcquireRelease | memory;
-	state.builder.AddFunction(
-	    {OpMemoryBarrier, ConstantU32(state, scope), ConstantU32(state, semantics)});
+	if (emit_memory_barrier) {
+		const auto semantics = MemorySemanticsAcquireRelease | memory;
+		state.builder.AddFunction(
+		    {OpMemoryBarrier, ConstantU32(state, scope), ConstantU32(state, semantics)});
+	}
 	return observed;
 }
 
@@ -725,14 +804,14 @@ void EmitMemoryStoreSubDwordU32(EmitterState& state, const IR::Instruction& inst
 			    {OpBitwiseOr, state.uint_type, merged, cleared, value_shifted});
 			return merged;
 		};
-		if (store_inst.memory.kind == IR::ResourceKind::Lds ||
-		    store_inst.memory.kind == IR::ResourceKind::Gds) {
-			EmitAtomicUpdateU32(state, pointer, store_inst.memory.kind, Merge);
-		} else {
-			const auto word = state.builder.AllocateId();
-			state.builder.AddFunction({OpLoad, state.uint_type, word, pointer});
-			state.builder.AddFunction({OpStore, pointer, Merge(word)});
-		}
+		// A guest sub-dword store updates only its selected byte or halfword. Multiple
+		// invocations may therefore target different fields of the same host dword.
+		// Preserve both updates with one atomic read/modify/write for LDS, GDS, and
+		// storage-buffer-backed memory alike.
+		const auto preserve_guest_ds_order = store_inst.memory.kind == IR::ResourceKind::Lds ||
+		                                     store_inst.memory.kind == IR::ResourceKind::Gds;
+		EmitAtomicUpdateU32(state, pointer, store_inst.memory.kind, Merge,
+		                    preserve_guest_ds_order);
 	});
 }
 
@@ -1134,15 +1213,15 @@ void EmitAtomicU32(EmitterState& state, const IR::Instruction& inst, uint32_t op
 		const auto in_bounds = EmitStorageBufferElementInBounds(state, inst.memory, index, inst.pc);
 		const auto value     = EmitValueLoad(state, inst.src[0]);
 		const auto old       = EmitValueOrZeroIfCondition(state, in_bounds, [&]() {
-			const auto pointer =
-			    EmitStorageBufferElementPointer(state, inst.memory, index, inst.pc);
-			const auto result = state.builder.AllocateId();
-			state.builder.AddFunction({opcode, state.uint_type, result, pointer,
-			                           ConstantU32(state, ScopeDevice),
-			                           ConstantU32(state, MemorySemanticsNone), value});
-			EmitDeviceAtomicMemoryBarrier(state);
-			return result;
-		});
+            const auto pointer =
+                EmitStorageBufferElementPointer(state, inst.memory, index, inst.pc);
+            const auto result = state.builder.AllocateId();
+            state.builder.AddFunction({opcode, state.uint_type, result, pointer,
+                                       ConstantU32(state, ScopeDevice),
+                                       ConstantU32(state, MemorySemanticsNone), value});
+            EmitDeviceAtomicMemoryBarrier(state);
+            return result;
+        });
 		EmitStoreU32(state, inst.dst, old);
 		return;
 	}
@@ -1151,14 +1230,14 @@ void EmitAtomicU32(EmitterState& state, const IR::Instruction& inst, uint32_t op
 		const auto in_bounds = EmitGdsElementInBounds(state, index);
 		const auto value     = EmitValueLoad(state, inst.src[0]);
 		const auto old       = EmitValueOrZeroIfCondition(state, in_bounds, [&]() {
-			const auto pointer = EmitGdsElementPointer(state, index);
-			const auto result  = state.builder.AllocateId();
-			state.builder.AddFunction({opcode, state.uint_type, result, pointer,
-			                           ConstantU32(state, ScopeDevice),
-			                           ConstantU32(state, MemorySemanticsNone), value});
-			EmitDeviceAtomicMemoryBarrier(state);
-			return result;
-		});
+            const auto pointer = EmitGdsElementPointer(state, index);
+            const auto result  = state.builder.AllocateId();
+            state.builder.AddFunction({opcode, state.uint_type, result, pointer,
+                                       ConstantU32(state, ScopeDevice),
+                                       ConstantU32(state, MemorySemanticsNone), value});
+            EmitDeviceAtomicMemoryBarrier(state);
+            return result;
+        });
 		EmitStoreU32(state, inst.dst, old);
 		return;
 	}
@@ -1198,10 +1277,10 @@ uint32_t EmitF32BitsOrderedCompare(EmitterState& state, uint32_t lhs_bits, uint3
 		const auto     exponent_max =
 		    EmitCompareU32Constant(state, OpIEqual, exponent_bits, 0x7f800000u);
 		const auto mantissa_nonzero = EmitCompareU32Constant(state, OpINotEqual, mantissa_bits, 0);
-		const auto negative = EmitCompareU32Constant(state, OpINotEqual,
-		                                             EmitAndConstant(state, bits, 0x80000000u), 0);
-		const auto negative_key = state.builder.AllocateId();
-		const auto positive_key = state.builder.AllocateId();
+		const auto negative         = EmitCompareU32Constant(state, OpINotEqual,
+		                                                     EmitAndConstant(state, bits, 0x80000000u), 0);
+		const auto negative_key     = state.builder.AllocateId();
+		const auto positive_key     = state.builder.AllocateId();
 		// Map all non-NaN IEEE-754 encodings to monotonically increasing unsigned keys.
 		state.builder.AddFunction({OpNot, state.uint_type, negative_key, bits});
 		state.builder.AddFunction(
@@ -1231,16 +1310,16 @@ void EmitAtomicFMinMaxF32(EmitterState& state, const IR::Instruction& inst,
 	const auto in_bounds = EmitStorageBufferElementInBounds(state, inst.memory, index, inst.pc);
 	const auto src_u32   = EmitValueLoad(state, inst.src[0]);
 	const auto old       = EmitValueOrZeroIfCondition(state, in_bounds, [&]() {
-		const auto pointer = EmitStorageBufferElementPointer(state, inst.memory, index, inst.pc);
-		return EmitAtomicUpdateU32(state, pointer, inst.memory.kind, [&](uint32_t old_u32) {
-			const auto replace_old = state.builder.AllocateId();
-			const auto replace =
-			    EmitF32BitsOrderedCompare(state, src_u32, old_u32, comparison_opcode);
-			state.builder.AddFunction(
-			    {OpSelect, state.uint_type, replace_old, replace, src_u32, old_u32});
-			return replace_old;
-		});
-	});
+        const auto pointer = EmitStorageBufferElementPointer(state, inst.memory, index, inst.pc);
+        return EmitAtomicUpdateU32(state, pointer, inst.memory.kind, [&](uint32_t old_u32) {
+            const auto replace_old = state.builder.AllocateId();
+            const auto replace =
+                EmitF32BitsOrderedCompare(state, src_u32, old_u32, comparison_opcode);
+            state.builder.AddFunction(
+                {OpSelect, state.uint_type, replace_old, replace, src_u32, old_u32});
+            return replace_old;
+        });
+    });
 	EmitStoreU32(state, inst.dst, old);
 }
 
@@ -1355,6 +1434,141 @@ void EmitBufferLoadDwordGroup(EmitterState& state, const IR::Instruction* instru
 	});
 }
 
+bool UseBinkWave64WorkgroupBarrier(const EmitterState& state, uint32_t guest_pc) {
+	if (std::getenv("KYTY_BINK_WORKGROUP_LDS_BARRIER") == nullptr) {
+		return false;
+	}
+	if (state.program.shader_hash == 0x0000000208a63b00ULL) {
+		// Diagnostic phase boundaries for the 64-thread intra-frame Bink kernel.
+		// Each site follows reconvergence/restoration of EXEC and is reached by the
+		// complete workgroup before later data-dependent transform branches.
+		switch (guest_pc) {
+			case 0x00000220u:
+			case 0x000002c4u:
+			case 0x00000364u:
+			case 0x00000408u:
+			case 0x000004acu:
+			case 0x00000550u:
+			case 0x000005f4u:
+			case 0x00000698u:
+			case 0x0000077cu: return true;
+			default: return false;
+		}
+	}
+	if (state.program.shader_hash != 0x0000000208a64d00ULL) {
+		return false;
+	}
+	switch (guest_pc) {
+		case 0x000003e4u:
+		case 0x0000049cu:
+		case 0x0000053cu:
+		case 0x000005dcu:
+		case 0x0000067cu:
+		case 0x0000071cu:
+		case 0x000007bcu:
+		case 0x0000085cu:
+		case 0x0000098cu:
+		case 0x00000af0u:
+		case 0x00000d54u:
+		case 0x00000df0u:
+		case 0x00000e90u:
+		case 0x00000f30u:
+		case 0x00000fd0u:
+		case 0x00001070u:
+		case 0x00001110u:
+		case 0x000011b0u:
+		case 0x00001284u:
+		case 0x00001414u:
+		case 0x00001bc0u:
+		case 0x00002084u:
+		case 0x0000221cu: return true;
+		default: return false;
+	}
+}
+
+void EmitDsReadVisibilityBarrier(EmitterState& state, IR::ResourceKind kind,
+                                 uint32_t guest_pc) {
+	if (kind != IR::ResourceKind::Lds || state.stage != ShaderType::Compute ||
+	    state.needs_function_lds) {
+		return;
+	}
+	// Logical single-wave lowering synchronizes once at the start of every
+	// complete guest LDS instruction in EmitBlockInstructions. Do not insert a
+	// second barrier for the split components of a wide read here.
+	if (IsLogicalWaveWorkgroup(state)) {
+		return;
+	}
+
+	// A guest wave issues earlier DS writes before its following DS read. SPIR-V
+	// workgroup loads otherwise have no peer-lane visibility guarantee, and the
+	// later s_waitcnt only waits for the already-issued read result. Synchronize
+	// the guest wave before issuing the host LDS load without rendezvousing the
+	// other wave that may share the workgroup.
+	const auto semantics = MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
+	const auto scope = UseBinkWave64WorkgroupBarrier(state, guest_pc) ? ScopeWorkgroup
+	                                                               : ScopeSubgroup;
+	state.builder.AddFunction({OpControlBarrier, ConstantU32(state, scope),
+	                           ConstantU32(state, scope), ConstantU32(state, semantics)});
+}
+
+void EmitLogicalWaveLdsInstructionBarrier(EmitterState& state,
+                                          const IR::Instruction& inst) {
+	if (!state.logical_single_wave_workgroup || inst.memory.kind != IR::ResourceKind::Lds) {
+		return;
+	}
+	// ResourceKind::Lds is only assigned by DS/LDS lowering, including the
+	// generic Atomic* IR opcodes used for DS_ADD/AND/etc. Keying on the memory
+	// kind avoids maintaining a second, incomplete opcode list here.
+	if (inst.memory.component_count > 1u && inst.memory.component_index != 0u) {
+		return;
+	}
+
+	// A guest wave issues each LDS instruction as one lockstep phase. Mapping it
+	// to two independently scheduled host subgroup32 waves requires a rendezvous
+	// before reads *and* writes: a fast half must not begin the next write/reset
+	// while the slow half still consumes the previous phase.
+	const auto semantics = MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
+	state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, semantics)});
+}
+
+void EmitDsAtomicPhaseBarrier(EmitterState& state, IR::ResourceKind kind) {
+	// One guest DS atomic instruction is issued wave-wide before the next DS
+	// instruction. Host invocations execute independently, so rendezvous the
+	// guest wave before starting the next atomic phase. The caller emits this
+	// outside the EXEC guard so inactive guest lanes still reach the barrier.
+	EmitDsReadVisibilityBarrier(state, kind);
+}
+
+void EmitDsReadB32Group(EmitterState& state, const IR::Instruction* instructions, uint32_t count) {
+	if (instructions == nullptr || count == 0u) {
+		return;
+	}
+	EmitDsReadVisibilityBarrier(state, instructions[0].memory.kind, instructions[0].pc);
+
+	// DS_READ2 and the wider DS reads capture VADDR before any VDST component is
+	// written. Lowering expands them into one IR read per dword, so defer every
+	// destination write until all LDS values have been loaded. This matters when
+	// VDST overlaps VADDR (for example, ds_read2_b32 v1, v1).
+	std::vector<uint32_t> values;
+	values.reserve(count);
+	for (uint32_t i = 0; i < count; i++) {
+		const auto& inst = instructions[i];
+		values.push_back(EmitMemoryLoadDwordValueU32(state, inst, inst.memory.kind, 0, 1));
+	}
+	if (BinkTraceEnabled(state) && instructions[0].pc == 0x221cu) {
+		const auto value = [&](uint32_t i) {
+			return i < values.size() ? values[i] : ConstantU32(state, 0);
+		};
+		EmitBinkTraceRecord(state, 1, instructions[0].pc, value(0), value(1), value(2),
+		                    value(3));
+	}
+	for (uint32_t i = 0; i < count; i++) {
+		EmitStoreU32(state, instructions[i].dst, values[i]);
+	}
+}
+
 void EmitBufferStoreDword(EmitterState& state, const IR::Instruction& inst) {
 	if (EmitBufferIntegerFormatStore(state, inst)) {
 		return;
@@ -1440,7 +1654,8 @@ void EmitDsWriteAddtidB32(EmitterState& state, const IR::Instruction& inst) {
 }
 
 void EmitDsReadAddtidB32(EmitterState& state, const IR::Instruction& inst) {
-	const auto index   = EmitDsAddtidDwordIndex(state, inst, 0);
+	const auto index = EmitDsAddtidDwordIndex(state, inst, 0);
+	EmitDsReadVisibilityBarrier(state, inst.memory.kind, inst.pc);
 	const auto pointer = EmitLdsElementPointer(state, index);
 	const auto value   = state.builder.AllocateId();
 	state.builder.AddFunction({OpLoad, state.uint_type, value, pointer});

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterModule.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterModule.cpp
@@ -12,6 +12,25 @@ uint32_t DescriptorCount(const EmitterState& state, IR::DescriptorBindingKind ki
 	return binding != nullptr ? static_cast<uint32_t>(binding->resources.size()) : 0;
 }
 
+bool StorageImageClassUsesAtomics(const EmitterState& state, bool integer,
+	                              ImageViewKind view) {
+	const auto* binding = DescriptorBinding(state, StorageBindingKind(integer, view));
+	if (binding == nullptr) {
+		return false;
+	}
+	return std::any_of(binding->resources.begin(), binding->resources.end(),
+	                   [&](uint32_t resource) {
+		                   return resource < state.program.info.images.size() &&
+		                          state.program.info.images[resource].atomic;
+	                   });
+}
+
+bool StorageImageClassIsFormatless(const EmitterState& state, uint32_t index) {
+	const auto view    = static_cast<ImageViewKind>(index % StorageImageViewKindCount);
+	const bool integer = index >= StorageImageViewKindCount;
+	return !integer || !StorageImageClassUsesAtomics(state, true, view);
+}
+
 uint32_t ConstantU32(EmitterState& state, uint32_t value) {
 	if (auto it = state.constants.find(value); it != state.constants.end()) {
 		return it->second;
@@ -181,9 +200,17 @@ static bool MrtUsesUintOutput(const EmitterState& state, uint32_t index) {
 }
 
 void AllocateInputVariables(EmitterState& state) {
+	bool needs_per_vertex = false;
 	for (auto& binding: state.inputs) {
 		binding.variable_id = state.builder.AllocateId();
 		state.interface_variables.push_back(binding.variable_id);
+		needs_per_vertex = needs_per_vertex || binding.per_vertex;
+	}
+	if (needs_per_vertex) {
+		state.bary_coord_variable = state.builder.AllocateId();
+		state.bary_coord_no_persp_variable = state.builder.AllocateId();
+		state.interface_variables.push_back(state.bary_coord_variable);
+		state.interface_variables.push_back(state.bary_coord_no_persp_variable);
 	}
 	if (state.needs_subgroup_local_invocation_id) {
 		state.subgroup_local_invocation_id_variable = state.builder.AllocateId();
@@ -241,6 +268,14 @@ uint32_t BuiltInForInput(IR::StageInputKind kind) {
 }
 
 void AddInputAnnotationsAndNames(EmitterState& state) {
+	if (state.bary_coord_variable != 0) {
+		state.builder.AddName(state.bary_coord_variable, "gl_BaryCoordKHR");
+		state.builder.AddAnnotation({OpDecorate, state.bary_coord_variable, DecorationBuiltIn,
+		                             BuiltInBaryCoordKHR});
+		state.builder.AddName(state.bary_coord_no_persp_variable, "gl_BaryCoordNoPerspKHR");
+		state.builder.AddAnnotation({OpDecorate, state.bary_coord_no_persp_variable,
+		                             DecorationBuiltIn, BuiltInBaryCoordNoPerspKHR});
+	}
 	if (state.subgroup_local_invocation_id_variable != 0) {
 		state.builder.AddName(state.subgroup_local_invocation_id_variable,
 		                      "gl_SubgroupInvocationID");
@@ -254,6 +289,14 @@ void AddInputAnnotationsAndNames(EmitterState& state) {
 	for (const auto& input: state.inputs) {
 		state.builder.AddName(input.variable_id, input.debug_name.c_str());
 		if (input.kind == IR::StageInputKind::Parameter) {
+			if (input.per_vertex) {
+				state.builder.AddAnnotation(
+				    {OpDecorate, input.variable_id, DecorationPerVertexKHR});
+				const auto location = PixelParameterLocation(state, input.location);
+				state.builder.AddAnnotation(
+				    {OpDecorate, input.variable_id, DecorationLocation, location});
+				continue;
+			}
 			const auto flat = PixelParameterIsFlat(state, input.location);
 			if (flat) {
 				state.builder.AddAnnotation({OpDecorate, input.variable_id, DecorationFlat});
@@ -282,7 +325,12 @@ void AddOutputAnnotationsAndNames(EmitterState& state) {
 		state.builder.AddName(state.per_vertex_variable, "outPerVertex");
 		state.builder.AddAnnotation(
 		    {OpMemberDecorate, state.per_vertex_type, 0, DecorationBuiltIn, BuiltInPosition});
+		state.builder.AddAnnotation({OpMemberDecorate, state.per_vertex_type, 1,
+		                             DecorationBuiltIn, BuiltInClipDistance});
 		state.builder.AddAnnotation({OpDecorate, state.per_vertex_type, DecorationBlock});
+		state.builder.AddName(state.synthetic_depth_clip, "syntheticDepthClip");
+		state.builder.AddAnnotation(
+		    {OpDecorate, state.synthetic_depth_clip, DecorationSpecId, 0});
 	}
 	if (state.depth_variable != 0) {
 		state.builder.AddName(state.depth_variable, "gl_FragDepth");
@@ -426,6 +474,10 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	state.ptr_input_vec3_uint          = state.builder.AllocateId();
 	state.ptr_input_vec4_uint          = state.builder.AllocateId();
 	state.ptr_input_vec4_float         = state.builder.AllocateId();
+	if (state.bary_coord_variable != 0) {
+		state.per_vertex_input_array_type = state.builder.AllocateId();
+		state.ptr_input_per_vertex_array  = state.builder.AllocateId();
+	}
 	state.sample_mask_array_type       = state.builder.AllocateId();
 	state.ptr_output_int               = state.builder.AllocateId();
 	state.ptr_output_sample_mask_array = state.builder.AllocateId();
@@ -434,6 +486,10 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	const auto ptr_output_vec4_uint    = state.builder.AllocateId();
 	state.per_vertex_type              = state.builder.AllocateId();
 	state.ptr_output_per_vertex        = state.builder.AllocateId();
+	if (state.per_vertex_variable != 0) {
+		state.clip_distance_array_type = state.builder.AllocateId();
+		state.synthetic_depth_clip     = state.builder.AllocateId();
+	}
 	state.storage_runtime_array_type   = state.builder.AllocateId();
 	state.storage_buffer_type          = state.builder.AllocateId();
 	state.ptr_storage_buffer           = state.builder.AllocateId();
@@ -454,6 +510,14 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	state.ptr_workgroup_array = state.builder.AllocateId();
 	state.ptr_workgroup_uint  = state.builder.AllocateId();
 	state.lds_variable        = state.builder.AllocateId();
+	if (IsLogicalWaveWorkgroup(state)) {
+		state.logical_wave_summary_variable = state.builder.AllocateId();
+		state.logical_wave_summary_array_type = state.builder.AllocateId();
+		state.ptr_logical_wave_summary_array = state.builder.AllocateId();
+		state.logical_wave_lane_array_type  = state.builder.AllocateId();
+		state.ptr_logical_wave_lane_array   = state.builder.AllocateId();
+		state.logical_wave_lane_variable    = state.builder.AllocateId();
+	}
 	for (auto& image: state.sampled_images) {
 		image.image_type         = state.builder.AllocateId();
 		image.sampled_image_type = state.builder.AllocateId();
@@ -478,15 +542,24 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	state.glsl_std450               = state.builder.AllocateId();
 
 	state.builder.AddCapability({CapabilityShader});
+	if (state.bary_coord_variable != 0) {
+		state.builder.AddCapability({CapabilityFragmentBarycentricKHR});
+		state.builder.AddExtension("SPV_KHR_fragment_shader_barycentric");
+	}
+	if (state.per_vertex_variable != 0) {
+		state.builder.AddCapability({CapabilityClipDistance});
+	}
 	state.builder.AddCapability({CapabilitySampled1D});
 	state.builder.AddCapability({CapabilityImage1D});
 	state.builder.AddCapability({CapabilityImageQuery});
 	if (state.needs_image_gather_extended) {
 		state.builder.AddCapability({CapabilityImageGatherExtended});
 	}
-	if (std::any_of(state.storage_images.begin(),
-	                state.storage_images.begin() + StorageImageViewKindCount,
-	                [](const auto& image) { return image.variable != 0; })) {
+	if (std::any_of(state.storage_images.begin(), state.storage_images.end(),
+	                [&](const auto& image) {
+		                const auto index = static_cast<uint32_t>(&image - state.storage_images.data());
+		                return image.variable != 0 && StorageImageClassIsFormatless(state, index);
+	                })) {
 		state.builder.AddCapability({CapabilityStorageImageReadWithoutFormat});
 		state.builder.AddCapability({CapabilityStorageImageWriteWithoutFormat});
 	}
@@ -499,6 +572,10 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	}
 	if (state.needs_subgroup_shuffle) {
 		state.builder.AddCapability({CapabilityGroupNonUniformShuffle});
+	}
+	if (state.needs_sampled_image_nonuniform) {
+		state.builder.AddCapability({CapabilitySampledImageArrayNonUniformIndexing});
+		state.builder.AddExtension("SPV_EXT_descriptor_indexing");
 	}
 	if (state.needs_compute_derivatives && state.stage == ShaderType::Compute) {
 		state.builder.AddCapability({CapabilityComputeDerivativeGroupQuadsKHR});
@@ -539,6 +616,12 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	state.builder.AddName(state.main_func, "main");
 	if (state.stage == ShaderType::Compute || state.needs_function_lds) {
 		state.builder.AddName(state.lds_variable, "lds_dwords");
+	}
+	if (state.logical_wave_summary_variable != 0) {
+		state.builder.AddName(state.logical_wave_summary_variable, "logical_wave_summary");
+	}
+	if (state.logical_wave_lane_variable != 0) {
+		state.builder.AddName(state.logical_wave_lane_variable, "logical_wave_lanes");
 	}
 	AddInputAnnotationsAndNames(state);
 	AddOutputAnnotationsAndNames(state);
@@ -593,6 +676,16 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	    {OpTypePointer, state.ptr_input_vec4_uint, StorageClassInput, state.vec4_uint_type});
 	state.builder.AddType(
 	    {OpTypePointer, state.ptr_input_vec4_float, StorageClassInput, state.vec4_float_type});
+	if (state.bary_coord_variable != 0) {
+		state.builder.AddType({OpTypeArray, state.per_vertex_input_array_type,
+		                       state.vec4_float_type, ConstantU32(state, 3)});
+		state.builder.AddType({OpTypePointer, state.ptr_input_per_vertex_array,
+		                       StorageClassInput, state.per_vertex_input_array_type});
+		state.builder.AddType({OpVariable, state.ptr_input_vec3_float,
+		                       state.bary_coord_variable, StorageClassInput});
+		state.builder.AddType({OpVariable, state.ptr_input_vec3_float,
+		                       state.bary_coord_no_persp_variable, StorageClassInput});
+	}
 	if (state.subgroup_local_invocation_id_variable != 0) {
 		state.builder.AddType({OpVariable, state.ptr_input_uint,
 		                       state.subgroup_local_invocation_id_variable, StorageClassInput});
@@ -610,7 +703,9 @@ void EmitHeaderAndTypes(EmitterState& state) {
 			case IR::StageInputKind::FragCoord: ptr_type = state.ptr_input_vec4_float; break;
 			case IR::StageInputKind::FrontFacing: ptr_type = state.ptr_input_bool; break;
 			case IR::StageInputKind::Parameter:
-				if (state.stage == ShaderType::Vertex) {
+				if (input.per_vertex) {
+					ptr_type = state.ptr_input_per_vertex_array;
+				} else if (state.stage == ShaderType::Vertex) {
 					const auto kind       = VertexParameterScalarKind(state, input.location);
 					const auto components = VertexParameterComponentCount(state, input);
 					ptr_type = VertexParameterInputPointerType(state, kind, components);
@@ -631,11 +726,16 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	state.builder.AddType(
 	    {OpTypePointer, ptr_output_vec4_uint, StorageClassOutput, state.vec4_uint_type});
 	if (state.per_vertex_variable != 0) {
-		state.builder.AddType({OpTypeStruct, state.per_vertex_type, state.vec4_float_type});
+		state.builder.AddType({OpTypeArray, state.clip_distance_array_type, state.float_type,
+		                       ConstantU32(state, 1)});
+		state.builder.AddType({OpTypeStruct, state.per_vertex_type, state.vec4_float_type,
+		                       state.clip_distance_array_type});
 		state.builder.AddType({OpTypePointer, state.ptr_output_per_vertex, StorageClassOutput,
 		                       state.per_vertex_type});
 		state.builder.AddType({OpVariable, state.ptr_output_per_vertex, state.per_vertex_variable,
 		                       StorageClassOutput});
+		state.builder.AddType(
+		    {OpSpecConstant, state.uint_type, state.synthetic_depth_clip, 0});
 	}
 	for (const auto& binding: state.outputs) {
 		if (binding.kind == IR::StageOutputKind::Parameter ||
@@ -716,7 +816,7 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	if (state.stage == ShaderType::Compute || state.needs_function_lds) {
 		const auto storage_class =
 		    state.needs_function_lds ? StorageClassFunction : StorageClassWorkgroup;
-		const auto lds_size = ConstantU32(state, state.needs_function_lds ? 8192u : 1024u);
+		const auto lds_size = ConstantU32(state, GetLdsDwordCount(state));
 		state.builder.AddType({OpTypeArray, state.lds_array_type, state.uint_type, lds_size});
 		state.builder.AddType(
 		    {OpTypePointer, state.ptr_workgroup_array, storage_class, state.lds_array_type});
@@ -725,6 +825,28 @@ void EmitHeaderAndTypes(EmitterState& state) {
 		if (state.stage == ShaderType::Compute) {
 			state.builder.AddType(
 			    {OpVariable, state.ptr_workgroup_array, state.lds_variable, StorageClassWorkgroup});
+			if (state.logical_wave_summary_variable != 0) {
+				const auto logical_wave_count =
+				    ConstantU32(state, std::max(state.logical_wave_count, 1u));
+				state.builder.AddType({OpTypeArray, state.logical_wave_summary_array_type,
+				                       state.uint_type, logical_wave_count});
+				state.builder.AddType({OpTypePointer, state.ptr_logical_wave_summary_array,
+				                       StorageClassWorkgroup,
+				                       state.logical_wave_summary_array_type});
+				state.builder.AddType({OpVariable, state.ptr_logical_wave_summary_array,
+				                       state.logical_wave_summary_variable,
+				                       StorageClassWorkgroup});
+			}
+			if (state.logical_wave_lane_variable != 0) {
+				const auto logical_wave_size =
+				    ConstantU32(state, std::max(state.logical_local_threads, 64u) * 2u);
+				state.builder.AddType({OpTypeArray, state.logical_wave_lane_array_type,
+				                       state.uint_type, logical_wave_size});
+				state.builder.AddType({OpTypePointer, state.ptr_logical_wave_lane_array,
+				                       StorageClassWorkgroup, state.logical_wave_lane_array_type});
+				state.builder.AddType({OpVariable, state.ptr_logical_wave_lane_array,
+				                       state.logical_wave_lane_variable, StorageClassWorkgroup});
+			}
 		}
 	}
 	for (uint32_t i = 0; i < state.sampled_images.size(); i++) {
@@ -765,7 +887,8 @@ void EmitHeaderAndTypes(EmitterState& state) {
 		const auto view      = static_cast<ImageViewKind>(i % StorageImageViewKindCount);
 		const bool integer   = i >= StorageImageViewKindCount;
 		const auto component = integer ? state.uint_type : state.float_type;
-		const auto format    = integer ? ImageFormatR32ui : ImageFormatUnknown;
+		const auto format = StorageImageClassIsFormatless(state, i) ? ImageFormatUnknown
+		                                                             : ImageFormatR32ui;
 		state.builder.AddType({OpTypeImage, image.image_type, component, ImageSpirvDimension(view),
 		                       0, ImageSpirvArrayed(view), 0, 2, format});
 		state.builder.AddType(

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterValues.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterValues.cpp
@@ -140,6 +140,14 @@ DppTargetLane EmitDppMirrorTargetLane(EmitterState& state, uint32_t subid, bool 
 	return {target, EmitTrueBool(state)};
 }
 
+DppTargetLane EmitDppRowXmaskTargetLane(EmitterState& state, uint32_t subid, uint32_t mask) {
+	const auto target = state.builder.AllocateId();
+	// RDNA DPP row_xmask operates independently inside each 16-lane row.
+	state.builder.AddFunction({OpBitwiseXor, state.uint_type, target, subid,
+	                           ConstantU32(state, mask & 0xfu)});
+	return {target, EmitTrueBool(state)};
+}
+
 DppTargetLane EmitDppTargetLane(EmitterState& state, uint32_t control) {
 	const auto subid = EmitSubgroupLocalInvocationId(state);
 	if (control <= 0xffu) {
@@ -160,6 +168,9 @@ DppTargetLane EmitDppTargetLane(EmitterState& state, uint32_t control) {
 	if (control == 0x141u) {
 		return EmitDppMirrorTargetLane(state, subid, true);
 	}
+	if (control >= 0x160u && control <= 0x16fu) {
+		return EmitDppRowXmaskTargetLane(state, subid, control & 0xfu);
+	}
 	return {subid, EmitTrueBool(state)};
 }
 
@@ -169,14 +180,23 @@ uint32_t EmitDppValueU32(EmitterState& state, const IR::Operand& operand, uint32
 	}
 
 	const auto target   = EmitDppTargetLane(state, operand.dpp_ctrl);
+	uint32_t   host_lane = target.lane;
+	if (IsLogicalWaveWorkgroup(state)) {
+		// Supported DPP controls never leave a 16-lane row. Convert the guest
+		// LocalInvocationIndex (0..63) back to the lane index expected by the
+		// containing host subgroup32.
+		host_lane = state.builder.AllocateId();
+		state.builder.AddFunction({OpBitwiseAnd, state.uint_type, host_lane, target.lane,
+		                           ConstantU32(state, 31u)});
+	}
 	const auto shuffled = state.builder.AllocateId();
 	state.builder.AddFunction({OpGroupNonUniformShuffle, state.uint_type, shuffled,
-	                           ConstantU32(state, ScopeSubgroup), value, target.lane});
+	                           ConstantU32(state, ScopeSubgroup), value, host_lane});
 	if (operand.dpp_fetch_inactive) {
 		return shuffled;
 	}
 
-	const auto source_active = EmitLaneIndexActiveBool(state, target.lane);
+	const auto source_active = EmitLaneIndexActiveBool(state, host_lane);
 	const auto can_fetch     = state.builder.AllocateId();
 	const auto ret           = state.builder.AllocateId();
 	state.builder.AddFunction(
@@ -199,6 +219,17 @@ uint32_t EmitValueLoad(EmitterState& state, const IR::Operand& operand) {
 			}
 			value = state.builder.AllocateId();
 			state.builder.AddFunction({OpLoad, state.uint_type, value, pointer});
+			if (operand.reg.file == IR::RegisterFile::Scc &&
+			    IsLogicalWaveWorkgroup(state)) {
+				const auto local   = state.builder.AllocateId();
+				const auto summary = state.builder.AllocateId();
+				state.builder.AddFunction({OpINotEqual, state.bool_type, local, value,
+				                           ConstantU32(state, 0)});
+				state.builder.AddFunction({OpSelect, state.uint_type, summary,
+				                           EmitLogicalWaveAnyBool(state, local),
+				                           ConstantU32(state, 1), ConstantU32(state, 0)});
+				value = summary;
+			}
 			break;
 		}
 		case IR::OperandKind::Null: value = ConstantU32(state, 0); break;
@@ -329,7 +360,13 @@ uint32_t EmitMaskZeroBool(EmitterState& state, IR::RegisterFile file, bool zero)
 
 uint32_t EmitMaskSummaryZeroBool(EmitterState& state, IR::RegisterFile file, bool zero) {
 	if (state.per_invocation_masks) {
-		return EmitMaskZeroBool(state, file, zero);
+		const auto active = EmitLogicalWaveAnyBool(state, EmitMaskActiveBool(state, file));
+		if (!zero) {
+			return active;
+		}
+		const auto inactive = state.builder.AllocateId();
+		state.builder.AddFunction({OpLogicalNot, state.bool_type, inactive, active});
+		return inactive;
 	}
 	if (state.exact_subgroup_operations) {
 		const auto low      = EmitRegisterLoad(state, {file, 0});
@@ -355,6 +392,103 @@ uint32_t EmitMaskSummaryZeroBool(EmitterState& state, IR::RegisterFile file, boo
 	return inactive;
 }
 
+uint32_t EmitLogicalWaveAnyBool(EmitterState& state, uint32_t value_bool) {
+	if (!IsLogicalWaveWorkgroup(state) ||
+	    state.logical_wave_lane_variable == 0) {
+		return value_bool;
+	}
+
+	// Do not depend on how Vulkan partitions local invocations into host subgroups.
+	// Snapshot every guest lane, let lane zero reduce its logical wave serially,
+	// then publish one summary value. This keeps the workgroup rendezvous count
+	// independent of the guest wave width and avoids a barrier at every tree stage.
+	const auto semantics = MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
+	const auto guest_lane = EmitLogicalWaveLaneIndex(state);
+	const auto own_index  = EmitLogicalWaveLaneArrayIndex(state, guest_lane);
+	const auto value      = state.builder.AllocateId();
+	const auto own_ptr    = state.builder.AllocateId();
+	state.builder.AddFunction({OpSelect, state.uint_type, value, value_bool,
+	                           ConstantU32(state, 1), ConstantU32(state, 0)});
+	state.builder.AddFunction({OpAccessChain, state.ptr_workgroup_uint, own_ptr,
+	                           state.logical_wave_lane_variable, own_index});
+	state.builder.AddFunction({OpStore, own_ptr, value});
+	state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, semantics)});
+
+	const auto lane_zero = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpIEqual, state.bool_type, lane_zero, guest_lane, ConstantU32(state, 0)});
+	const auto summary_ptr = EmitLogicalWaveSummaryPointer(state);
+	EmitIfCondition(state, lane_zero, [&]() {
+		uint32_t aggregate = ConstantU32(state, 0);
+		for (uint32_t lane = 0; lane < 64u; lane++) {
+			const auto lane_ptr   = state.builder.AllocateId();
+			const auto lane_value = state.builder.AllocateId();
+			const auto combined   = state.builder.AllocateId();
+			state.builder.AddFunction(
+			    {OpAccessChain, state.ptr_workgroup_uint, lane_ptr,
+			     state.logical_wave_lane_variable,
+			     EmitLogicalWaveLaneArrayIndex(state, ConstantU32(state, lane))});
+			state.builder.AddFunction({OpLoad, state.uint_type, lane_value, lane_ptr});
+			state.builder.AddFunction(
+			    {OpBitwiseOr, state.uint_type, combined, aggregate, lane_value});
+			aggregate = combined;
+		}
+		state.builder.AddFunction({OpStore, summary_ptr, aggregate});
+	});
+	state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, semantics)});
+
+	const auto summary = state.builder.AllocateId();
+	const auto active  = state.builder.AllocateId();
+	state.builder.AddFunction({OpLoad, state.uint_type, summary, summary_ptr});
+	state.builder.AddFunction(
+	    {OpINotEqual, state.bool_type, active, summary, ConstantU32(state, 0)});
+	return active;
+}
+
+uint32_t EmitLogicalWaveIndex(EmitterState& state) {
+	if (!state.logical_multi_wave_workgroup) {
+		return ConstantU32(state, 0);
+	}
+	const auto wave = state.builder.AllocateId();
+	state.builder.AddFunction({OpUDiv, state.uint_type, wave,
+	                           EmitLocalInvocationIndex(state), ConstantU32(state, 64u)});
+	return wave;
+}
+
+uint32_t EmitLogicalWaveLaneIndex(EmitterState& state) {
+	if (!IsLogicalWaveWorkgroup(state)) {
+		return EmitSubgroupLocalInvocationId(state);
+	}
+	const auto lane = state.builder.AllocateId();
+	state.builder.AddFunction({OpBitwiseAnd, state.uint_type, lane,
+	                           EmitLocalInvocationIndex(state), ConstantU32(state, 63u)});
+	return lane;
+}
+
+uint32_t EmitLogicalWaveSummaryPointer(EmitterState& state) {
+	const auto pointer = state.builder.AllocateId();
+	state.builder.AddFunction({OpAccessChain, state.ptr_workgroup_uint, pointer,
+	                           state.logical_wave_summary_variable,
+	                           EmitLogicalWaveIndex(state)});
+	return pointer;
+}
+
+uint32_t EmitLogicalWaveLaneArrayIndex(EmitterState& state, uint32_t guest_lane) {
+	if (!state.logical_multi_wave_workgroup) {
+		return guest_lane;
+	}
+	const auto base  = state.builder.AllocateId();
+	const auto index = state.builder.AllocateId();
+	state.builder.AddFunction({OpIMul, state.uint_type, base, EmitLogicalWaveIndex(state),
+	                           ConstantU32(state, 64u)});
+	state.builder.AddFunction({OpIAdd, state.uint_type, index, base, guest_lane});
+	return index;
+}
+
 uint32_t EmitExecActiveBool(EmitterState& state) {
 	return EmitMaskZeroBool(state, IR::RegisterFile::Exec, false);
 }
@@ -374,6 +508,9 @@ uint32_t EmitConditionBool(EmitterState& state, const IR::Operand& operand) {
 }
 
 uint32_t EmitSubgroupLocalInvocationId(EmitterState& state) {
+	if (IsLogicalWaveWorkgroup(state)) {
+		return EmitLogicalWaveLaneIndex(state);
+	}
 	if (state.subgroup_local_invocation_id_variable == 0) {
 		return ConstantU32(state, 0);
 	}
@@ -482,7 +619,6 @@ void EmitLoadInputF32(EmitterState& state, const IR::Instruction& inst) {
 		             EmitVertexParameterComponentU32(state, *input, inst.input_info.chan & 3u));
 		return;
 	}
-
 	const auto input_value = state.builder.AllocateId();
 	const auto component   = state.builder.AllocateId();
 	const auto bits        = state.builder.AllocateId();
@@ -495,10 +631,16 @@ void EmitLoadInputF32(EmitterState& state, const IR::Instruction& inst) {
 
 uint32_t EmitSccBool(EmitterState& state, bool non_zero) {
 	const auto value = EmitRegisterLoad(state, SccRegister());
-	const auto cond  = state.builder.AllocateId();
+	const auto local = state.builder.AllocateId();
 	state.builder.AddFunction(
-	    {non_zero ? OpINotEqual : OpIEqual, state.bool_type, cond, value, ConstantU32(state, 0)});
-	return cond;
+	    {OpINotEqual, state.bool_type, local, value, ConstantU32(state, 0)});
+	const auto summary = EmitLogicalWaveAnyBool(state, local);
+	if (non_zero) {
+		return summary;
+	}
+	const auto zero = state.builder.AllocateId();
+	state.builder.AddFunction({OpLogicalNot, state.bool_type, zero, summary});
+	return zero;
 }
 
 uint32_t EmitFloatLoad(EmitterState& state, const IR::Operand& operand) {

--- a/src/graphics/shader/recompiler/ir/ShaderIR.h
+++ b/src/graphics/shader/recompiler/ir/ShaderIR.h
@@ -457,6 +457,9 @@ struct Program {
 	uint32_t                wave_size           = 64;
 	uint32_t                user_data_base      = 0;
 	uint32_t                user_data_count     = 64;
+	bool                    compute_linear_local64 = false;
+	int32_t                 compute_workgroup_register = -1;
+	int32_t                 compute_thread_ids_num     = 0;
 	bool                    dispatcher_fallback = false;
 	CFG::FailureKind        cfg_failure_kind    = CFG::FailureKind::None;
 	std::string             fallback_reason;

--- a/src/graphics/shader/recompiler/ir/ShaderIRMemory.cpp
+++ b/src/graphics/shader/recompiler/ir/ShaderIRMemory.cpp
@@ -209,6 +209,7 @@ bool LowerDsRead(const Decoder::Instruction& decoded, BasicBlock& block, std::st
 bool LowerDsRead2(const Decoder::Instruction& decoded, BasicBlock& block, uint32_t dwords_per_read,
                   std::string* error) {
 	const uint32_t offsets[] = {decoded.offset, decoded.secondary_offset};
+	const uint32_t component_count = 2u * dwords_per_read;
 	for (uint32_t read = 0; read < 2u; read++) {
 		for (uint32_t dword = 0; dword < dwords_per_read; dword++) {
 			const auto  index = read * dwords_per_read + dword;
@@ -218,6 +219,11 @@ bool LowerDsRead2(const Decoder::Instruction& decoded, BasicBlock& block, uint32
 			inst.src_count = 1;
 			inst.memory =
 			    ByteOffsetMemoryInfo(decoded, DsMemoryKind(decoded), offsets[read] + dword * 4u);
+			// DS_READ2 captures VADDR once and completes every component before any VDST
+			// write becomes visible. Preserve that instruction boundary after lowering so
+			// the emitter can defer stores when VDST overlaps VADDR.
+			inst.memory.component_index = index;
+			inst.memory.component_count = component_count;
 			if (!LowerRegisterOperand(OffsetDecodedRegister(decoded.dst, index), inst.dst, error) ||
 			    !LowerSourceOperand(decoded.src0, inst.src[0], error)) {
 				return false;
@@ -451,14 +457,21 @@ bool LowerDsWrite2(const Decoder::Instruction& decoded, BasicBlock& block,
                    uint32_t dwords_per_write, std::string* error) {
 	const Decoder::Operand* data[]    = {&decoded.src1, &decoded.src2};
 	const uint32_t          offsets[] = {decoded.offset, decoded.secondary_offset};
+	const uint32_t          component_count = 2u * dwords_per_write;
 	for (uint32_t write = 0; write < 2u; write++) {
 		for (uint32_t dword = 0; dword < dwords_per_write; dword++) {
+			const auto index = write * dwords_per_write + dword;
 			Instruction inst;
 			inst.pc        = decoded.pc;
 			inst.op        = Opcode::DsWriteB32;
 			inst.src_count = 2;
 			inst.memory =
 			    ByteOffsetMemoryInfo(decoded, DsMemoryKind(decoded), offsets[write] + dword * 4u);
+			// Keep the native DS_WRITE2/B64 instruction as one LDS phase after
+			// lowering. Logical wave64 workgroup synchronization must occur once,
+			// never between its component stores.
+			inst.memory.component_index = index;
+			inst.memory.component_count = component_count;
 			inst.dst.kind = OperandKind::Null;
 			if (!LowerSourceOperand(OffsetDecodedRegister(*data[write], dword), inst.src[0],
 			                        error) ||

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -884,6 +884,7 @@ static void ShaderGetStaticInputInfoPS(
 
 static void ShaderGetStaticInputInfoCS(const HW::ComputeShaderInfo& regs,
                                        const HW::ShaderRegisters& /*sh*/,
+                                       uint32_t guest_wave_size,
                                        ShaderComputeInputInfo& info) {
 	info = {};
 
@@ -893,8 +894,9 @@ static void ShaderGetStaticInputInfoCS(const HW::ComputeShaderInfo& regs,
 	info.group_id[0]    = regs.cs_regs.tgid_x_en != 0;
 	info.group_id[1]    = regs.cs_regs.tgid_y_en != 0;
 	info.group_id[2]    = regs.cs_regs.tgid_z_en != 0;
-	info.wave_size      = regs.cs_regs.wave_size;
+	info.wave_size      = guest_wave_size;
 	info.thread_ids_num = regs.cs_regs.tidig_comp_cnt + 1;
+	info.lds_size_dwords = static_cast<uint32_t>(regs.cs_regs.lds_size) * 128u;
 	info.tg_size_en     = regs.cs_regs.tg_size_en != 0;
 
 	info.workgroup_register = regs.cs_regs.user_sgpr;
@@ -1182,14 +1184,15 @@ bool ShaderCompileInfoPS(const HW::PixelShaderInfo& regs, const HW::ShaderRegist
 }
 
 bool ShaderCompileInfoCS(const HW::ComputeShaderInfo& regs, const HW::ShaderRegisters& sh,
-                         ShaderComputeInputInfo& info, std::span<const uint32_t>& spirv) {
+	                     uint32_t guest_wave_size, ShaderLaneMaskMode lane_mask_mode,
+	                     ShaderComputeInputInfo& info, std::span<const uint32_t>& spirv) {
 	spirv = {};
 
-	ShaderGetStaticInputInfoCS(regs, sh, info);
+	ShaderGetStaticInputInfoCS(regs, sh, guest_wave_size, info);
 	const auto shader_hash = regs.cs_regs.data_addr;
 	const auto program_id  = ShaderGetIdCS(regs, info, false);
-	const auto key         = MakeShaderStageProgramKey(ShaderType::Compute, shader_hash, program_id,
-	                                                   ShaderLaneMaskMode::NativeWave);
+	const auto key =
+	    MakeShaderStageProgramKey(ShaderType::Compute, shader_hash, program_id, lane_mask_mode);
 
 	{
 		std::scoped_lock lock(g_shader_program_cache_mutex);
@@ -1206,7 +1209,7 @@ bool ShaderCompileInfoCS(const HW::ComputeShaderInfo& regs, const HW::ShaderRegi
 	}
 
 	std::vector<uint32_t> compiled_spirv;
-	if (!ShaderCompileSpirvCS(regs, sh, info, compiled_spirv)) {
+	if (!ShaderCompileSpirvCS(regs, sh, lane_mask_mode, info, compiled_spirv)) {
 		return false;
 	}
 
@@ -1311,10 +1314,12 @@ void ShaderDbgDumpInputInfo(const ShaderComputeInputInfo& info) {
 	LOGF("\t workgroup_register = %d\n"
 	     "\t thread_ids_num     = %d\n"
 	     "\t wave_size          = %u\n"
+	     "\t lds_size_dwords    = %u\n"
 	     "\t threads_num        = {%u, %u, %u}\n"
 	     "\t tg_size_en         = %s\n",
-	     info.workgroup_register, info.thread_ids_num, info.wave_size, info.threads_num[0],
-	     info.threads_num[1], info.threads_num[2], info.tg_size_en ? "true" : "false");
+	     info.workgroup_register, info.thread_ids_num, info.wave_size, info.lds_size_dwords,
+	     info.threads_num[0], info.threads_num[1], info.threads_num[2],
+	     info.tg_size_en ? "true" : "false");
 	LOGF("\t threadgroup_id     = {%s, %s, %s}\n", info.group_id[0] ? "true" : "false",
 	     info.group_id[1] ? "true" : "false", info.group_id[2] ? "true" : "false");
 }
@@ -1520,7 +1525,8 @@ bool ShaderCompileSpirvPS(const HW::PixelShaderInfo& regs, const HW::ShaderRegis
 }
 
 bool ShaderCompileSpirvCS(const HW::ComputeShaderInfo& regs, const HW::ShaderRegisters& sh,
-                          ShaderComputeInputInfo& input_info, std::vector<uint32_t>& spirv) {
+	                      ShaderLaneMaskMode lane_mask_mode,
+	                      ShaderComputeInputInfo& input_info, std::vector<uint32_t>& spirv) {
 	KYTY_PROFILER_FUNCTION(profiler::colors::CyanA700);
 
 	const uint64_t shader_addr = regs.cs_regs.data_addr;
@@ -1536,6 +1542,7 @@ bool ShaderCompileSpirvCS(const HW::ComputeShaderInfo& regs, const HW::ShaderReg
 	options.push_constant_offset = 0;
 	options.compute_input_info   = &input_info;
 	options.wave_size            = input_info.wave_size;
+	options.lane_mask_mode       = lane_mask_mode;
 	options.dump_ir              = ShaderRecompilerTextDumpEnabled();
 	options.early_dump           = options.dump_ir;
 	options.dump_label           = "ShaderRecompiler CS";

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -25,6 +25,9 @@ enum class ShaderType { Unknown, Vertex, Pixel, Fetch, Compute };
 
 enum class ShaderLaneMaskMode { NativeWave, PerInvocation };
 
+// Writes a compact, opt-in shader/pipeline trace when KYTY_SHADER_TRACE_FILE is set.
+// Each call is flushed so the final completed boundary survives an abnormal process exit.
+
 namespace ShaderRecompiler::IR {
 struct Program;
 struct ResourceSnapshot;
@@ -86,6 +89,7 @@ struct ShaderVertexInputInfo {
 struct ShaderComputeInputInfo {
 	uint32_t           threads_num[3]             = {0, 0, 0};
 	uint32_t           dispatch_threads_num[3]    = {0, 0, 0};
+	uint32_t           lds_size_dwords            = 0;
 	bool               group_id[3]                = {false, false, false};
 	bool               dispatch_thread_dimensions = false;
 	uint32_t           wave_size                  = 64;
@@ -240,7 +244,9 @@ bool ShaderCompileInfoPS(const HW::PixelShaderInfo& regs, const HW::ShaderRegist
                          std::span<const Prospero::ColorComponentMapping, 8> target_export_mapping,
                          ShaderPixelInputInfo& input_info, std::span<const uint32_t>& spirv);
 bool ShaderCompileInfoCS(const HW::ComputeShaderInfo& regs, const HW::ShaderRegisters& sh,
-                         ShaderComputeInputInfo& input_info, std::span<const uint32_t>& spirv);
+	                     uint32_t guest_wave_size, ShaderLaneMaskMode lane_mask_mode,
+	                     ShaderComputeInputInfo& input_info,
+                         std::span<const uint32_t>& spirv);
 bool ShaderCompileSpirvVS(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
                           ShaderLaneMaskMode lane_mask_mode, ShaderVertexInputInfo& input_info,
                           std::vector<uint32_t>& spirv);
@@ -248,7 +254,8 @@ bool ShaderCompileSpirvPS(const HW::PixelShaderInfo& regs, const HW::ShaderRegis
                           ShaderLaneMaskMode lane_mask_mode, ShaderPixelInputInfo& input_info,
                           std::vector<uint32_t>& spirv);
 bool ShaderCompileSpirvCS(const HW::ComputeShaderInfo& regs, const HW::ShaderRegisters& sh,
-                          ShaderComputeInputInfo& input_info, std::vector<uint32_t>& spirv);
+	                      ShaderLaneMaskMode lane_mask_mode,
+	                      ShaderComputeInputInfo& input_info, std::vector<uint32_t>& spirv);
 bool ShaderAddressValid(uint64_t addr);
 
 } // namespace Libs::Graphics

--- a/tests/shaderCfgTests.cpp
+++ b/tests/shaderCfgTests.cpp
@@ -517,7 +517,15 @@ void TestNativeSubgroupPolicy() {
 	context.max_subgroup_size             = 32;
 	context.subgroup_size_control_enabled = true;
 	context.required_subgroup_size_stages = vk::ShaderStageFlagBits::eAll;
+	const ShaderSubgroupCapabilities subgroup_caps {context};
+	Check(SelectComputeLaneMaskMode(subgroup_caps, 64, 64) ==
+	          ShaderLaneMaskMode::PerInvocation,
+	      "host wave32 did not select logical masks for a single guest wave64");
+	Check(SelectComputeLaneMaskMode(subgroup_caps, 32, 32) ==
+	          ShaderLaneMaskMode::NativeWave,
+	      "native wave32 compute unexpectedly selected logical masks");
 	ShaderRecompiler::IR::Program safe;
+	safe.stage          = ShaderType::Compute;
 	safe.wave_size      = 32;
 	safe.lane_mask_mode = ShaderLaneMaskMode::NativeWave;
 	Check(ConfigureShaderSubgroup(ShaderSubgroupCapabilities {context},
@@ -550,6 +558,14 @@ void TestNativeSubgroupPolicy() {
 	                              vk::ShaderStageFlagBits::eCompute, cross_lane_compute)
 	              .mode == ShaderSubgroupMode::Unsupported,
 	      "cross-lane compute mismatch bypassed the exact subgroup requirement");
+	cross_lane_compute.lane_mask_mode = ShaderLaneMaskMode::PerInvocation;
+	Check(ShaderRecompiler::Spirv::ProgramSupportsLogicalSingleWaveWorkgroup(
+	          cross_lane_compute) &&
+	          ConfigureShaderSubgroup(subgroup_caps, vk::ShaderStageFlagBits::eCompute,
+	                                  cross_lane_compute, 64)
+	                  .mode == ShaderSubgroupMode::LogicalSingleWaveWorkgroup,
+	      "supported logical wave64 compute program was rejected");
+	cross_lane_compute.lane_mask_mode = ShaderLaneMaskMode::NativeWave;
 
 	ShaderRecompiler::IR::Program zero_exec = safe;
 	zero_exec.lane_mask_mode                = ShaderLaneMaskMode::NativeWave;
@@ -5995,22 +6011,10 @@ void TestNewShaderRecompilerExecMaskHelpers() {
 }
 
 void TestComputeShaderInputWaveSize() {
-	const auto decode_wave_size = [](uint32_t rsrc1) {
-		const bool wave32 = (((rsrc1 >> Pm4::COMPUTE_PGM_RSRC1_W32_EN_SHIFT) &
-		                      Pm4::COMPUTE_PGM_RSRC1_W32_EN_MASK) != 0u);
-		return wave32 ? 32u : 64u;
-	};
-
-	constexpr uint32_t observed_wave32_rsrc1_a = 0x402c0146u;
-	constexpr uint32_t observed_wave32_rsrc1_b = 0x402c00c1u;
-	Check(decode_wave_size(observed_wave32_rsrc1_a) == 32u,
-	      "COMPUTE_PGM_RSRC1 W32_EN bit did not match observed PS5 value A");
-	Check(decode_wave_size(observed_wave32_rsrc1_b) == 32u,
-	      "COMPUTE_PGM_RSRC1 W32_EN bit did not match observed PS5 value B");
-
-	constexpr uint32_t w32_en_bit = 1u << Pm4::COMPUTE_PGM_RSRC1_W32_EN_SHIFT;
-	Check(decode_wave_size(observed_wave32_rsrc1_a & ~w32_en_bit) == 64u,
-	      "cleared COMPUTE_PGM_RSRC1 W32_EN bit did not decode as wave64");
+	Check(Pm4::GetComputeWaveSizeFromDispatchModifier(0x00000041u) == 64u,
+	      "wave64 dispatch modifier was decoded incorrectly");
+	Check(Pm4::GetComputeWaveSizeFromDispatchModifier(0x00008041u) == 32u,
+	      "wave32 dispatch modifier was decoded incorrectly");
 }
 
 void TestNewShaderRecompilerWave32MasksExecHighStores() {


### PR DESCRIPTION
Note: This is a big change and maybe needs more discussion. Also shader is currently compiled twice to determine the runtime selection without restructuring the compiler. This was the minimal solution added to make this work. 

Some PS5 compute shaders are made to run as wave64. This means that 64 shader
threads are expected to work together as one group.

The problem is that many GPUs, especially NVIDIA GPUs through Vulkan, only
support native groups of 32 threads. We cannot simply run the shader as two
separate wave32 groups, because both halves can make different branch
decisions and will not automatically share the same EXEC/VCC masks or
wave-local data.

This PR adds three possible paths for these shaders:

**1. Native wave64**
If the GPU and Vulkan driver support a real 64-thread subgroup, Kyty uses it
directly. This is the most accurate and preferred path. Supported on older AMD GCN Hardware for example. 

**2. Logical wave64**
If the GPU only supports subgroup32, Kyty can run the 64-thread PS5 wave as
two physical groups of 32 threads. It will run in 2 vulkan subgroups and joined by using the sharing state. 

Kyty connects both halves using shared workgroup data and synchronization.
This allows supported shaders to keep their wave64 behaviour, including
EXEC/VCC masks, scalar branch decisions, LDS visibility and several
cross-lane instructions.

**3. Legacy wave32 fallback**
If a shader cannot safely use the logical wave64 implementation, Kyty can
recompile it as two separate wave32 groups.

This is not an exact replacement for wave64. It is a compatibility fallback
for shaders that currently cannot be handled by the logical path. In practice,
this can allow a shader to continue working instead of stopping the emulator.

Before choosing a path, Kyty analyzes the shader and checks which wave
operations and control flow it uses. Logical wave64 is only selected when the
shader can be handled safely. Unsupported cases are kept out of that path
instead of silently compiling them with incorrect behaviour.

The selected wave mode is also included in the shader and pipeline cache
identity. This prevents a shader compiled for one mode from accidentally
reusing a cached version made for another mode.

Testing:
- Built kyty_emulator successfully from this branch alone.
- Built and ran shader_cfg_tests successfully.
- Added policy and logical-wave CFG coverage.