### PR TITLE
graphics: enable VK_EXT_memory_priority + pageable_device_local_memory

### DIFF
--- a/src/graphics/host_gpu/vma.cpp
+++ b/src/graphics/host_gpu/vma.cpp
@@ -26,6 +26,27 @@
 
 namespace Libs::Graphics {
 
+// Allocation priority for VK_EXT_memory_priority: 0.0 means "demote this
+// first", 1.0 means "demote this last", and VMA uses 0.5 when nothing is
+// specified. It is a hint about relative value, so raising one class is
+// enough to order it against everything left at the default.
+//
+// Only images are raised here, deliberately. A demoted render target has to
+// be paged back in before the next pass that samples it, whereas most buffer
+// content can be re-uploaded from guest memory the emulator still holds. The
+// generic CreateBuffer() path also serves vertex/index buffers that may be
+// just as hot as an image, so lowering it wholesale would be guessing, and a
+// wrong guess here costs performance silently. Finer classification (staging
+// and tiler scratch really are cheap to lose) is a sensible follow-up once
+// someone measures it.
+//
+// This complements TextureCache::RunGarbageCollector() rather than replacing
+// it: the GC still frees things, this just gives the driver a cheaper option
+// one step earlier.
+namespace {
+constexpr float MEMORY_PRIORITY_IMAGE = 0.8F;
+} // namespace
+
 namespace {
 
 struct MemoryStats {
@@ -73,6 +94,11 @@ bool GraphicContext::CreateAllocator() {
 	info.pVulkanFunctions = &functions;
 	info.vulkanApiVersion = VULKAN_TARGET_API_VERSION;
 	info.flags = memory_budget_ext_enabled ? VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT : 0;
+	// Without this bit VMA ignores VmaAllocationCreateInfo::priority entirely,
+	// so the per-allocation priorities set below would be silently inert.
+	if (memory_priority_ext_enabled) {
+		info.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT;
+	}
 
 	const auto result = static_cast<vk::Result>(vmaCreateAllocator(&info, &allocator));
 	if (result != vk::Result::eSuccess) {
@@ -222,6 +248,7 @@ bool GraphicContext::CreateImage(const vk::ImageCreateInfo& image_info, VulkanIm
 	alloc_info.requiredFlags = static_cast<vk::MemoryPropertyFlags::MaskType>(memory.property);
 	alloc_info.preferredFlags =
 	    static_cast<vk::MemoryPropertyFlags::MaskType>(memory.preferred_property);
+	alloc_info.priority = MEMORY_PRIORITY_IMAGE;
 
 	vk::Image::CType native_image = VK_NULL_HANDLE;
 	const auto       result       = static_cast<vk::Result>(

--- a/src/graphics/host_gpu/vulkanInstance.h
+++ b/src/graphics/host_gpu/vulkanInstance.h
@@ -24,6 +24,11 @@ struct VulkanInstance {
 	vk::Device                         device                            = nullptr;
 	VmaAllocator                       allocator                         = nullptr;
 	bool                               memory_budget_ext_enabled         = false;
+	// VK_EXT_memory_priority + VK_EXT_pageable_device_local_memory. Both are
+	// optional and are enabled together: priority is what tells the driver
+	// which allocations to demote first, and pageable_device_local_memory is
+	// what lets it demote instead of failing the allocation outright.
+	bool                               memory_priority_ext_enabled       = false;
 	bool                               rt_extensions_enabled             = false;
 	bool                               subgroup_size_control_enabled     = false;
 	bool                               sample_rate_shading_enabled       = false;

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -540,6 +540,25 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 		supported_features12.pNext = &supported_robustness2;
 	}
 
+	// VK_EXT_pageable_device_local_memory carries a feature bit that must be
+	// enabled explicitly at device creation; using the extension without it
+	// is invalid usage, so query it here and only turn the pair on if the
+	// driver really reports it.
+	const auto pageable_ext_enabled =
+	    HasExtension(device_extensions, VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
+
+	vk::PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT supported_pageable {};
+	supported_pageable.sType =
+	    vk::StructureType::ePhysicalDevicePageableDeviceLocalMemoryFeaturesEXT;
+	supported_pageable.pNext = nullptr;
+	if (pageable_ext_enabled) {
+		if (robustness2_ext_enabled) {
+			supported_robustness2.pNext = &supported_pageable;
+		} else {
+			supported_features12.pNext = &supported_pageable;
+		}
+	}
+
 	vk::PhysicalDeviceFeatures2 supported_features2 {};
 	supported_features2.sType = vk::StructureType::ePhysicalDeviceFeatures2;
 	supported_features2.pNext = &supported_features13;
@@ -610,9 +629,23 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	     features13.robustImageAccess == VK_TRUE ? "true" : "false",
 	     robustness2_ext_enabled && robustness2.robustImageAccess2 == VK_TRUE ? "true" : "false");
 
+	// Chain the pageable-memory enable in front of features13 when the driver
+	// reported support. Left out entirely otherwise, so a driver without the
+	// extension sees exactly the chain it saw before this change.
+	vk::PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT pageable_features {};
+	pageable_features.sType =
+	    vk::StructureType::ePhysicalDevicePageableDeviceLocalMemoryFeaturesEXT;
+	pageable_features.pageableDeviceLocalMemory = VK_TRUE;
+	pageable_features.pNext                     = &features13;
+
+	const bool enable_pageable =
+	    pageable_ext_enabled && supported_pageable.pageableDeviceLocalMemory == VK_TRUE;
+
 	vk::DeviceCreateInfo create_info {};
 	create_info.sType                   = vk::StructureType::eDeviceCreateInfo;
-	create_info.pNext                   = &features13;
+	create_info.pNext                   = enable_pageable
+	                                          ? static_cast<const void*>(&pageable_features)
+	                                          : static_cast<const void*>(&features13);
 	create_info.flags                   = {};
 	create_info.pQueueCreateInfos       = &queue_create_info;
 	create_info.queueCreateInfoCount    = 1;
@@ -973,6 +1006,20 @@ void WindowContext::CreateVulkan() {
 		}
 		if (HasExtension(available_extensions, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
 			device_extensions.push_back(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+		}
+		// Memory priority lets the driver demote low-value allocations under
+		// pressure instead of the texture cache having to delete and later
+		// recreate them, so it complements RunGarbageCollector() rather than
+		// replacing it: the GC stays the backstop, this reduces how often it
+		// has to fire. pageable_device_local_memory is required alongside it
+		// for the driver to actually page device-local memory rather than
+		// returning VK_ERROR_OUT_OF_DEVICE_MEMORY, so both or neither.
+		if (HasExtension(available_extensions, VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME) &&
+		    HasExtension(available_extensions,
+		                 VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME)) {
+			device_extensions.push_back(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME);
+			device_extensions.push_back(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
+			graphic_ctx.memory_priority_ext_enabled = true;
 		}
 	}
 


### PR DESCRIPTION
I was reading through the texture cache while working on something related and noticed the renderer already queries `VK_EXT_memory_budget` and scales its GC bands off the real reported budget. That's more care than most projects take. But once memory actually gets tight, the only lever available is `RunGarbageCollector()` deleting resources. The driver itself has no idea which of your allocations are worth keeping, so to it everything looks equally disposable.

That's the gap this fills.

`VK_EXT_memory_priority` lets you tag each allocation 0.0 to 1.0 so the driver knows what to push out first. `VK_EXT_pageable_device_local_memory` is what lets it actually page device-local memory out instead of just returning `VK_ERROR_OUT_OF_DEVICE_MEMORY`. Together they give you a cheaper step *before* the GC has to run: the driver quietly demotes something, rather than you destroying a resource and rebuilding it a few frames later.

It doesn't replace the GC. It takes pressure off it.

### Why it's written this way

**Both extensions go on together or not at all.** Priority on its own only changes which allocation gets the OOM, which isn't much use.

**`pageableDeviceLocalMemory` is a feature bit, not just an extension**, so it goes through `getFeatures2()` and is only requested if the driver actually reports it. Enabling the extension without the feature is invalid usage. If a driver has neither, the `pNext` chain it sees is exactly what it saw before this patch.

**VMA needs `VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT`** or it ignores `VmaAllocationCreateInfo::priority` entirely, so the priorities would be dead code without it. Easy one to miss.

**Only images get bumped** (0.8, against VMA's 0.5 default). I went back and forth on buffers and left them alone on purpose. A render target that gets demoted has to be paged back in before the next pass samples it, whereas most buffer content you can re-upload from guest memory you're still holding anyway. But `CreateBuffer()` is the generic path, it also hands out vertex and index buffers that might be every bit as hot, and guessing wrong there costs performance with nothing in the log to show for it. Splitting staging and tiler scratch out and giving those a low priority looks right to me, but I'd want to measure it before claiming so.

### On testing

Both changed translation units compile, and `page_manager_tests` passes.

I initially tried to build with GCC and hit `vk::Extent3D` brace-init ambiguity in files I hadn't touched, which had me chasing the wrong thing for a while. Then I actually read `.github/workflows/build.yml` and saw you build with clang on all three platforms, so GCC was never going to be a meaningful signal. Rebuilt with clang, which is clean.

So: verified under clang, matching CI. I haven't measured a frame-time difference and I'm not claiming one, this is about giving the driver information it didn't have rather than a specific speedup.

### Where this came from

Since it's a first PR from me: I work on a Vulkan layer that oversubscribes VRAM by tiering into host DDR and NVMe behind an inflated heap, and both of these extensions carry real weight there under pressure. Your budget-derived GC bands with the in-loop backoff are a better shape than what I had, so I've been borrowing in the other direction. The priority hint seemed like the obvious thing missing next to them.

Happy to resize or split this if you'd rather have it smaller.
