### PR TITLE
gpu: preflight overlapping buffer descriptor ranges

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -526,6 +526,23 @@ BufferBinding BufferCache::ObtainBuffer(CommandBuffer& command, uint64_t vaddr, 
 	return {owner, owner->Handle(), offset};
 }
 
+void BufferCache::PrepareBufferRanges(CommandBuffer& command,
+                                      std::span<const BufferRange> ranges) {
+	if (command.IsInvalid() || command.IsExecute()) {
+		EXIT("BufferCache: buffer range preparation requires a recording command buffer\n");
+	}
+	for (const auto& range: ranges) {
+		if (range.address == 0 || range.size == 0) {
+			continue;
+		}
+		if (range.address >= TRACKER_ADDRESS_SIZE ||
+		    range.size > TRACKER_ADDRESS_SIZE - range.address) {
+			EXIT("BufferCache: invalid prepared buffer range\n");
+		}
+		(void)GetOrCreateBuffer(command, range.address, range.size);
+	}
+}
+
 std::shared_ptr<Buffer> BufferCache::ObtainNullBuffer() {
 	if (m_null_buffer != nullptr) {
 		return m_null_buffer;

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.h
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.h
@@ -26,6 +26,11 @@ struct BufferBinding {
 	uint64_t              offset = 0;
 };
 
+struct BufferRange {
+	uint64_t address = 0;
+	uint64_t size    = 0;
+};
+
 struct ImageBufferSource {
 	Buffer*  buffer = nullptr;
 	uint64_t offset = 0;
@@ -49,6 +54,7 @@ public:
 	[[nodiscard]] BufferBinding ObtainBuffer(CommandBuffer& command, uint64_t vaddr, uint64_t size,
 	                                         bool is_written = false, bool is_read = true,
 	                                         bool is_formatted = false);
+	void PrepareBufferRanges(CommandBuffer& command, std::span<const BufferRange> ranges);
 	[[nodiscard]] StreamBuffer& GetUtilityBuffer(MemoryUsage usage) noexcept;
 	[[nodiscard]] Buffer&       GetGdsBuffer() noexcept { return m_gds_buffer; }
 	[[nodiscard]] const Buffer& GetGdsBuffer() const noexcept { return m_gds_buffer; }

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -27,6 +27,7 @@
 #include "graphics/shader/recompiler/ir/ResourceMaterialization.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 #include "graphics/shader/shader.h"
+#include "kernel/memory.h"
 
 #include <algorithm>
 #include <atomic>
@@ -78,6 +79,57 @@ static bool IsMultisampledTexture(Prospero::ImageType type) {
 	       type == Prospero::ImageType::kColor2DMsaaArray;
 }
 
+static BufferRange StorageBufferRange(RenderContext& context,
+                                      const ShaderBufferResource& descriptor) {
+	const auto address = descriptor.Base48();
+	const auto stride  = descriptor.Stride();
+	const auto records = descriptor.NumRecords();
+	if (stride != 0 && records > UINT64_MAX / stride) {
+		EXIT("storage buffer descriptor footprint overflow\n");
+	}
+	const auto requested_size = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
+	if (address == 0 || requested_size == 0) {
+		return {};
+	}
+	const auto size       = Libs::LibKernel::Memory::ClampRangeSize(address, requested_size);
+	const auto& graphics  = context.GetGraphics();
+	const auto  alignment = graphics.StorageMinAlignment();
+	if (alignment == 0 || size == 0 ||
+	    size > graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange) {
+		EXIT("storage buffer range or device alignment is unsupported\n");
+	}
+	return {.address = address, .size = size};
+}
+
+static BufferRange AddressBufferRange(
+    RenderContext& context, const ShaderRecompiler::IR::AddressResource& resource,
+    const ShaderRecompiler::IR::ResourceSnapshot::Address& address) {
+	if (address.binding_base == 0) {
+		return {};
+	}
+	if (resource.written) {
+		EXIT("writable address resources are unsupported\n");
+	}
+	const auto limit =
+	    resource.kind == ShaderRecompiler::IR::ResourceKind::Flat
+	        ? ShaderRecompiler::IR::FlatAddressWindowSize
+	        : static_cast<uint64_t>(
+	              context.GetGraphics().GetPhysicalDeviceProperties().limits.maxStorageBufferRange);
+	uint64_t size = 0;
+	if (!HostMemoryQueryRange(address.binding_base, limit, HostMemoryAccess::Mapped, size)) {
+		EXIT("address resource is not host-accessible: base=0x%016" PRIx64 "\n",
+		     address.binding_base);
+	}
+	const auto& graphics  = context.GetGraphics();
+	const auto  alignment = graphics.StorageMinAlignment();
+	if (alignment == 0 || size == 0 ||
+	    size > graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange ||
+	    BufferCache::GetBufferOffset(address.binding_base) % alignment != 0) {
+		EXIT("address resource range or alignment is unsupported\n");
+	}
+	return {.address = address.binding_base, .size = size};
+}
+
 static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& command_buffer,
                                       const ShaderBufferResource&                 descriptor,
                                       const ShaderRecompiler::IR::BufferResource& resource,
@@ -85,23 +137,15 @@ static BufferView NativeStorageBuffer(RenderContext& context, CommandBuffer& com
 	BufferView result;
 	buffer_offset = 0;
 
-	const auto address = descriptor.Base48();
-	const auto stride  = descriptor.Stride();
-	const auto records = descriptor.NumRecords();
-	if (stride != 0 && records > UINT64_MAX / stride) {
-		EXIT("storage buffer descriptor footprint overflow\n");
-	}
-	const auto size = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
-	if (address == 0 || size == 0) {
+	const auto range = StorageBufferRange(context, descriptor);
+	if (range.address == 0) {
 		BindNullStorageBuffer(context, result);
 		return result;
 	}
+	const auto address = range.address;
+	const auto size    = range.size;
 	const auto& graphics  = context.GetGraphics();
 	const auto  alignment = graphics.StorageMinAlignment();
-	if (alignment == 0 ||
-	    size > graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange) {
-		EXIT("storage buffer range or device alignment is unsupported\n");
-	}
 	auto binding = context.GetBufferCache().ObtainBuffer(
 	    command_buffer, address, size, resource.written, resource.read, resource.formatted);
 	const auto aligned_offset = binding.offset - binding.offset % alignment;
@@ -123,38 +167,35 @@ NativeAddressBuffer(RenderContext& context, CommandBuffer& command_buffer,
                     const ShaderRecompiler::IR::AddressResource&           resource,
                     const ShaderRecompiler::IR::ResourceSnapshot::Address& address) {
 	BufferView result;
-	if (address.binding_base == 0) {
+	const auto range = AddressBufferRange(context, resource, address);
+	if (range.address == 0) {
 		BindNullStorageBuffer(context, result);
 		return result;
 	}
-	if (resource.written) {
-		EXIT("writable address resources are unsupported\n");
-	}
-	const auto limit =
-	    resource.kind == ShaderRecompiler::IR::ResourceKind::Flat
-	        ? ShaderRecompiler::IR::FlatAddressWindowSize
-	        : static_cast<uint64_t>(
-	              context.GetGraphics().GetPhysicalDeviceProperties().limits.maxStorageBufferRange);
-	uint64_t   size   = 0;
-	const auto access = HostMemoryAccess::Mapped;
-	if (!HostMemoryQueryRange(address.binding_base, limit, access, size)) {
-		EXIT("address resource is not host-accessible: base=0x%016" PRIx64 "\n",
-		     address.binding_base);
-	}
-	const auto& graphics  = context.GetGraphics();
-	const auto  alignment = graphics.StorageMinAlignment();
-	if (alignment == 0 ||
-	    size > graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange ||
-	    BufferCache::GetBufferOffset(address.binding_base) % alignment != 0) {
-		EXIT("address resource range or alignment is unsupported\n");
-	}
-	auto binding =
-	    context.GetBufferCache().ObtainBuffer(command_buffer, address.binding_base, size);
+	auto binding = context.GetBufferCache().ObtainBuffer(command_buffer, range.address, range.size);
 	result.owner  = std::move(binding.owner);
 	result.buffer = binding.buffer;
 	result.offset = binding.offset;
-	result.range  = static_cast<vk::DeviceSize>(size);
+	result.range  = static_cast<vk::DeviceSize>(range.size);
 	return result;
+}
+
+static void CollectNativeBufferRanges(RenderContext& context,
+                                      const DescriptorCache::PreparedBindings& prepared,
+                                      std::vector<BufferRange>& ranges) {
+	EXIT_IF(prepared.program == nullptr || prepared.snapshot == nullptr);
+	const auto& program  = *prepared.program;
+	const auto& snapshot = *prepared.snapshot;
+	ranges.reserve(ranges.size() + program.info.buffers.size() + program.info.addresses.size());
+	for (uint32_t i = 0; i < program.info.buffers.size(); i++) {
+		ShaderBufferResource descriptor;
+		CopyNativeDescriptor(snapshot.buffers[i], descriptor.fields);
+		ranges.push_back(StorageBufferRange(context, descriptor));
+	}
+	for (uint32_t i = 0; i < program.info.addresses.size(); i++) {
+		ranges.push_back(
+		    AddressBufferRange(context, program.info.addresses[i], snapshot.addresses[i]));
+	}
 }
 
 static bool IsSupportedSampledColorResource(const ShaderRecompiler::IR::ImageResource& resource) {
@@ -859,6 +900,9 @@ void RenderExecutor::RebindBuffers(CommandBuffer&                     buffer,
 	const auto& snapshot  = *prepared.snapshot;
 	auto&       resources = prepared.resources;
 	const auto& layout    = program.bindings;
+	std::vector<BufferRange> ranges;
+	CollectNativeBufferRanges(m_context, prepared, ranges);
+	m_context.GetBufferCache().PrepareBufferRanges(buffer, ranges);
 
 	resources.buffers.clear();
 	resources.buffers.reserve(program.info.buffers.size());
@@ -918,11 +962,19 @@ RenderExecutor::PrepareGraphicsBindings(CommandBuffer& buffer, const ShaderStage
 	    .vertex = PrepareBindings(buffer, vertex, vk::ShaderStageFlagBits::eVertex,
 	                              DescriptorCache::Stage::Vertex),
 	};
-	RebindBuffers(buffer, bindings.vertex);
-	RebindImages(buffer, bindings.vertex);
 	if (pixel_active) {
 		bindings.pixel.emplace(PrepareBindings(buffer, pixel, vk::ShaderStageFlagBits::eFragment,
 		                                       DescriptorCache::Stage::Pixel));
+	}
+	std::vector<BufferRange> ranges;
+	CollectNativeBufferRanges(m_context, bindings.vertex, ranges);
+	if (bindings.pixel.has_value()) {
+		CollectNativeBufferRanges(m_context, *bindings.pixel, ranges);
+	}
+	m_context.GetBufferCache().PrepareBufferRanges(buffer, ranges);
+	RebindBuffers(buffer, bindings.vertex);
+	RebindImages(buffer, bindings.vertex);
+	if (bindings.pixel.has_value()) {
 		RebindBuffers(buffer, *bindings.pixel);
 		RebindImages(buffer, *bindings.pixel);
 	}

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -2491,6 +2491,43 @@ public:
 			        !cache.IsRegionRegistered(index_begin, index_span),
 			        "unmapped Buffer owner remained in the registered-range index");
 
+			constexpr uint64_t prepared_offset = 0x300000;
+			const uint64_t prepared_base = base + prepared_offset;
+			const std::array<BufferRange, 2> prepared_ranges {{
+			    {.address = prepared_base + 0x480, .size = 0x1000},
+			    {.address = prepared_base, .size = 0x5000},
+			}};
+			cache.PrepareBufferRanges(scheduler.Current(), prepared_ranges);
+			auto prepared_inner = cache.ObtainBuffer(
+			    scheduler.Current(), prepared_base + 0x480, 0x1000, true, true);
+			auto prepared_outer =
+			    cache.ObtainBuffer(scheduler.Current(), prepared_base, 0x5000, false, true);
+			Require(name, "prepared overlapping ranges",
+			        prepared_inner.owner != nullptr && prepared_outer.owner != nullptr &&
+			            prepared_inner.buffer == prepared_outer.buffer &&
+			            prepared_inner.offset == prepared_outer.offset + 0x480,
+			        "preflight published stale native views for overlapping guest ranges");
+			scheduler.Current().RetainResourceUntilFence(prepared_inner.owner);
+			scheduler.Current().RetainResourceUntilFence(prepared_outer.owner);
+
+			constexpr uint64_t reverse_offset = 0x380000;
+			const uint64_t reverse_base = base + reverse_offset;
+			const std::array<BufferRange, 2> reverse_ranges {{
+			    {.address = reverse_base, .size = 0x5000},
+			    {.address = reverse_base + 0x480, .size = 0x1000},
+			}};
+			cache.PrepareBufferRanges(scheduler.Current(), reverse_ranges);
+			auto reverse_outer =
+			    cache.ObtainBuffer(scheduler.Current(), reverse_base, 0x5000, false, true);
+			auto reverse_inner = cache.ObtainBuffer(
+			    scheduler.Current(), reverse_base + 0x480, 0x1000, true, true);
+			Require(name, "reverse prepared overlapping ranges",
+			        reverse_inner.buffer == reverse_outer.buffer &&
+			            reverse_inner.offset == reverse_outer.offset + 0x480,
+			        "reverse preflight order changed native buffer ownership");
+			scheduler.Current().RetainResourceUntilFence(reverse_inner.owner);
+			scheduler.Current().RetainResourceUntilFence(reverse_outer.owner);
+
 			MarkGpuWrite(base + first_offset, sizeof(first_value));
 			MarkGpuWrite(base + second_offset, sizeof(second_value));
 			cache.FillBuffer(base + first_offset, sizeof(first_value), first_value);


### PR DESCRIPTION
This fixes stale Vulkan buffer views when multiple guest descriptors refer to overlapping memory ranges. This broke the coefficient data passed between the guest Bink compute shaders, producing corrupted luma and chroma output. This fixed the .bk2 video corruption. 

Creating a larger native buffer can replace an earlier cached allocation. If a view was published before that replacement, one dispatch could use two different VkBuffer objects for overlapping guest memory.

The new preflight resolves all buffer and address ranges before descriptor views are published. Overlapping descriptors therefore refer to the same final native allocation with the correct relative offsets.

Testing:
- Added focused tests for inner/enclosing ranges and reversed acquisition order.
- Built shader_recompiler_compute_tests successfully.
- The new preflight tests pass before the existing unrelated multisample-depth baseline failure.