### PR TITLE
graphics: fix storage stencil writes and sampled depth target layout

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1142,6 +1142,29 @@ void TextureCache::RefreshImage(ImageId id, const ImageDesc& desc) {
 	InitializeImage(id, desc);
 }
 
+void TextureCache::FlushStencilWrite(const std::shared_ptr<Image>& source) {
+	CacheLock lock(*this, m_lock);
+	if (source == nullptr || !source->depth_id) {
+		EXIT("TextureCache: stencil write flush requires an associated image\n");
+	}
+	auto depth = ResolveOwner(source->depth_id);
+	if (depth == nullptr) {
+		EXIT("TextureCache: stencil write flush lost its depth image\n");
+	}
+	if (!depth->info.IsDepth() || !depth->info.HasStencil()) {
+		EXIT("TextureCache: stencil write flush target is not a depth/stencil image\n");
+	}
+	auto& command = m_scheduler.Current();
+	if (command.IsInvalid()) {
+		EXIT("TextureCache: stencil write flush requires a valid command buffer\n");
+	}
+	depth->CopyStencilFromColor(*source, m_buffer_cache.GetUtilityBuffer(MemoryUsage::DeviceLocal));
+	TouchImage(*depth);
+	CommitGpuWrite(*depth);
+	command.RetainResourceUntilFence(source);
+	command.RetainResourceUntilFence(depth);
+}
+
 void TextureCache::AssociateStencil(ImageId depth_id, GuestRange stencil) {
 	CacheLock lock(*this, m_lock);
 	AssociateStencilLocked(depth_id, stencil);
@@ -1315,8 +1338,10 @@ vk::ImageView TextureCache::FindTexture(ImageId id, const ImageDesc& desc) {
 	CacheLock lock(*this, m_lock);
 	auto&     image = ResolveImage(id);
 	TouchImage(image);
+	const bool stencil_write =
+	    desc.type == BindingType::Storage && static_cast<bool>(image.depth_id);
 	if (!image.info.data.Empty()) {
-		if (!image.registered || image.depth_id || image.binding.needs_rebind) {
+		if (!image.registered || (image.depth_id && !stencil_write) || image.binding.needs_rebind) {
 			EXIT("TextureCache: texture requires rediscovery before final acquisition\n");
 		}
 	}
@@ -1330,10 +1355,12 @@ vk::ImageView TextureCache::FindTexture(ImageId id, const ImageDesc& desc) {
 		case BindingType::Texture: break;
 		case BindingType::Storage:
 			if (!image.info.data.Empty()) {
-				if (!image.registered || image.depth_id) {
+				if (!image.registered) {
 					EXIT("TextureCache: cannot acquire an unavailable storage image\n");
 				}
-				CommitGpuWrite(image);
+				if (!stencil_write) {
+					CommitGpuWrite(image);
+				}
 			}
 			TrackImageDownloadLocked(id, image);
 			break;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -62,6 +62,7 @@ public:
 	[[nodiscard]] Image&        GetImage(ImageId id);
 	[[nodiscard]] const Image&  GetImage(ImageId id) const;
 	void                        MarkGpuWritten(ImageId id);
+	void                        FlushStencilWrite(const std::shared_ptr<Image>& source);
 
 	[[nodiscard]] bool ClearImageFromBuffer(CommandBuffer& command, uint64_t address, uint64_t size,
 	                                        uint32_t packed_clear);

--- a/src/graphics/host_gpu/renderer/image/image.cpp
+++ b/src/graphics/host_gpu/renderer/image/image.cpp
@@ -531,6 +531,80 @@ void Image::CopyImageWithBuffer(Image& source, Buffer& buffer) {
 	        vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eTransferRead, {}, command);
 }
 
+void Image::CopyStencilFromColor(Image& source, Buffer& buffer) {
+	EXIT_IF(m_scheduler == nullptr || buffer.Handle() == nullptr);
+	const bool destination_has_stencil =
+	    static_cast<bool>(FullAspectMask(backing.format) & vk::ImageAspectFlagBits::eStencil);
+	if (!destination_has_stencil ||
+	    FullAspectMask(source.backing.format) != vk::ImageAspectFlagBits::eColor ||
+	    source.info.bytes_per_block != 1 || source.backing.samples != 1 || backing.samples != 1 ||
+	    source.backing.image == nullptr || backing.image == nullptr ||
+	    source.backing.mip_levels != 1 || backing.mip_levels != 1 ||
+	    source.backing.image_type != vk::ImageType::e2D ||
+	    backing.image_type != vk::ImageType::e2D ||
+	    source.backing.extent.width != backing.extent.width ||
+	    source.backing.extent.height != backing.extent.height) {
+		EXIT("unsupported stencil plane copy: source_format=%d source_bpb=%u source=%ux%u "
+		     "source_levels=%u source_samples=%u source_type=%d destination_format=%d "
+		     "destination=%ux%u destination_levels=%u destination_samples=%u destination_type=%d\n",
+		     static_cast<int>(source.backing.format), source.info.bytes_per_block,
+		     source.backing.extent.width, source.backing.extent.height, source.backing.mip_levels,
+		     source.backing.samples, static_cast<int>(source.backing.image_type),
+		     static_cast<int>(backing.format), backing.extent.width, backing.extent.height,
+		     backing.mip_levels, backing.samples, static_cast<int>(backing.image_type));
+	}
+	m_scheduler->EndRendering();
+
+	const auto     width         = backing.extent.width;
+	const auto     height        = backing.extent.height;
+	const auto     layers        = std::min(source.backing.layers, backing.layers);
+	const uint64_t row_size      = width;
+	const auto     rows_per_copy = CopyRows(row_size, height, buffer.Size());
+	EXIT_IF(layers == 0 || rows_per_copy == 0);
+
+	vk::BufferMemoryBarrier2 barrier {};
+	barrier.srcStageMask        = vk::PipelineStageFlagBits2::eTransfer;
+	barrier.srcAccessMask       = vk::AccessFlagBits2::eTransferRead;
+	barrier.dstStageMask        = vk::PipelineStageFlagBits2::eTransfer;
+	barrier.dstAccessMask       = vk::AccessFlagBits2::eTransferWrite;
+	barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	barrier.buffer              = buffer.Handle();
+	barrier.offset              = 0;
+	vk::DependencyInfo dependency {};
+	dependency.dependencyFlags          = vk::DependencyFlagBits::eByRegion;
+	dependency.bufferMemoryBarrierCount = 1;
+	dependency.pBufferMemoryBarriers    = &barrier;
+
+	auto command = m_scheduler->Current().Handle();
+	source.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead, {},
+	               command);
+	Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite, {}, command);
+	for (uint32_t layer = 0; layer < layers; layer++) {
+		for (uint32_t row = 0; row < height; row += rows_per_copy) {
+			const auto          copy_height = std::min(rows_per_copy, height - row);
+			vk::BufferImageCopy copy {};
+			copy.imageSubresource = {vk::ImageAspectFlagBits::eColor, 0, layer, 1};
+			copy.imageOffset      = {0, static_cast<int32_t>(row), 0};
+			copy.imageExtent      = {width, copy_height, 1};
+			auto stencil_copy     = copy;
+			stencil_copy.imageSubresource = {vk::ImageAspectFlagBits::eStencil, 0, layer, 1};
+
+			barrier.size          = row_size * copy_height;
+			barrier.srcAccessMask = vk::AccessFlagBits2::eTransferRead;
+			barrier.dstAccessMask = vk::AccessFlagBits2::eTransferWrite;
+			command.pipelineBarrier2(dependency);
+			command.copyImageToBuffer(source.backing.image, vk::ImageLayout::eTransferSrcOptimal,
+			                          buffer.Handle(), copy);
+			barrier.srcAccessMask = vk::AccessFlagBits2::eTransferWrite;
+			barrier.dstAccessMask = vk::AccessFlagBits2::eTransferRead;
+			command.pipelineBarrier2(dependency);
+			command.copyBufferToImage(buffer.Handle(), backing.image,
+			                          vk::ImageLayout::eTransferDstOptimal, stencil_copy);
+		}
+	}
+}
+
 void Image::CopyMip(Image& source, uint32_t mip, uint32_t layer) {
 	EXIT_IF(m_scheduler == nullptr || source.backing.samples != backing.samples ||
 	        mip >= backing.mip_levels || layer >= backing.layers);

--- a/src/graphics/host_gpu/renderer/image/image.h
+++ b/src/graphics/host_gpu/renderer/image/image.h
@@ -55,6 +55,7 @@ struct ImageBinding {
 	bool is_target     = false;
 	bool needs_rebind  = false;
 	bool force_general = false;
+	bool stencil_write = false;
 };
 
 class Image final {
@@ -80,6 +81,7 @@ public:
 	void Resolve(Image& source, const ImageSubresourceRange& source_range,
 	             const ImageSubresourceRange& destination_range);
 	void CopyImageWithBuffer(Image& source, Buffer& buffer);
+	void CopyStencilFromColor(Image& source, Buffer& buffer);
 	void CopyMip(Image& source, uint32_t mip, uint32_t layer);
 
 	void InvalidateCpuWrite(uint64_t vaddr, uint64_t size) {

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -723,7 +723,7 @@ RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageResource&   reso
 	auto       id                  = texture_cache.FindImage(desc);
 	auto*      image               = &texture_cache.GetImage(id);
 	const bool stencil_association = static_cast<bool>(image->depth_id);
-	if (stencil_association) {
+	if (stencil_association && !storage) {
 		id    = image->depth_id;
 		image = &texture_cache.GetImage(id);
 	} else if (image->info.IsDepth()) {
@@ -798,6 +798,9 @@ void RenderExecutor::BindRenderTarget(ImageId id) {
 
 void RenderExecutor::ResetBindings() {
 	for (const auto& image: m_bound_images) {
+		if (image->binding.stencil_write) {
+			m_context.GetTextureCache().FlushStencilWrite(image);
+		}
 		image->binding = {};
 	}
 	m_bound_images.clear();
@@ -984,6 +987,9 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 		const ImageSubresourceRange range {view.base_level, view.level_count, view.base_layer,
 		                                   view.layer_count};
 		const bool storage = binding.desc.type == TextureCache::BindingType::Storage;
+		if (storage && image.depth_id) {
+			image.binding.stencil_write = true;
+		}
 		if (image.info.data.Empty()) {
 			image.Transit(vk::ImageLayout::eGeneral,
 			              storage

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -996,13 +996,14 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 			                  ? vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eShaderWrite
 			                  : vk::AccessFlagBits2::eShaderRead,
 			              range, vk_buffer);
-		} else if ((image.binding.force_general || image.binding.is_target) &&
-		           !image.info.IsDepth()) {
+		} else if (image.binding.force_general || image.binding.is_target) {
+			const auto attachment_access =
+			    image.info.IsDepth() ? vk::AccessFlagBits2::eDepthStencilAttachmentRead |
+			                               vk::AccessFlagBits2::eDepthStencilAttachmentWrite
+			                         : vk::AccessFlagBits2::eColorAttachmentRead |
+			                               vk::AccessFlagBits2::eColorAttachmentWrite;
 			image.Transit(vk::ImageLayout::eGeneral,
-			              vk::AccessFlagBits2::eShaderRead |
-			                  vk::AccessFlagBits2::eColorAttachmentRead |
-			                  vk::AccessFlagBits2::eColorAttachmentWrite,
-			              {}, vk_buffer);
+			              vk::AccessFlagBits2::eShaderRead | attachment_access, {}, vk_buffer);
 		} else if (storage) {
 			image.Transit(vk::ImageLayout::eGeneral,
 			              vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eShaderWrite,

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -615,7 +615,8 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 			EXIT("mixed color/depth sample counts are unsupported: %u and %u\n", attachment_samples,
 			     depth.samples);
 		}
-		const auto layout = depth_attachment_layout(depth);
+		const auto layout =
+		    image.binding.is_bound ? vk::ImageLayout::eGeneral : depth_attachment_layout(depth);
 		const auto writes = depth.AttachmentWriteAspects();
 		auto       access = vk::AccessFlags2 {vk::AccessFlagBits2::eDepthStencilAttachmentRead};
 		if (writes) {

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -6768,11 +6768,15 @@ public:
 			    scheduler.Current(), stencil_storage_runtime, vk::ShaderStageFlagBits::eCompute,
 			    DescriptorCache::Stage::Compute);
 			executor.RebindImages(scheduler.Current(), storage_redirected);
+			const auto storage_stencil_id = storage_redirected.resources.images[0].image_id;
 			Require(name, "storage stencil acquisition",
-			        storage_redirected.resources.images[0].image_id == depth_id &&
+			        storage_stencil_id != depth_id &&
+			            texture_cache.GetImage(storage_stencil_id).depth_id == depth_id &&
 			            storage_redirected.resources.images[0].image_view != nullptr &&
-			            texture_cache.GetImage(depth_id).usage.storage,
-			        "storage stencil binding did not acquire the associated depth owner");
+			            texture_cache.GetImage(storage_stencil_id).usage.storage &&
+			            !texture_cache.GetImage(depth_id).usage.storage,
+			        "a storage stencil binding must acquire the stencil plane itself, not the "
+			        "depth owner that cannot hold VK_IMAGE_USAGE_STORAGE_BIT");
 			RenderExecutorTestAccess::ResetBindings(executor);
 			resources.UnmapMemory(base, allocation_size);
 			scheduler.Finish();


### PR DESCRIPTION
Two independent depth/stencil bug fixes. 

## Summary
-  Resolve a storage stencil binding to the stencil plane itself instead of the depth owner and copy the written plane into the depth image stencil aspect after the draw.
- placed a depth target in eGeneral if the same draw samples it so the attachment layout still matches after the binding transition.

bugs were identified on silent hill the short message with vulkan validation enabled


PR follows contribution guidelines and and the windows build is verified


