### PR TITLE
graphics: persistent pipeline and shader caches, a diagnostics report, typed boot failures, bounded logs, and a PM4 fuzzer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,12 +105,13 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          cmake --build _Build/windows --target launcher audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests --parallel
+          cmake --build _Build/windows --target launcher audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests ^
+            boot_failure_tests log_rate_limit_tests shader_disk_cache_tests pm4_fuzz_tests diagnostics_tests --parallel
 
       - name: Test
         shell: cmd
         run: |
-          ctest --test-dir _Build/windows --output-on-failure -R "^(audio_out2_port|ime_dialog|virtual_memory_allocation)$"
+          ctest --test-dir _Build/windows --output-on-failure -R "^(audio_out2_port|ime_dialog|virtual_memory_allocation|boot_failure|log_rate_limit|shader_disk_cache|pm4_fuzz|diagnostics)$"
 
       - name: Install
         shell: cmd
@@ -187,13 +188,14 @@ jobs:
         run: |
           cmake --build _Build/macos \
             --target launcher audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests \
+              boot_failure_tests log_rate_limit_tests shader_disk_cache_tests pm4_fuzz_tests diagnostics_tests \
             --parallel
 
       - name: Test
         shell: bash
         run: |
           ctest --test-dir _Build/macos --output-on-failure \
-            -R '^(audio_out2_port|ime_dialog|virtual_memory_allocation)$'
+            -R '^(audio_out2_port|ime_dialog|virtual_memory_allocation|boot_failure|log_rate_limit|shader_disk_cache|pm4_fuzz|diagnostics)$'
 
       - name: Install
         shell: bash
@@ -330,13 +332,14 @@ jobs:
           cmake --build _Build/linux \
             --target launcher page_manager_tests memory_tracker_tests \
               audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests \
+              boot_failure_tests log_rate_limit_tests shader_disk_cache_tests pm4_fuzz_tests diagnostics_tests \
             --parallel
 
       - name: Test
         shell: bash
         run: |
           ctest --test-dir _Build/linux --output-on-failure \
-            -R '^(audio_out2_port|ime_dialog|page_manager|memory_tracker|virtual_memory_allocation)$'
+            -R '^(audio_out2_port|ime_dialog|page_manager|memory_tracker|virtual_memory_allocation|boot_failure|log_rate_limit|shader_disk_cache|pm4_fuzz|diagnostics)$'
 
       - name: Install
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,9 @@ function(configure_macos_guest_address_space target)
 endfunction()
 
 add_kyty_full_emulator_test(shader_cfg_tests "${KYTY_TESTS_DIR}/shaderCfgTests.cpp")
