### PR TITLE
Fixes to get Demon's Souls booting on Linux

### DIFF
--- a/src/common/hostException.cpp
+++ b/src/common/hostException.cpp
@@ -92,7 +92,7 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) noexcept {
 	return EXCEPTION_CONTINUE_SEARCH;
 }
 
-void SetupSignalStack() {}
+void SetupSignalStack() noexcept {}
 
 #elif defined(__APPLE__)
 
@@ -165,7 +165,7 @@ static void SignalHandler(int sig, siginfo_t* si, void* uctx) {
 	sigaction(sig, &dfl, nullptr);
 }
 
-void SetupSignalStack() {}
+void SetupSignalStack() noexcept {}
 
 #else
 

--- a/src/common/hostException.cpp
+++ b/src/common/hostException.cpp
@@ -11,6 +11,7 @@
 #else
 #include <csignal>
 #include <initializer_list>
+#include <sys/mman.h>
 #include <ucontext.h> // IWYU pragma: keep
 #include <unistd.h>
 #endif
@@ -91,6 +92,8 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) noexcept {
 	return EXCEPTION_CONTINUE_SEARCH;
 }
 
+void SetupSignalStack() {}
+
 #elif defined(__APPLE__)
 
 static std::atomic<Handler> g_handler {nullptr};
@@ -162,11 +165,45 @@ static void SignalHandler(int sig, siginfo_t* si, void* uctx) {
 	sigaction(sig, &dfl, nullptr);
 }
 
+void SetupSignalStack() {}
+
 #else
 
 // x86-64 page-fault error bits.
 constexpr uint64_t PAGE_FAULT_ERROR_WRITE       = 0x02;
 constexpr uint64_t PAGE_FAULT_ERROR_INSTRUCTION = 0x10;
