### PR TITLE
graphics: fix copy extents, render area, storage usage, and eviction

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1951,10 +1951,15 @@ void TextureCache::RunGarbageCollector() {
 			}
 			if (owner->IsGpuModified()) {
 				const bool safe = SafeToDownload(*owner);
+				const bool gpu_authored =
+				    owner->usage.storage && !owner->usage.render_target && !owner->usage.video_out;
 				if (safe && owner->info.IsTiled()) {
 					continue;
 				}
 				if (safe && !pressured) {
+					continue;
+				}
+				if (gpu_authored) {
 					continue;
 				}
 				if (safe && !TryDownloadImage(id)) {

--- a/src/graphics/host_gpu/renderer/image/image.cpp
+++ b/src/graphics/host_gpu/renderer/image/image.cpp
@@ -344,9 +344,15 @@ void Image::CopyImage(Image& source) {
 	std::vector<vk::ImageCopy> copies;
 	copies.reserve(levels);
 	for (uint32_t level = 0; level < levels; level++) {
-		const auto width  = std::max(source.backing.extent.width >> level, 1u);
-		const auto height = std::max(source.backing.extent.height >> level, 1u);
-		const auto depth  = std::max(base_depth >> level, 1u);
+		const auto width  = std::min(std::max(source.backing.extent.width >> level, 1u),
+		                             std::max(backing.extent.width >> level, 1u));
+		const auto height = std::min(std::max(source.backing.extent.height >> level, 1u),
+		                             std::max(backing.extent.height >> level, 1u));
+		auto       depth  = std::max(base_depth >> level, 1u);
+		if (source.backing.image_type == vk::ImageType::e3D &&
+		    backing.image_type == vk::ImageType::e3D) {
+			depth = std::min(depth, std::max(source.backing.extent.depth >> level, 1u));
+		}
 		const auto [source_layers, destination_layers] = SanitizeCopyLayers(source, *this, depth);
 		vk::ImageCopy copy {};
 		copy.srcSubresource = {source_aspect, level, 0, 1};
@@ -487,8 +493,10 @@ void Image::CopyImageWithBuffer(Image& source, Buffer& buffer) {
 	               command);
 	Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite, {}, command);
 	for (uint32_t level = 0; level < levels; level++) {
-		const auto width             = std::max(source.backing.extent.width >> level, 1u);
-		const auto height            = std::max(source.backing.extent.height >> level, 1u);
+		const auto width             = std::min(std::max(source.backing.extent.width >> level, 1u),
+		                                        std::max(backing.extent.width >> level, 1u));
+		const auto height            = std::min(std::max(source.backing.extent.height >> level, 1u),
+		                                        std::max(backing.extent.height >> level, 1u));
 		const auto source_depth      = source.backing.image_type == vk::ImageType::e3D
 		                                   ? std::max(source.backing.extent.depth >> level, 1u)
 		                                   : source.backing.layers;

--- a/src/graphics/host_gpu/renderer/image/image.cpp
+++ b/src/graphics/host_gpu/renderer/image/image.cpp
@@ -46,6 +46,14 @@ namespace {
 	return static_cast<bool>(properties.optimalTilingFeatures & feature);
 }
 
+[[nodiscard]] vk::Format BlockStorageViewFormat(Prospero::BufferFormat guest_format) {
+	switch (Prospero::BlockCompressedBytesPerBlock(guest_format)) {
+		case 8: return vk::Format::eR32G32Uint;
+		case 16: return vk::Format::eR32G32B32A32Uint;
+		default: return vk::Format::eUndefined;
+	}
+}
+
 [[nodiscard]] vk::ImageUsageFlags ImageUsageFlags(GraphicContext& graphics, const ImageInfo& info) {
 	const auto properties = graphics.GetFormatProperties(info.pixel_format);
 	auto       usage = vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eTransferDst;
@@ -63,7 +71,9 @@ namespace {
 	    HasFormatFeature(properties, vk::FormatFeatureFlagBits::eStorageImage)) {
 		usage |= vk::ImageUsageFlagBits::eStorage;
 	} else if (info.samples == 1) {
-		const auto compatible = SrgbStorageViewFormat(info.pixel_format);
+		const auto compatible = BlockStorageViewFormat(info.guest_format) != vk::Format::eUndefined
+		                            ? BlockStorageViewFormat(info.guest_format)
+		                            : SrgbStorageViewFormat(info.pixel_format);
 		if (compatible != vk::Format::eUndefined &&
 		    HasFormatFeature(graphics.GetFormatProperties(compatible),
 		                     vk::FormatFeatureFlagBits::eStorageImage)) {

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -541,6 +541,11 @@ struct DrawCallInfo {
 	uint32_t             first_instance = 0;
 };
 
+static vk::Extent2D AttachmentViewExtent(const Image& image, const ImageViewInfo& view) {
+	return {std::max(image.backing.extent.width >> view.base_level, 1u),
+	        std::max(image.backing.extent.height >> view.base_level, 1u)};
+}
+
 RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderColorInfo* colors,
                                                  uint32_t color_count, RenderDepthInfo& depth) {
 	EXIT_IF(colors == nullptr || color_count > RENDER_COLOR_ATTACHMENTS_MAX);
@@ -581,8 +586,9 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 		              ImageSubresourceRange {view.base_level, view.level_count, view.base_layer,
 		                                     view.layer_count},
 		              buffer.Handle());
-		state.width             = std::min(state.width, target.extent.width);
-		state.height            = std::min(state.height, target.extent.height);
+		const auto view_extent  = AttachmentViewExtent(image, view);
+		state.width             = std::min({state.width, target.extent.width, view_extent.width});
+		state.height            = std::min({state.height, target.extent.height, view_extent.height});
 		state.num_layers        = std::min(state.num_layers, view.layer_count);
 		auto& attachment        = state.color_attachments[i];
 		attachment.image_view   = target.image_view;
@@ -626,8 +632,9 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 		              ImageSubresourceRange {view.base_level, view.level_count, view.base_layer,
 		                                     view.layer_count},
 		              buffer.Handle());
-		state.width               = std::min(state.width, depth.width);
-		state.height              = std::min(state.height, depth.height);
+		const auto view_extent    = AttachmentViewExtent(image, view);
+		state.width               = std::min({state.width, depth.width, view_extent.width});
+		state.height              = std::min({state.height, depth.height, view_extent.height});
 		state.num_layers          = std::min(state.num_layers, view.layer_count);
 		const auto aspects        = ImageViewOps::DepthAspectMask(depth.format);
 		auto&      attachment     = state.depth_stencil_attachment;


### PR DESCRIPTION
Four independent fixes for texture cache and image bugs

## Summary
-  Grant storage usage to block compressed images through BLOCK_TEXEL_VIEW_COMPATIBLE view in the matching uncompressed class.
- Only copy the region that both images both images actually have in CopyImage and CopyImageWithBuffer.
- fix the render area to what the attachment views cover and just the guest extents. A same pitch merge means that a 190 texel target can resolve to a 189 wide image.
- No longer evict gpu authored storage images because the garbage collector would skip downloading and discard the only copy in memory. the next draw would be built from empty guest memory  and cause black textures.

bugs were identified while trying to get bg&e stable

PR follows contribution guidelines and and the windows is build verified