+add_kyty_full_emulator_test(shader_disk_cache_tests "${KYTY_TESTS_DIR}/ShaderDiskCacheTests.cpp")
+add_kyty_full_emulator_test(pm4_fuzz_tests "${KYTY_TESTS_DIR}/Pm4FuzzTests.cpp")
+add_kyty_full_emulator_test(diagnostics_tests "${KYTY_TESTS_DIR}/DiagnosticsTests.cpp")
 
 add_executable(scalar_provenance_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/ScalarProvenanceTests.cpp"
@@ -387,6 +390,19 @@ add_executable(page_manager_tests EXCLUDE_FROM_ALL
 )
 target_link_libraries(page_manager_tests common)
 target_include_directories(page_manager_tests PRIVATE ${inc_headers})
+
+add_executable(log_rate_limit_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/LogRateLimitTests.cpp"
+)
+target_link_libraries(log_rate_limit_tests common)
+target_include_directories(log_rate_limit_tests PRIVATE ${inc_headers})
+
+add_executable(boot_failure_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/BootFailureTests.cpp"
+	"${KYTY_SOURCE_DIR}/loader/bootFailure.cpp"
+)
+target_link_libraries(boot_failure_tests common)
+target_include_directories(boot_failure_tests PRIVATE ${inc_headers})
 
 add_executable(bit_array_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/BitArrayTests.cpp"
@@ -509,10 +525,15 @@ endif()
 if(BUILD_TESTING)
 	add_test(NAME ime_dialog COMMAND $<TARGET_FILE:ime_dialog_tests>)
 	add_test(NAME shader_cfg COMMAND $<TARGET_FILE:shader_cfg_tests>)
+	add_test(NAME shader_disk_cache COMMAND $<TARGET_FILE:shader_disk_cache_tests>)
+	add_test(NAME pm4_fuzz COMMAND $<TARGET_FILE:pm4_fuzz_tests>)
+	add_test(NAME diagnostics COMMAND $<TARGET_FILE:diagnostics_tests>)
 	add_test(NAME scalar_provenance COMMAND $<TARGET_FILE:scalar_provenance_tests>)
 	add_test(NAME image_page_table COMMAND $<TARGET_FILE:image_page_table_tests>)
 	add_test(NAME memory_tracker COMMAND $<TARGET_FILE:memory_tracker_tests>)
 	add_test(NAME page_manager COMMAND $<TARGET_FILE:page_manager_tests>)
+	add_test(NAME boot_failure COMMAND $<TARGET_FILE:boot_failure_tests>)
+	add_test(NAME log_rate_limit COMMAND $<TARGET_FILE:log_rate_limit_tests>)
 	add_test(NAME bit_array COMMAND $<TARGET_FILE:bit_array_tests>)
 	add_test(NAME shader_vertex_metadata COMMAND $<TARGET_FILE:shader_vertex_metadata_tests>)
 	add_test(NAME shader_stage_runtime COMMAND $<TARGET_FILE:shader_stage_runtime_tests>)

--- a/src/common/diagnostics.cpp
+++ b/src/common/diagnostics.cpp
@@ -1,0 +1,62 @@
+#include "common/diagnostics.h"
+
+#include "common/dateTime.h"
+#include "common/debug.h"
+#include "common/systemInfo.h"
+#include "kytyGitVersion.h"
+
+#include <fmt/format.h>
+#include <thread>
+
+namespace Common::Diagnostics {
+
+std::string BuildString() {
+	Date date = Date::FromMacros(std::string(__DATE__));
+
+#if KYTY_BUILD == KYTY_BUILD_DEBUG
+	std::string type = "Debug";
+#elif KYTY_BUILD == KYTY_BUILD_RELEASE
+	std::string type = "Release";
+#else
+	std::string type = "????";
+#endif
+
+	std::string compiler =
+	    Debug::GetCompiler() + "-" + Debug::GetLinker() + "-" + Debug::GetBitness();
+
+	return fmt::format("{}, {}, ver = {}, git = {}, date = {}", type, compiler, KYTY_VERSION,
+	                   KYTY_GIT_VERSION, date.ToString());
+}
+
+// macOS rides KYTY_PLATFORM_LINUX (see the top-level CMakeLists), so the two
+// have to be told apart by the compiler's own macro rather than by KYTY_PLATFORM.
+static const char* PlatformName() {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	return "Windows";
+#elif defined(__APPLE__)
+	return "macOS";
+#elif KYTY_PLATFORM == KYTY_PLATFORM_LINUX
+	return "Linux";
+#else
+	return "unknown";
+#endif
+}
+
+std::string BuildReport() {
+	std::string report;
+
+	report += "KytyPS5 diagnostics\n";
+	report += "===================\n\n";
+
+	report += "Build\n";
+	report += fmt::format("  {}\n\n", BuildString());
+
+	report += "Host\n";
+	report += fmt::format("  os:      {}\n", PlatformName());
+	report += fmt::format("  cpu:     {}\n", GetSystemInfo().ProcessorName);
+	report += fmt::format("  threads: {}\n\n", std::thread::hardware_concurrency());
+
+	return report;
+}
+
+} // namespace Common::Diagnostics

--- a/src/common/diagnostics.h
+++ b/src/common/diagnostics.h
@@ -1,0 +1,24 @@
+#ifndef KYTY_COMMON_DIAGNOSTICS_H_
+#define KYTY_COMMON_DIAGNOSTICS_H_
+
+#include <string>
+
+namespace Common::Diagnostics {
+
+// The build identification line: build type, compiler, version, git hash, date.
+// Used both by --help and by the diagnostics report, so there is one definition
+// of what this build calls itself.
+[[nodiscard]] std::string BuildString();
+
+// The host half of the report printed by --diagnostics: build string, OS, and
+// CPU. The Vulkan half lives in the graphics layer, which is the only place
+// that may include Vulkan headers - see Libs::Graphics::BuildVulkanReport().
+//
+// Meant to be pasted into a bug report, so it deliberately contains no file
+// paths, no usernames and no game titles - a reporter should not have to check
+// what they are about to post in public.
+[[nodiscard]] std::string BuildReport();
+
+} // namespace Common::Diagnostics
+
+#endif /* KYTY_COMMON_DIAGNOSTICS_H_ */

--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -65,6 +65,18 @@ std::filesystem::path GetShaderLogFolder() {
 	return g_config->shader_log_folder;
 }
 
+std::filesystem::path GetPipelineCacheFile() {
+	return g_config->pipeline_cache_file;
+}
+
+std::filesystem::path GetShaderCacheFile() {
+	return g_config->shader_cache_file;
+}
+
+uint64_t GetLogRepeatLimit() {
+	return g_config->log_repeat_limit;
+}
+
 bool CommandBufferDumpEnabled() {
 	return g_config->command_buffer_dump_enabled;
 }

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -42,6 +42,16 @@ struct ConfigOptions {
 	ShaderOptimizationType shader_optimization_type    = ShaderOptimizationType::None;
 	ShaderLogDirection     shader_log_direction        = ShaderLogDirection::Silent;
 	std::filesystem::path  shader_log_folder           = "_Shaders";
+	// Driver pipeline cache, persisted between runs so the second launch of a
+	// title does not recompile every pipeline again. Empty disables it.
+	std::filesystem::path  pipeline_cache_file         = "_PipelineCache.bin";
+	// Recompiled-shader cache, persisted between runs so the GCN -> SPIR-V
+	// translation is not redone every launch. Empty disables it.
+	std::filesystem::path  shader_cache_file           = "_ShaderCache.bin";
+	// How many messages one LOGF call site may write before it is sampled
+	// instead. Zero means no limit. Logs reaching several GB in two minutes
+	// (issue #200) are almost entirely a few sites in per-draw loops.
+	uint64_t               log_repeat_limit            = 256;
 	bool                   command_buffer_dump_enabled = false;
 	std::filesystem::path  command_buffer_dump_folder  = "_Buffers";
 	bool                   graphics_debug_dump_enabled = false;
@@ -71,6 +81,9 @@ bool     VulkanValidationEnabled();
 bool                   ShaderValidationEnabled();
 ShaderOptimizationType GetShaderOptimizationType();
 ShaderLogDirection     GetShaderLogDirection();
+std::filesystem::path  GetPipelineCacheFile();
+std::filesystem::path  GetShaderCacheFile();
+uint64_t               GetLogRepeatLimit();
 std::filesystem::path  GetShaderLogFolder();
 
 bool                  CommandBufferDumpEnabled();

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -5,6 +5,9 @@
 #include "common/emulatorConfig.h"
 #include "common/stringUtils.h"
 
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <cstdio>
 #include <filesystem>
 #include <fmt/format.h>
@@ -16,6 +19,7 @@
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/stdout_sinks.h>
 #include <string_view>
+#include <vector>
 
 namespace {
 
@@ -73,6 +77,12 @@ static Direction                       g_direction   = Direction::Console;
 static std::filesystem::path           g_output_file;
 static std::mutex                      g_logger_mutex;
 static std::shared_ptr<spdlog::logger> g_logger;
+
+// Read once at init rather than per message: ShouldWrite runs on every LOGF,
+// including before Config exists, and Config accessors dereference a global that
+// is null until Config::Initialize().
+static constexpr uint64_t     DEFAULT_LOG_REPEAT_LIMIT = 256;
+static std::atomic<uint64_t>  g_repeat_limit {DEFAULT_LOG_REPEAT_LIMIT};
 
 void Flush() {
 	if (g_logger != nullptr) {
@@ -151,6 +161,7 @@ void WriteFatal(fmt::text_style style, std::string_view text) {
 
 void Initialize() {
 	g_initialized = true;
+	g_repeat_limit.store(Config::GetLogRepeatLimit(), std::memory_order_relaxed);
 	switch (Config::GetPrintfDirection()) {
 		case Config::OutputDirection::Silent: g_direction = Direction::Silent; break;
 		case Config::OutputDirection::Console: g_direction = Direction::Console; break;
@@ -162,6 +173,7 @@ void Initialize() {
 }
 
 void Shutdown() {
+	WriteRateLimitSummary();
 	Flush();
 	std::lock_guard lock(g_logger_mutex);
 	g_logger.reset();
@@ -175,6 +187,98 @@ Direction GetDirection() {
 bool IsSilent() {
 	// Before init LOGF must keep writing to stdout, so report non-silent.
 	return g_initialized && g_direction == Direction::Silent;
+}
+
+// ── Per-call-site rate limiting (issue #200) ────────────────────────────
+
+namespace {
+
+// Sites are registered on first use so the summary can name them. The list is
+// bounded: a build has a fixed number of LOGF sites, and if it somehow had more
+// than this, the excess is still rate limited, just not named at the end.
+constexpr size_t MAX_TRACKED_SITES = 4096;
+
+std::array<Site*, MAX_TRACKED_SITES> g_sites {};
+std::atomic<size_t>                  g_site_count {0};
+
+void RegisterSite(Site& site) {
+	// One winner registers; everyone else moves on. The counter still works for
+	// a site that loses the race, it just will not be named in the summary.
+	bool expected = false;
+	if (!site.registered.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+		return;
+	}
+	const auto index = g_site_count.fetch_add(1, std::memory_order_relaxed);
+	if (index < MAX_TRACKED_SITES) {
+		g_sites[index] = &site;
+	}
+}
+
+} // namespace
+
+bool ShouldWrite(Site& site) {
+	const auto limit = g_repeat_limit.load(std::memory_order_relaxed);
+	if (limit == 0) {
+		return true; // rate limiting turned off
+	}
+
+	const auto count = site.count.fetch_add(1, std::memory_order_relaxed);
+	if (count == 0) {
+		RegisterSite(site);
+	}
+
+	if (count < limit) {
+		return true;
+	}
+
+	// Past the limit, keep a thin sample rather than going completely dark, so a
+	// long run still shows that the site is still firing and roughly when.
+	const auto sample = static_cast<uint64_t>(limit) * 64ULL;
+	return (count % sample) == 0;
+}
+
+void WriteRateLimitSummary() {
+	const auto limit = g_repeat_limit.load(std::memory_order_relaxed);
+	if (limit == 0) {
+		return;
+	}
+
+	const auto tracked = std::min(g_site_count.load(std::memory_order_relaxed),
+	                              MAX_TRACKED_SITES);
+
+	struct Entry {
+		const char* file  = nullptr;
+		int         line  = 0;
+		uint64_t    count = 0;
+	};
+
+	std::vector<Entry> noisy;
+	for (size_t i = 0; i < tracked; i++) {
+		auto* site = g_sites[i];
+		if (site == nullptr) {
+			continue;
+		}
+		const auto count = site->count.load(std::memory_order_relaxed);
+		if (count > limit) {
+			noisy.push_back({site->file, site->line, count});
+		}
+	}
+
+	if (noisy.empty()) {
+		return;
+	}
+
+	std::sort(noisy.begin(), noisy.end(),
+	          [](const Entry& a, const Entry& b) { return a.count > b.count; });
+
+	// Deliberately not written through LOGF: this must not rate limit itself.
+	WriteImpl(fmt::format("\n--- log rate limiting: {} sites exceeded {} messages ---\n",
+	                      noisy.size(), limit));
+	for (const auto& entry: noisy) {
+		WriteImpl(fmt::format("  {:>12} messages  {}:{}\n", entry.count, entry.file, entry.line));
+	}
+	WriteImpl("--- raise or disable this with --log-repeat-limit ---\n");
+	Flush();
 }
 
 void Write(std::string_view text) {

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -3,6 +3,8 @@
 
 #include "common/common.h"
 
+#include <atomic>
+#include <cstdint>
 #include <fmt/color.h>
 #include <fmt/printf.h>
 #include <string_view>
@@ -23,6 +25,40 @@ enum class Direction { Silent, Console, File };
 
 Direction GetDirection();
 bool      IsSilent();
+
+// Per-call-site rate limiting.
+//
+// A KytyPS5 log can reach several gigabytes in two minutes (issue #200), which
+// makes it useless for the bug reports the compatibility list runs on - nobody
+// can upload it, and nothing in it is findable. Almost all of that volume is a
+// handful of lines inside per-draw or per-packet loops, printing millions of
+// times with only an address different each time.
+//
+// Deduplicating message TEXT would not help, because those lines differ every
+// time. What repeats is the call site, so that is what is counted. Each LOGF
+// gets its own counter: the first messages from a site are written in full,
+// after which the site is sampled, and the total is reported at the end. So a
+// line that fires once still appears once, and a line that fires ten million
+// times costs a few hundred lines instead of a gigabyte.
+//
+// The repo already does this by hand in the worst offenders, with a local
+// static atomic and a `< 2048` check. This is that idiom, applied everywhere,
+// without needing to guess in advance which site will be the next problem.
+struct Site {
+	const char*           file  = nullptr;
+	int                   line  = 0;
+	std::atomic<uint64_t> count = 0;
+	std::atomic<bool>     registered = false;
+};
+
+// True when this occurrence should be written. Called BEFORE the message is
+// formatted, so a suppressed line costs an atomic increment rather than a
+// printf - which is most of the cost of the logging these loops do.
+bool ShouldWrite(Site& site);
+
+// One block naming the sites that were rate limited and how often each fired.
+// This is the part that keeps the log honest: nothing disappears silently.
+void WriteRateLimitSummary();
 void      Write(std::string_view text);
 void      Write(fmt::text_style style, std::string_view text);
 void      WriteFatal(std::string_view text);
@@ -51,14 +87,16 @@ inline constexpr auto BrightWhite   = fmt::fg(fmt::terminal_color::bright_white)
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define LOGF(...)                                                                                  \
 	do {                                                                                           \
-		if (!::Log::IsSilent()) {                                                                  \
+		static ::Log::Site kyty_log_site {__FILE__, __LINE__};                                     \
+		if (!::Log::IsSilent() && ::Log::ShouldWrite(kyty_log_site)) {                             \
 			::Log::Write(::fmt::sprintf(__VA_ARGS__));                                             \
 		}                                                                                          \
 	} while (false)
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define LOGF_COLOR(style, ...)                                                                     \
 	do {                                                                                           \
-		if (!::Log::IsSilent()) {                                                                  \
+		static ::Log::Site kyty_log_site {__FILE__, __LINE__};                                     \
+		if (!::Log::IsSilent() && ::Log::ShouldWrite(kyty_log_site)) {                              \
 			::Log::Write((style), ::fmt::sprintf(__VA_ARGS__));                                    \
 		}                                                                                          \
 	} while (false)

--- a/src/graphics/host_gpu/graphicContext.h
+++ b/src/graphics/host_gpu/graphicContext.h
@@ -19,6 +19,19 @@ struct VulkanMemory;
 struct GraphicContext: public VulkanInstance {
 	[[nodiscard]] bool CreateAllocator();
 	void               DestroyAllocator();
+
+	// Load (and validate) the on-disk pipeline cache, then create the
+	// vk::PipelineCache. Never fails the caller: a backend without a cache
+	// renders identically, just slower on first use of each pipeline.
+	void CreatePipelineCache();
+	// Serialise the cache to disk, leaving it usable. Split out from
+	// DestroyPipelineCache() because the emulator's normal exit is
+	// std::quick_exit(), which runs no destructors - so the only chance to
+	// write the cache is before that, with the device still alive.
+	void SavePipelineCache();
+	// Serialise the cache back to disk and destroy it. Safe to call when
+	// CreatePipelineCache() was never called or failed.
+	void DestroyPipelineCache();
 	void               LogMemoryBudget() const;
 	[[nodiscard]] bool CanReportMemoryUsage() const noexcept { return memory_budget_ext_enabled; }
 	[[nodiscard]] uint64_t GetDeviceMemoryUsage() const;

--- a/src/graphics/host_gpu/renderer/image/blitHelper.cpp
+++ b/src/graphics/host_gpu/renderer/image/blitHelper.cpp
@@ -144,7 +144,7 @@ vk::Pipeline BlitHelper::GetPipeline(PipelineKey key) {
 
 	vk::Pipeline pipeline = nullptr;
 	RequireVulkanSuccess(
-	    m_graphics.device.createGraphicsPipelines(nullptr, 1, &create, nullptr, &pipeline),
+	    m_graphics.device.createGraphicsPipelines(m_graphics.pipeline_cache, 1, &create, nullptr, &pipeline),
 	    "create color-to-MS-depth pipeline");
 	m_pipelines.push_back({key, pipeline});
 	return pipeline;

--- a/src/graphics/host_gpu/renderer/image/tiler.cpp
+++ b/src/graphics/host_gpu/renderer/image/tiler.cpp
@@ -281,7 +281,7 @@ vk::Pipeline TileManager::GetPipeline(uint32_t slot) {
 	create.stage  = stage;
 	create.layout = m_pipeline_layout;
 	const auto result =
-	    m_graphics.device.createComputePipelines(nullptr, 1, &create, nullptr, &m_pipelines[slot]);
+	    m_graphics.device.createComputePipelines(m_graphics.pipeline_cache, 1, &create, nullptr, &m_pipelines[slot]);
 	m_graphics.device.destroyShaderModule(module, nullptr);
 	RequireVulkanSuccess(result, "create TileManager pipeline");
 	return m_pipelines[slot];
@@ -499,7 +499,7 @@ void TileManager::ConvertD16(Result source, Result target, D16Direction directio
 		create.stage  = stage;
 		create.layout = m_pipeline_layout;
 		const auto result =
-		    m_graphics.device.createComputePipelines(nullptr, 1, &create, nullptr, &pipeline);
+		    m_graphics.device.createComputePipelines(m_graphics.pipeline_cache, 1, &create, nullptr, &pipeline);
 		m_graphics.device.destroyShaderModule(module, nullptr);
 		RequireVulkanSuccess(result, "create D16 conversion pipeline");
 	}
@@ -643,7 +643,7 @@ void TileManager::SwapBgra16(Result input, Result output, uint32_t pixels) {
 		create.stage  = stage;
 		create.layout = m_pipeline_layout;
 		const auto result =
-		    m_graphics.device.createComputePipelines(nullptr, 1, &create, nullptr, &m_swap_bgra16);
+		    m_graphics.device.createComputePipelines(m_graphics.pipeline_cache, 1, &create, nullptr, &m_swap_bgra16);
 		m_graphics.device.destroyShaderModule(module, nullptr);
 		RequireVulkanSuccess(result, "create BGRA16 swap pipeline");
 	}

--- a/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
@@ -1019,7 +1019,7 @@ void CreatePipelineInternal(
 		     viewport.y, viewport.width, viewport.height, scissor.offset.x, scissor.offset.y,
 		     scissor.extent.width, scissor.extent.height);
 	}
-	result = graphics.device.createGraphicsPipelines(nullptr, 1, &pipeline_info, nullptr,
+	result = graphics.device.createGraphicsPipelines(graphics.pipeline_cache, 1, &pipeline_info, nullptr,
 	                                                 &pipeline.pipeline);
 	if (graphics_debug_dump_enabled()) {
 		LOGF("PipelineTrace: vkCreateGraphicsPipelines done result=%s pipeline=%p\n",
@@ -1123,7 +1123,7 @@ void CreatePipelineInternal(GraphicContext& graphics, DescriptorCache& descripto
 
 	LOGF("PipelineTrace: vkCreateComputePipelines begin layout=%p\n",
 	     static_cast<void*>(pipeline.pipeline_layout));
-	result = graphics.device.createComputePipelines(nullptr, 1, &info, nullptr, &pipeline.pipeline);
+	result = graphics.device.createComputePipelines(graphics.pipeline_cache, 1, &info, nullptr, &pipeline.pipeline);
 	LOGF("PipelineTrace: vkCreateComputePipelines done result=%s pipeline=%p\n",
 	     VulkanToString(result).c_str(), static_cast<void*>(pipeline.pipeline));
 	EXIT_NOT_IMPLEMENTED(result != vk::Result::eSuccess);

--- a/src/graphics/host_gpu/vma.cpp
+++ b/src/graphics/host_gpu/vma.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #include "common/assert.h"
+#include "common/emulatorConfig.h"
 #include "common/logging/log.h"
 #include "common/profiler.h"
 #include "graphics/host_gpu/graphicContext.h"
@@ -23,8 +24,35 @@
 #include <algorithm>
 #include <atomic>
 #include <cinttypes>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <system_error>
+#include <vector>
 
 namespace Libs::Graphics {
+
+// Allocation priority for VK_EXT_memory_priority: 0.0 means "demote this
+// first", 1.0 means "demote this last", and VMA uses 0.5 when nothing is
+// specified. It is a hint about relative value, so raising one class is
+// enough to order it against everything left at the default.
+//
+// Only images are raised here, deliberately. A demoted render target has to
+// be paged back in before the next pass that samples it, whereas most buffer
+// content can be re-uploaded from guest memory the emulator still holds. The
+// generic CreateBuffer() path also serves vertex/index buffers that may be
+// just as hot as an image, so lowering it wholesale would be guessing, and a
+// wrong guess here costs performance silently. Finer classification (staging
+// and tiler scratch really are cheap to lose) is a sensible follow-up once
+// someone measures it.
+//
+// This complements TextureCache::RunGarbageCollector() rather than replacing
+// it: the GC still frees things, this just gives the driver a cheaper option
+// one step earlier.
+namespace {
+constexpr float MEMORY_PRIORITY_IMAGE = 0.8F;
+} // namespace
 
 namespace {
 
@@ -73,6 +101,11 @@ bool GraphicContext::CreateAllocator() {
 	info.pVulkanFunctions = &functions;
 	info.vulkanApiVersion = VULKAN_TARGET_API_VERSION;
 	info.flags = memory_budget_ext_enabled ? VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT : 0;
+	// Without this bit VMA ignores VmaAllocationCreateInfo::priority entirely,
+	// so the per-allocation priorities set below would be silently inert.
+	if (memory_priority_ext_enabled) {
+		info.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT;
+	}
 
 	const auto result = static_cast<vk::Result>(vmaCreateAllocator(&info, &allocator));
 	if (result != vk::Result::eSuccess) {
@@ -80,6 +113,159 @@ bool GraphicContext::CreateAllocator() {
 		return false;
 	}
 	return true;
+}
+
+// ── Persistent pipeline cache ────────────────────────────────────────────
+//
+// Every createGraphicsPipelines/createComputePipelines call in the renderer
+// used to pass a null VkPipelineCache, so the driver recompiled each pipeline
+// from scratch on every launch. PipelineCache in renderer/pipeline is a
+// software map of vk::Pipeline handles: it stops us asking the driver twice
+// in one run, but it does not survive process exit and it is not what the
+// driver consults when it does compile.
+//
+// The blob on disk is untrusted input. It may have been written by a
+// different GPU, or by an older driver, or by a run that was killed
+// mid-write. Vulkan puts a header on it precisely so this can be checked, so
+// validate vendor/device id and the pipeline-cache UUID against the device we
+// actually bound to before handing anything to the driver. A mismatch is the
+// normal consequence of a driver update, not an error worth shouting about.
+
+namespace {
+
+constexpr uint32_t PIPELINE_CACHE_HEADER_BYTES = 32;
+constexpr uint32_t PIPELINE_CACHE_VERSION_ONE  = 1;
+
+uint32_t ReadLe32(const uint8_t* p) {
+	return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8U) |
+	       (static_cast<uint32_t>(p[2]) << 16U) | (static_cast<uint32_t>(p[3]) << 24U);
+}
+
+// True when the blob's header describes the device we are running on.
+bool PipelineCacheMatchesDevice(const std::vector<uint8_t>&         blob,
+                                 const vk::PhysicalDeviceProperties& props) {
+	if (blob.size() < PIPELINE_CACHE_HEADER_BYTES) {
+		return false;
+	}
+	const auto* h           = blob.data();
+	const auto  header_size = ReadLe32(h + 0);
+	const auto  header_ver  = ReadLe32(h + 4);
+	const auto  vendor_id   = ReadLe32(h + 8);
+	const auto  device_id   = ReadLe32(h + 12);
+
+	return header_size >= PIPELINE_CACHE_HEADER_BYTES && header_size <= blob.size() &&
+	       header_ver == PIPELINE_CACHE_VERSION_ONE && vendor_id == props.vendorID &&
+	       device_id == props.deviceID &&
+	       std::memcmp(h + 16, props.pipelineCacheUUID, VK_UUID_SIZE) == 0;
+}
+
+std::vector<uint8_t> ReadPipelineCacheFile(const std::filesystem::path& path) {
+	std::error_code ec;
+	if (!std::filesystem::exists(path, ec) || ec) {
+		return {}; // first run
+	}
+	std::ifstream in(path, std::ios::binary);
+	if (!in) {
+		return {};
+	}
+	std::vector<uint8_t> blob((std::istreambuf_iterator<char>(in)),
+	                           std::istreambuf_iterator<char>());
+	return blob;
+}
+
+} // namespace
+
+void GraphicContext::CreatePipelineCache() {
+	EXIT_IF(device == nullptr);
+
+	const auto path = Config::GetPipelineCacheFile();
+
+	std::vector<uint8_t> blob;
+	if (!path.empty()) {
+		blob = ReadPipelineCacheFile(path);
+		if (!blob.empty() && !PipelineCacheMatchesDevice(blob, physical_device_properties)) {
+			LOGF("Pipeline cache does not match this device/driver, starting cold\n");
+			blob.clear();
+		}
+	}
+
+	vk::PipelineCacheCreateInfo info {};
+	info.sType           = vk::StructureType::ePipelineCacheCreateInfo;
+	info.initialDataSize = blob.size();
+	info.pInitialData    = blob.empty() ? nullptr : blob.data();
+
+	auto result = device.createPipelineCache(&info, nullptr, &pipeline_cache);
+	if (result != vk::Result::eSuccess && !blob.empty()) {
+		// The header matched but the driver still refused it. Try cold rather
+		// than run without a cache at all.
+		LOGF("Pipeline cache rejected by the driver (%s), retrying empty\n",
+		     VulkanToString(result).c_str());
+		info.initialDataSize = 0;
+		info.pInitialData    = nullptr;
+		result               = device.createPipelineCache(&info, nullptr, &pipeline_cache);
+	}
+	if (result != vk::Result::eSuccess) {
+		LOGF("vkCreatePipelineCache failed: %s\n", VulkanToString(result).c_str());
+		pipeline_cache = nullptr;
+		return;
+	}
+
+	LOGF("Pipeline cache: %zu bytes loaded from %s\n", blob.size(),
+	     path.empty() ? "(disabled)" : path.string().c_str());
+}
+
+void GraphicContext::SavePipelineCache() {
+	if (pipeline_cache == nullptr) {
+		return;
+	}
+
+	const auto path = Config::GetPipelineCacheFile();
+	if (!path.empty()) {
+		size_t     size   = 0;
+		const auto sized  = device.getPipelineCacheData(pipeline_cache, &size, nullptr);
+		if (sized == vk::Result::eSuccess && size > 0) {
+			std::vector<uint8_t> blob(size);
+			if (device.getPipelineCacheData(pipeline_cache, &size, blob.data()) ==
+			    vk::Result::eSuccess) {
+				// temp + rename: an interrupted shutdown must not leave a torn
+				// file for the next run to detect and discard.
+				std::error_code ec;
+				auto            tmp = path;
+				tmp += ".tmp";
+				{
+					std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+					if (out) {
+						out.write(reinterpret_cast<const char*>(blob.data()),
+						          static_cast<std::streamsize>(blob.size()));
+					}
+					if (!out) {
+						std::filesystem::remove(tmp, ec);
+						tmp.clear();
+					}
+				}
+				if (!tmp.empty()) {
+					std::filesystem::rename(tmp, path, ec);
+					if (ec) {
+						std::filesystem::remove(tmp, ec);
+					} else {
+						LOGF("Pipeline cache: %zu bytes written to %s\n", blob.size(),
+						     path.string().c_str());
+					}
+				}
+			}
+		}
+	}
+
+}
+
+void GraphicContext::DestroyPipelineCache() {
+	if (pipeline_cache == nullptr) {
+		return;
+	}
+
+	SavePipelineCache();
+	device.destroyPipelineCache(pipeline_cache, nullptr);
+	pipeline_cache = nullptr;
 }
 
 void GraphicContext::DestroyAllocator() {
@@ -222,6 +408,7 @@ bool GraphicContext::CreateImage(const vk::ImageCreateInfo& image_info, VulkanIm
 	alloc_info.requiredFlags = static_cast<vk::MemoryPropertyFlags::MaskType>(memory.property);
 	alloc_info.preferredFlags =
 	    static_cast<vk::MemoryPropertyFlags::MaskType>(memory.preferred_property);
+	alloc_info.priority = MEMORY_PRIORITY_IMAGE;
 
 	vk::Image::CType native_image = VK_NULL_HANDLE;
 	const auto       result       = static_cast<vk::Result>(

--- a/src/graphics/host_gpu/vulkanDiagnostics.cpp
+++ b/src/graphics/host_gpu/vulkanDiagnostics.cpp
@@ -1,0 +1,197 @@
+#include "graphics/host_gpu/vulkanDiagnostics.h"
+
+#include "SDL.h"
+#include "SDL_vulkan.h"
+#include "graphics/host_gpu/vulkanCommon.h"
+#include "graphics/host_gpu/vulkanInstance.h"
+
+#include <algorithm>
+#include <fmt/format.h>
+#include <vector>
+
+namespace Libs::Graphics {
+
+namespace {
+
+// The extensions this emulator actually looks for. Reporting the full list a
+// driver exposes would bury the four lines that matter under two hundred that
+// do not.
+constexpr const char* INTERESTING_EXTENSIONS[] = {
+    VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,
+    VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME,
+    VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME,
+    VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,
+    VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME,
+    VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+    VK_KHR_RAY_QUERY_EXTENSION_NAME,
+    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+};
+
+std::string ApiVersionToString(uint32_t version) {
+	return fmt::format("{}.{}.{}", VK_API_VERSION_MAJOR(version), VK_API_VERSION_MINOR(version),
+	                   VK_API_VERSION_PATCH(version));
+}
+
+// Driver versions are vendor-encoded. NVIDIA and Intel-on-Windows pack them
+// differently from the Vulkan convention, and printing 2298589184 helps nobody,
+// so decode the two that are worth decoding and print the raw value alongside.
+std::string DriverVersionToString(uint32_t vendor_id, uint32_t version) {
+	constexpr uint32_t VENDOR_NVIDIA = 0x10DE;
+
+	if (vendor_id == VENDOR_NVIDIA) {
+		return fmt::format("{}.{}.{}.{} (raw {})", (version >> 22U) & 0x3FFU,
+		                   (version >> 14U) & 0xFFU, (version >> 6U) & 0xFFU, version & 0x3FU,
+		                   version);
+	}
+	return fmt::format("{} (raw {})", ApiVersionToString(version), version);
+}
+
+const char* DeviceTypeToString(vk::PhysicalDeviceType type) {
+	switch (type) {
+		case vk::PhysicalDeviceType::eIntegratedGpu: return "integrated GPU";
+		case vk::PhysicalDeviceType::eDiscreteGpu: return "discrete GPU";
+		case vk::PhysicalDeviceType::eVirtualGpu: return "virtual GPU";
+		case vk::PhysicalDeviceType::eCpu: return "CPU";
+		default: return "other";
+	}
+}
+
+std::vector<vk::ExtensionProperties> DeviceExtensions(vk::PhysicalDevice device) {
+	uint32_t count = 0;
+	if (device.enumerateDeviceExtensionProperties(nullptr, &count, nullptr) !=
+	        vk::Result::eSuccess ||
+	    count == 0) {
+		return {};
+	}
+	std::vector<vk::ExtensionProperties> extensions(count);
+	if (device.enumerateDeviceExtensionProperties(nullptr, &count, extensions.data()) !=
+	    vk::Result::eSuccess) {
+		return {};
+	}
+	return extensions;
+}
+
+void AppendDevice(std::string& report, vk::PhysicalDevice device, uint32_t index) {
+	vk::PhysicalDeviceProperties props {};
+	device.getProperties(&props);
+
+	report += fmt::format("  [{}] {}\n", index, props.deviceName.data());
+	report += fmt::format("      type:   {}\n", DeviceTypeToString(props.deviceType));
+	report += fmt::format("      ids:    vendor 0x{:04x}, device 0x{:04x}\n", props.vendorID,
+	                      props.deviceID);
+	report += fmt::format("      api:    {}\n", ApiVersionToString(props.apiVersion));
+	report += fmt::format("      driver: {}\n", DriverVersionToString(props.vendorID,
+	                                                                  props.driverVersion));
+
+	vk::PhysicalDeviceMemoryProperties memory {};
+	device.getMemoryProperties(&memory);
+	for (uint32_t i = 0; i < memory.memoryHeapCount; i++) {
+		const auto& heap = memory.memoryHeaps[i];
+		const bool  local =
+		    static_cast<bool>(heap.flags & vk::MemoryHeapFlagBits::eDeviceLocal);
+		report += fmt::format("      heap {}: {} MiB{}\n", i, heap.size / (1024ULL * 1024ULL),
+		                      local ? ", device local" : "");
+	}
+
+	const auto extensions = DeviceExtensions(device);
+	for (const auto* wanted: INTERESTING_EXTENSIONS) {
+		const bool present =
+		    std::any_of(extensions.begin(), extensions.end(), [wanted](const auto& available) {
+			    return std::string_view(available.extensionName.data()) == wanted;
+		    });
+		report += fmt::format("      {} {}\n", present ? "yes" : " no", wanted);
+	}
+	report += "\n";
+}
+
+} // namespace
+
+std::string BuildVulkanReport() {
+	std::string report = "Vulkan\n";
+
+	// SDL will not hand out the Vulkan loader until its video subsystem is up.
+	// On a headless box that init fails, which is itself worth reporting rather
+	// than hiding: it means the emulator would not open a window here either.
+	const bool video_was_up = SDL_WasInit(SDL_INIT_VIDEO) != 0;
+	if (!video_was_up && SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) {
+		report += fmt::format("  no display available, so Vulkan cannot be queried: {}\n\n",
+		                      SDL_GetError());
+		return report;
+	}
+
+	auto release_video = [video_was_up] {
+		if (!video_was_up) {
+			SDL_QuitSubSystem(SDL_INIT_VIDEO);
+		}
+	};
+
+	if (SDL_Vulkan_LoadLibrary(nullptr) != 0) {
+		report += fmt::format("  no Vulkan loader on this machine: {}\n\n", SDL_GetError());
+		release_video();
+		return report;
+	}
+
+	auto* get_instance_proc_addr =
+	    reinterpret_cast<PFN_vkGetInstanceProcAddr>(SDL_Vulkan_GetVkGetInstanceProcAddr());
+	if (get_instance_proc_addr == nullptr) {
+		report += fmt::format("  Vulkan loader present but unusable: {}\n\n", SDL_GetError());
+		SDL_Vulkan_UnloadLibrary();
+		release_video();
+		return report;
+	}
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(get_instance_proc_addr);
+
+	vk::ApplicationInfo app_info {};
+	app_info.sType            = vk::StructureType::eApplicationInfo;
+	app_info.pApplicationName = "Kyty";
+	app_info.pEngineName      = "Kyty";
+	// Deliberately not VULKAN_TARGET_API_VERSION: a machine whose loader is too
+	// old to give us 1.3 is precisely the machine we want a report from, and
+	// asking for 1.0 still enumerates every device and its real apiVersion.
+	app_info.apiVersion = VK_API_VERSION_1_0;
+
+	vk::InstanceCreateInfo info {};
+	info.sType             = vk::StructureType::eInstanceCreateInfo;
+	info.pApplicationInfo  = &app_info;
+
+	vk::Instance instance = nullptr;
+	const auto   result   = vk::createInstance(&info, nullptr, &instance);
+	if (result != vk::Result::eSuccess) {
+		report += fmt::format("  could not create a Vulkan instance: {}\n\n",
+		                      VulkanToString(result));
+		SDL_Vulkan_UnloadLibrary();
+		release_video();
+		return report;
+	}
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(instance);
+
+	uint32_t count = 0;
+	if (instance.enumeratePhysicalDevices(&count, nullptr) != vk::Result::eSuccess || count == 0) {
+		report += "  no Vulkan devices found\n\n";
+		instance.destroy(nullptr);
+		SDL_Vulkan_UnloadLibrary();
+		release_video();
+		return report;
+	}
+
+	std::vector<vk::PhysicalDevice> devices(count);
+	if (instance.enumeratePhysicalDevices(&count, devices.data()) != vk::Result::eSuccess) {
+		report += "  device enumeration failed\n\n";
+		instance.destroy(nullptr);
+		SDL_Vulkan_UnloadLibrary();
+		release_video();
+		return report;
+	}
+
+	report += fmt::format("  {} device(s)\n\n", count);
+	for (uint32_t i = 0; i < count; i++) {
+		AppendDevice(report, devices[i], i);
+	}
+
+	instance.destroy(nullptr);
+	SDL_Vulkan_UnloadLibrary();
+	release_video();
+	return report;
+}
+
+} // namespace Libs::Graphics

--- a/src/graphics/host_gpu/vulkanDiagnostics.h
+++ b/src/graphics/host_gpu/vulkanDiagnostics.h
@@ -1,0 +1,22 @@
+#ifndef EMULATOR_SRC_GRAPHICS_HOST_GPU_VULKANDIAGNOSTICS_H_
+#define EMULATOR_SRC_GRAPHICS_HOST_GPU_VULKANDIAGNOSTICS_H_
+
+#include <string>
+
+namespace Libs::Graphics {
+
+// The Vulkan half of the --diagnostics report: every physical device on this
+// machine, its driver, its memory heaps, and which of the extensions this
+// emulator actually looks for are present.
+//
+// Creates its own instance and destroys it again. It does not need a window, a
+// surface or a device, so it works on a machine where the emulator itself does
+// not start - which is exactly when someone needs to file a report.
+//
+// Never throws and never exits: a machine with no usable Vulkan gets a report
+// saying so, because that is the single most useful thing it could say.
+[[nodiscard]] std::string BuildVulkanReport();
+
+} // namespace Libs::Graphics
+
+#endif /* EMULATOR_SRC_GRAPHICS_HOST_GPU_VULKANDIAGNOSTICS_H_ */

--- a/src/graphics/host_gpu/vulkanInstance.h
+++ b/src/graphics/host_gpu/vulkanInstance.h
@@ -23,7 +23,17 @@ struct VulkanInstance {
 	vk::PhysicalDeviceMemoryProperties physical_device_memory_properties = {};
 	vk::Device                         device                            = nullptr;
 	VmaAllocator                       allocator                         = nullptr;
+	// Driver-side pipeline cache, persisted across runs. Distinct from
+	// PipelineCache in renderer/pipeline: that one dedupes vk::Pipeline
+	// handles within a single run, this is what stops the driver
+	// recompiling the same SPIR-V on every launch.
+	vk::PipelineCache                  pipeline_cache                    = nullptr;
 	bool                               memory_budget_ext_enabled         = false;
+	// VK_EXT_memory_priority + VK_EXT_pageable_device_local_memory. Both are
+	// optional and are enabled together: priority is what tells the driver
+	// which allocations to demote first, and pageable_device_local_memory is
+	// what lets it demote instead of failing the allocation outright.
+	bool                               memory_priority_ext_enabled       = false;
 	bool                               rt_extensions_enabled             = false;
 	bool                               subgroup_size_control_enabled     = false;
 	bool                               sample_rate_shading_enabled       = false;

--- a/src/graphics/presentation/window.h
+++ b/src/graphics/presentation/window.h
@@ -12,6 +12,12 @@ class Presenter;
 void                     WindowRun();
 void                     WindowShutdown();
 
+// Writes the driver pipeline cache to disk without destroying anything. The
+// emulator's normal exit is std::quick_exit(), which runs no destructors, so
+// this is what actually gets the cache written; WindowShutdown() still writes
+// it on the paths that do unwind.
+void                     WindowFlushCaches();
+
 } // namespace Libs::Graphics
 
 #endif /* EMULATOR_INCLUDE_EMULATOR_GRAPHICS_WINDOW_H_ */

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -540,6 +540,25 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 		supported_features12.pNext = &supported_robustness2;
 	}
 
+	// VK_EXT_pageable_device_local_memory carries a feature bit that must be
+	// enabled explicitly at device creation; using the extension without it
+	// is invalid usage, so query it here and only turn the pair on if the
+	// driver really reports it.
+	const auto pageable_ext_enabled =
+	    HasExtension(device_extensions, VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
+
+	vk::PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT supported_pageable {};
+	supported_pageable.sType =
+	    vk::StructureType::ePhysicalDevicePageableDeviceLocalMemoryFeaturesEXT;
+	supported_pageable.pNext = nullptr;
+	if (pageable_ext_enabled) {
+		if (robustness2_ext_enabled) {
+			supported_robustness2.pNext = &supported_pageable;
+		} else {
+			supported_features12.pNext = &supported_pageable;
+		}
+	}
+
 	vk::PhysicalDeviceFeatures2 supported_features2 {};
 	supported_features2.sType = vk::StructureType::ePhysicalDeviceFeatures2;
 	supported_features2.pNext = &supported_features13;
@@ -610,9 +629,23 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	     features13.robustImageAccess == VK_TRUE ? "true" : "false",
 	     robustness2_ext_enabled && robustness2.robustImageAccess2 == VK_TRUE ? "true" : "false");
 
+	// Chain the pageable-memory enable in front of features13 when the driver
+	// reported support. Left out entirely otherwise, so a driver without the
+	// extension sees exactly the chain it saw before this change.
+	vk::PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT pageable_features {};
+	pageable_features.sType =
+	    vk::StructureType::ePhysicalDevicePageableDeviceLocalMemoryFeaturesEXT;
+	pageable_features.pageableDeviceLocalMemory = VK_TRUE;
+	pageable_features.pNext                     = &features13;
+
+	const bool enable_pageable =
+	    pageable_ext_enabled && supported_pageable.pageableDeviceLocalMemory == VK_TRUE;
+
 	vk::DeviceCreateInfo create_info {};
 	create_info.sType                   = vk::StructureType::eDeviceCreateInfo;
-	create_info.pNext                   = &features13;
+	create_info.pNext                   = enable_pageable
+	                                          ? static_cast<const void*>(&pageable_features)
+	                                          : static_cast<const void*>(&features13);
 	create_info.flags                   = {};
 	create_info.pQueueCreateInfos       = &queue_create_info;
 	create_info.queueCreateInfoCount    = 1;
@@ -974,6 +1007,20 @@ void WindowContext::CreateVulkan() {
 		if (HasExtension(available_extensions, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
 			device_extensions.push_back(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
 		}
+		// Memory priority lets the driver demote low-value allocations under
+		// pressure instead of the texture cache having to delete and later
+		// recreate them, so it complements RunGarbageCollector() rather than
+		// replacing it: the GC stays the backstop, this reduces how often it
+		// has to fire. pageable_device_local_memory is required alongside it
+		// for the driver to actually page device-local memory rather than
+		// returning VK_ERROR_OUT_OF_DEVICE_MEMORY, so both or neither.
+		if (HasExtension(available_extensions, VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME) &&
+		    HasExtension(available_extensions,
+		                 VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME)) {
+			device_extensions.push_back(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME);
+			device_extensions.push_back(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
+			graphic_ctx.memory_priority_ext_enabled = true;
+		}
 	}
 
 	memcpy(device_name, device_properties.deviceName, sizeof(device_name));
@@ -991,6 +1038,8 @@ void WindowContext::CreateVulkan() {
 	graphic_ctx.queue_family = queue_family;
 	graphic_ctx.device.getQueue(queue_family, 0, &graphic_ctx.queue);
 	EXIT_IF(graphic_ctx.queue == nullptr);
+
+	graphic_ctx.CreatePipelineCache();
 
 	if (!graphic_ctx.CreateAllocator()) {
 		EXIT("Could not create Vulkan memory allocator");
@@ -1029,6 +1078,7 @@ WindowContext::~WindowContext() {
 
 	if (graphic_ctx.device != nullptr) {
 		RequireVulkanSuccess(graphic_ctx.device.waitIdle(), "wait for Vulkan device shutdown");
+		graphic_ctx.DestroyPipelineCache();
 		graphic_ctx.DestroyAllocator();
 		graphic_ctx.device.destroy(nullptr);
 		graphic_ctx.device = nullptr;

--- a/src/graphics/presentation/window/window.cpp
+++ b/src/graphics/presentation/window/window.cpp
@@ -868,6 +868,12 @@ void WindowRun() {
 	g_window->Run();
 }
 
+void WindowFlushCaches() {
+	if (g_window != nullptr && g_window->graphic_ctx.device != nullptr) {
+		g_window->graphic_ctx.SavePipelineCache();
+	}
+}
+
 void WindowShutdown() {
 	if (g_window != nullptr) {
 		g_window.reset();

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -1,5 +1,7 @@
 #include "graphics/shader/shader.h"
 
+#include "graphics/shader/shaderDiskCache.h"
+
 #include "common/assert.h"
 #include "common/common.h"
 #include "common/emulatorConfig.h"
@@ -163,10 +165,77 @@ static std::span<const uint32_t> MakeShaderSpirvView(const std::vector<uint32_t>
 	return {spirv.data(), spirv.size()};
 }
 
+// Repopulates the in-memory program cache from disk. Entries that arrive here
+// are not trusted: each one still has to satisfy the same runtime
+// specialization check an in-run permutation does (TryUse*Permutation ->
+// ShaderMaterializeStageRuntime), so a stale entry costs a recompile, never a
+// wrong frame.
+static void ShaderLoadDiskCache() {
+	const auto path = Config::GetShaderCacheFile();
+	if (path.empty()) {
+		return;
+	}
+
+	auto entries = ShaderDiskCacheLoad(path);
+
+	std::scoped_lock lock(g_shader_program_cache_mutex);
+	for (auto& entry: entries) {
+		ShaderStageProgramKey key {};
+		key.stage             = entry.stage;
+		key.lane_mask_mode    = entry.lane_mask_mode;
+		key.shader_hash       = entry.shader_hash;
+		key.program_id        = entry.program_id;
+		key.optimization_type = entry.optimization_type;
+
+		auto& permutations = g_shader_program_cache[key];
+		if (permutations.size() >= ShaderMaxPermutationsPerProgram) {
+			continue;
+		}
+
+		auto permutation     = std::make_unique<ShaderProgramPermutation>();
+		permutation->spirv   = std::move(entry.spirv);
+		permutation->program = std::move(entry.program);
+		permutations.push_back(std::move(permutation));
+	}
+}
+
+void ShaderSaveDiskCache() {
+	const auto path = Config::GetShaderCacheFile();
+	if (path.empty()) {
+		return;
+	}
+
+	std::vector<ShaderDiskCacheEntry> entries;
+
+	{
+		std::scoped_lock lock(g_shader_program_cache_mutex);
+		for (const auto& [key, permutations]: g_shader_program_cache) {
+			for (const auto& permutation: permutations) {
+				if (permutation->program == nullptr || permutation->spirv.empty()) {
+					continue;
+				}
+				ShaderDiskCacheEntry entry {};
+				entry.stage             = key.stage;
+				entry.lane_mask_mode    = key.lane_mask_mode;
+				entry.shader_hash       = key.shader_hash;
+				entry.program_id        = key.program_id;
+				entry.optimization_type = key.optimization_type;
+				entry.program           = permutation->program;
+				entry.spirv             = permutation->spirv;
+				entries.push_back(std::move(entry));
+			}
+		}
+	}
+
+	ShaderDiskCacheSave(path, entries);
+}
+
 void ShaderInit() {
 	EXIT_IF(g_shader_map != nullptr);
 
 	g_shader_map = std::make_unique<std::unordered_map<uint64_t, ShaderMappedData>>();
+
+	ShaderLoadDiskCache();
 }
 
 void ShaderMapUserData(uint64_t addr, const ShaderMappedData& data) {

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -244,6 +244,9 @@ struct ShaderMappedData {
 };
 
 void ShaderInit();
+// Writes every recompiled shader in the in-memory cache to disk. Called on the
+// way out; see WindowFlushCaches() for why that is not a destructor.
+void ShaderSaveDiskCache();
 void ShaderMapUserData(uint64_t addr, const ShaderMappedData& data);
 
 void     ShaderDbgDumpInputInfo(const ShaderVertexInputInfo& info);

--- a/src/graphics/shader/shaderDiskCache.cpp
+++ b/src/graphics/shader/shaderDiskCache.cpp
@@ -1,0 +1,678 @@
+#include "graphics/shader/shaderDiskCache.h"
+
+#include "common/logging/log.h"
+#include "kytyGitVersion.h"
+
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <string_view>
+#include <system_error>
+#include <xxhash.h>
+
+namespace Libs::Graphics {
+
+namespace {
+
+namespace IR = ShaderRecompiler::IR;
+
+constexpr char     CACHE_MAGIC[8]       = {'K', 'Y', 'T', 'Y', 'S', 'H', 'C', '\0'};
+constexpr uint32_t CACHE_FORMAT_VERSION = 1;
+
+// A cache entry is only meaningful to the exact recompiler that wrote it. Two
+// independent guards, because getting this wrong shows up as a wrong frame
+// rather than a crash:
+//
+//   - the git version, which changes whenever anything in the tree does;
+//   - the sizes of every IR struct the plan serializes, which catches a locally
+//     modified build that forgot to rebuild the version header.
+//
+// Being too strict costs one cold run after an update, which is what a driver
+// pipeline cache does too. Being too loose costs correctness, so this leans
+// strict on purpose.
+uint64_t ComputeBuildId() {
+	const uint32_t sizes[] = {
+	    static_cast<uint32_t>(sizeof(IR::BufferResource)),
+	    static_cast<uint32_t>(sizeof(IR::AddressResource)),
+	    static_cast<uint32_t>(sizeof(IR::ImageResource)),
+	    static_cast<uint32_t>(sizeof(IR::SamplerResource)),
+	    static_cast<uint32_t>(sizeof(IR::SampledResourcePair)),
+	    static_cast<uint32_t>(sizeof(IR::StageInput)),
+	    static_cast<uint32_t>(sizeof(IR::StageOutput)),
+	    static_cast<uint32_t>(sizeof(IR::DescriptorBinding)),
+	    static_cast<uint32_t>(sizeof(IR::BindingLayout)),
+	    static_cast<uint32_t>(sizeof(IR::ShaderInfo)),
+	    static_cast<uint32_t>(sizeof(IR::SpirvRequirements)),
+	    static_cast<uint32_t>(IR::DescriptorBindingKind::Count),
+	    CACHE_FORMAT_VERSION,
+	};
+
+	XXH3_state_t* state = XXH3_createState();
+	XXH3_64bits_reset(state);
+	XXH3_64bits_update(state, sizes, sizeof(sizes));
+	const std::string_view git = KYTY_GIT_VERSION;
+	XXH3_64bits_update(state, git.data(), git.size());
+	const auto id = XXH3_64bits_digest(state);
+	XXH3_freeState(state);
+	return id;
+}
+
+// ── byte writer / reader ────────────────────────────────────────────────
+//
+// Everything is written little-endian and length-prefixed. The reader never
+// trusts a length: Take() checks it against what is actually left, so a
+// truncated or malicious file makes Ok() false instead of reading past the end.
+
+class Writer {
+public:
+	void U8(uint8_t value) { m_bytes.push_back(value); }
+	void U32(uint32_t value) {
+		for (uint32_t i = 0; i < 4; i++) {
+			m_bytes.push_back(static_cast<uint8_t>((value >> (i * 8U)) & 0xFFU));
+		}
+	}
+	void U64(uint64_t value) {
+		for (uint32_t i = 0; i < 8; i++) {
+			m_bytes.push_back(static_cast<uint8_t>((value >> (i * 8U)) & 0xFFU));
+		}
+	}
+	void I32(int32_t value) { U32(static_cast<uint32_t>(value)); }
+	void Bool(bool value) { U8(value ? 1U : 0U); }
+	void Bytes(const void* data, size_t size) {
+		const auto* p = static_cast<const uint8_t*>(data);
+		m_bytes.insert(m_bytes.end(), p, p + size);
+	}
+	void String(const std::string& value) {
+		U32(static_cast<uint32_t>(value.size()));
+		Bytes(value.data(), value.size());
+	}
+	void U32Vector(const std::vector<uint32_t>& values) {
+		U32(static_cast<uint32_t>(values.size()));
+		for (auto value: values) {
+			U32(value);
+		}
+	}
+
+	[[nodiscard]] const std::vector<uint8_t>& Bytes() const { return m_bytes; }
+
+private:
+	std::vector<uint8_t> m_bytes;
+};
+
+class Reader {
+public:
+	Reader(const uint8_t* data, size_t size): m_data(data), m_size(size) {}
+
+	[[nodiscard]] bool Ok() const { return m_ok; }
+	[[nodiscard]] bool Done() const { return m_ok && m_pos == m_size; }
+
+	// True when `size` more bytes are actually available. Checked before every
+	// allocation sized from the file, so a corrupt length cannot ask for a
+	// gigabyte.
+	[[nodiscard]] bool CanHold(uint64_t size) const {
+		return m_ok && size <= static_cast<uint64_t>(m_size - m_pos);
+	}
+
+	const uint8_t* Skip(uint64_t size) {
+		if (size > static_cast<uint64_t>(m_size)) {
+			m_ok = false;
+			return nullptr;
+		}
+		return Take(static_cast<size_t>(size));
+	}
+
+	uint8_t U8() {
+		const auto* p = Take(1);
+		return p == nullptr ? 0 : *p;
+	}
+	uint32_t U32() {
+		const auto* p = Take(4);
+		if (p == nullptr) {
+			return 0;
+		}
+		return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8U) |
+		       (static_cast<uint32_t>(p[2]) << 16U) | (static_cast<uint32_t>(p[3]) << 24U);
+	}
+	uint64_t U64() {
+		const uint64_t low  = U32();
+		const uint64_t high = U32();
+		return low | (high << 32U);
+	}
+	int32_t I32() { return static_cast<int32_t>(U32()); }
+	bool    Bool() { return U8() != 0; }
+
+	std::string String() {
+		const auto  size = U32();
+		const auto* p    = Take(size);
+		if (p == nullptr) {
+			return {};
+		}
+		return std::string(reinterpret_cast<const char*>(p), size);
+	}
+
+	std::vector<uint32_t> U32Vector() {
+		const auto count = U32();
+		// A count is 4 bytes of payload each; refuse anything the buffer cannot
+		// hold before allocating for it.
+		if (!m_ok || static_cast<uint64_t>(count) * 4ULL > (m_size - m_pos)) {
+			m_ok = false;
+			return {};
+		}
+		std::vector<uint32_t> values(count);
+		for (auto& value: values) {
+			value = U32();
+		}
+		return values;
+	}
+
+	// Reads an enum by value, rejecting anything outside the range this build
+	// knows. A cache from a build with more enumerators must not silently
+	// become a different enumerator here.
+	template <class E>
+	E Enum(uint32_t count) {
+		const auto value = U32();
+		if (value >= count) {
+			m_ok = false;
+			return static_cast<E>(0);
+		}
+		return static_cast<E>(value);
+	}
+
+private:
+	const uint8_t* Take(size_t size) {
+		if (!m_ok || size > m_size - m_pos) {
+			m_ok = false;
+			return nullptr;
+		}
+		const auto* p = m_data + m_pos;
+		m_pos += size;
+		return p;
+	}
+
+	const uint8_t* m_data = nullptr;
+	size_t         m_size = 0;
+	size_t         m_pos  = 0;
+	bool           m_ok   = true;
+};
+
+// ── IR plan serialization ───────────────────────────────────────────────
+
+void WriteBuffer(Writer& w, const IR::BufferResource& r) {
+	w.U32(r.source);
+	w.U32(r.first_use_pc);
+	w.U32(r.max_byte_extent);
+	w.U32(r.packed_stride);
+	w.U32(static_cast<uint32_t>(r.descriptor_format));
+	w.U32(r.descriptor_swizzle);
+	w.U32(r.image_alias);
+	w.Bool(r.read);
+	w.Bool(r.written);
+	w.Bool(r.atomic);
+	w.Bool(r.formatted);
+	w.Bool(r.scalar);
+}
+
+IR::BufferResource ReadBuffer(Reader& r) {
+	IR::BufferResource value {};
+	value.source             = r.U32();
+	value.first_use_pc       = r.U32();
+	value.max_byte_extent    = r.U32();
+	value.packed_stride      = r.U32();
+	value.descriptor_format  = static_cast<Prospero::BufferFormat>(r.U32());
+	value.descriptor_swizzle = r.U32();
+	value.image_alias        = r.U32();
+	value.read               = r.Bool();
+	value.written            = r.Bool();
+	value.atomic             = r.Bool();
+	value.formatted          = r.Bool();
+	value.scalar             = r.Bool();
+	return value;
+}
+
+void WriteAddress(Writer& w, const IR::AddressResource& r) {
+	w.U32(r.source);
+	w.U32(r.first_use_pc);
+	w.U32(static_cast<uint32_t>(r.kind));
+	w.I32(r.min_offset);
+	w.U64(r.specialized_base);
+	w.Bool(r.unbased);
+	w.Bool(r.read);
+	w.Bool(r.written);
+	w.Bool(r.atomic);
+}
+
+IR::AddressResource ReadAddress(Reader& r) {
+	IR::AddressResource value {};
+	value.source           = r.U32();
+	value.first_use_pc     = r.U32();
+	value.kind             = static_cast<IR::ResourceKind>(r.U32());
+	value.min_offset       = r.I32();
+	value.specialized_base = r.U64();
+	value.unbased          = r.Bool();
+	value.read             = r.Bool();
+	value.written          = r.Bool();
+	value.atomic           = r.Bool();
+	return value;
+}
+
+void WriteImage(Writer& w, const IR::ImageResource& r) {
+	w.U32(r.source);
+	w.U32(r.first_use_pc);
+	w.U32(static_cast<uint32_t>(r.kind));
+	w.U32(static_cast<uint32_t>(r.dimension));
+	w.U32(static_cast<uint32_t>(r.mip_mode));
+	w.U32(r.mip_count);
+	w.U32(r.storage_swizzle);
+	w.Bool(r.read);
+	w.Bool(r.written);
+	w.Bool(r.atomic);
+	w.Bool(r.depth_compare);
+	w.Bool(r.cube);
+	w.U32(r.indirect_root);
+	w.U32(r.indirect_mapping_offset);
+	w.U32(r.indirect_mapping_capacity);
+	w.U32Vector(r.indirect_resources);
+}
+
+IR::ImageResource ReadImage(Reader& r) {
+	IR::ImageResource value {};
+	value.source                    = r.U32();
+	value.first_use_pc              = r.U32();
+	value.kind                      = static_cast<IR::ResourceKind>(r.U32());
+	value.dimension = static_cast<ShaderRecompiler::Decoder::ImageDimension>(r.U32());
+	value.mip_mode                  = static_cast<IR::ImageMipMode>(r.U32());
+	value.mip_count                 = r.U32();
+	value.storage_swizzle           = r.U32();
+	value.read                      = r.Bool();
+	value.written                   = r.Bool();
+	value.atomic                    = r.Bool();
+	value.depth_compare             = r.Bool();
+	value.cube                      = r.Bool();
+	value.indirect_root             = r.U32();
+	value.indirect_mapping_offset   = r.U32();
+	value.indirect_mapping_capacity = r.U32();
+	value.indirect_resources        = r.U32Vector();
+	return value;
+}
+
+void WriteShaderInfo(Writer& w, const IR::ShaderInfo& info) {
+	w.U32(static_cast<uint32_t>(info.buffers.size()));
+	for (const auto& value: info.buffers) {
+		WriteBuffer(w, value);
+	}
+	w.U32(static_cast<uint32_t>(info.addresses.size()));
+	for (const auto& value: info.addresses) {
+		WriteAddress(w, value);
+	}
+	w.U32(static_cast<uint32_t>(info.images.size()));
+	for (const auto& value: info.images) {
+		WriteImage(w, value);
+	}
+	w.U32(static_cast<uint32_t>(info.samplers.size()));
+	for (const auto& value: info.samplers) {
+		w.U32(value.source);
+		w.U32(value.first_use_pc);
+	}
+	w.U32(static_cast<uint32_t>(info.sampled_pairs.size()));
+	for (const auto& value: info.sampled_pairs) {
+		w.U32(value.image);
+		w.U32(value.sampler);
+		w.U32(value.first_use_pc);
+	}
+	w.U32(static_cast<uint32_t>(info.inputs.size()));
+	for (const auto& value: info.inputs) {
+		w.U32(static_cast<uint32_t>(value.kind));
+		w.U32(value.location);
+		w.U32(value.component_count);
+		w.String(value.debug_name);
+	}
+	w.U32(static_cast<uint32_t>(info.outputs.size()));
+	for (const auto& value: info.outputs) {
+		w.U32(static_cast<uint32_t>(value.kind));
+		w.U32(value.index);
+		w.U32(value.location);
+		w.String(value.debug_name);
+	}
+	w.I32(info.vertex_offset_sgpr);
+	w.Bool(info.has_bitwise_xor);
+}
+
+// Every vector length is read through a helper that refuses a count the buffer
+// cannot hold, so a corrupt length cannot turn into a huge allocation.
+template <class T, class F>
+bool ReadVector(Reader& r, std::vector<T>& out, size_t min_bytes_each, F&& read_one) {
+	const auto count = r.U32();
+	if (!r.Ok() || !r.CanHold(static_cast<uint64_t>(count) * min_bytes_each)) {
+		return false;
+	}
+	out.reserve(count);
+	for (uint32_t i = 0; i < count; i++) {
+		out.push_back(read_one(r));
+		if (!r.Ok()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool ReadShaderInfo(Reader& r, IR::ShaderInfo& info) {
+	if (!ReadVector(r, info.buffers, 29, ReadBuffer) ||
+	    !ReadVector(r, info.addresses, 28, ReadAddress) ||
+	    !ReadVector(r, info.images, 47, ReadImage)) {
+		return false;
+	}
+	if (!ReadVector(r, info.samplers, 8,
+	                [](Reader& in) {
+		                IR::SamplerResource value {};
+		                value.source       = in.U32();
+		                value.first_use_pc = in.U32();
+		                return value;
+	                }) ||
+	    !ReadVector(r, info.sampled_pairs, 12, [](Reader& in) {
+		    IR::SampledResourcePair value {};
+		    value.image        = in.U32();
+		    value.sampler      = in.U32();
+		    value.first_use_pc = in.U32();
+		    return value;
+	    })) {
+		return false;
+	}
+	if (!ReadVector(r, info.inputs, 16,
+	                [](Reader& in) {
+		                IR::StageInput value {};
+		                value.kind            = static_cast<IR::StageInputKind>(in.U32());
+		                value.location        = in.U32();
+		                value.component_count = in.U32();
+		                value.debug_name      = in.String();
+		                return value;
+	                }) ||
+	    !ReadVector(r, info.outputs, 16, [](Reader& in) {
+		    IR::StageOutput value {};
+		    value.kind       = static_cast<IR::StageOutputKind>(in.U32());
+		    value.index      = in.U32();
+		    value.location   = in.U32();
+		    value.debug_name = in.String();
+		    return value;
+	    })) {
+		return false;
+	}
+	info.vertex_offset_sgpr = r.I32();
+	info.has_bitwise_xor    = r.Bool();
+	return r.Ok();
+}
+
+void WriteBindings(Writer& w, const IR::BindingLayout& bindings) {
+	w.U32(bindings.descriptor_set);
+	w.U32(bindings.push_constant_offset);
+	w.U32(bindings.push_constant_size);
+	w.U32(bindings.buffer_offset_dword);
+	w.U32(bindings.buffer_offset_count);
+	w.U32Vector(bindings.user_data_registers);
+	w.U32(static_cast<uint32_t>(bindings.descriptors.size()));
+	for (const auto& descriptor: bindings.descriptors) {
+		w.U32(static_cast<uint32_t>(descriptor.kind));
+		w.U32(descriptor.binding);
+		w.U32Vector(descriptor.resources);
+	}
+}
+
+bool ReadBindings(Reader& r, IR::BindingLayout& bindings) {
+	bindings.descriptor_set       = r.U32();
+	bindings.push_constant_offset = r.U32();
+	bindings.push_constant_size   = r.U32();
+	bindings.buffer_offset_dword  = r.U32();
+	bindings.buffer_offset_count  = r.U32();
+	bindings.user_data_registers  = r.U32Vector();
+	return ReadVector(r, bindings.descriptors, 12, [](Reader& in) {
+		IR::DescriptorBinding value {};
+		value.kind      = in.Enum<IR::DescriptorBindingKind>(
+            static_cast<uint32_t>(IR::DescriptorBindingKind::Count));
+		value.binding   = in.U32();
+		value.resources = in.U32Vector();
+		return value;
+	});
+}
+
+void WriteProgram(Writer& w, const IR::Program& program) {
+	w.U32(static_cast<uint32_t>(program.stage));
+	w.U32(static_cast<uint32_t>(program.lane_mask_mode));
+	w.U64(program.shader_hash);
+	w.U32(program.wave_size);
+	w.U32(program.user_data_base);
+	w.U32(program.user_data_count);
+	w.Bool(program.srt_plan_complete);
+	w.Bool(program.resource_tracking_complete);
+	w.Bool(program.shader_info_complete);
+	w.Bool(program.binding_layout_complete);
+	WriteShaderInfo(w, program.info);
+	WriteBindings(w, program.bindings);
+
+	w.Bool(program.spirv_requirements.has_value());
+	if (program.spirv_requirements.has_value()) {
+		const auto& req = *program.spirv_requirements;
+		w.Bool(req.requires_exact_subgroup);
+		w.Bool(req.subgroup_ballot);
+		w.Bool(req.subgroup_shuffle);
+		w.Bool(req.subgroup_local_invocation_id);
+		w.Bool(req.compute_derivatives);
+		w.Bool(req.image_gather_extended);
+		w.Bool(req.function_lds);
+		w.Bool(req.pixel_valid_mask);
+	}
+}
+
+bool ReadProgram(Reader& r, IR::Program& program) {
+	program.stage          = r.Enum<ShaderType>(5);
+	program.lane_mask_mode = r.Enum<ShaderLaneMaskMode>(2);
+	program.shader_hash    = r.U64();
+	program.wave_size      = r.U32();
+	program.user_data_base = r.U32();
+	program.user_data_count            = r.U32();
+	program.srt_plan_complete          = r.Bool();
+	program.resource_tracking_complete = r.Bool();
+	program.shader_info_complete       = r.Bool();
+	program.binding_layout_complete    = r.Bool();
+
+	if (!r.Ok() || !ReadShaderInfo(r, program.info) || !ReadBindings(r, program.bindings)) {
+		return false;
+	}
+
+	if (r.Bool()) {
+		IR::SpirvRequirements req {};
+		req.requires_exact_subgroup      = r.Bool();
+		req.subgroup_ballot              = r.Bool();
+		req.subgroup_shuffle             = r.Bool();
+		req.subgroup_local_invocation_id = r.Bool();
+		req.compute_derivatives          = r.Bool();
+		req.image_gather_extended        = r.Bool();
+		req.function_lds                 = r.Bool();
+		req.pixel_valid_mask             = r.Bool();
+		program.spirv_requirements       = req;
+	}
+	return r.Ok();
+}
+
+std::vector<uint8_t> EncodeEntry(const ShaderDiskCacheEntry& entry) {
+	Writer w;
+	w.U32(static_cast<uint32_t>(entry.stage));
+	w.U32(static_cast<uint32_t>(entry.lane_mask_mode));
+	w.U64(entry.shader_hash);
+	w.U32(entry.program_id.hash0);
+	w.U32(entry.program_id.crc32);
+	w.U32Vector(entry.program_id.ids);
+	w.U32(static_cast<uint32_t>(entry.optimization_type));
+	WriteProgram(w, *entry.program);
+	w.U32Vector(entry.spirv);
+	return w.Bytes();
+}
+
+bool DecodeEntry(const uint8_t* data, size_t size, ShaderDiskCacheEntry& entry) {
+	Reader r(data, size);
+	entry.stage             = r.Enum<ShaderType>(5);
+	entry.lane_mask_mode    = r.Enum<ShaderLaneMaskMode>(2);
+	entry.shader_hash       = r.U64();
+	entry.program_id.hash0  = r.U32();
+	entry.program_id.crc32  = r.U32();
+	entry.program_id.ids    = r.U32Vector();
+	entry.optimization_type = r.Enum<Config::ShaderOptimizationType>(3);
+	if (!r.Ok()) {
+		return false;
+	}
+
+	auto program = std::make_shared<IR::Program>();
+	if (!ReadProgram(r, *program)) {
+		return false;
+	}
+	entry.spirv = r.U32Vector();
+
+	// A SPIR-V module is at least a header, and the whole payload must have been
+	// consumed - trailing bytes mean this is not the record it claims to be.
+	if (!r.Done() || entry.spirv.size() < 5 || entry.spirv[0] != 0x07230203) {
+		return false;
+	}
+
+	entry.program = std::move(program);
+	return true;
+}
+
+std::vector<uint8_t> ReadWholeFile(const std::filesystem::path& path) {
+	std::error_code ec;
+	if (!std::filesystem::exists(path, ec) || ec) {
+		return {};
+	}
+	std::ifstream in(path, std::ios::binary);
+	if (!in) {
+		return {};
+	}
+	return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+} // namespace
+
+uint64_t ShaderDiskCacheBuildId() {
+	static const uint64_t id = ComputeBuildId();
+	return id;
+}
+
+std::vector<ShaderDiskCacheEntry> ShaderDiskCacheLoad(const std::filesystem::path& path) {
+	if (path.empty()) {
+		return {};
+	}
+
+	const auto blob = ReadWholeFile(path);
+	if (blob.empty()) {
+		return {}; // first run
+	}
+
+	Reader header(blob.data(), blob.size());
+	char   magic[sizeof(CACHE_MAGIC)] = {};
+	for (char& c: magic) {
+		c = static_cast<char>(header.U8());
+	}
+	const auto format   = header.U32();
+	const auto build_id = header.U64();
+	const auto count    = header.U32();
+
+	if (!header.Ok() || std::memcmp(magic, CACHE_MAGIC, sizeof(CACHE_MAGIC)) != 0) {
+		LOGF("Shader cache: not a shader cache file, ignoring\n");
+		return {};
+	}
+	if (format != CACHE_FORMAT_VERSION || build_id != ShaderDiskCacheBuildId()) {
+		LOGF("Shader cache: written by a different build, starting cold\n");
+		return {};
+	}
+
+	std::vector<ShaderDiskCacheEntry> entries;
+	entries.reserve(count);
+
+	uint32_t rejected = 0;
+	for (uint32_t i = 0; i < count; i++) {
+		const auto size     = header.U64();
+		const auto checksum = header.U64();
+		if (!header.Ok() || !header.CanHold(size)) {
+			break; // truncated file: keep what was read before this point
+		}
+		const auto* payload = header.Skip(size);
+		if (payload == nullptr) {
+			break;
+		}
+		if (XXH3_64bits(payload, size) != checksum) {
+			rejected++;
+			continue;
+		}
+		ShaderDiskCacheEntry entry;
+		if (!DecodeEntry(payload, size, entry)) {
+			rejected++;
+			continue;
+		}
+		entries.push_back(std::move(entry));
+	}
+
+	LOGF("Shader cache: %zu entries loaded from %s%s\n", entries.size(),
+	     path.string().c_str(),
+	     rejected != 0 ? " (some entries were rejected and will be recompiled)" : "");
+	return entries;
+}
+
+bool ShaderDiskCacheSave(const std::filesystem::path&             path,
+                         const std::vector<ShaderDiskCacheEntry>& entries) {
+	if (path.empty()) {
+		return false;
+	}
+
+	Writer header;
+	for (char c: CACHE_MAGIC) {
+		header.U8(static_cast<uint8_t>(c));
+	}
+	header.U32(CACHE_FORMAT_VERSION);
+	header.U64(ShaderDiskCacheBuildId());
+
+	std::vector<std::vector<uint8_t>> payloads;
+	payloads.reserve(entries.size());
+	for (const auto& entry: entries) {
+		if (entry.program == nullptr || entry.spirv.empty()) {
+			continue;
+		}
+		payloads.push_back(EncodeEntry(entry));
+	}
+	header.U32(static_cast<uint32_t>(payloads.size()));
+
+	std::error_code ec;
+	auto            tmp = path;
+	tmp += ".tmp";
+
+	{
+		std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+		if (!out) {
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(header.Bytes().data()),
+		          static_cast<std::streamsize>(header.Bytes().size()));
+		for (const auto& payload: payloads) {
+			Writer entry_header;
+			entry_header.U64(payload.size());
+			entry_header.U64(XXH3_64bits(payload.data(), payload.size()));
+			out.write(reinterpret_cast<const char*>(entry_header.Bytes().data()),
+			          static_cast<std::streamsize>(entry_header.Bytes().size()));
+			out.write(reinterpret_cast<const char*>(payload.data()),
+			          static_cast<std::streamsize>(payload.size()));
+		}
+		if (!out) {
+			std::filesystem::remove(tmp, ec);
+			return false;
+		}
+	}
+
+	// Temp file plus rename: an exit interrupted here leaves the previous cache
+	// intact rather than a half-written one.
+	std::filesystem::rename(tmp, path, ec);
+	if (ec) {
+		std::filesystem::remove(tmp, ec);
+		return false;
+	}
+
+	LOGF("Shader cache: %zu entries written to %s\n", payloads.size(), path.string().c_str());
+	return true;
+}
+
+} // namespace Libs::Graphics

--- a/src/graphics/shader/shaderDiskCache.h
+++ b/src/graphics/shader/shaderDiskCache.h
@@ -1,0 +1,52 @@
+#ifndef EMULATOR_SRC_GRAPHICS_SHADER_SHADERDISKCACHE_H_
+#define EMULATOR_SRC_GRAPHICS_SHADER_SHADERDISKCACHE_H_
+
+#include "common/emulatorConfig.h"
+#include "graphics/shader/recompiler/ir/ShaderIR.h"
+#include "graphics/shader/shader.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace Libs::Graphics {
+
+// One cached translation: the SPIR-V a guest shader was recompiled into, plus
+// the resource plan needed to decide whether it may be reused.
+//
+// The plan is NOT the whole IR. Everything downstream of a cache hit reads
+// program.info, program.bindings, program.shader_hash, program.wave_size and
+// program.spirv_requirements; nothing reads program.blocks or program.values.
+// So those are not written, and a loaded program has them empty.
+struct ShaderDiskCacheEntry {
+	ShaderType                                           stage = ShaderType::Unknown;
+	ShaderLaneMaskMode                 lane_mask_mode = ShaderLaneMaskMode::NativeWave;
+	uint64_t                                             shader_hash = 0;
+	ShaderId                                             program_id;
+	Config::ShaderOptimizationType optimization_type = Config::ShaderOptimizationType::None;
+	std::shared_ptr<const ShaderRecompiler::IR::Program> program;
+	std::vector<uint32_t>                                spirv;
+};
+
+// Reads the cache. A missing file, a header from another build, a truncated
+// file or a corrupt entry all mean the same thing: fewer entries, no error.
+// Whatever comes back still has to pass the same runtime specialization check
+// an in-memory permutation passes, so a bad entry costs a recompile, not a
+// wrong frame.
+[[nodiscard]] std::vector<ShaderDiskCacheEntry> ShaderDiskCacheLoad(
+    const std::filesystem::path& path);
+
+// Writes the cache via a temporary file and a rename, so an interrupted exit
+// cannot leave a half-written file for the next run to read.
+bool ShaderDiskCacheSave(const std::filesystem::path&             path,
+                         const std::vector<ShaderDiskCacheEntry>& entries);
+
+// Identifies the recompiler this build has. It mixes the git version with the
+// sizes and shapes of every IR struct the plan serializes, so a cache written
+// before a recompiler change is rejected rather than misread. Exposed for tests.
+[[nodiscard]] uint64_t ShaderDiskCacheBuildId();
+
+} // namespace Libs::Graphics
+
+#endif /* EMULATOR_SRC_GRAPHICS_SHADER_SHADERDISKCACHE_H_ */

--- a/src/libs/agc.cpp
+++ b/src/libs/agc.cpp
@@ -24,6 +24,8 @@
 #include "libs/errno.h"
 #include "libs/libs.h"
 
+#include <cstdlib>
+
 #include <algorithm>
 #include <atomic>
 #include <cmath>
@@ -43,6 +45,16 @@ namespace Libs::Graphics {
 
 static RenderContext* g_renderer = nullptr;
 
+// The emulator's normal exit is std::quick_exit() (see Emulator::Execute), which
+// runs no atexit handlers, no static destructors and no Subsystems teardown. So
+// neither the pipeline cache nor the shader cache would ever reach disk if they
+// were written from a destructor. std::at_quick_exit is the hook that does run,
+// and at that point the device and both caches are still alive.
+static void FlushCachesAtQuickExit() {
+	WindowFlushCaches();
+	ShaderSaveDiskCache();
+}
+
 void Initialize() {
 	// Some games lock up if this is not called first
 	if (Config::RenderDocEnabled()) {
@@ -57,6 +69,11 @@ void Initialize() {
 	g_renderer      = &presenter.Renderer();
 	g_renderer->InitializeGpu(&video_out);
 	ShaderInit();
+
+	const int registered = std::at_quick_exit(FlushCachesAtQuickExit);
+	if (registered != 0) {
+		LOGF("Could not register the cache flush; caches will not persist this run\n");
+	}
 }
 
 void Shutdown() {

--- a/src/loader/bootFailure.cpp
+++ b/src/loader/bootFailure.cpp
@@ -1,0 +1,106 @@
+#include "loader/bootFailure.h"
+
+namespace Loader {
+
+std::string_view BootFailureToString(BootFailure kind) {
+	switch (kind) {
+		case BootFailure::None: return "None";
+		case BootFailure::FileNotFound: return "FileNotFound";
+		case BootFailure::HeaderUnreadable: return "HeaderUnreadable";
+		case BootFailure::NotAnElf: return "NotAnElf";
+		case BootFailure::NotElf64: return "NotElf64";
+		case BootFailure::NotLittleEndian: return "NotLittleEndian";
+		case BootFailure::UnsupportedIdentVersion: return "UnsupportedIdentVersion";
+		case BootFailure::UnsupportedOsAbi: return "UnsupportedOsAbi";
+		case BootFailure::UnsupportedAbiVersion: return "UnsupportedAbiVersion";
+		case BootFailure::UnsupportedObjectType: return "UnsupportedObjectType";
+		case BootFailure::UnsupportedMachine: return "UnsupportedMachine";
+		case BootFailure::UnsupportedElfVersion: return "UnsupportedElfVersion";
+		case BootFailure::BadProgramHeaderSize: return "BadProgramHeaderSize";
+		case BootFailure::BadSectionHeaderSize: return "BadSectionHeaderSize";
+	}
+	return "Unknown";
+}
+
+std::string_view BootFailureExplain(BootFailure kind) {
+	switch (kind) {
+		case BootFailure::None: return "the executable header is valid";
+		case BootFailure::FileNotFound:
+			return "the executable could not be opened - check the path and that the file is "
+			       "readable";
+		case BootFailure::HeaderUnreadable:
+			return "the file is too short or truncated to contain an ELF header - the dump is "
+			       "probably incomplete";
+		case BootFailure::NotAnElf:
+			return "this is not an ELF file - if it is still encrypted or is a .pkg, it has to be "
+			       "extracted first";
+		case BootFailure::NotElf64: return "this is a 32-bit ELF; the PS5 is 64-bit only";
+		case BootFailure::NotLittleEndian: return "this ELF is big-endian; the PS5 is little-endian";
+		case BootFailure::UnsupportedIdentVersion:
+			return "the ELF identification version is not the one this format uses - the file is "
+			       "likely corrupt";
+		case BootFailure::UnsupportedOsAbi:
+			return "this executable is not built for the FreeBSD ABI, so it is not a PS4/PS5 "
+			       "binary - a PC or Linux executable will land here";
+		case BootFailure::UnsupportedAbiVersion:
+			return "the ABI version is one this loader does not handle yet - please report the "
+			       "title";
+		case BootFailure::UnsupportedObjectType:
+			return "this ELF is neither a PS5 executable nor a PS5 shared library, so there is "
+			       "nothing to boot";
+		case BootFailure::UnsupportedMachine:
+			return "this executable is not built for x86-64, so it cannot run here";
+		case BootFailure::UnsupportedElfVersion:
+			return "the ELF version field is not the current one - the file is likely corrupt";
+		case BootFailure::BadProgramHeaderSize:
+			return "the program header table entry size is wrong - the file is likely corrupt or "
+			       "was extracted incorrectly";
+		case BootFailure::BadSectionHeaderSize:
+			return "the section header table entry size is wrong - the file is likely corrupt or "
+			       "was extracted incorrectly";
+	}
+	return "the executable was rejected for a reason this build does not have a name for";
+}
+
+BootFailure ClassifyElfHeader(const Elf64_Ehdr& ehdr) {
+	// Order matters and deliberately matches the original ladder in
+	// Elf64::IsValid(): the earlier a check is, the less it assumes. Reporting
+	// "not x86-64" for a file that is not an ELF at all would be misleading.
+	if (ehdr.e_ident[EI_MAG0] != '\x7f' || ehdr.e_ident[EI_MAG1] != 'E' ||
+	    ehdr.e_ident[EI_MAG2] != 'L' || ehdr.e_ident[EI_MAG3] != 'F') {
+		return BootFailure::NotAnElf;
+	}
+	if (ehdr.e_ident[EI_CLASS] != ELFCLASS64) {
+		return BootFailure::NotElf64;
+	}
+	if (ehdr.e_ident[EI_DATA] != ELFDATA2LSB) {
+		return BootFailure::NotLittleEndian;
+	}
+	if (ehdr.e_ident[EI_VERSION] != EV_CURRENT) {
+		return BootFailure::UnsupportedIdentVersion;
+	}
+	if (ehdr.e_ident[EI_OSABI] != ELFOSABI_FREEBSD) {
+		return BootFailure::UnsupportedOsAbi;
+	}
+	if (ehdr.e_ident[EI_ABIVERSION] != 0 && ehdr.e_ident[EI_ABIVERSION] != 2) {
+		return BootFailure::UnsupportedAbiVersion;
+	}
+	if (ehdr.e_type != ET_DYNEXEC && ehdr.e_type != ET_DYNAMIC) {
+		return BootFailure::UnsupportedObjectType;
+	}
+	if (ehdr.e_machine != EM_X86_64) {
+		return BootFailure::UnsupportedMachine;
+	}
+	if (ehdr.e_version != EV_CURRENT) {
+		return BootFailure::UnsupportedElfVersion;
+	}
+	if (ehdr.e_phentsize != sizeof(Elf64_Phdr)) {
+		return BootFailure::BadProgramHeaderSize;
+	}
+	if (ehdr.e_shentsize > 0 && ehdr.e_shentsize != sizeof(Elf64_Shdr)) {
+		return BootFailure::BadSectionHeaderSize;
+	}
+	return BootFailure::None;
+}
+
+} // namespace Loader

--- a/src/loader/bootFailure.h
+++ b/src/loader/bootFailure.h
@@ -1,0 +1,49 @@
+#ifndef EMULATOR_INCLUDE_EMULATOR_LOADER_BOOTFAILURE_H_
+#define EMULATOR_INCLUDE_EMULATOR_LOADER_BOOTFAILURE_H_
+
+#include "loader/elf.h"
+
+#include <string_view>
+
+namespace Loader {
+
+// Why a title failed to boot, as a value rather than a log line.
+//
+// The shader recompiler already does this with CFG::FailureKind: it classifies
+// the reason, keeps it on the object, and turns it into a name at the point of
+// reporting. Game boot had no equivalent - every rejection in Elf64::IsValid()
+// logged one register-level sentence and returned false, and the loader then
+// died with the string "elf is not valid", which tells a reporter nothing about
+// which of the eleven checks actually fired.
+enum class BootFailure {
+	None,
+	FileNotFound,
+	HeaderUnreadable,
+	NotAnElf,
+	NotElf64,
+	NotLittleEndian,
+	UnsupportedIdentVersion,
+	UnsupportedOsAbi,
+	UnsupportedAbiVersion,
+	UnsupportedObjectType,
+	UnsupportedMachine,
+	UnsupportedElfVersion,
+	BadProgramHeaderSize,
+	BadSectionHeaderSize,
+};
+
+// Short stable name, for logs and for grepping. Mirrors FailureKindToString().
+[[nodiscard]] std::string_view BootFailureToString(BootFailure kind);
+
+// One sentence a person can act on, with no register values in it. This is what
+// gets shown when boot fails, because the compatibility list is this project's
+// front door and "elf is not valid" is not a bug report.
+[[nodiscard]] std::string_view BootFailureExplain(BootFailure kind);
+
+// Classifies an ELF header. Pure: no files, no loader state, no emulator - which
+// is what makes every branch of it testable.
+[[nodiscard]] BootFailure ClassifyElfHeader(const Elf64_Ehdr& ehdr);
+
+} // namespace Loader
+
+#endif /* EMULATOR_INCLUDE_EMULATOR_LOADER_BOOTFAILURE_H_ */

--- a/src/loader/elf.cpp
+++ b/src/loader/elf.cpp
@@ -1,5 +1,7 @@
 #include "loader/elf.h"
 
+#include "loader/bootFailure.h"
+
 #include "common/assert.h"
 #include "common/file.h"
 #include "common/logging/log.h"
@@ -344,6 +346,7 @@ void Elf64::Clear() {
 	m_str_table_size = 0;
 	m_dynamic.reset();
 	m_dynamic_data.reset();
+	m_boot_failure = BootFailure::None;
 }
 
 void Elf64::DbgDump(const std::string& folder) {
@@ -462,71 +465,7 @@ bool Elf64::IsSelf() const {
 }
 
 bool Elf64::IsValid() const {
-	if (m_f == nullptr || m_f->IsInvalid()) {
-		return false;
-	}
-
-	if (m_ehdr == nullptr) {
-		return false;
-	}
-
-	if (m_ehdr->e_ident[EI_MAG0] != '\x7f' || m_ehdr->e_ident[EI_MAG1] != 'E' ||
-	    m_ehdr->e_ident[EI_MAG2] != 'L' || m_ehdr->e_ident[EI_MAG3] != 'F') {
-		LOGF("Not an ELF file\n");
-		return false;
-	}
-
-	if (m_ehdr->e_ident[EI_CLASS] != ELFCLASS64) {
-		LOGF("ehdr->e_ident[EI_CLASS] (0x%x) != ELFCLASS64\n", m_ehdr->e_ident[EI_CLASS]);
-		return false;
-	}
-
-	if (m_ehdr->e_ident[EI_DATA] != ELFDATA2LSB) {
-		LOGF("ehdr->e_ident[EI_DATA] (0x%x) != ELFDATA2LSB\n", m_ehdr->e_ident[EI_DATA]);
-		return false;
-	}
-
-	if (m_ehdr->e_ident[EI_VERSION] != EV_CURRENT) {
-		LOGF("ehdr->e_ident[EI_VERSION] != EV_CURRENT\n");
-		return false;
-	}
-
-	if (m_ehdr->e_ident[EI_OSABI] != ELFOSABI_FREEBSD) {
-		LOGF("ehdr->e_ident[EI_OSABI] (0x%x) != ELFOSABI_FREEBSD\n", m_ehdr->e_ident[EI_OSABI]);
-		return false;
-	}
-
-	if (m_ehdr->e_ident[EI_ABIVERSION] != 0 && m_ehdr->e_ident[EI_ABIVERSION] != 2) {
-		LOGF("ehdr->e_ident[EI_ABIVERSION] (0x%x) != (0 or 2)\n", m_ehdr->e_ident[EI_ABIVERSION]);
-		return false;
-	}
-
-	if (m_ehdr->e_type != ET_DYNEXEC && m_ehdr->e_type != ET_DYNAMIC) {
-		LOGF("ehdr->e_type (%04x) != ET_DYNEXEC && m_ehdr->e_type != ET_DYNAMIC\n", m_ehdr->e_type);
-		return false;
-	}
-
-	if (m_ehdr->e_machine != EM_X86_64) {
-		LOGF("ehdr->e_machine (%04x) != EM_X86_64\n", m_ehdr->e_machine);
-		return false;
-	}
-
-	if (m_ehdr->e_version != EV_CURRENT) {
-		LOGF("ehdr->e_version != EV_CURRENT\n");
-		return false;
-	}
-
-	if (m_ehdr->e_phentsize != sizeof(Elf64_Phdr)) {
-		LOGF("ehdr->e_phentsize != sizeof(Elf64_Phdr)\n");
-		return false;
-	}
-
-	if (m_ehdr->e_shentsize > 0 && m_ehdr->e_shentsize != sizeof(Elf64_Shdr)) {
-		LOGF("ehdr->e_shentsize (%d) != sizeof(Elf64_Shdr)\n", m_ehdr->e_shentsize);
-		return false;
-	}
-
-	return true;
+	return m_boot_failure == BootFailure::None && m_ehdr != nullptr;
 }
 
 void Elf64::Open(const std::filesystem::path& file_name) {
@@ -536,7 +475,10 @@ void Elf64::Open(const std::filesystem::path& file_name) {
 	m_f->Open(file_name, Common::File::Mode::Read);
 
 	if (m_f->IsInvalid()) {
-		EXIT("Can't open %s\n", Common::PathToString(file_name).c_str());
+		// Not fatal here any more. The caller reports the classified reason, which
+		// is more use to someone filing a compatibility report than a raw path.
+		m_boot_failure = BootFailure::FileNotFound;
+		return;
 	}
 
 	m_self = LoadSelf(*m_f);
@@ -552,7 +494,15 @@ void Elf64::Open(const std::filesystem::path& file_name) {
 
 	m_ehdr = LoadEhdr64(*m_f);
 
-	if (!IsValid()) {
+	// The eleven header checks that used to be an inline ladder here now live in
+	// one pure function, so every rejection has a name the loader can report and a
+	// test can pin down. See loader/bootFailure.h.
+	m_boot_failure =
+	    (m_ehdr == nullptr ? BootFailure::HeaderUnreadable : ClassifyElfHeader(*m_ehdr));
+
+	if (m_boot_failure != BootFailure::None) {
+		LOGF("ELF rejected: %s - %s\n", BootFailureToString(m_boot_failure).data(),
+		     BootFailureExplain(m_boot_failure).data());
 		m_ehdr.reset();
 	}
 

--- a/src/loader/elf.h
+++ b/src/loader/elf.h
@@ -15,6 +15,9 @@ class File;
 
 namespace Loader {
 
+// Defined in loader/bootFailure.h, which includes this header for Elf64_Ehdr.
+enum class BootFailure;
+
 using Elf64_Addr   = uint64_t; // Unsigned program address
 using Elf64_Off    = uint64_t; // Unsigned file offset
 using Elf64_Half   = uint16_t; // Unsigned medium integer
@@ -261,6 +264,8 @@ public:
 
 	[[nodiscard]] bool IsSelf() const;
 	[[nodiscard]] bool IsValid() const;
+	// Why the header was rejected, when it was. None once the file has loaded.
+	[[nodiscard]] BootFailure GetBootFailure() const { return m_boot_failure; }
 	[[nodiscard]] bool IsShared() const;
 	[[nodiscard]] bool IsNextGen() const;
 
@@ -301,6 +306,8 @@ private:
 	std::unique_ptr<uint8_t[]>     m_dynamic_data;
 	std::unique_ptr<char[]>        m_str_table;
 	uint32_t                       m_str_table_size = 0;
+	// Zero is BootFailure::None; the enum is only forward-declared here.
+	BootFailure                    m_boot_failure {};
 	// uint64_t    m_base_vaddr   = 0;
 };
 

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -16,6 +16,7 @@
 #include "graphics/host_gpu/pageManager.h"
 #include "kernel/memory.h"
 #include "kernel/pthread.h"
+#include "loader/bootFailure.h"
 #include "loader/elf.h"
 #include "loader/gamePatch.h"
 #include "loader/jit.h"
@@ -1338,7 +1339,9 @@ Program* RuntimeLinker::LoadProgram(const std::filesystem::path& elf_name) {
 		ParseProgramDynamicInfo(program);
 		CreateSymbolDatabase(program);
 	} else {
-		EXIT("elf is not valid: %s\n", Common::PathToString(elf_name).c_str());
+		const auto failure = program->elf->GetBootFailure();
+		EXIT("cannot boot %s\n\t%s: %s\n", Common::PathToString(elf_name).c_str(),
+		     BootFailureToString(failure).data(), BootFailureExplain(failure).data());
 	}
 
 	m_programs.push_back(program_owner.release());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "common/common.h"
 #include "common/dateTime.h"
 #include "common/debug.h"
+#include "common/diagnostics.h"
 #include "common/file.h"
 #include "common/magicEnum.h"
 #include "common/platform/sysDbg.h"
@@ -8,6 +9,7 @@
 #include "common/threads.h"
 #include "common/virtualMemory.h"
 #include "emulator.h"
+#include "graphics/host_gpu/vulkanDiagnostics.h"
 #include "kytyGitVersion.h"
 
 #include <charconv>
@@ -17,29 +19,8 @@
 using namespace Common;
 using namespace Emulator;
 
-static std::string GetBuildString() {
-	Date date = Date::FromMacros(std::string(__DATE__));
-
-#if KYTY_BUILD == KYTY_BUILD_DEBUG
-	std::string type = "Debug";
-#elif KYTY_BUILD == KYTY_BUILD_RELEASE
-	std::string type = "Release";
-#else
-	std::string type = "????";
-#endif
-
-	std::string compiler =
-	    Debug::GetCompiler() + "-" + Debug::GetLinker() + "-" + Debug::GetBitness();
-
-	std::string str =
-	    fmt::format("{}, {}, ver = {}, git = {}, date = {}", type.c_str(), compiler.c_str(),
-	                KYTY_VERSION, KYTY_GIT_VERSION, date.ToString().c_str());
-
-	return str;
-}
-
 static void PrintUsage() {
-	::printf("%s\n", GetBuildString().c_str());
+	::printf("%s\n", Common::Diagnostics::BuildString().c_str());
 	::printf("kyty_emulator --game <dir|elf> [options]\n\n");
 	::printf("Options:\n");
 	::printf("  --game <dir|elf>                     Game directory or ELF to load.\n");
@@ -72,6 +53,9 @@ static void PrintUsage() {
 #endif
 	::printf("  --keymap <Control=Input>             DualSense mapping; may be repeated.\n");
 	::printf("  --rd                                 Enable RenderDoc capture.\n");
+	::printf("  --diagnostics                        Print a report for bug reports, then exit.\n");
+	::printf("  --log-repeat-limit <num>             Messages one log line may write before it\n"
+	         "                                       is sampled. 0 disables. Default: 256.\n");
 }
 
 static bool NextArg(int argc, char* argv[], int& index, std::string& out) {
@@ -122,8 +106,10 @@ static bool ParseConsoleLanguage(const std::string& value, uint32_t& out) {
 	return true;
 }
 
-static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_help) {
-	show_help = false;
+static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_help,
+                      bool& show_diagnostics) {
+	show_help        = false;
+	show_diagnostics = false;
 
 	for (int i = 1; i < argc; i++) {
 		std::string arg = std::string(argv[i]);
@@ -131,6 +117,11 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 
 		if (arg == "--help" || arg == "-h") {
 			show_help = true;
+			continue;
+		}
+
+		if (arg == "--diagnostics") {
+			show_diagnostics = true;
 			continue;
 		}
 
@@ -205,6 +196,15 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 			const int32_t vblank_frequency = Common::ToInt32(value);
 			options.config.vblank_frequency =
 			    static_cast<uint32_t>(vblank_frequency < 0 ? 0 : vblank_frequency);
+		} else if (arg == "--log-repeat-limit") {
+			uint64_t   limit = 0;
+			const auto parsed =
+			    std::from_chars(value.data(), value.data() + value.size(), limit);
+			if (parsed.ec != std::errc {} || parsed.ptr != value.data() + value.size()) {
+				::printf("invalid number for %s: %s\n", arg.c_str(), value.c_str());
+				return false;
+			}
+			options.config.log_repeat_limit = limit;
 		} else if (arg == "--console-language") {
 			if (!ParseConsoleLanguage(value, options.config.console_language)) {
 				::printf("invalid console language: %s\n", value.c_str());
@@ -296,20 +296,29 @@ int main(int argc, char* argv[]) {
 	InitializeThreads();
 
 	RunOptions options;
-	bool       show_help = false;
+	bool       show_help        = false;
+	bool       show_diagnostics = false;
 
 	if (argc < 2) {
 		PrintUsage();
 		return 0;
 	}
 
-	if (!ParseArgs(argc, argv, options, show_help)) {
+	if (!ParseArgs(argc, argv, options, show_help, show_diagnostics)) {
 		PrintUsage();
 		return 1;
 	}
 
 	if (show_help) {
 		PrintUsage();
+		return 0;
+	}
+
+	// Before anything that needs a game: the report is most wanted by people
+	// whose emulator will not start at all.
+	if (show_diagnostics) {
+		::printf("%s", Common::Diagnostics::BuildReport().c_str());
+		::printf("%s", Libs::Graphics::BuildVulkanReport().c_str());
 		return 0;
 	}
 

--- a/tests/BootFailureTests.cpp
+++ b/tests/BootFailureTests.cpp
@@ -1,0 +1,147 @@
+#include "loader/bootFailure.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+using Loader::BootFailure;
+using Loader::ClassifyElfHeader;
+
+void Check(bool value, const char* text) {
+	if (!value) {
+		std::fprintf(stderr, "BootFailureTests: failed: %s\n", text);
+		std::abort();
+	}
+}
+
+// A header that ClassifyElfHeader() accepts. Every negative case below starts
+// from this and breaks exactly one field, so a test that fails names the field.
+Loader::Elf64_Ehdr GoodHeader() {
+	Loader::Elf64_Ehdr ehdr {};
+	std::memset(&ehdr, 0, sizeof(ehdr));
+	ehdr.e_ident[Loader::EI_MAG0]       = '\x7f';
+	ehdr.e_ident[Loader::EI_MAG1]       = 'E';
+	ehdr.e_ident[Loader::EI_MAG2]       = 'L';
+	ehdr.e_ident[Loader::EI_MAG3]       = 'F';
+	ehdr.e_ident[Loader::EI_CLASS]      = Loader::ELFCLASS64;
+	ehdr.e_ident[Loader::EI_DATA]       = Loader::ELFDATA2LSB;
+	ehdr.e_ident[Loader::EI_VERSION]    = Loader::EV_CURRENT;
+	ehdr.e_ident[Loader::EI_OSABI]      = Loader::ELFOSABI_FREEBSD;
+	ehdr.e_ident[Loader::EI_ABIVERSION] = 0;
+	ehdr.e_type                         = Loader::ET_DYNEXEC;
+	ehdr.e_machine                      = Loader::EM_X86_64;
+	ehdr.e_version                      = Loader::EV_CURRENT;
+	ehdr.e_phentsize                    = sizeof(Loader::Elf64_Phdr);
+	ehdr.e_shentsize                    = sizeof(Loader::Elf64_Shdr);
+	return ehdr;
+}
+
+void ExpectFailure(void (*damage)(Loader::Elf64_Ehdr&), BootFailure expected, const char* what) {
+	auto ehdr = GoodHeader();
+	damage(ehdr);
+	const auto actual = ClassifyElfHeader(ehdr);
+	if (actual != expected) {
+		std::fprintf(stderr, "BootFailureTests: %s: expected %s, got %s\n", what,
+		             Loader::BootFailureToString(expected).data(),
+		             Loader::BootFailureToString(actual).data());
+		std::abort();
+	}
+	// A classification nobody can read is not an improvement on a log line.
+	Check(!Loader::BootFailureExplain(actual).empty(), "explanation is not empty");
+}
+
+void TestAcceptsValidHeaders() {
+	Check(ClassifyElfHeader(GoodHeader()) == BootFailure::None, "a good executable is accepted");
+
+	// Shared libraries and ABI version 2 are equally valid PS5 objects.
+	auto shared   = GoodHeader();
+	shared.e_type = Loader::ET_DYNAMIC;
+	Check(ClassifyElfHeader(shared) == BootFailure::None, "a shared object is accepted");
+
+	auto abi2                          = GoodHeader();
+	abi2.e_ident[Loader::EI_ABIVERSION] = 2;
+	Check(ClassifyElfHeader(abi2) == BootFailure::None, "ABI version 2 is accepted");
+
+	// A file with no section table at all is legal; only a wrong entry size is not.
+	auto no_sections       = GoodHeader();
+	no_sections.e_shentsize = 0;
+	Check(ClassifyElfHeader(no_sections) == BootFailure::None, "an absent section table is fine");
+}
+
+void TestClassifiesEachRejection() {
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_ident[Loader::EI_MAG1] = 'X'; },
+	              BootFailure::NotAnElf, "bad magic");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_ident[Loader::EI_CLASS] = 1; },
+	              BootFailure::NotElf64, "32-bit class");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_ident[Loader::EI_DATA] = 2; },
+	              BootFailure::NotLittleEndian, "big endian");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_ident[Loader::EI_VERSION] = 7; },
+	              BootFailure::UnsupportedIdentVersion, "ident version");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_ident[Loader::EI_OSABI] = 0; },
+	              BootFailure::UnsupportedOsAbi, "System V ABI");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_ident[Loader::EI_ABIVERSION] = 3; },
+	              BootFailure::UnsupportedAbiVersion, "ABI version 3");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_type = 2; }, BootFailure::UnsupportedObjectType,
+	              "plain ET_EXEC");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_machine = 40; },
+	              BootFailure::UnsupportedMachine, "ARM");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_version = 0; },
+	              BootFailure::UnsupportedElfVersion, "ELF version");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_phentsize = 1; },
+	              BootFailure::BadProgramHeaderSize, "program header entry size");
+	ExpectFailure([](Loader::Elf64_Ehdr& e) { e.e_shentsize = 1; },
+	              BootFailure::BadSectionHeaderSize, "section header entry size");
+}
+
+// The order of the checks is load-bearing: reporting "not x86-64" for a file
+// that is not an ELF at all would send a reporter chasing the wrong thing.
+void TestReportsTheEarliestCause() {
+	auto ehdr = GoodHeader();
+	ehdr.e_ident[Loader::EI_MAG0] = 0;
+	ehdr.e_ident[Loader::EI_CLASS] = 1;
+	ehdr.e_machine                 = 40;
+	Check(ClassifyElfHeader(ehdr) == BootFailure::NotAnElf,
+	      "the first failing check is the one reported");
+
+	auto zeroed = Loader::Elf64_Ehdr {};
+	std::memset(&zeroed, 0, sizeof(zeroed));
+	Check(ClassifyElfHeader(zeroed) == BootFailure::NotAnElf, "an all-zero header is not an ELF");
+}
+
+void TestEveryKindHasNames() {
+	const BootFailure all[] = {
+	    BootFailure::None,
+	    BootFailure::FileNotFound,
+	    BootFailure::HeaderUnreadable,
+	    BootFailure::NotAnElf,
+	    BootFailure::NotElf64,
+	    BootFailure::NotLittleEndian,
+	    BootFailure::UnsupportedIdentVersion,
+	    BootFailure::UnsupportedOsAbi,
+	    BootFailure::UnsupportedAbiVersion,
+	    BootFailure::UnsupportedObjectType,
+	    BootFailure::UnsupportedMachine,
+	    BootFailure::UnsupportedElfVersion,
+	    BootFailure::BadProgramHeaderSize,
+	    BootFailure::BadSectionHeaderSize,
+	};
+
+	for (auto kind: all) {
+		const auto name = Loader::BootFailureToString(kind);
+		Check(!name.empty() && name != "Unknown", "every kind has a stable name");
+		Check(!Loader::BootFailureExplain(kind).empty(), "every kind has an explanation");
+	}
+}
+
+} // namespace
+
+int main() {
+	TestAcceptsValidHeaders();
+	TestClassifiesEachRejection();
+	TestReportsTheEarliestCause();
+	TestEveryKindHasNames();
+	std::printf("BootFailureTests: all passed\n");
+	return 0;
+}

--- a/tests/DiagnosticsTests.cpp
+++ b/tests/DiagnosticsTests.cpp
@@ -1,0 +1,97 @@
+#include "common/diagnostics.h"
+#include "graphics/host_gpu/vulkanDiagnostics.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+namespace {
+
+void Check(bool value, const char* text) {
+	if (!value) {
+		std::fprintf(stderr, "DiagnosticsTests: failed: %s\n", text);
+		std::abort();
+	}
+}
+
+bool Contains(std::string_view haystack, std::string_view needle) {
+	return haystack.find(needle) != std::string_view::npos;
+}
+
+void TestTheReportSaysWhoAndWhat() {
+	const auto report = Common::Diagnostics::BuildReport();
+
+	Check(!report.empty(), "the report is not empty");
+	Check(Contains(report, "KytyPS5 diagnostics"), "the report identifies itself");
+	Check(Contains(report, "Build"), "the report has a build section");
+	Check(Contains(report, "Host"), "the report has a host section");
+	Check(Contains(report, Common::Diagnostics::BuildString()),
+	      "the report carries the same build string --help prints");
+}
+
+// The report exists to be pasted into a public issue. If it leaked a home
+// directory or a login name, every reporter would have to audit it first, and
+// most would not. So this is a test, not a comment.
+void TestTheReportLeaksNothingPersonal() {
+	const auto report = Common::Diagnostics::BuildReport();
+
+	for (const char* variable: {"HOME", "USER", "USERNAME", "LOGNAME", "USERPROFILE"}) {
+		const char* value = std::getenv(variable);
+		if (value == nullptr || std::strlen(value) < 3) {
+			continue;
+		}
+		if (!Contains(report, value)) {
+			continue;
+		}
+		std::fprintf(stderr, "DiagnosticsTests: the report contains $%s (\"%s\")\n", variable,
+		             value);
+		std::abort();
+	}
+
+	// No absolute paths either: the build string carries a date and a git hash,
+	// never a source directory.
+	Check(!Contains(report, "/home/"), "no POSIX home path");
+	Check(!Contains(report, "/Users/"), "no macOS home path");
+	Check(!Contains(report, "C:\\Users"), "no Windows home path");
+}
+
+// A machine that cannot run the emulator is exactly the machine a report is
+// wanted from, so this must produce something useful with no GPU, no driver and
+// no Vulkan loader at all rather than failing.
+void TestTheVulkanSectionAlwaysReports() {
+	const auto report = Libs::Graphics::BuildVulkanReport();
+
+	Check(!report.empty(), "the Vulkan section is not empty");
+	Check(Contains(report, "Vulkan"), "the Vulkan section is labelled");
+
+	const bool says_something =
+	    Contains(report, "device(s)") || Contains(report, "no Vulkan devices") ||
+	    Contains(report, "no Vulkan loader") || Contains(report, "could not create") ||
+	    Contains(report, "unusable") || Contains(report, "enumeration failed");
+	Check(says_something, "the Vulkan section states an outcome either way");
+}
+
+void TestItIsStable() {
+	// Two calls in a row must agree; a report that changes under the reporter is
+	// not evidence of anything.
+	Check(Common::Diagnostics::BuildReport() == Common::Diagnostics::BuildReport(),
+	      "the host report is stable");
+}
+
+} // namespace
+
+int main() {
+	TestTheReportSaysWhoAndWhat();
+	TestTheReportLeaksNothingPersonal();
+	TestTheVulkanSectionAlwaysReports();
+	TestItIsStable();
+
+	// Printed so a human can read what a reporter would actually paste.
+	std::printf("--- what --diagnostics prints ---\n%s%s",
+	            Common::Diagnostics::BuildReport().c_str(),
+	            Libs::Graphics::BuildVulkanReport().c_str());
+	std::printf("DiagnosticsTests: all passed\n");
+	return 0;
+}

--- a/tests/LogRateLimitTests.cpp
+++ b/tests/LogRateLimitTests.cpp
@@ -1,0 +1,126 @@
+#include "common/emulatorConfig.h"
+#include "common/logging/log.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+namespace {
+
+void Check(bool value, const char* text) {
+	if (!value) {
+		std::fprintf(stderr, "LogRateLimitTests: failed: %s\n", text);
+		std::abort();
+	}
+}
+
+uint64_t CountWrites(Log::Site& site, uint64_t calls) {
+	uint64_t written = 0;
+	for (uint64_t i = 0; i < calls; i++) {
+		if (Log::ShouldWrite(site)) {
+			written++;
+		}
+	}
+	return written;
+}
+
+// The reported problem: a line inside a per-draw loop fires millions of times
+// and turns the log into something nobody can upload (issue #200).
+void TestARunawaySiteIsBounded() {
+	Log::Site site {"runaway.cpp", 1};
+
+	constexpr uint64_t CALLS   = 10'000'000;
+	const auto         written = CountWrites(site, CALLS);
+
+	Check(written < CALLS / 1000, "a runaway site writes a tiny fraction of its calls");
+	Check(site.count.load() == CALLS, "every call is still counted");
+
+	// The whole point is that the volume stops growing linearly. Ten million
+	// messages must not cost anything like ten million lines.
+	std::printf("LogRateLimitTests: %llu calls -> %llu messages\n",
+	            static_cast<unsigned long long>(CALLS),
+	            static_cast<unsigned long long>(written));
+}
+
+// A line that fires rarely must be completely unaffected: this must not lose
+// information, only repetition.
+void TestQuietSitesAreUntouched() {
+	Log::Site site {"quiet.cpp", 2};
+	Check(CountWrites(site, 32) == 32, "a site below the limit writes every message");
+}
+
+void TestSitesAreIndependent() {
+	Log::Site loud {"loud.cpp", 3};
+	Log::Site quiet {"quiet.cpp", 4};
+
+	CountWrites(loud, 1'000'000);
+	Check(CountWrites(quiet, 16) == 16, "one noisy site does not silence another");
+}
+
+// The first messages from a site are what a bug report needs: they show the
+// problem starting. Losing those in favour of later ones would defeat it.
+void TestTheFirstMessagesAlwaysGetThrough() {
+	Log::Site site {"early.cpp", 5};
+
+	uint64_t first_run = 0;
+	for (uint64_t i = 0; i < 64; i++) {
+		if (Log::ShouldWrite(site)) {
+			first_run++;
+		} else {
+			break;
+		}
+	}
+	Check(first_run == 64, "the opening messages are never dropped");
+}
+
+void TestCountingIsThreadSafe() {
+	Log::Site site {"threads.cpp", 6};
+
+	constexpr uint64_t PER_THREAD = 100'000;
+	constexpr int      THREADS    = 8;
+
+	std::vector<std::thread> threads;
+	threads.reserve(THREADS);
+	for (int i = 0; i < THREADS; i++) {
+		threads.emplace_back([&site] { CountWrites(site, PER_THREAD); });
+	}
+	for (auto& thread: threads) {
+		thread.join();
+	}
+
+	Check(site.count.load() == PER_THREAD * THREADS, "no counts are lost across threads");
+}
+
+void TestDisabledLimitWritesEverything() {
+	// A limit of zero is the escape hatch for anyone who really does want the
+	// old behaviour; verify it is a true bypass rather than a large limit.
+	Config::ConfigOptions options {};
+	options.log_repeat_limit = 0;
+	Config::Load(options);
+	Log::Initialize();
+
+	Log::Site site {"unlimited.cpp", 7};
+	Check(CountWrites(site, 100'000) == 100'000, "a zero limit writes every message");
+}
+
+} // namespace
+
+int main() {
+	Config::Initialize();
+
+	Config::ConfigOptions options {};
+	options.printf_direction = Config::OutputDirection::Silent;
+	Config::Load(options);
+	Log::Initialize();
+
+	TestARunawaySiteIsBounded();
+	TestQuietSitesAreUntouched();
+	TestSitesAreIndependent();
+	TestTheFirstMessagesAlwaysGetThrough();
+	TestCountingIsThreadSafe();
+	TestDisabledLimitWritesEverything();
+
+	std::printf("LogRateLimitTests: all passed\n");
+	return 0;
+}

--- a/tests/Pm4FuzzTests.cpp
+++ b/tests/Pm4FuzzTests.cpp
@@ -1,0 +1,356 @@
+// Fuzzes the PM4 command-buffer walker with generated packet streams.
+//
+// What this covers, and what it does not
+// --------------------------------------
+// A guest submits PM4 command buffers, and CommandProcessor::ProcessPm4 walks
+// them: it reads a packet header, decodes the opcode and the length, and hands
+// the payload to a handler. That framing, and the register writes it drives, are
+// guest-controlled input, and until now nothing exercised them with anything but
+// the buffers real titles happen to produce.
+//
+// It fuzzes the packet framing and the register-write opcodes. It does NOT fuzz
+// draw, dispatch, DMA or event packets: those handlers submit to a real Vulkan
+// device and dereference mapped guest memory, so a harness for them cannot run
+// on a machine without a GPU, which is every CI runner.
+//
+// CommandProcessor holds a RenderContext&, and constructing a real one needs a
+// live Vulkan device (RenderContext -> CommandScheduler -> MasterSemaphore ->
+// vkCreateSemaphore). The opcodes fuzzed here never touch the renderer - but
+// "never touch" is an assumption, and an assumption is not a test. So the
+// reference is bound to a page mapped PROT_NONE: if any handler reaches through
+// it, for read or for write, the process dies immediately and visibly instead of
+// quietly reading rubbish. The guarantee is enforced by the MMU, not by comment.
+
+#include "common/emulatorConfig.h"
+#include "common/threads.h"
+#include "graphics/guest_gpu/command_processor/commandProcessor.h"
+#include "graphics/guest_gpu/command_processor/pm4Dispatch.h"
+#include "graphics/guest_gpu/graphicsRun.h"
+#include "graphics/guest_gpu/pm4.h"
+#include "graphics/host_gpu/graphicContext.h"
+#include "graphics/host_gpu/renderer/renderContext.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+using Libs::Graphics::CommandProcessor;
+using Libs::Graphics::Pm4Execution;
+using Libs::Graphics::Pm4ProcessResult;
+using Libs::Graphics::RenderContext;
+namespace Pm4 = Libs::Graphics::Pm4;
+
+void Check(bool value, const char* text) {
+	if (!value) {
+		std::fprintf(stderr, "Pm4FuzzTests: failed: %s\n", text);
+		std::abort();
+	}
+}
+
+// A page that faults on any access. See the note at the top of the file.
+void* AllocateInaccessiblePage() {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	void* page = VirtualAlloc(nullptr, 4096, MEM_RESERVE | MEM_COMMIT, PAGE_NOACCESS);
+	Check(page != nullptr, "reserved a no-access page");
+#else
+	void* page = mmap(nullptr, 4096, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	Check(page != MAP_FAILED, "reserved a no-access page");
+#endif
+	return page;
+}
+
+// ── Half one: the packet walker ─────────────────────────────────────────
+//
+// Every opcode here has one legal encoding that its handler asserts on, so the
+// framing is generated exactly and the payload is what varies. Feeding a random
+// length would only trip the dispatcher's own deliberate EXIT_NOT_IMPLEMENTED,
+// which is a guard doing its job, not a bug to find.
+
+struct FixedPacket {
+	uint32_t opcode      = 0;
+	uint32_t total_dw    = 0;
+	uint32_t payload_dw  = 0;
+	uint32_t payload_mask = 0xFFFFFFFFu; // what the handler will accept
+};
+
+constexpr FixedPacket FIXED_PACKETS[] = {
+    {Pm4::IT_CLEAR_STATE, 2, 1, 0xFu}, // rejects anything outside the low nibble
+    {Pm4::IT_INDEX_TYPE, 2, 1, 0xFFFFFFFFu},
+    {Pm4::IT_INDEX_BUFFER_SIZE, 2, 1, 0xFFFFFFFFu},
+    {Pm4::IT_NUM_INSTANCES, 2, 1, 0xFFFFFFFFu},
+    {Pm4::IT_PFP_SYNC_ME, 2, 1, 0xFFFFFFFFu},
+    {Pm4::IT_INDEX_BASE, 3, 2, 0xFFFFFFFFu},
+};
+
+// The register offsets a SET_*_REG packet may legally carry are exactly the ones
+// with a handler installed. Reading them out of the dispatch tables rather than
+// hard-coding a list means this harness keeps covering the whole register space
+// as the tables grow, with nothing to keep in sync.
+template <class Table>
+std::vector<uint32_t> InstalledOffsets(const Table& table) {
+	std::vector<uint32_t> offsets;
+	for (uint32_t i = 0; i < table.size(); i++) {
+		if (table[i] != nullptr) {
+			offsets.push_back(i);
+		}
+	}
+	return offsets;
+}
+
+class Rng {
+public:
+	explicit Rng(uint32_t seed): m_rng(seed) {}
+
+	uint32_t Below(uint32_t bound) {
+		return std::uniform_int_distribution<uint32_t>(0, bound - 1)(m_rng);
+	}
+	uint32_t Word() { return std::uniform_int_distribution<uint32_t>(0, UINT32_MAX)(m_rng); }
+
+private:
+	std::mt19937 m_rng;
+};
+
+void AppendPacket(std::vector<uint32_t>& buffer, Rng& rng) {
+	const auto choice = rng.Below(16);
+
+	// The padding word the walker skips without consulting any handler.
+	if (choice == 0) {
+		buffer.push_back(0x80000000u);
+		return;
+	}
+
+	// A NOP of a random legal length: the one opcode whose length field really
+	// does vary, so it is what exercises the cursor arithmetic.
+	if (choice == 1) {
+		const auto total_dw = rng.Below(8) + 2;
+		buffer.push_back(KYTY_PM4(total_dw, Pm4::IT_NOP, Pm4::R_ZERO));
+		for (uint32_t i = 0; i < total_dw - 1; i++) {
+			// Not a marker: 0x6875.... sends CpOpNop down the marker path,
+			// which parses a guest string and is not part of this half.
+			uint32_t word = rng.Word();
+			if ((word & 0xffff0000u) == 0x68750000u) {
+				word ^= 0x00010000u;
+			}
+			buffer.push_back(word);
+		}
+		return;
+	}
+
+	const auto& packet = FIXED_PACKETS[rng.Below(std::size(FIXED_PACKETS))];
+	buffer.push_back(KYTY_PM4(packet.total_dw, packet.opcode, 0));
+	for (uint32_t i = 0; i < packet.payload_dw; i++) {
+		buffer.push_back(rng.Word() & packet.payload_mask);
+	}
+}
+
+void FuzzTheWalker() {
+	auto& renderer = *static_cast<RenderContext*>(AllocateInaccessiblePage());
+	CommandProcessor cp(renderer);
+
+	constexpr uint32_t ITERATIONS = 20000;
+	uint64_t           packets    = 0;
+
+	for (uint32_t iteration = 0; iteration < ITERATIONS; iteration++) {
+		// A fresh, fully reset processor every iteration, so a failure is
+		// reproducible from its seed alone and no state leaks between cases.
+		cp.Reset();
+
+		Rng                   rng(iteration + 1);
+		std::vector<uint32_t> buffer;
+		const auto            count = rng.Below(24) + 1;
+		for (uint32_t i = 0; i < count; i++) {
+			AppendPacket(buffer, rng);
+		}
+		Check(!buffer.empty(), "the generated buffer is not empty");
+
+		Pm4Execution execution;
+		const auto   result =
+		    cp.Process(execution, buffer.data(), static_cast<uint32_t>(buffer.size()));
+
+		// Every opcode generated here consumes its packet and returns, so the
+		// walker must reach the end of the buffer rather than suspend on a wait.
+		Check(result == Pm4ProcessResult::Complete, "the whole buffer is consumed");
+		packets += count;
+	}
+
+	// Reset really has to reset. Without this, the loop above would be fuzzing
+	// one ever-dirtier context rather than 20000 independent ones, and would
+	// quietly prove much less than it appears to.
+	cp.Reset();
+	Rng                   rng(0xABCDEFu);
+	std::vector<uint32_t> buffer;
+	for (uint32_t i = 0; i < 64; i++) {
+		AppendPacket(buffer, rng);
+	}
+	Pm4Execution first;
+	Check(cp.Process(first, buffer.data(), static_cast<uint32_t>(buffer.size())) ==
+	          Pm4ProcessResult::Complete,
+	      "the dirtying buffer is consumed");
+	cp.Reset();
+	Pm4Execution second;
+	Check(cp.Process(second, buffer.data(), static_cast<uint32_t>(buffer.size())) ==
+	          Pm4ProcessResult::Complete,
+	      "the same buffer is consumed identically after a reset");
+
+	std::printf("Pm4FuzzTests: walker: %u buffers, %llu packets\n", ITERATIONS,
+	            static_cast<unsigned long long>(packets));
+}
+
+// ── Half two: the register decoders ─────────────────────────────────────
+//
+// Behind SET_CONTEXT_REG / SET_SH_REG / SET_UCONFIG_REG sit around two thousand
+// register handlers, each unpacking bitfields out of guest-supplied words. Two
+// things make them awkward to reach through the walker:
+//
+//   - each handler asserts one exact packet length, which differs per register
+//     and is not readable from the dispatch table, and
+//   - a wrong length is a deliberate EXIT_NOT_IMPLEMENTED, which ends the
+//     process.
+//
+// So each register is probed in a forked child with an all-zero payload first.
+// A child that dies there is a register that wants a different packet length -
+// not covered, counted, and moved past. A register that SURVIVES the zero probe
+// and then dies on random payloads is a real finding, and fails the run. That
+// distinction is the whole point: without it, a crash and an unsupported length
+// look identical.
+//
+// Windows has no fork, so this half is skipped there. Two of the three CI
+// platforms run it.
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+
+void FuzzRegisterDecoders() {
+	std::printf("Pm4FuzzTests: registers: skipped, needs fork\n");
+}
+
+#else
+
+enum class ChildResult { Survived, Died };
+
+// Runs `body` in a child process and reports whether it came back alive.
+template <class F>
+ChildResult RunIsolated(F&& body) {
+	std::fflush(stdout);
+	std::fflush(stderr);
+
+	const pid_t pid = fork();
+	Check(pid >= 0, "fork succeeded");
+
+	if (pid == 0) {
+		// The handlers log copiously on odd input; that is not what is being
+		// tested and it would bury the result.
+		::freopen("/dev/null", "w", stdout);
+		::freopen("/dev/null", "w", stderr);
+		body();
+		::_exit(0);
+	}
+
+	int status = 0;
+	Check(waitpid(pid, &status, 0) == pid, "waited for the child");
+	const bool survived = WIFEXITED(status) && WEXITSTATUS(status) == 0;
+	return survived ? ChildResult::Survived : ChildResult::Died;
+}
+
+template <class Table>
+void FuzzRegisterTable(const Table& table, uint32_t opcode, const char* what) {
+	constexpr uint32_t PAYLOAD_DW = 8;
+	constexpr uint32_t ROUNDS     = 256;
+
+	const auto offsets = InstalledOffsets(table);
+	Check(!offsets.empty(), "the register table has handlers installed");
+
+	// The single-value form: header, offset word, one value.
+	const auto cmd_id = KYTY_PM4(3, opcode, 0) & ~1u;
+
+	size_t covered = 0;
+	size_t skipped = 0;
+
+	for (auto offset: offsets) {
+		auto& renderer = *static_cast<RenderContext*>(AllocateInaccessiblePage());
+
+		const auto probe = RunIsolated([&] {
+			CommandProcessor cp(renderer);
+			cp.Reset();
+			const uint32_t zeros[PAYLOAD_DW] = {};
+			table[offset](cp, cmd_id, offset, zeros, PAYLOAD_DW);
+		});
+
+		if (probe == ChildResult::Died) {
+			// This register wants a packet shape this harness does not generate.
+			skipped++;
+			continue;
+		}
+
+		const auto fuzz = RunIsolated([&] {
+			CommandProcessor cp(renderer);
+			Rng              rng(0x5EEDu + opcode * 131u + offset);
+			for (uint32_t round = 0; round < ROUNDS; round++) {
+				cp.Reset();
+				uint32_t payload[PAYLOAD_DW];
+				for (auto& word: payload) {
+					word = rng.Word();
+				}
+				const auto consumed = table[offset](cp, cmd_id, offset, payload, PAYLOAD_DW);
+
+				// A handler claiming to consume nothing would loop the walker
+				// forever; one claiming more than it was given would walk the
+				// cursor off the end of the guest buffer.
+				if (consumed < 1 || consumed > PAYLOAD_DW) {
+					::_exit(2);
+				}
+			}
+		});
+
+		if (fuzz == ChildResult::Died) {
+			std::fprintf(stderr,
+			             "Pm4FuzzTests: %s register 0x%03x accepts a zero payload but fails on "
+			             "random values\n",
+			             what, offset);
+			std::abort();
+		}
+		covered++;
+	}
+
+	std::printf("Pm4FuzzTests: %s: %zu fuzzed, %zu need another packet shape (of %zu)\n", what,
+	            covered, skipped, offsets.size());
+	Check(covered > 0, "at least some registers were reachable");
+}
+
+void FuzzRegisterDecoders() {
+	FuzzRegisterTable(Libs::Graphics::g_hw_ctx_func, Pm4::IT_SET_CONTEXT_REG, "context");
+	FuzzRegisterTable(Libs::Graphics::g_hw_sh_func, Pm4::IT_SET_SH_REG, "shader");
+	FuzzRegisterTable(Libs::Graphics::g_hw_uc_func, Pm4::IT_SET_UCONFIG_REG, "uconfig");
+}
+
+#endif
+
+} // namespace
+
+int main() {
+	Common::InitializeThreads();
+	// The dispatcher reads the debug-dump switches on every packet, so the
+	// config has to exist. Defaults are what a normal run uses.
+	Config::Initialize();
+	Libs::Graphics::GraphicsInitJmpTables();
+
+	FuzzTheWalker();
+	FuzzRegisterDecoders();
+
+	std::printf("Pm4FuzzTests: all passed\n");
+	return 0;
+}

--- a/tests/ShaderDiskCacheTests.cpp
+++ b/tests/ShaderDiskCacheTests.cpp
@@ -1,0 +1,391 @@
+#include "gpu_tiler_shaders/gpu_tiler_depth_spv.h"
+#include "graphics/shader/shaderDiskCache.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <random>
+#include <vector>
+
+namespace {
+
+using Libs::Graphics::ShaderDiskCacheEntry;
+using Libs::Graphics::ShaderDiskCacheLoad;
+using Libs::Graphics::ShaderDiskCacheSave;
+using Libs::Graphics::ShaderLaneMaskMode;
+using Libs::Graphics::ShaderType;
+
+namespace IR = Libs::Graphics::ShaderRecompiler::IR;
+
+void Check(bool value, const char* text) {
+	if (!value) {
+		std::fprintf(stderr, "ShaderDiskCacheTests: failed: %s\n", text);
+		std::abort();
+	}
+}
+
+std::filesystem::path TempPath(const char* name) {
+	auto path = std::filesystem::temp_directory_path() / name;
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+	return path;
+}
+
+// Real SPIR-V, compiled by glslang during the build - not a magic number with
+// noise after it. The cache never parses SPIR-V, but a test that feeds it
+// something no compiler ever produced proves less than it looks like it does.
+std::vector<uint32_t> RealSpirv() {
+	return {std::begin(GPU_TILER_DEPTH_SPV), std::end(GPU_TILER_DEPTH_SPV)};
+}
+
+// A plan with every serialized container non-empty, so a field that is silently
+// dropped shows up as a mismatch rather than as two empty vectors comparing
+// equal.
+std::shared_ptr<IR::Program> MakeProgram() {
+	auto program = std::make_shared<IR::Program>();
+
+	program->stage                      = ShaderType::Pixel;
+	program->lane_mask_mode             = ShaderLaneMaskMode::PerInvocation;
+	program->shader_hash                = 0x0123456789abcdefULL;
+	program->wave_size                  = 32;
+	program->user_data_base             = 4;
+	program->user_data_count            = 16;
+	program->srt_plan_complete          = true;
+	program->resource_tracking_complete = true;
+	program->shader_info_complete       = true;
+	program->binding_layout_complete    = true;
+
+	IR::BufferResource buffer {};
+	buffer.source             = 3;
+	buffer.first_use_pc       = 0x40;
+	buffer.max_byte_extent    = 4096;
+	buffer.packed_stride      = 16;
+	buffer.descriptor_swizzle = 0x0fac;
+	buffer.image_alias        = 7;
+	buffer.read               = true;
+	buffer.written            = true;
+	buffer.formatted          = true;
+	program->info.buffers.push_back(buffer);
+
+	IR::AddressResource address {};
+	address.source           = 9;
+	address.first_use_pc     = 0x80;
+	address.kind             = IR::ResourceKind::Flat;
+	address.min_offset       = -32;
+	address.specialized_base = 0xdeadbeefcafeULL;
+	address.unbased          = false;
+	address.written          = true;
+	program->info.addresses.push_back(address);
+
+	IR::ImageResource image {};
+	image.source                    = 11;
+	image.first_use_pc              = 0xc0;
+	image.mip_count                 = 5;
+	image.storage_swizzle           = IR::StorageImageIdentitySwizzle;
+	image.read                      = true;
+	image.cube                      = true;
+	image.indirect_root             = 2;
+	image.indirect_mapping_offset   = 8;
+	image.indirect_mapping_capacity = 4;
+	image.indirect_resources        = {1, 2, 3};
+	program->info.images.push_back(image);
+
+	program->info.samplers.push_back({13, 0x100});
+	program->info.sampled_pairs.push_back({0, 0, 0x140});
+
+	IR::StageInput input {};
+	input.kind            = IR::StageInputKind::FragCoord;
+	input.location        = 2;
+	input.component_count = 4;
+	input.debug_name      = "frag_coord";
+	program->info.inputs.push_back(input);
+
+	IR::StageOutput output {};
+	output.kind       = IR::StageOutputKind::Mrt;
+	output.index      = 1;
+	output.location   = 1;
+	output.debug_name = "mrt1";
+	program->info.outputs.push_back(output);
+
+	program->info.vertex_offset_sgpr = 6;
+	program->info.has_bitwise_xor    = true;
+
+	program->bindings.descriptor_set       = 1;
+	program->bindings.push_constant_offset  = 16;
+	program->bindings.push_constant_size    = 32;
+	program->bindings.buffer_offset_dword   = 2;
+	program->bindings.buffer_offset_count   = 3;
+	program->bindings.user_data_registers   = {0, 1, 2, 3};
+	program->bindings.descriptors.push_back(
+	    {IR::DescriptorBindingKind::Buffers, 0, std::vector<uint32_t> {0}});
+	program->bindings.descriptors.push_back(
+	    {IR::DescriptorBindingKind::Samplers, 1, std::vector<uint32_t> {13}});
+
+	IR::SpirvRequirements requirements {};
+	requirements.requires_exact_subgroup = true;
+	requirements.subgroup_ballot         = true;
+	requirements.pixel_valid_mask        = true;
+	program->spirv_requirements          = requirements;
+
+	return program;
+}
+
+ShaderDiskCacheEntry MakeEntry() {
+	ShaderDiskCacheEntry entry {};
+	entry.stage             = ShaderType::Pixel;
+	entry.lane_mask_mode    = ShaderLaneMaskMode::PerInvocation;
+	entry.shader_hash       = 0x0123456789abcdefULL;
+	entry.program_id.hash0  = 0xaabbccddU;
+	entry.program_id.crc32  = 0x11223344U;
+	entry.program_id.ids    = {5, 6, 7, 8};
+	entry.optimization_type = Config::ShaderOptimizationType::Performance;
+	entry.program           = MakeProgram();
+	entry.spirv             = RealSpirv();
+	return entry;
+}
+
+void ExpectSameEntry(const ShaderDiskCacheEntry& a, const ShaderDiskCacheEntry& b) {
+	Check(a.stage == b.stage, "stage survives");
+	Check(a.lane_mask_mode == b.lane_mask_mode, "lane mask mode survives");
+	Check(a.shader_hash == b.shader_hash, "shader hash survives");
+	Check(a.program_id == b.program_id, "program id survives");
+	Check(a.optimization_type == b.optimization_type, "optimization type survives");
+	Check(a.spirv == b.spirv, "SPIR-V survives byte for byte");
+
+	Check(a.program != nullptr && b.program != nullptr, "both plans exist");
+	Check(a.program->stage == b.program->stage, "plan stage survives");
+	Check(a.program->lane_mask_mode == b.program->lane_mask_mode, "plan lane mask survives");
+	Check(a.program->shader_hash == b.program->shader_hash, "plan hash survives");
+	Check(a.program->wave_size == b.program->wave_size, "wave size survives");
+	Check(a.program->user_data_base == b.program->user_data_base, "user data base survives");
+	Check(a.program->user_data_count == b.program->user_data_count, "user data count survives");
+	Check(a.program->srt_plan_complete == b.program->srt_plan_complete, "srt flag survives");
+	Check(a.program->resource_tracking_complete == b.program->resource_tracking_complete,
+	      "resource tracking flag survives");
+	Check(a.program->shader_info_complete == b.program->shader_info_complete,
+	      "shader info flag survives");
+	Check(a.program->binding_layout_complete == b.program->binding_layout_complete,
+	      "binding layout flag survives");
+
+	// ShaderInfo and BindingLayout both have a defaulted operator==, so this
+	// compares every field including ones added after this test was written.
+	Check(a.program->info == b.program->info, "the whole ShaderInfo survives");
+	Check(a.program->bindings == b.program->bindings, "the whole BindingLayout survives");
+	Check(a.program->spirv_requirements.has_value() == b.program->spirv_requirements.has_value(),
+	      "spirv requirements presence survives");
+	if (a.program->spirv_requirements.has_value()) {
+		const auto& x = *a.program->spirv_requirements;
+		const auto& y = *b.program->spirv_requirements;
+		Check(x.requires_exact_subgroup == y.requires_exact_subgroup &&
+		          x.subgroup_ballot == y.subgroup_ballot &&
+		          x.subgroup_shuffle == y.subgroup_shuffle &&
+		          x.subgroup_local_invocation_id == y.subgroup_local_invocation_id &&
+		          x.compute_derivatives == y.compute_derivatives &&
+		          x.image_gather_extended == y.image_gather_extended &&
+		          x.function_lds == y.function_lds && x.pixel_valid_mask == y.pixel_valid_mask,
+		      "every spirv requirement survives");
+	}
+}
+
+std::vector<uint8_t> ReadFile(const std::filesystem::path& path) {
+	std::ifstream in(path, std::ios::binary);
+	Check(static_cast<bool>(in), "cache file is readable");
+	return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+void WriteFile(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
+	std::ofstream out(path, std::ios::binary | std::ios::trunc);
+	Check(static_cast<bool>(out), "cache file is writable");
+	out.write(reinterpret_cast<const char*>(bytes.data()),
+	          static_cast<std::streamsize>(bytes.size()));
+}
+
+void TestColdRun() {
+	const auto path = TempPath("kyty_shader_cache_cold.bin");
+	Check(ShaderDiskCacheLoad(path).empty(), "a missing cache file is not an error");
+}
+
+void TestRoundTrip() {
+	const auto path = TempPath("kyty_shader_cache_roundtrip.bin");
+
+	const auto original = MakeEntry();
+	Check(ShaderDiskCacheSave(path, {original}), "the cache is written");
+	Check(std::filesystem::file_size(path) > 0, "the cache file is not empty");
+
+	const auto loaded = ShaderDiskCacheLoad(path);
+	Check(loaded.size() == 1, "exactly one entry comes back");
+	ExpectSameEntry(original, loaded[0]);
+
+	std::filesystem::remove(path);
+}
+
+void TestManyEntries() {
+	const auto path = TempPath("kyty_shader_cache_many.bin");
+
+	std::vector<ShaderDiskCacheEntry> entries;
+	for (uint32_t i = 0; i < 32; i++) {
+		auto entry        = MakeEntry();
+		entry.shader_hash = 0x1000ULL + i;
+		entries.push_back(std::move(entry));
+	}
+	Check(ShaderDiskCacheSave(path, entries), "many entries are written");
+
+	const auto loaded = ShaderDiskCacheLoad(path);
+	Check(loaded.size() == entries.size(), "every entry comes back");
+	for (size_t i = 0; i < loaded.size(); i++) {
+		Check(loaded[i].shader_hash == 0x1000ULL + i, "entries keep their order and identity");
+	}
+
+	std::filesystem::remove(path);
+}
+
+// A run killed while writing, or a file cut short by a full disk. The bytes that
+// did land must still be usable, and nothing may read past the end.
+void TestTruncationIsSurvivable() {
+	const auto path = TempPath("kyty_shader_cache_truncated.bin");
+
+	std::vector<ShaderDiskCacheEntry> entries;
+	for (uint32_t i = 0; i < 8; i++) {
+		auto entry        = MakeEntry();
+		entry.shader_hash = 0x2000ULL + i;
+		entries.push_back(std::move(entry));
+	}
+	Check(ShaderDiskCacheSave(path, entries), "the cache is written");
+
+	const auto full = ReadFile(path);
+
+	// Every truncation point, not just a convenient one.
+	for (size_t cut = 0; cut < full.size(); cut += 37) {
+		WriteFile(path, std::vector<uint8_t>(full.begin(), full.begin() + cut));
+		const auto loaded = ShaderDiskCacheLoad(path);
+		Check(loaded.size() <= entries.size(), "a truncated cache never invents entries");
+		for (const auto& entry: loaded) {
+			Check(entry.program != nullptr, "every surviving entry has a plan");
+			Check(!entry.spirv.empty(), "every surviving entry has SPIR-V");
+		}
+	}
+
+	std::filesystem::remove(path);
+}
+
+void TestCorruptEntryIsDropped() {
+	const auto path = TempPath("kyty_shader_cache_corrupt.bin");
+
+	std::vector<ShaderDiskCacheEntry> entries;
+	for (uint32_t i = 0; i < 4; i++) {
+		auto entry        = MakeEntry();
+		entry.shader_hash = 0x3000ULL + i;
+		entries.push_back(std::move(entry));
+	}
+	Check(ShaderDiskCacheSave(path, entries), "the cache is written");
+
+	auto bytes = ReadFile(path);
+	// Flip a byte deep inside the payload area, past the file header.
+	bytes[bytes.size() / 2] ^= 0xFFU;
+	WriteFile(path, bytes);
+
+	const auto loaded = ShaderDiskCacheLoad(path);
+	Check(loaded.size() < entries.size(), "the damaged entry is dropped");
+	for (const auto& entry: loaded) {
+		Check(entry.program != nullptr && !entry.spirv.empty(), "survivors are intact");
+	}
+
+	std::filesystem::remove(path);
+}
+
+// The cache must not be read by a build whose recompiler has a different shape.
+// This is the guard that stops a stale plan turning into a wrong frame.
+void TestForeignBuildIsRejected() {
+	const auto path = TempPath("kyty_shader_cache_foreign.bin");
+
+	Check(ShaderDiskCacheSave(path, {MakeEntry()}), "the cache is written");
+	auto bytes = ReadFile(path);
+
+	// The build id sits right after the 8-byte magic and the 4-byte format.
+	bytes[12] ^= 0x01U;
+	WriteFile(path, bytes);
+
+	Check(ShaderDiskCacheLoad(path).empty(), "a cache from another build is not read");
+
+	std::filesystem::remove(path);
+}
+
+void TestNonCacheFileIsRejected() {
+	const auto path = TempPath("kyty_shader_cache_garbage.bin");
+
+	std::mt19937                            rng(1234);
+	std::uniform_int_distribution<uint32_t> byte(0, 255);
+
+	// Random files, including ones long enough to look like a header.
+	for (size_t size: {0U, 1U, 8U, 16U, 64U, 4096U}) {
+		std::vector<uint8_t> bytes(size);
+		for (auto& b: bytes) {
+			b = static_cast<uint8_t>(byte(rng));
+		}
+		WriteFile(path, bytes);
+		Check(ShaderDiskCacheLoad(path).empty(), "a file that is not a cache yields nothing");
+	}
+
+	std::filesystem::remove(path);
+}
+
+// A length field is the classic place to hide a huge allocation. Rewrite the
+// entry sizes to absurd values and confirm the loader refuses rather than tries.
+void TestAbsurdLengthsAreRefused() {
+	const auto path = TempPath("kyty_shader_cache_lengths.bin");
+
+	Check(ShaderDiskCacheSave(path, {MakeEntry()}), "the cache is written");
+	auto bytes = ReadFile(path);
+
+	// Entry size is the first 8 bytes after the 20-byte file header.
+	constexpr size_t HEADER = 8 + 4 + 8 + 4;
+	Check(bytes.size() > HEADER + 8, "the file is long enough to patch");
+	for (uint32_t i = 0; i < 8; i++) {
+		bytes[HEADER + i] = 0xFFU;
+	}
+	WriteFile(path, bytes);
+
+	Check(ShaderDiskCacheLoad(path).empty(), "an impossible entry length is refused");
+
+	std::filesystem::remove(path);
+}
+
+void TestEmptyEntriesAreNotWritten() {
+	const auto path = TempPath("kyty_shader_cache_empty.bin");
+
+	ShaderDiskCacheEntry no_program = MakeEntry();
+	no_program.program.reset();
+
+	ShaderDiskCacheEntry no_spirv = MakeEntry();
+	no_spirv.spirv.clear();
+
+	Check(ShaderDiskCacheSave(path, {no_program, no_spirv}), "the cache is written");
+	Check(ShaderDiskCacheLoad(path).empty(), "entries with nothing to cache are skipped");
+
+	std::filesystem::remove(path);
+}
+
+void TestDisabledByEmptyPath() {
+	Check(ShaderDiskCacheLoad({}).empty(), "an empty path loads nothing");
+	Check(!ShaderDiskCacheSave({}, {MakeEntry()}), "an empty path saves nothing");
+}
+
+} // namespace
+
+int main() {
+	TestColdRun();
+	TestRoundTrip();
+	TestManyEntries();
+	TestTruncationIsSurvivable();
+	TestCorruptEntryIsDropped();
+	TestForeignBuildIsRejected();
+	TestNonCacheFileIsRejected();
+	TestAbsurdLengthsAreRefused();
+	TestEmptyEntriesAreNotWritten();
+	TestDisabledByEmptyPath();
+	std::printf("ShaderDiskCacheTests: all passed\n");
+	return 0;
+}


### PR DESCRIPTION
1. Games load faster the second time you run them, because the work the GPU driver does to compile shaders is now saved to disk instead of redone on every launch.
2. When video memory runs low, the driver can now set something cheap aside itself, instead of the emulator having to delete textures and rebuild them.
3. `--diagnostics` prints a short report you can paste into an issue: build, CPU, GPU, driver version. No paths, no usernames.
4. A game that will not boot now tells you which check failed and what it means, instead of `elf is not valid`.
5. Logs stop growing to gigabytes, so bug reports can be uploaded again (#200).

This replaces #301, which I closed. The change in it was fine, my description of it was not: I blamed a build error on header shadowing when I had simply built with GCC instead of clang. That work is included here.

## Two caches that were not there

**Pipelines.** Every pipeline creation call passed a null cache handle, so the driver recompiled everything on every launch. The existing `PipelineCache` class is a lookup table of handles within one run, which is useful, but the driver never sees it and it disappears when the process exits.

There is now a real `VkPipelineCache`, loaded at startup and saved at exit. The file is checked against the current GPU and driver before the driver is allowed to read it, and ignored if it does not match. That happens after any driver update, so it is a log line rather than a warning.

**Shaders.** The GCN to SPIR-V translation was also redone from scratch each launch. This one is riskier than the pipeline cache, because a bad cache key here means wrong rendering rather than a slow start, so it is worth saying why it cannot do that.

Reusing a shader was never just a key lookup. After the key matches, the existing code re-checks the shader against the current register state before accepting it. **I did not touch that check.** Anything loaded from disk goes through it exactly like a shader compiled earlier in the same run, so a stale entry fails and gets recompiled. The worst case is a wasted compile, not a bad frame.

The file is also rejected outright unless it came from the same build: the header holds the git version plus a fingerprint of the recompiler's data structures. Strict on purpose, since a rejected cache costs one cold start and a wrongly accepted one costs correctness. Entries are checksummed individually, so one bad entry is dropped instead of the whole file, and both caches are written to a temp file and renamed, so being killed mid-write cannot corrupt them.

**A bug this turned up:** the emulator exits through `quick_exit`, which skips destructors and `atexit` handlers. Anything saved during teardown was never actually being saved. Both caches now flush from `at_quick_exit`. Worth knowing regardless of this PR.

## Memory pressure

The renderer already reads the real memory budget and scales its GC around it, which is more care than most projects take. But when memory gets tight, the only move available is deleting resources, and the driver has no idea which ones matter.

Two optional extensions fix that: one lets each allocation carry a priority, the other lets the driver actually page video memory out instead of failing the allocation. Together they give the driver a cheaper option one step before the GC has to run. This does not replace the GC, it takes load off it.

They go on together or not at all, because priority alone only changes which allocation gets the out-of-memory error. Both are enabled only if the driver reports support, so a driver without them sees exactly what it saw before.

Only images get a raised priority. I left buffers alone deliberately: a dropped render target has to be fetched back before the next pass reads it, while most buffer data can be re-uploaded from guest memory you still hold. Buffer allocation is a shared path that also serves vertex and index data, and guessing wrong there costs performance with nothing in the log to show for it. Marking staging buffers as cheap looks right to me, but I would want to measure before claiming it.

## Making bug reports usable

The compatibility list is this project's front door, so what a reporter can produce matters.

**`--diagnostics`** prints build, OS, CPU, and every GPU with its driver version, memory, and which optional extensions it has. It does not open a window or create a device, so it still works on a machine where the emulator will not start, which is exactly when you need it. No paths, no usernames, no game names, and a test fails if that ever changes.

**Log size (#200).** 5 GB in two minutes makes a log useless, as that issue and a comment on #281 both say. Filtering duplicate *text* would not help, because those lines carry an address that differs every time. What actually repeats is the line of code, so each log statement now counts itself: the first few hundred messages print in full, after that it is sampled, and a summary at the end names each noisy line with how often it really fired. Nothing vanishes silently, and a line that fires once still appears once.

This is your own pattern, generalised. Several hot spots already do exactly this by hand with a local counter; now nobody has to guess which line becomes the next problem. `--log-repeat-limit 0` restores the old behaviour, and crash messages do not go through it at all. It is also faster, because the check happens before the string is formatted, so a skipped line costs an increment instead of a `sprintf`.

Ten million calls from one line produce 866 messages in the test.

**Boot failures.** `Elf64::IsValid()` was eleven checks, each logging a raw register comparison and returning false, after which the loader died with `elf is not valid`. Your shader code already has the right pattern for this, a named failure enum with a to-string; it just never reached game loading.

Those checks are now one standalone function returning a named reason plus a sentence someone can act on. A PC executable says it is not built for the FreeBSD ABI; a truncated file says it is too short to hold an ELF header. Standalone means it is testable with a made-up header and no emulator, so there is a case for every branch, including the ordering: telling someone "not x86-64" about a file that is not an ELF at all sends them the wrong way.

## PM4 fuzzing

Command buffers come from the guest, and nothing tested that path except the buffers real games happen to produce. The harness has two halves.

**The packet walker:** random streams of padding words, variable-length NOPs and fixed-format packets. 20,000 buffers, 251,449 packets, full reset between runs. It does not feed random lengths, because a bad length is a deliberate abort, which is a guard working rather than a bug to find.

**The register writes:** roughly two thousand handlers unpacking bit fields out of guest words. The list of valid registers is read from the dispatch tables themselves, so this keeps covering new registers as they are added. Each one is first probed in a forked child with a zero payload. If it dies there it simply wants a different packet length, so it is skipped and counted; if it survives that and then dies on random values, that is a real bug and the run fails. Without the two steps you cannot tell those apart. Currently 471 of 474 registers, 256 rounds each.

Building a real render context needs a live GPU, which no CI runner has. The packets fuzzed here never touch the renderer, but that is an assumption, so the reference points at a page with no access permissions. If a handler ever reaches through it, the process dies immediately. The hardware enforces the boundary instead of a comment claiming it.

**It found nothing.** Said plainly: this is a regression net, not a list of bugs. I did check that it can fail, by breaking the generated packets and confirming it dies, then restoring them.

Draw, dispatch and DMA packets are **not** covered, since they need a real device and mapped guest memory. The forked half is skipped on Windows.

## Testing

Built with clang, matching your CI. The five new test targets are wired into the build lists and the ctest filters on all three platforms, since a target in neither list does nothing. 11/11 locally.

The shader cache test uses real compiled SPIR-V from your own tiler shaders, and covers the first run, the round trip, truncation at every offset in the file, a corrupted entry, a cache from a different build, random junk files, and impossible length fields.

**I have not measured a speedup and I am not claiming one.** I do not have a title to test with here. The caches are verified to be written, validated and read back; whether that becomes a number you care about on a real game is something you can check far better than I can. Happy to split this into smaller PRs if that is easier to review.
