### PR TITLE
graphics: fix an upload-callback deadlock and exception filter scope

### DIFF
--- a/src/common/hostException.cpp
+++ b/src/common/hostException.cpp
@@ -1,6 +1,7 @@
 #include "common/hostException.h"
 
 #include <atomic>
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 
@@ -74,8 +75,6 @@ static Handler LoadInstalledHandler() noexcept {
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 
 static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
-	FilterScope filter_scope;
-
 	auto* exception_record = exception->ExceptionRecord;
 
 	if (exception_record->ExceptionCode == DBG_PRINTEXCEPTION_C ||
@@ -87,6 +86,19 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 		// Set a thread name.
 		return EXCEPTION_CONTINUE_EXECUTION;
 	}
+
+	if (exception_record->ExceptionCode != EXCEPTION_ACCESS_VIOLATION &&
+	    exception_record->ExceptionCode != EXCEPTION_ILLEGAL_INSTRUCTION) {
+		printf("Unhandled win exception: code=0x%08" PRIx32 ", addr=0x%016" PRIx64
+		       ", rip=0x%016" PRIx64 ", rsp=0x%016" PRIx64 ", rbp=0x%016" PRIx64 "\n",
+		       static_cast<uint32_t>(exception_record->ExceptionCode),
+		       reinterpret_cast<uint64_t>(exception_record->ExceptionAddress),
+		       exception->ContextRecord->Rip, exception->ContextRecord->Rsp,
+		       exception->ContextRecord->Rbp);
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	FilterScope filter_scope;
 
 	ExceptionInfo info {};
 	info.exception_address = reinterpret_cast<uint64_t>(exception_record->ExceptionAddress);
@@ -102,16 +114,8 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) {
 			default: info.access_violation_type = AccessViolationType::Unknown; break;
 		}
 		info.access_violation_vaddr = exception_record->ExceptionInformation[1];
-	} else if (exception_record->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION) {
-		info.type = ExceptionType::IllegalInstruction;
 	} else {
-		printf("Unhandled win exception: code=0x%08" PRIx32 ", addr=0x%016" PRIx64
-		       ", rip=0x%016" PRIx64 ", rsp=0x%016" PRIx64 ", rbp=0x%016" PRIx64 "\n",
-		       static_cast<uint32_t>(exception_record->ExceptionCode),
-		       reinterpret_cast<uint64_t>(exception_record->ExceptionAddress),
-		       exception->ContextRecord->Rip, exception->ContextRecord->Rsp,
-		       exception->ContextRecord->Rbp);
-		return EXCEPTION_CONTINUE_SEARCH;
+		info.type = ExceptionType::IllegalInstruction;
 	}
 
 	info.rax = exception->ContextRecord->Rax;

--- a/src/graphics/host_gpu/memoryTracker.h
+++ b/src/graphics/host_gpu/memoryTracker.h
@@ -23,6 +23,8 @@ public:
 
 	KYTY_CLASS_NO_COPY(MemoryTracker);
 
+	[[nodiscard]] static bool InUploadCallback() noexcept { return s_upload_owner != nullptr; }
+
 	[[nodiscard]] bool IsRegionCpuModified(uint64_t vaddr, uint64_t size);
 	[[nodiscard]] bool IsRegionGpuModified(uint64_t vaddr, uint64_t size);
 	void               MarkRegionAsCpuModified(uint64_t vaddr, uint64_t size);

--- a/src/graphics/host_gpu/renderer/commandScheduler.cpp
+++ b/src/graphics/host_gpu/renderer/commandScheduler.cpp
@@ -2,6 +2,7 @@
 
 #include "common/assert.h"
 #include "graphics/host_gpu/graphicContext.h"
+#include "graphics/host_gpu/memoryTracker.h"
 
 #include <algorithm>
 
@@ -239,6 +240,9 @@ void CommandScheduler::PopPendingOperations() {
 }
 
 void CommandScheduler::PopPendingOperations(bool refresh_gpu_tick) {
+	if (MemoryTracker::InUploadCallback()) {
+		return;
+	}
 	if (refresh_gpu_tick) {
 		m_master.Refresh();
 	}


### PR DESCRIPTION
Two independent fixes: a deadlock during buffer upload, and an exception filter that armed too early.

## Summary

- Do not drain deferred operations from inside an upload callback. A buffer upload can exhaust the
  staging buffer and wait for the GPU while MemoryTracker holds its region locks across the
  callback, and the deferred operations reclaim buffers and unmark tracker ranges, so draining them
  there re-entered the tracker and deadlocked on non-recursive locks. The wait still frees the
  staging space and the callbacks run at the next drain.
- Classify host exceptions before arming the re-entrancy guard, so the guard is only armed for
  exceptions the filter actually handles rather than for every exception passed straight on to
  EXCEPTION_CONTINUE_SEARCH.

PR follows contribution guidelines and the Windows build is verified.