### PR TITLE
graphics: dcc fast clear for color render targets

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -252,9 +252,7 @@ void TextureCache::DeleteImage(ImageId id) {
 		EXIT("TextureCache: deleting a GPU-modified image without resolving its contents\n");
 	}
 	m_download_images.erase(id);
-	if (owner->info.metadata.kind == ImageMetadataKind::Htile) {
-		m_surface_metas.erase(owner->info.metadata.range.address);
-	}
+	UnregisterMetadataLocked(id, *owner);
 	UnregisterImage(id);
 	const auto erase_slot = [this, id, retained = owner] {
 		auto& slot = m_slots[id.index];
@@ -717,7 +715,7 @@ ImageId TextureCache::ResolveDepthOverlap(const ImageInfo& requested, BindingTyp
 	             ImageDesc {.info = cached.info, .view_info = {}, .type = UploadBinding(cached)});
 	auto info                 = requested;
 	info.resources            = std::max(requested.resources, cached.info.resources);
-	info.htile_clear_mask     = 0;
+	info.metadata_clear_mask  = 0;
 	const auto replacement_id = InsertImage(info);
 	auto&      replacement    = ResolveImage(replacement_id);
 	replacement.usage         = cached.usage;
@@ -1344,6 +1342,35 @@ vk::ImageView TextureCache::FindTexture(ImageId id, const ImageDesc& desc) {
 	return view;
 }
 
+void TextureCache::RegisterMetadataLocked(ImageId id, Image& image, const ImageDesc& desc) {
+	if (!desc.info.HasMetadata()) {
+		return;
+	}
+	if (image.info.HasMetadata() &&
+	    image.info.metadata.range.address != desc.info.metadata.range.address) {
+		UnregisterMetadataLocked(id, image);
+	}
+	image.info.metadata    = desc.info.metadata;
+	auto [entry, inserted] = m_surface_metas.try_emplace(
+	    desc.info.metadata.range.address,
+	    MetaDataInfo {.clear_mask = image.info.metadata_clear_mask, .kind = desc.info.metadata.kind});
+	entry->second.owners.insert(id);
+}
+
+void TextureCache::UnregisterMetadataLocked(ImageId id, const Image& image) {
+	if (!image.info.HasMetadata()) {
+		return;
+	}
+	const auto found = m_surface_metas.find(image.info.metadata.range.address);
+	if (found == m_surface_metas.end()) {
+		return;
+	}
+	found->second.owners.erase(id);
+	if (found->second.owners.empty()) {
+		m_surface_metas.erase(found);
+	}
+}
+
 vk::ImageView TextureCache::FindRenderTarget(ImageId id, const ImageDesc& desc) {
 	if (desc.type != BindingType::RenderTarget) {
 		EXIT("TextureCache: invalid color-target binding\n");
@@ -1357,6 +1384,7 @@ vk::ImageView TextureCache::FindRenderTarget(ImageId id, const ImageDesc& desc) 
 	image.MarkGpuModified();
 	image.usage.render_target = true;
 	RefreshImage(id, desc);
+	RegisterMetadataLocked(id, image, desc);
 	CommitGpuWrite(image);
 	TrackImageDownloadLocked(id, image);
 	const auto view = image.FindView(desc.view_info);
@@ -1377,11 +1405,7 @@ vk::ImageView TextureCache::FindDepthTarget(ImageId id, const ImageDesc& desc) {
 	image.MarkGpuModified();
 	image.usage.depth_target = true;
 	RefreshImage(id, desc);
-	if (desc.info.HasMetadata()) {
-		image.info.metadata = desc.info.metadata;
-		m_surface_metas.try_emplace(desc.info.metadata.range.address,
-		                            MetaDataInfo {.clear_mask = image.info.htile_clear_mask});
-	}
+	RegisterMetadataLocked(id, image, desc);
 	CommitGpuWrite(image);
 	if (desc.info.HasStencil()) {
 		AssociateStencilLocked(id, desc.info.stencil);
@@ -1862,6 +1886,12 @@ void TextureCache::ClearGpuModified(ImageId id) {
 bool TextureCache::IsMeta(uint64_t address) {
 	CacheLock lock(*this, m_lock);
 	return m_surface_metas.contains(address);
+}
+
+ImageMetadataKind TextureCache::MetaKind(uint64_t address) {
+	CacheLock  lock(*this, m_lock);
+	const auto found = m_surface_metas.find(address);
+	return found == m_surface_metas.end() ? ImageMetadataKind::None : found->second.kind;
 }
 
 bool TextureCache::IsMetaCleared(uint64_t address, uint32_t slice) {

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -71,6 +71,7 @@ public:
 	[[nodiscard]] RegionInfo QueryRegion(uint64_t address, uint64_t size);
 
 	[[nodiscard]] bool IsMeta(uint64_t address);
+	[[nodiscard]] ImageMetadataKind MetaKind(uint64_t address);
 	[[nodiscard]] bool IsMetaCleared(uint64_t address, uint32_t slice);
 	[[nodiscard]] bool ClearMeta(uint64_t address);
 	[[nodiscard]] bool TouchMeta(uint64_t address, uint32_t slice, bool is_clear);
@@ -91,6 +92,8 @@ private:
 
 	struct MetaDataInfo {
 		uint32_t clear_mask = 0;
+		ImageMetadataKind kind       = ImageMetadataKind::None;
+		std::set<ImageId> owners;
 	};
 
 	struct OverlapResult {
@@ -134,8 +137,10 @@ private:
 	[[nodiscard]] ImageId       ResolveDepthOverlap(const ImageInfo& requested, BindingType binding,
 	                                                ImageId cached);
 	[[nodiscard]] ImageId       ExpandImage(const ImageInfo& info, ImageId source);
-	void                        RefreshImage(ImageId id, const ImageDesc& desc);
-	void                        InitializeImage(ImageId id, const ImageDesc& desc);
+	void RegisterMetadataLocked(ImageId id, Image& image, const ImageDesc& desc);
+	void UnregisterMetadataLocked(ImageId id, const Image& image);
+	void RefreshImage(ImageId id, const ImageDesc& desc);
+	void InitializeImage(ImageId id, const ImageDesc& desc);
 	[[nodiscard]] ColorTransferPlan BuildColorTransfer(const Image& image, BindingType binding,
 	                                                   TransferDirection direction) const;
 	[[nodiscard]] DownloadPlan      BuildDownload(const Image& image) const;

--- a/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
@@ -327,20 +327,43 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, RenderCommandB
 	desc.view_info.base_layer  = view.base_layer;
 	desc.view_info.layer_count = view.layer_count;
 	desc.view_info.usage       = vk::ImageUsageFlagBits::eColorAttachment;
-	auto& texture_cache        = m_context.GetTextureCache();
-	r.desc                     = std::move(desc);
-	r.image_id                 = texture_cache.FindImage(r.desc, exact_format);
-	r.type                     = RenderColorType::RenderTexture;
-	r.base_addr                = rt.base.addr;
-	r.image_view               = nullptr;
-	r.format                   = r.desc.view_info.format;
-	r.extent                   = view_extent;
-	r.base_mip_level           = rt.view.current_mip_level;
-	r.buffer_size              = backing_size;
-	r.samples                  = samples;
-	r.export_mapping           = target_format.export_mapping;
-	r.color_clear_enable       = false;
-	r.color_clear_value        = {};
+	if (rt.info.dcc_compression_enable && rt.dcc_addr.addr != 0) {
+		desc.info.metadata.range = {rt.dcc_addr.addr, 0};
+		desc.info.metadata.kind  = ImageMetadataKind::Dcc;
+		desc.info.metadata_clear_mask = 0;
+	}
+	auto& texture_cache  = m_context.GetTextureCache();
+	r.desc               = std::move(desc);
+	r.image_id           = texture_cache.FindImage(r.desc, exact_format);
+	r.type               = RenderColorType::RenderTexture;
+	r.base_addr          = rt.base.addr;
+	r.image_view         = nullptr;
+	r.format             = r.desc.view_info.format;
+	r.extent             = view_extent;
+	r.base_mip_level     = rt.view.current_mip_level;
+	r.buffer_size        = backing_size;
+	r.samples            = samples;
+	r.export_mapping     = target_format.export_mapping;
+	r.color_clear_enable = false;
+	r.color_clear_value  = {};
+	// A fast clear stores its colour in CB_COLOR*_CLEAR_WORD0/1, already encoded in the surface's
+	// native format. An all-zero pair is zero in every format we support, so it needs no decode;
+	// any other value would need a per-format decoder that does not exist yet, and guessing it
+	// would silently render the wrong colour. Those targets keep today's preserving load.
+	if (rt.info.dcc_compression_enable && rt.dcc_addr.addr != 0) {
+		if (rt.clear_word0.word0 == 0 && rt.clear_word1.word1 == 0) {
+			// color_clear_value is already value-initialised to all zeros above, which is the
+			// bit pattern this clear key asks for.
+			r.dcc_meta_clear_capable = true;
+		} else {
+			static std::atomic<uint32_t> log_count {0};
+			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
+				LOGF("RenderColorTarget: non-zero DCC clear key (0x%08" PRIx32 " 0x%08" PRIx32
+				     ") has no decoder; skipping metadata clear\n",
+				     rt.clear_word0.word0, rt.clear_word1.word1);
+			}
+		}
+	}
 	BindRenderTarget(r.image_id);
 }
 

--- a/src/graphics/host_gpu/renderer/colorRenderTarget.h
+++ b/src/graphics/host_gpu/renderer/colorRenderTarget.h
@@ -33,6 +33,7 @@ struct RenderColorInfo {
 	Prospero::ColorComponentMapping export_mapping;
 	bool                            color_clear_enable = false;
 	vk::ClearColorValue             color_clear_value {};
+	bool dcc_meta_clear_capable = false;
 };
 
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/image/imageInfo.h
+++ b/src/graphics/host_gpu/renderer/image/imageInfo.h
@@ -65,7 +65,7 @@ struct ImageInfo {
 	GuestRange                   data;
 	GuestRange                   stencil;
 	ImageMetadataInfo            metadata;
-	uint32_t                     htile_clear_mask = UINT32_MAX;
+	uint32_t                     metadata_clear_mask = UINT32_MAX;
 	vk::Format                   pixel_format     = vk::Format::eUndefined;
 	Prospero::BufferFormat       guest_format     = Prospero::BufferFormat::kInvalid;
 	Prospero::ImageType          type             = Prospero::ImageType::kColor2D;

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -572,9 +572,19 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 			EXIT("mixed color attachment sample counts are unsupported: %u and %u\n",
 			     attachment_samples, target.samples);
 		}
-		const auto& view   = target.desc.view_info;
-		const auto  layout = image.binding.is_bound ? vk::ImageLayout::eGeneral
-		                                            : vk::ImageLayout::eColorAttachmentOptimal;
+		const auto& view = target.desc.view_info;
+		if (target.dcc_meta_clear_capable &&
+		    target.desc.info.metadata.kind == ImageMetadataKind::Dcc) {
+			const auto dcc_addr = target.desc.info.metadata.range.address;
+			if (cache.IsMetaCleared(dcc_addr, view.base_layer)) {
+				target.color_clear_enable = true;
+				if (!cache.TouchMeta(dcc_addr, view.base_layer, false)) {
+					EXIT("failed to consume DCC clear state\n");
+				}
+			}
+		}
+		const auto layout = image.binding.is_bound ? vk::ImageLayout::eGeneral
+		                                           : vk::ImageLayout::eColorAttachmentOptimal;
 		image.Transit(layout,
 		              vk::AccessFlagBits2::eColorAttachmentRead |
 		                  vk::AccessFlagBits2::eColorAttachmentWrite,

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -3506,7 +3506,7 @@ public:
 			            texture_cache.GetImage(ms_depth_image).backing.state.layout ==
 			                vk::ImageLayout::eDepthStencilAttachmentOptimal &&
 			            texture_cache.GetImage(ms_depth_image).IsGpuModified() &&
-			            texture_cache.GetImage(ms_depth_image).info.htile_clear_mask == 0 &&
+			            texture_cache.GetImage(ms_depth_image).info.metadata_clear_mask == 0 &&
 			            texture_cache.GetImage(ms_depth_image).info.metadata.range ==
 			                ms_depth_desc.info.metadata.range &&
 			            texture_cache.IsMeta(ms_htile_address) &&


### PR DESCRIPTION
Implemented the dcc fast clear for color render targets.

PS% games clear render targets by writing a key into dcc metadata instead of writing color. Before this change, the registers were decoded and discarded after so each clear was dropped silently. 

Verified

- ctest 29/29.
- Stray: 18,303 clears applied from 21,265 metadata writes; 69 colour targets.
- Silent Hill the short message: 583 clears applied.
- Dreaming Sarah: locked 60.0 FPS, unchanged (no dcc).

PR follows contribution guidelines and the Windows build is verified.