### PR TITLE
shader: storage image formats, VS/PS interface fix and scalar decode implementations

### DIFF
--- a/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
@@ -18,6 +18,8 @@
 #include "graphics/shader/shader.h"
 
 #include <algorithm>
+#include <atomic>
+#include <cstdio>
 #include <limits>
 #include <span>
 
@@ -466,6 +468,106 @@ void CreatePipelineInternal(
     const PipelineStaticParameters& static_params, uint32_t vs_hash0, uint32_t vs_crc32,
     uint32_t ps_hash0, uint32_t ps_crc32, bool ps_active) {
 	EXIT_IF(ps_active && ps_input_info == nullptr);
+
+	if (ps_active && vs_input_info.stage && ps_input_info->stage) {
+		const auto& vs_info = vs_input_info.stage.program->info;
+		const auto& ps_info = ps_input_info->stage.program->info;
+		std::array<uint32_t, 32> active {};
+		uint32_t                 active_count = 0;
+		for (const auto& input: ps_info.inputs) {
+			if (input.kind == ShaderRecompiler::IR::StageInputKind::Parameter) {
+				active[active_count++] = input.location;
+			}
+		}
+		std::string vs_out;
+		for (const auto& output: vs_info.outputs) {
+			if (output.kind == ShaderRecompiler::IR::StageOutputKind::Parameter) {
+				vs_out += fmt::format("{}(idx{}) ", output.location, output.index);
+			}
+		}
+		std::string ps_in;
+		bool        missing = false;
+		for (uint32_t i = 0; i < active_count; i++) {
+			const auto location = ShaderPixelParameterLocation(
+			    *ps_input_info, {active.data(), active_count}, active[i]);
+			const bool found = std::any_of(
+			    vs_info.outputs.begin(), vs_info.outputs.end(), [&](const auto& output) {
+				    return output.kind == ShaderRecompiler::IR::StageOutputKind::Parameter &&
+				           output.location == location;
+			    });
+			bool used = false;
+			for (const auto& block: ps_input_info->stage.program->blocks) {
+				for (const auto& inst: block.instructions) {
+					used |= inst.op == ShaderRecompiler::IR::Opcode::LoadInputF32 &&
+					        inst.input_info.attr == active[i];
+				}
+			}
+			const bool synthesized =
+			    location < 32 &&
+			    (vs_input_info.required_param_locations & (1u << location)) != 0;
+			missing |= !found && !synthesized;
+			ps_in += fmt::format("{}->{}{}{} ", active[i], location,
+			                     found ? "" : (synthesized ? "!ZEROED" : "!MISSING"),
+			                     used ? "[READ]" : "[unread]");
+		}
+		if (missing) {
+			std::string interp;
+			for (uint32_t i = 0; i < ps_input_info->input_num && i < 32; i++) {
+				interp += fmt::format("{:#x} ", ps_input_info->interpolator_settings[i]);
+			}
+			const auto target_name = [](ShaderRecompiler::IR::ExportTargetKind kind) {
+				switch (kind) {
+					case ShaderRecompiler::IR::ExportTargetKind::Null: return "null";
+					case ShaderRecompiler::IR::ExportTargetKind::Position: return "pos";
+					case ShaderRecompiler::IR::ExportTargetKind::Primitive: return "prim";
+					case ShaderRecompiler::IR::ExportTargetKind::Parameter: return "param";
+					case ShaderRecompiler::IR::ExportTargetKind::Mrt: return "mrt";
+					case ShaderRecompiler::IR::ExportTargetKind::MrtZ: return "mrtz";
+					default: return "unknown";
+				}
+			};
+			std::string vs_exports;
+			size_t      vs_instructions = 0;
+			for (const auto& block: vs_input_info.stage.program->blocks) {
+				vs_instructions += block.instructions.size();
+				for (const auto& inst: block.instructions) {
+					if (inst.op != ShaderRecompiler::IR::Opcode::Export) {
+						continue;
+					}
+					const auto& e = inst.export_info;
+					vs_exports += fmt::format("{}[{}]tgt{} en=0x{:x}{}{} ", target_name(e.kind),
+					                          e.index, e.target, e.en, e.done ? " done" : "",
+					                          e.compr ? " compr" : "");
+				}
+			}
+			if (vs_exports.empty()) {
+				vs_exports = "(none decoded)";
+			}
+			const auto& vs_program = *vs_input_info.stage.program;
+			std::string vs_cfg;
+			for (const auto& block: vs_program.blocks) {
+				vs_cfg += fmt::format("b{}[{:#x}..{:#x}] term={} succ={}; ", block.id,
+				                      block.start_pc, block.end_pc,
+				                      static_cast<uint32_t>(block.terminator.kind),
+				                      block.successors.size());
+			}
+			LOGF("SPIR-V interface mismatch: vs_exports: %s\n", vs_exports.c_str());
+			std::printf("SPIR-V interface mismatch: vs_blocks=%zu vs_instructions=%zu "
+			            "cfg_failure=%u wave=%u stage=%u fallback='%s'\n"
+			            "  vs_exports: %s\n  vs_cfg: %s\n",
+			            vs_program.blocks.size(), vs_instructions,
+			            static_cast<uint32_t>(vs_program.cfg_failure_kind), vs_program.wave_size,
+			            static_cast<uint32_t>(vs_program.stage), vs_program.fallback_reason.c_str(),
+			            vs_exports.c_str(), vs_cfg.c_str());
+			EXIT("SPIR-V interface mismatch: vs_hash=0x%08x ps_hash=0x%08x ps_input_num=%u "
+			     "vs_export_count=%d vs_param_mask=0x%08x rect_list=%d\n  vs_outputs: %s\n  "
+			     "ps_inputs: %s\n  interp: %s\n",
+			     vs_hash0, ps_hash0, ps_input_info->input_num, vs_input_info.export_count,
+			     vs_input_info.param_export_mask,
+			     static_cast<int>(static_params.topology == vk::PrimitiveTopology::ePatchList),
+			     vs_out.c_str(), ps_in.c_str(), interp.c_str());
+		}
+	}
 
 	const bool rect_list = static_params.topology == vk::PrimitiveTopology::ePatchList;
 

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -955,9 +955,25 @@ static void RefreshShaders(RenderCommandBuffer& buffer, const DrawCallInfo& draw
 	if (log_phases) {
 		LogDrawPhase(draw.name, "ShaderCompileInfoPS");
 	}
-	if (!ShaderCompileInfoPS(pixel_shader_info, shader_regs, lane_mask_mode, state.vs_input_info,
-	                         target_export_mapping, state.ps_input_info, state.ps_shader)) {
+	const bool ps_ok = [&] {
+		return ShaderCompileInfoPS(pixel_shader_info, shader_regs, lane_mask_mode,
+		                           state.vs_input_info, target_export_mapping, state.ps_input_info,
+		                           state.ps_shader);
+	}();
+	if (!ps_ok) {
 		EXIT("ShaderCompileInfoPS failed for draw %s\n", draw.name);
+	}
+
+	const uint32_t missing_param_locations =
+	    ShaderPixelParameterLocationMask(state.ps_input_info) & ~state.vs_input_info.param_export_mask;
+	if (missing_param_locations != 0) {
+		if (log_phases) {
+			LogDrawPhase(draw.name, "ShaderCompileInfoVS(unexported parameters)");
+		}
+		if (!ShaderCompileInfoVS(vertex_shader_info, shader_regs, lane_mask_mode,
+		                         state.vs_input_info, state.vs_shader, missing_param_locations)) {
+			EXIT("ShaderCompileInfoVS failed for draw %s\n", draw.name);
+		}
 	}
 }
 

--- a/src/graphics/shader/recompiler/decompiler/ScalarAluOps.cpp
+++ b/src/graphics/shader/recompiler/decompiler/ScalarAluOps.cpp
@@ -74,7 +74,8 @@ constexpr OpcodeMap SOPP_OPS[] = {
     {0x04u, Opcode::SCbranchScc0},  {0x05u, Opcode::SCbranchScc1},  {0x06u, Opcode::SCbranchVccz},
     {0x07u, Opcode::SCbranchVccnz}, {0x08u, Opcode::SCbranchExecz}, {0x09u, Opcode::SCbranchExecnz},
     {0x0au, Opcode::SBarrier},      {0x0cu, Opcode::SWaitcnt},      {0x0eu, Opcode::SSleep},
-    {0x10u, Opcode::SSendmsg},      {0x16u, Opcode::STtraceData},   {0x20u, Opcode::SInstPrefetch},
+    {0x10u, Opcode::SSendmsg},      {0x16u, Opcode::STtraceData},   {0x1fu, Opcode::SCodeEnd},
+    {0x20u, Opcode::SInstPrefetch},
 };
 static_assert(Detail::HasUniqueEncodings(SOP1_OPS));
 static_assert(Detail::HasUniqueEncodings(SOP2_OPS));

--- a/src/graphics/shader/recompiler/decompiler/ShaderDecoder.cpp
+++ b/src/graphics/shader/recompiler/decompiler/ShaderDecoder.cpp
@@ -241,6 +241,12 @@ bool DecodeScalarSource(uint32_t code, uint32_t pc, Operand& operand, std::strin
 		return DecodeVectorGpr(code - 256u, operand, error);
 	}
 
+	if (code >= 108u && code <= 123u) {
+		operand.kind = OperandKind::Ttmp;
+		operand.reg  = code - 108u;
+		return true;
+	}
+
 	switch (code) {
 		case 106u: operand.kind = OperandKind::VccLo; return true;
 		case 107u: operand.kind = OperandKind::VccHi; return true;
@@ -273,6 +279,12 @@ bool DecodeScalarDestination(uint32_t code, uint32_t pc, Operand& operand, std::
 	if (code <= 105u) {
 		operand.kind = OperandKind::Sgpr;
 		operand.reg  = code;
+		return true;
+	}
+
+	if (code >= 108u && code <= 123u) {
+		operand.kind = OperandKind::Ttmp;
+		operand.reg  = code - 108u;
 		return true;
 	}
 
@@ -966,6 +978,7 @@ std::string OperandToString(const Operand& operand) {
 		case OperandKind::ExecZ: text = "execz"; break;
 		case OperandKind::Scc: text = "scc"; break;
 		case OperandKind::M0: text = "m0"; break;
+		case OperandKind::Ttmp: text = fmt::format("ttmp{}", operand.reg); break;
 		case OperandKind::PopsExitingWaveId: text = "pops_exiting_wave_id"; break;
 		case OperandKind::Null: text = "null"; break;
 		default: text = "unknown"; break;

--- a/src/graphics/shader/recompiler/decompiler/ShaderDecoder.cpp
+++ b/src/graphics/shader/recompiler/decompiler/ShaderDecoder.cpp
@@ -402,6 +402,10 @@ bool DecodeProgram(std::span<const uint32_t> code, Program& program, std::string
 		if (IsControlFlowBranch(inst.opcode)) {
 			branch_targets.insert(inst.branch_target);
 		}
+		if (inst.opcode == Opcode::SCodeEnd) {
+			program.instructions.pop_back();
+			return true;
+		}
 		if (inst.opcode == Opcode::SEndpgm &&
 		    (word_index >= code.size() || !branch_targets.contains(word_index * 4u))) {
 			return true;
@@ -936,6 +940,7 @@ std::string OpcodeToString(Opcode opcode) {
 		case Opcode::SSleep: return "s_sleep";
 		case Opcode::STtraceData: return "s_ttracedata";
 		case Opcode::SInstPrefetch: return "s_inst_prefetch";
+		case Opcode::SCodeEnd: return "s_code_end";
 		case Opcode::SEndpgm: return "s_endpgm";
 		case Opcode::Exp: return "exp";
 		case Opcode::Unsupported: return "unsupported";

--- a/src/graphics/shader/recompiler/decompiler/ShaderDecoder.h
+++ b/src/graphics/shader/recompiler/decompiler/ShaderDecoder.h
@@ -537,6 +537,7 @@ enum class Opcode {
 	STtraceData,
 	SInstPrefetch,
 	SEndpgm,
+	SCodeEnd,
 	Exp
 };
 

--- a/src/graphics/shader/recompiler/decompiler/ShaderDecoder.h
+++ b/src/graphics/shader/recompiler/decompiler/ShaderDecoder.h
@@ -558,6 +558,7 @@ enum class OperandKind {
 	PopsExitingWaveId,
 	Null,
 	Vgpr,
+	Ttmp,
 };
 
 enum ImageSampleFlag : uint32_t {

--- a/src/graphics/shader/recompiler/emitter/SpirvEmitter.cpp
+++ b/src/graphics/shader/recompiler/emitter/SpirvEmitter.cpp
@@ -120,6 +120,10 @@ bool IsDsWrite(IR::Opcode op) {
 	}
 }
 
+} // namespace
+
+namespace Emitter {
+
 bool IsAtomic(IR::Opcode op) {
 	switch (op) {
 		case IR::Opcode::AtomicSwapU32:
@@ -137,6 +141,10 @@ bool IsAtomic(IR::Opcode op) {
 		default: return false;
 	}
 }
+
+} // namespace Emitter
+
+namespace {
 
 uint32_t BufferAddressOperandCount(const IR::Instruction& inst) {
 	return 1u + (inst.memory.idxen ? 1u : 0u) + (inst.memory.offen ? 1u : 0u);
@@ -211,7 +219,7 @@ bool ValidateInstructionContract(const IR::Instruction& inst, std::string* error
 	    (kind != IR::ResourceKind::Buffer || inst.src_count != buffer_address_count + 1u)) {
 		return Fail(error, "floating-point atomic instruction must target a buffer");
 	}
-	if (IsAtomic(inst.op) &&
+	if (Emitter::IsAtomic(inst.op) &&
 	    !((kind == IR::ResourceKind::Buffer && inst.src_count == buffer_address_count + 1u) ||
 	      ((kind == IR::ResourceKind::Lds || kind == IR::ResourceKind::Gds) &&
 	       inst.memory.resource == 0 && inst.src_count == 2 &&

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterAnalysis.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterAnalysis.cpp
@@ -255,6 +255,32 @@ void CopyProgramInputsAndOutputs(EmitterState& state, const IR::Program& program
 		}
 		state.outputs.push_back({output.kind, output.index, output.location, 0, output.debug_name});
 	}
+	AddSyntheticParameterOutputs(state);
+}
+
+void AddSyntheticParameterOutputs(EmitterState& state) {
+	if (state.stage != ShaderType::Vertex || state.vertex_input_info == nullptr) {
+		return;
+	}
+	const auto required = state.vertex_input_info->required_param_locations;
+	if (required == 0) {
+		return;
+	}
+	for (uint32_t location = 0; location < 32; location++) {
+		if ((required & (1u << location)) == 0) {
+			continue;
+		}
+		const bool exported = std::any_of(
+		    state.outputs.begin(), state.outputs.end(), [location](const OutputBinding& binding) {
+			    return binding.kind == IR::StageOutputKind::Parameter &&
+			           binding.location == location;
+		    });
+		if (exported) {
+			continue;
+		}
+		state.outputs.push_back({IR::StageOutputKind::Parameter, location, location, 0,
+		                         "out_param_" + std::to_string(location) + "_unexported", true});
+	}
 }
 
 uint32_t OutputVariableForExport(const EmitterState& state, const IR::ExportInfo& exp) {

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterControlFlow.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterControlFlow.cpp
@@ -1100,6 +1100,22 @@ void EmitDispatcherFunction(EmitterState& state, const IR::Program& program) {
 	EmitDispatcherLoopTail(state);
 }
 
+void EmitSyntheticParameterOutputStores(EmitterState& state) {
+	uint32_t zero_vec4 = 0;
+	for (const auto& binding: state.outputs) {
+		if (!binding.synthetic || binding.variable_id == 0) {
+			continue;
+		}
+		if (zero_vec4 == 0) {
+			const auto zero = ConstantF32Value(state, 0.0F);
+			zero_vec4       = state.builder.AllocateId();
+			state.builder.AddType(
+			    {OpConstantComposite, state.vec4_float_type, zero_vec4, zero, zero, zero, zero});
+		}
+		state.builder.AddFunction({OpStore, binding.variable_id, zero_vec4});
+	}
+}
+
 void EmitFunction(EmitterState& state, const IR::Program& program) {
 	state.builder.AddFunction(
 	    {OpFunction, state.void_type, state.main_func, FunctionControlNone, state.func_type});
@@ -1110,6 +1126,7 @@ void EmitFunction(EmitterState& state, const IR::Program& program) {
 	EmitPixelInputRegisters(state);
 	EmitVertexInputRegisters(state);
 	EmitStorageBufferOffsets(state);
+	EmitSyntheticParameterOutputStores(state);
 	if (state.dispatcher_fallback) {
 		EmitDispatcherFunction(state, program);
 		state.builder.AddFunction({OpFunctionEnd});

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
@@ -700,6 +700,8 @@ uint32_t MakeSampledImage(EmitterState& state, const IR::MemoryInfo& mem, uint32
 ImageViewKind StorageImageViewKind(const EmitterState& state, const IR::MemoryInfo& mem,
                                    bool uint_image, uint32_t use_pc);
 
+bool IsAtomic(IR::Opcode op);
+
 uint32_t StorageImageDescriptorPointer(EmitterState& state, uint32_t resource, bool uint_image,
                                        uint32_t      use_pc = UINT32_MAX,
                                        ImageViewKind view   = ImageViewKind::Dim2D);

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterInternal.h
@@ -284,6 +284,7 @@ struct OutputBinding {
 	uint32_t            location    = 0;
 	uint32_t            variable_id = 0;
 	std::string         debug_name;
+	bool                synthetic = false;
 };
 
 struct DescriptorResourceBinding {
@@ -633,6 +634,8 @@ void CollectRegisters(const IR::Program& program, std::vector<RegisterBinding>& 
 bool HasOutput(const std::vector<OutputBinding>& outputs, IR::StageOutputKind kind, uint32_t index);
 
 void CopyProgramInputsAndOutputs(EmitterState& state, const IR::Program& program);
+void AddSyntheticParameterOutputs(EmitterState& state);
+void EmitSyntheticParameterOutputStores(EmitterState& state);
 
 uint32_t OutputVariableForExport(const EmitterState& state, const IR::ExportInfo& exp);
 

--- a/src/graphics/shader/recompiler/emitter/spirvEmitterModule.cpp
+++ b/src/graphics/shader/recompiler/emitter/spirvEmitterModule.cpp
@@ -395,6 +395,25 @@ void AddVsharpAnnotationsAndNames(EmitterState& state) {
 	}
 }
 
+static bool StorageImageNeedsConcreteFormat(const EmitterState& state, ImageViewKind view,
+                                            bool integer) {
+	if (!integer) {
+		return false;
+	}
+	for (const auto& block: state.program.blocks) {
+		for (const auto& inst: block.instructions) {
+			if (!IsAtomic(inst.op) ||
+			    inst.memory.kind != IR::ResourceKind::StorageImageUint) {
+				continue;
+			}
+			if (StorageImageViewKind(state, inst.memory, true, inst.pc) == view) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 void EmitHeaderAndTypes(EmitterState& state) {
 	state.void_type                    = state.builder.AllocateId();
 	state.bool_type                    = state.builder.AllocateId();
@@ -484,8 +503,7 @@ void EmitHeaderAndTypes(EmitterState& state) {
 	if (state.needs_image_gather_extended) {
 		state.builder.AddCapability({CapabilityImageGatherExtended});
 	}
-	if (std::any_of(state.storage_images.begin(),
-	                state.storage_images.begin() + StorageImageViewKindCount,
+	if (std::any_of(state.storage_images.begin(), state.storage_images.end(),
 	                [](const auto& image) { return image.variable != 0; })) {
 		state.builder.AddCapability({CapabilityStorageImageReadWithoutFormat});
 		state.builder.AddCapability({CapabilityStorageImageWriteWithoutFormat});
@@ -765,7 +783,9 @@ void EmitHeaderAndTypes(EmitterState& state) {
 		const auto view      = static_cast<ImageViewKind>(i % StorageImageViewKindCount);
 		const bool integer   = i >= StorageImageViewKindCount;
 		const auto component = integer ? state.uint_type : state.float_type;
-		const auto format    = integer ? ImageFormatR32ui : ImageFormatUnknown;
+		const auto format =
+		    StorageImageNeedsConcreteFormat(state, view, integer) ? ImageFormatR32ui
+		                                                          : ImageFormatUnknown;
 		state.builder.AddType({OpTypeImage, image.image_type, component, ImageSpirvDimension(view),
 		                       0, ImageSpirvArrayed(view), 0, 2, format});
 		state.builder.AddType(

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -81,6 +81,31 @@ bool ShaderPixelParameterIsFlat(const ShaderPixelInputInfo& info, uint32_t input
 	return input < info.input_num && (info.interpolator_settings[input] & PsInputFlatShade) != 0;
 }
 
+uint32_t ShaderPixelParameterLocationMask(const ShaderPixelInputInfo& info) {
+	if (!info.stage || info.stage.program == nullptr) {
+		return 0;
+	}
+
+	std::array<uint32_t, 32> active {};
+	uint32_t                 active_count = 0;
+	for (const auto& input: info.stage.program->info.inputs) {
+		if (input.kind == ShaderRecompiler::IR::StageInputKind::Parameter &&
+		    active_count < active.size()) {
+			active[active_count++] = input.location;
+		}
+	}
+
+	uint32_t mask = 0;
+	for (uint32_t i = 0; i < active_count; i++) {
+		const auto location =
+		    ShaderPixelParameterLocation(info, {active.data(), active_count}, active[i]);
+		if (location < 32) {
+			mask |= 1u << location;
+		}
+	}
+	return mask;
+}
+
 struct ShaderBinaryInfo {
 	uint8_t  signature[7];
 	uint8_t  version;
@@ -1105,12 +1130,13 @@ static std::span<const uint32_t> AddShaderProgramPermutation(const char* stage,
 
 bool ShaderCompileInfoVS(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
                          ShaderLaneMaskMode lane_mask_mode, ShaderVertexInputInfo& info,
-                         std::span<const uint32_t>& spirv) {
+                         std::span<const uint32_t>& spirv, uint32_t required_param_locations) {
 	spirv = {};
 
 	if (!ShaderGetStaticInputInfoVS(regs, sh, info)) {
 		return false;
 	}
+	info.required_param_locations = required_param_locations;
 	const auto shader_hash = regs.gs_regs.chksum;
 	const auto program_id  = ShaderGetIdVS(regs, info, false);
 	const auto key =
@@ -1586,6 +1612,7 @@ ShaderId ShaderGetIdVS(const HW::VertexShaderInfo& regs, const ShaderVertexInput
 	ret.ids.push_back(static_cast<uint32_t>(input_info.fetch_embedded));
 	ret.ids.push_back(input_info.resources_num);
 	ret.ids.push_back(input_info.export_count);
+	ret.ids.push_back(input_info.required_param_locations);
 
 	for (int i = 0; i < input_info.resources_num; i++) {
 		const auto& r  = input_info.resources[i];

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -79,6 +79,7 @@ struct ShaderVertexInputInfo {
 	int                     buffers_num       = 0;
 	int                     export_count      = 0;
 	uint32_t                param_export_mask = 0;
+	uint32_t                required_param_locations = 0;
 	bool                    fetch_external    = false;
 	bool                    fetch_embedded    = false;
 };
@@ -123,6 +124,7 @@ struct ShaderPixelInputInfo {
 };
 
 uint32_t ShaderPixelParameterMappedLocation(const ShaderPixelInputInfo& info, uint32_t input);
+uint32_t ShaderPixelParameterLocationMask(const ShaderPixelInputInfo& info);
 uint32_t ShaderPixelParameterLocation(const ShaderPixelInputInfo& info,
                                       std::span<const uint32_t> active_inputs, uint32_t input);
 bool     ShaderPixelParameterIsFlat(const ShaderPixelInputInfo& info, uint32_t input);
@@ -234,7 +236,8 @@ ShaderId ShaderGetIdCS(const HW::ComputeShaderInfo& regs, const ShaderComputeInp
 // Returned SPIR-V spans are read-only views backed by the shader program cache.
 bool ShaderCompileInfoVS(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
                          ShaderLaneMaskMode lane_mask_mode, ShaderVertexInputInfo& input_info,
-                         std::span<const uint32_t>& spirv);
+                         std::span<const uint32_t>& spirv,
+                         uint32_t required_param_locations = 0);
 bool ShaderCompileInfoPS(const HW::PixelShaderInfo& regs, const HW::ShaderRegisters& sh,
                          ShaderLaneMaskMode lane_mask_mode, const ShaderVertexInputInfo& vs_info,
                          std::span<const Prospero::ColorComponentMapping, 8> target_export_mapping,

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -15208,7 +15208,7 @@ TestCase ImageStoreR32UintUsesUintStorageImage() {
 	test.storage_image_rgba           = MakeRgbaImage(4, 4);
 	test.storage_image_r32ui          = std::vector<u32>(16, 0);
 	test.expected_storage_image_r32ui = expected_image;
-	test.required_spirv               = {"R32ui", "storage_uint_2d"};
+	test.required_spirv               = {"Unknown", "storage_uint_2d"};
 	return test;
 }
 


### PR DESCRIPTION
Four independent shader recompiler bugs fixes. 

## Summary
-  Only declare storage image formats only if it's an atomic and stopped declaring a concrete format that does not match the view
- Made VS/PS interfaces legal when the pixel shader reads parameters that the vertex shader never outputs.
- dump the vertex program on VS/PS interface mismatch and turned silent invalid stages into hard failures.
- stop decoding at s_code_end
- added scalar operand decoding for ttmp0-15

PR follows contribution guidelines and and the windows is build verified