+
+// Size of the private stack used to run host fault handlers.
+constexpr size_t kSignalStackSize = 1u * 1024u * 1024u;
+
+// Runs every fault handler for this thread on a private host stack instead of the thread's
+// current stack. The guest stack and the flexible-memory GPU buffers share the same address
+// region, and the GPU write-watching sweeps mprotect that region to PROT_READ (r--s). If a
+// handler were running on a stack inside a chunk that gets swept read-only, its next stack
+// write would fault and the kernel could not build a signal frame on the read-only pages,
+// killing the process with a silent SIGSEGV (no nested dump). A private stack is never part
+// of the guarded guest region, so it can never lose write permission.
+void SetupSignalStack() noexcept {
+	thread_local bool installed = false;
+	if (installed) {
+		return;
+	}
+	installed = true;
+
+	stack_t ss {};
+	ss.ss_size = kSignalStackSize;
+#if defined(SS_AUTODISARM)
+	ss.ss_flags |= SS_AUTODISARM;
+#endif
+	ss.ss_sp = mmap(nullptr, kSignalStackSize, PROT_READ | PROT_WRITE,
+	                MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+	if (ss.ss_sp == MAP_FAILED) {
+		return; // Fall back to the normal stack; only affects robustness.
+	}
+	if (sigaltstack(&ss, nullptr) != 0) {
+		munmap(ss.ss_sp, kSignalStackSize);
+	}
+}
 
 // Let the kernel handle an unresolved fault on retry.
 static void ChainToDefault(int signal_number) noexcept {
@@ -271,11 +308,16 @@ bool InstallHandler(Handler handler) {
 		return false;
 	}
 #else
+	// Install the private fault-handler stack before the handlers so they never run on a stack
+	// that the GPU protection sweeps can make read-only (see SetupSignalStack).
+	SetupSignalStack();
+
 	struct sigaction action {};
 	action.sa_sigaction = SignalHandler;
 	sigemptyset(&action.sa_mask);
-	// Fault resolution needs the normal thread stack.
-	action.sa_flags = SA_SIGINFO | SA_RESTART;
+	// SA_ONSTACK runs the handler on the thread's private signal stack, keeping it out of the
+	// flexible-memory region that the GPU write-watching sweeps mprotect to PROT_READ.
+	action.sa_flags = SA_SIGINFO | SA_RESTART | SA_ONSTACK;
 
 	for (const int signal_number: {SIGSEGV, SIGBUS, SIGILL}) {
 		if (::sigaction(signal_number, &action, nullptr) != 0) {

--- a/src/common/hostException.h
+++ b/src/common/hostException.h
@@ -39,6 +39,12 @@ using Handler = bool (*)(const ExceptionInfo&);
 
 bool InstallHandler(Handler handler);
 
+// Gives the current thread a private stack for host fault handlers. The guest stack lives
+// inside the flexible-memory region that the GPU write-watching sweeps mprotect to read-only;
+// a handler running on it would kill the process the moment its own stack pages lose write
+// permission (see hostException.cpp). No-op on platforms that do not need it.
+void SetupSignalStack() noexcept;
+
 } // namespace Common::HostException
 
 #endif /* KYTY_COMMON_HOST_EXCEPTION_H_ */

--- a/src/graphics/host_gpu/memoryTracker.cpp
+++ b/src/graphics/host_gpu/memoryTracker.cpp
@@ -95,6 +95,9 @@ bool MemoryTracker::IsRegionGpuModified(uint64_t vaddr, uint64_t size) {
 
 void MemoryTracker::MarkRegionAsCpuModified(uint64_t vaddr, uint64_t size) {
 	CheckNotInUploadCallback();
+	// ChangeState runs an mprotect under the region lock; hold the guest address-space mutex first
+	// (see InvalidateRegion in memoryTracker.h).
+	std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 	Iterate<true>(vaddr, size, [](RegionManager* manager, uint64_t offset, uint64_t bytes) {
 		std::scoped_lock lock(manager->lock);
 		manager->ChangeState<DirtySource::Cpu, true>(manager->GetCpuAddr() + offset, bytes);
@@ -103,6 +106,7 @@ void MemoryTracker::MarkRegionAsCpuModified(uint64_t vaddr, uint64_t size) {
 
 void MemoryTracker::MarkRegionAsGpuModified(uint64_t vaddr, uint64_t size) {
 	CheckNotInUploadCallback();
+	std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 	Iterate<true>(vaddr, size, [](RegionManager* manager, uint64_t offset, uint64_t bytes) {
 		std::scoped_lock lock(manager->lock);
 		manager->ChangeState<DirtySource::Gpu, true>(manager->GetCpuAddr() + offset, bytes);
@@ -111,6 +115,7 @@ void MemoryTracker::MarkRegionAsGpuModified(uint64_t vaddr, uint64_t size) {
 
 void MemoryTracker::UnmarkRegionAsGpuModified(uint64_t vaddr, uint64_t size) {
 	CheckNotInUploadCallback();
+	std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 	Iterate<false>(vaddr, size, [](RegionManager* manager, uint64_t offset, uint64_t bytes) {
 		std::scoped_lock lock(manager->lock);
 		manager->ChangeState<DirtySource::Gpu, false>(manager->GetCpuAddr() + offset, bytes);
@@ -118,6 +123,7 @@ void MemoryTracker::UnmarkRegionAsGpuModified(uint64_t vaddr, uint64_t size) {
 }
 
 void MemoryTracker::UntrackMemoryImpl(uint64_t vaddr, uint64_t size) {
+	std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 	std::vector<RegionManager*> managers;
 	managers.reserve((vaddr % TRACKER_REGION_SIZE + size + TRACKER_REGION_SIZE - 1) /
 	                 TRACKER_REGION_SIZE);

--- a/src/graphics/host_gpu/memoryTracker.h
+++ b/src/graphics/host_gpu/memoryTracker.h
@@ -5,6 +5,7 @@
 #include "graphics/host_gpu/pageManager.h"
 #include "graphics/host_gpu/rangeSet.h"
 #include "graphics/host_gpu/regionManager.h"
+#include "kernel/memory.h"
 
 #include <algorithm>
 #include <atomic>
@@ -36,8 +37,16 @@ public:
 		CheckNotInUploadCallback();
 		ValidateRange(vaddr, size);
 
+		// The protection update below runs an mprotect (ProtectGuestHostMemory) that iterates the
+		// guest-address-space registry. Hold its mutex before taking the region-tracking lock so
+		// the mprotect never acquires it while a region lock is held; otherwise a guest thread
+		// that faults on its own stack (swept read-only by the GPU) while holding that mutex in a
+		// syscall deadlocks against the thread performing the sweep. The guard is scoped to the
+		// region-lock section: on_flush hands work to the GPU thread (SendCommandSync) and must
+		// run with no tracking locks held.
 		Iterate<false>(vaddr, size, [&](RegionManager* manager, uint64_t offset, uint64_t bytes) {
 			const bool should_flush = [&] {
+				std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 				// Perform both the GPU modification check and CPU state change with the lock in
 				// case the GPU thread is racing to mark the page modified. If a flush is needed,
 				// on_flush performs the CPU state change.
@@ -68,6 +77,7 @@ public:
 		static_assert(std::is_nothrow_invocable_v<Preflight&, uint64_t, uint64_t>);
 		static_assert(std::is_nothrow_invocable_v<Func&, uint64_t, uint64_t>);
 		CheckNotInUploadCallback();
+		std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 		std::vector<RegionManager*> managers;
 		Iterate<false>(vaddr, size, [&](RegionManager* manager, uint64_t, uint64_t) {
 			managers.push_back(manager);
@@ -108,6 +118,9 @@ public:
 		static_assert(std::is_nothrow_invocable_v<RangeFunc&, uint64_t, uint64_t>);
 		static_assert(std::is_nothrow_invocable_v<UploadFunc&>);
 		CheckNotInUploadCallback();
+		// See InvalidateRegion: the sweep mprotects inside the region locks, so the guest
+		// address-space mutex must be held first to keep the lock order consistent.
+		std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 		Iterate<true>(vaddr, size, [](RegionManager*, uint64_t, uint64_t) {});
 		const auto* previous_upload_owner = std::exchange(s_upload_owner, this);
 		Iterate<false>(vaddr, size, [&](RegionManager* manager, uint64_t offset, uint64_t bytes) {

--- a/src/graphics/host_gpu/memoryTracker.h
+++ b/src/graphics/host_gpu/memoryTracker.h
@@ -77,7 +77,15 @@ public:
 		static_assert(std::is_nothrow_invocable_v<Preflight&, uint64_t, uint64_t>);
 		static_assert(std::is_nothrow_invocable_v<Func&, uint64_t, uint64_t>);
 		CheckNotInUploadCallback();
-		std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
+		// Only the clear phase runs an mprotect (under the region locks), so the guest
+		// address-space mutex (see InvalidateRegion) is required for that path alone. Read-only
+		// downloads must not hold it while the callback runs, or a disjoint-region GPU
+		// modification would serialize behind the download.
+		std::unique_lock<std::recursive_mutex> guest_as_lock(
+		    Libs::LibKernel::Memory::GetGuestAddressSpaceMutex(), std::defer_lock);
+		if constexpr (clear) {
+			guest_as_lock.lock();
+		}
 		std::vector<RegionManager*> managers;
 		Iterate<false>(vaddr, size, [&](RegionManager* manager, uint64_t, uint64_t) {
 			managers.push_back(manager);

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -404,7 +404,15 @@ vk::Buffer BufferCache::UploadCopies(Buffer& buffer, std::span<vk::BufferCopy> c
 	if (mapped != nullptr) {
 		for (auto& copy: copies) {
 			const auto address = buffer.CpuAddress() + copy.dstOffset;
-			std::memcpy(mapped + copy.srcOffset, reinterpret_cast<const void*>(address), copy.size);
+			// Read the source through the guest backing instead of the guest virtual mapping.
+			// A CPU-modified page whose backing was released (guest unmap) has no host mapping
+			// (PROT_NONE) and a direct read would fault inside the upload callback. The backing
+			// carries the same data for backed pages; unbacked copies are zeroed so the GPU reads
+			// nothing meaningful instead of crashing.
+			auto* const dst = mapped + copy.srcOffset;
+			if (!Libs::LibKernel::Memory::TryReadBacking(address, dst, copy.size)) {
+				std::memset(dst, 0, copy.size);
+			}
 			copy.srcOffset += base_offset;
 		}
 		m_staging_buffer.Commit();
@@ -415,8 +423,10 @@ vk::Buffer BufferCache::UploadCopies(Buffer& buffer, std::span<vk::BufferCopy> c
 	                                         vk::BufferUsageFlagBits::eTransferSrc, total_size);
 	for (const auto& copy: copies) {
 		const auto address = buffer.CpuAddress() + copy.dstOffset;
-		std::memcpy(temporary->Mapped().data() + copy.srcOffset,
-		            reinterpret_cast<const void*>(address), copy.size);
+		auto* const dst    = temporary->Mapped().data() + copy.srcOffset;
+		if (!Libs::LibKernel::Memory::TryReadBacking(address, dst, copy.size)) {
+			std::memset(dst, 0, copy.size);
+		}
 	}
 	temporary->Flush(0, total_size);
 	const auto handle = temporary->Handle();

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -684,14 +684,17 @@ bool BufferCache::IsRegionCpuModified(uint64_t vaddr, uint64_t size) {
 
 void BufferCache::RunGarbageCollector() {
 	const auto tick = m_gc_tick++;
-	if (m_graphics.CanReportMemoryUsage()) {
-		m_total_used_memory = m_graphics.GetDeviceMemoryUsage();
-	}
-	if (m_total_used_memory < m_trigger_gc_memory) {
+	// Keep the Register/Unregister byte ledger intact; use the actual device usage (or the
+	// ledger when the driver cannot report budgets) only to decide whether to collect. Overwriting
+	// the ledger with raw VMA heap usage (which also covers textures, staging and fixed buffers)
+	// made Unregister underflow whenever a large merged buffer was retired after a collection.
+	const auto usage = m_graphics.CanReportMemoryUsage() ? m_graphics.GetDeviceMemoryUsage()
+	                                                     : m_total_used_memory;
+	if (usage < m_trigger_gc_memory) {
 		return;
 	}
 
-	const bool     aggressive = m_total_used_memory >= m_critical_gc_memory;
+	const bool     aggressive = usage >= m_critical_gc_memory;
 	const uint64_t age        = std::min<uint64_t>(aggressive ? 80 : 160, tick);
 	const size_t   limit      = aggressive ? 64 : 32;
 

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -13,10 +13,19 @@ GpuResourceManager::~GpuResourceManager() = default;
 
 bool GpuResourceManager::HandleFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept {
 	constexpr uint64_t fault_size = 8;
-	if (!IsMapped(fault_vaddr, fault_size)) {
+	// A buffer whose guest pages are GPU-owned (uploaded, CPU reads protected) is registered in
+	// m_mapped_ranges when the guest mapped it as GPU memory. Shader/utility code can also live
+	// inside such a buffer even when the range itself was never registered there, so a CPU read
+	// of a GPU-dirty page must still be resolved through the buffer cache.
+	const bool mapped = IsMapped(fault_vaddr, fault_size);
+	const bool gpu_owned = m_buffer_cache.IsRegionGpuModified(fault_vaddr, fault_size);
+	if (!mapped && !gpu_owned) {
 		return false;
 	}
 	if (access == PageFaultAccess::Write) {
+		if (!mapped) {
+			return false;
+		}
 		m_buffer_cache.InvalidateMemory(fault_vaddr, fault_size);
 		m_texture_cache.InvalidateMemory(fault_vaddr, fault_size);
 	} else {

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -269,6 +269,7 @@ void TextureCache::TrackImage(ImageId id) {
 	if (!image.IsTracked()) {
 		image.track_addr     = image_begin;
 		image.track_addr_end = image_end;
+		std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 		m_page_manager.UpdatePageWatchers<true>(image_begin, image.info.data.size);
 		return;
 	}
@@ -294,6 +295,7 @@ void TextureCache::TrackImageHead(ImageId id) {
 	}
 	const auto size  = image.track_addr - image_begin;
 	image.track_addr = image_begin;
+	std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 	m_page_manager.UpdatePageWatchers<true>(image_begin, size);
 }
 
@@ -312,6 +314,7 @@ void TextureCache::TrackImageTail(ImageId id) {
 	const auto address   = image.track_addr_end;
 	const auto size      = image_end - address;
 	image.track_addr_end = image_end;
+	std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 	m_page_manager.UpdatePageWatchers<true>(address, size);
 }
 
@@ -325,6 +328,7 @@ void TextureCache::UntrackImage(ImageId id) {
 	image.track_addr     = 0;
 	image.track_addr_end = 0;
 	if (size != 0) {
+		std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 		m_page_manager.UpdatePageWatchers<false>(address, size);
 	}
 }
@@ -342,6 +346,7 @@ void TextureCache::UntrackImageHead(ImageId id) {
 		MarkAsMaybeDirty(id, image);
 	}
 	if (size != 0) {
+		std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 		m_page_manager.UpdatePageWatchers<false>(begin, size);
 	}
 }
@@ -359,6 +364,7 @@ void TextureCache::UntrackImageTail(ImageId id) {
 		MarkAsMaybeDirty(id, image);
 	}
 	if (size != 0) {
+		std::lock_guard<std::recursive_mutex> guest_as_lock(Libs::LibKernel::Memory::GetGuestAddressSpaceMutex());
 		m_page_manager.UpdatePageWatchers<false>(address, size);
 	}
 }

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -3688,6 +3688,10 @@ bool ProtectGuestHostMemory(uint64_t vaddr, uint64_t size, VirtualMemory::Mode m
 // same mutex. The mutex is recursive because a sweep both acquires it and runs an mprotect that
 // re-acquires it on the same thread.
 std::recursive_mutex& GetGuestAddressSpaceMutex() {
+	static std::recursive_mutex fallback;
+	if (g_guest_address_space == nullptr) {
+		return fallback;
+	}
 	return g_guest_address_space->GetMutex();
 }
 

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -3681,6 +3681,16 @@ bool ProtectGuestHostMemory(uint64_t vaddr, uint64_t size, VirtualMemory::Mode m
 	       g_guest_address_space->ProtectTransient(vaddr, size, mode);
 }
 
+// Guards the guest address-space registry (ProtectTransient iterates it). The GPU protection
+// sweeps hold this mutex before any region-tracking lock so the mprotect inside a sweep never
+// takes it while a region lock is held, avoiding a lock-order inversion with a guest thread that
+// faults on its own stack (swept read-only by the GPU) while executing a syscall that holds this
+// same mutex. The mutex is recursive because a sweep both acquires it and runs an mprotect that
+// re-acquires it on the same thread.
+std::recursive_mutex& GetGuestAddressSpaceMutex() {
+	return g_guest_address_space->GetMutex();
+}
+
 bool FreeGuestMemory(uint64_t vaddr, uint64_t size) {
 	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
 

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -5,6 +5,8 @@
 #include "common/common.h"
 #include "common/virtualMemory.h"
 
+#include <mutex>
+
 namespace Libs::Graphics {
 class GpuResourceManager;
 enum class PageFaultAccess;
@@ -182,6 +184,9 @@ bool     ProtectGuestMemory(uint64_t vaddr, uint64_t size, Common::VirtualMemory
                             Common::VirtualMemory::Mode* old_mode = nullptr);
 // Transient PageManager watch state; does not change the guest mapping's semantic protection.
 bool ProtectGuestHostMemory(uint64_t vaddr, uint64_t size, Common::VirtualMemory::Mode mode);
+// Recursive mutex guarding the guest address-space mapping registry. GPU protection sweeps must
+// hold it before acquiring region-tracking locks; see the implementation for the rationale.
+std::recursive_mutex& GetGuestAddressSpaceMutex();
 bool FreeGuestMemory(uint64_t vaddr, uint64_t size);
 
 #if defined(KYTY_VIRTUAL_MEMORY_ALLOCATION_TESTS)

--- a/src/kernel/memoryAddressSpace.inc
+++ b/src/kernel/memoryAddressSpace.inc
@@ -698,6 +698,7 @@ public:
 	[[nodiscard]] uint64_t GetGranularity() const { return m_granularity; }
 	[[nodiscard]] uint64_t GetBackingBase() const { return m_backing->GetBackingBase(); }
 	[[nodiscard]] uint64_t GetBackingSize() const { return m_backing->GetBackingSize(); }
+	[[nodiscard]] std::recursive_mutex& GetMutex() { return m_mutex; }
 
 	bool ZeroBacking(uint64_t backing_offset, uint64_t size) {
 		return m_backing->ZeroRange(backing_offset, size);
@@ -1339,7 +1340,7 @@ private:
 #endif
 	}
 
-	std::mutex                                 m_mutex;
+	std::recursive_mutex                       m_mutex;
 	std::map<uint64_t, uint64_t>               m_free;
 	std::map<uint64_t, MappedRegion>            m_mapped;
 	std::vector<std::pair<uint64_t, uint64_t>> m_owned;

--- a/src/kernel/pthread.cpp
+++ b/src/kernel/pthread.cpp
@@ -4,6 +4,7 @@
 #include "common/common.h"
 #include "common/dateTime.h"
 #include "common/emulatorConfig.h"
+#include "common/hostException.h"
 #include "common/logging/log.h"
 #include "common/singleton.h"
 #include "common/stringUtils.h"
@@ -3369,6 +3370,11 @@ static void CleanupThread(void* arg) {
 static void* RunThread(void* arg) {
 	auto* thread = static_cast<Pthread>(arg);
 	void* ret    = nullptr;
+
+	// Guest code faults on its own stack, which lives inside the GPU-guarded flexible-memory
+	// region; give the fault handler a private stack so the GPU protection sweeps can never
+	// remove write permission from the stack the handler is executing on.
+	Common::HostException::SetupSignalStack();
 
 	thread->unique_id = Common::Thread::GetThreadIdUnique();
 

--- a/src/libs/libC.cpp
+++ b/src/libs/libC.cpp
@@ -360,6 +360,36 @@ static KYTY_SYSV_ABI double libc_difftime(int64_t time1, int64_t time0) {
 	return std::difftime(static_cast<std::time_t>(time1), static_cast<std::time_t>(time0));
 }
 
+// The guest `struct tm` (Orbis) is the 9-field, 36-byte layout: tm_sec..tm_isdst with no
+// tm_gmtoff/tm_zone. glibc's std::tm adds tm_gmtoff and tm_zone (56 bytes total), and std::mktime
+// writes the full host struct back into the caller's buffer. Passing the guest pointer straight
+// through therefore overflows the guest allocation and clobbers the stack canary on Linux/macOS,
+// while the MSVC _mktime64 path used on Windows writes only the matching 36-byte layout. Copy
+// through a sanitized host struct tm, mirroring the in-place fields the guest libc updates.
+static void CopyGuestTmToHost(std::tm* dst, const std::tm* src) {
+	dst->tm_sec   = src->tm_sec;
+	dst->tm_min   = src->tm_min;
+	dst->tm_hour  = src->tm_hour;
+	dst->tm_mday  = src->tm_mday;
+	dst->tm_mon   = src->tm_mon;
+	dst->tm_year  = src->tm_year;
+	dst->tm_wday  = src->tm_wday;
+	dst->tm_yday  = src->tm_yday;
+	dst->tm_isdst = src->tm_isdst;
+}
+
+static void CopyHostTmToGuest(std::tm* dst, const std::tm* src) {
+	dst->tm_sec   = src->tm_sec;
+	dst->tm_min   = src->tm_min;
+	dst->tm_hour  = src->tm_hour;
+	dst->tm_mday  = src->tm_mday;
+	dst->tm_mon   = src->tm_mon;
+	dst->tm_year  = src->tm_year;
+	dst->tm_wday  = src->tm_wday;
+	dst->tm_yday  = src->tm_yday;
+	dst->tm_isdst = src->tm_isdst;
+}
+
 static KYTY_SYSV_ABI std::tm* libc_gmtime(const int64_t* timer) {
 	if (timer == nullptr) {
 		return nullptr;
@@ -410,7 +440,16 @@ static KYTY_SYSV_ABI int64_t libc_mktime(std::tm* timeptr) {
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	return static_cast<int64_t>(_mktime64(timeptr));
 #else
-	return static_cast<int64_t>(std::mktime(timeptr));
+	std::tm sanitized {};
+	CopyGuestTmToHost(&sanitized, timeptr);
+	sanitized.tm_gmtoff = 0;
+	sanitized.tm_zone   = nullptr;
+
+	const auto result = static_cast<int64_t>(std::mktime(&sanitized));
+
+	CopyHostTmToGuest(timeptr, &sanitized);
+
+	return result;
 #endif
 }
 
@@ -421,9 +460,12 @@ static KYTY_SYSV_ABI size_t libc_strftime(char* str, size_t count, const char* f
 	}
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_LINUX && !defined(__APPLE__)
-	// Guest-created tm values do not initialize glibc's tm_zone pointer.
-	std::tm sanitized = *timeptr;
-	sanitized.tm_zone = nullptr;
+	// Guest-created tm values do not initialize glibc's tm_gmtoff/tm_zone fields, and the guest
+	// allocation may not even cover them.
+	std::tm sanitized {};
+	CopyGuestTmToHost(&sanitized, timeptr);
+	sanitized.tm_gmtoff = 0;
+	sanitized.tm_zone   = nullptr;
 
 	return std::strftime(str, count, format, &sanitized);
 #else

--- a/src/libs/libKernel.cpp
+++ b/src/libs/libKernel.cpp
@@ -2458,47 +2458,53 @@ static void FiberSetContextValid(FiberObject* fiber, bool valid) {
 }
 
 #if defined(__x86_64__) || defined(_M_X64)
-__attribute__((noinline, returns_twice)) static int FiberSaveContext(FiberCpuContext* ctx) {
-	int ret = 0;
-	asm volatile("movq %[ctx], %%r10\n\t"
-	             "movq %%rbx, 0(%%r10)\n\t"
-	             "movq %%rbp, 8(%%r10)\n\t"
-	             "movq %%rdi, 16(%%r10)\n\t"
-	             "movq %%rsi, 24(%%r10)\n\t"
-	             "movq %%r12, 32(%%r10)\n\t"
-	             "movq %%r13, 40(%%r10)\n\t"
-	             "movq %%r14, 48(%%r10)\n\t"
-	             "movq %%r15, 56(%%r10)\n\t"
-	             "leaq 8(%%rsp), %%r11\n\t"
-	             "movq %%r11, 64(%%r10)\n\t"
-	             "movq (%%rsp), %%r11\n\t"
-	             "movq %%r11, 72(%%r10)\n\t"
-	             "xorl %%eax, %%eax\n\t"
-	             : "=a"(ret)
-	             : [ctx] "r"(ctx)
-	             : "memory", "r10", "r11");
-	return ret;
+// The context-switch helpers are written as naked functions: the compiler must
+// not emit a frame-pointer prologue, because the inline asm reads the return
+// address directly off the stack ([rsp] on entry). With a regular function the
+// prologue (push %rbp) shifts rsp by 8, so (%rsp) holds the saved rbp (a stack
+// address) instead of the return address, and FiberRestoreContext would jump to
+// a stack address.
+#if defined(_WIN32)
+#define KYTY_FIBER_CTX_REG "%rcx"
+#define KYTY_FIBER_RET_REG "%rdx"
+#else
+#define KYTY_FIBER_CTX_REG "%rdi"
+#define KYTY_FIBER_RET_REG "%rsi"
+#endif
+
+__attribute__((naked, noinline, returns_twice)) static int FiberSaveContext(FiberCpuContext* ctx) {
+	asm volatile("movq " KYTY_FIBER_CTX_REG ", %r10\n\t"
+	             "movq %rbx, 0(%r10)\n\t"
+	             "movq %rbp, 8(%r10)\n\t"
+	             "movq %rdi, 16(%r10)\n\t"
+	             "movq %rsi, 24(%r10)\n\t"
+	             "movq %r12, 32(%r10)\n\t"
+	             "movq %r13, 40(%r10)\n\t"
+	             "movq %r14, 48(%r10)\n\t"
+	             "movq %r15, 56(%r10)\n\t"
+	             "leaq 8(%rsp), %r11\n\t"
+	             "movq %r11, 64(%r10)\n\t"
+	             "movq (%rsp), %r11\n\t"
+	             "movq %r11, 72(%r10)\n\t"
+	             "xorl %eax, %eax\n\t"
+	             "ret\n\t");
 }
 
-__attribute__((noreturn, noinline)) static void FiberRestoreContext(FiberCpuContext* ctx,
-                                                                    uint64_t         ret) {
-	asm volatile("movq %[ctx], %%r10\n\t"
-	             "movq 72(%%r10), %%r11\n\t"
-	             "movq 0(%%r10), %%rbx\n\t"
-	             "movq 8(%%r10), %%rbp\n\t"
-	             "movq 16(%%r10), %%rdi\n\t"
-	             "movq 24(%%r10), %%rsi\n\t"
-	             "movq 32(%%r10), %%r12\n\t"
-	             "movq 40(%%r10), %%r13\n\t"
-	             "movq 48(%%r10), %%r14\n\t"
-	             "movq 56(%%r10), %%r15\n\t"
-	             "movq 64(%%r10), %%rsp\n\t"
-	             "movq %[ret], %%rax\n\t"
-	             "jmp *%%r11\n\t"
-	             :
-	             : [ctx] "r"(ctx), [ret] "r"(ret)
-	             : "memory", "rax", "r10", "r11");
-	__builtin_unreachable();
+__attribute__((naked, noreturn, noinline)) static void FiberRestoreContext(FiberCpuContext* ctx,
+                                                                           uint64_t         ret) {
+	asm volatile("movq " KYTY_FIBER_RET_REG ", %rax\n\t"
+	             "movq " KYTY_FIBER_CTX_REG ", %r10\n\t"
+	             "movq 72(%r10), %r11\n\t"
+	             "movq 0(%r10), %rbx\n\t"
+	             "movq 8(%r10), %rbp\n\t"
+	             "movq 16(%r10), %rdi\n\t"
+	             "movq 24(%r10), %rsi\n\t"
+	             "movq 32(%r10), %r12\n\t"
+	             "movq 40(%r10), %r13\n\t"
+	             "movq 48(%r10), %r14\n\t"
+	             "movq 56(%r10), %r15\n\t"
+	             "movq 64(%r10), %rsp\n\t"
+	             "jmp *%r11\n\t");
 }
 #else
 static int FiberSaveContext(FiberCpuContext* ctx) {

--- a/tests/MemoryTrackerTests.cpp
+++ b/tests/MemoryTrackerTests.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 #include <semaphore>
 #include <string>
 #include <thread>
@@ -821,6 +822,11 @@ namespace Libs::LibKernel::Memory {
 bool ProtectGuestHostMemory(uint64_t vaddr, uint64_t size,
                             Common::VirtualMemory::Mode mode) {
   return ProtectAddressSpace(vaddr, size, mode);
+}
+
+std::recursive_mutex &GetGuestAddressSpaceMutex() {
+  static std::recursive_mutex mutex;
+  return mutex;
 }
 
 } // namespace Libs::LibKernel::Memory


### PR DESCRIPTION
A series of Linux-specific fixes that let Demon's Souls (PPSA01341) boot and run on
Linux. The game already works on Windows on `main`; every change here is targeted at a
Linux-only failure mode and deliberately does not alter Windows code paths.

Note: All fixes were made with help of AI and verified that there was progress in booting the game after every commit in sequence. The unchanged Windows behavior claim is untested as I don't have Windows machine at the moment. This PR should be reviewed by someone who has deeper knowledge of kyty and linux before merging. 
  
## What's fixes

- **libC: guest `struct tm` overflow** — the guest uses the 9-field Orbis `struct tm`
  (36 bytes, no `tm_gmtoff`/`tm_zone`), while glibc's `std::tm` is 56 bytes.
  `std::mktime` writes the full host struct back into the caller's buffer, overflowing the
  guest allocation and clobbering the stack canary; `std::strftime` reads the uninitialized
  `tm_zone`. The Windows `_mktime64` path only writes the matching 36-byte layout, so this
  only failed on Linux. Fix: copy through a sanitized host `std::tm` and write the
  normalized 9 fields back after `mktime`.

- **fiber: context save jumping to a stack address** — `FiberSaveContext` read the return
  address from `(%rsp)`, but the compiler's frame-pointer prologue (`push %rbp`) shifted
  `rsp`, so `(%rsp)` held the saved `rbp` (a stack address). `FiberRestoreContext` then
  jumped into stack data, causing SIGILL when a fiber completed its first run. Fix: rewrite
  both helpers as naked functions (no prologue) with explicit Win64/SysV argument passing.

- **hostException: private altstack for fault handlers** — the guest stack and the
  flexible-memory GPU buffers share the same address region; the GPU write-watching sweeps
  mprotect that region to `PROT_READ`, so a fault handler running on the guest stack could
  lose write permission on its own pages and the process died with a silent SIGSEGV.
  Fix: run Linux fault handlers on a per-thread private stack installed via `sigaltstack`
  with `SA_ONSTACK` (no-op on Windows/Apple).

- **bufferCache: upload sources through the guest backing** — a CPU-modified page whose
  backing was released by a guest unmap has no host mapping on Linux, so `UploadCopies`
  faulted inside the upload callback and aborted with "memory tracker re-entered from
  upload callback". Fix: read each copy's source through `TryReadBacking` (zeroing unbacked
  copies) instead of the guest virtual mapping, and resolve CPU reads of GPU-dirty pages
  that are not in the registered GPU ranges via the buffer cache.

- **bufferCache: stop corrupting the allocation ledger** — `RunGarbageCollector` overwrote
  the Register/Unregister byte ledger with raw VMA heap usage, so a later `Unregister`
  underflowed after a collection retired a large merged buffer. Fix: sample device usage
  into a local for the collection trigger and keep `m_total_used_memory` as a pure ledger.

- **memoryTracker: atomic protection updates + consistent lock order** — the GPU protection
  sweeps ran `mprotect` under the per-region tracking lock, and that `mprotect` iterates the
  guest-address-space registry under its mutex. A guest thread executing a syscall holds
  that mutex, and when a sweep made its own stack read-only its fault handler blocked on the
  region lock while the sweeping thread waited for the address-space mutex: deadlock.
  Fix: every protection path acquires the guest-address-space mutex before any
  region-tracking lock (made recursive), keeping the updates atomic; `InvalidateRegion`
  scopes the guard so `on_flush` runs with no tracking locks held.

## Why it's safe for Windows

All changes are either guarded to the Linux code paths or are cross-platform correctness
fixes (fiber context save, GC ledger, buffer upload/read fallback, lock-order discipline)
that leave Windows behavior equivalent or strictly more correct.

## Testing

- Demon's Souls (PPSA01341) boots and renders on Linux. Windows build untested.