### PR TITLE
graphics: support NGG merged geometry shaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,25 @@ add_executable(shader_vertex_metadata_tests EXCLUDE_FROM_ALL
 )
 target_include_directories(shader_vertex_metadata_tests PRIVATE ${inc_headers})
 
+add_executable(shader_stages_en_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/ShaderStagesEnTests.cpp"
+)
+target_link_libraries(shader_stages_en_tests fmt::fmt)
+target_include_directories(shader_stages_en_tests PRIVATE ${inc_headers})
+
+add_executable(merged_geometry_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/MergedGeometryTests.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/shader/shaderMergedGeometry.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/shader/recompiler/frontend/decode/ShaderDecoder.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/shader/recompiler/frontend/decode/VectorAluOps.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/shader/recompiler/frontend/decode/MemoryOps.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/shader/recompiler/frontend/decode/ImageOps.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/shader/recompiler/frontend/decode/ExportOps.cpp"
+)
+target_link_libraries(merged_geometry_tests fmt::fmt common)
+target_include_directories(merged_geometry_tests PRIVATE ${inc_headers})
+
 add_executable(shader_stage_runtime_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/ShaderStageRuntimeTests.cpp"
 	"${KYTY_SOURCE_DIR}/graphics/guest_gpu/gpu_format.cpp"
@@ -532,6 +551,8 @@ if(BUILD_TESTING)
 	add_test(NAME page_manager COMMAND $<TARGET_FILE:page_manager_tests>)
 	add_test(NAME bit_array COMMAND $<TARGET_FILE:bit_array_tests>)
 	add_test(NAME shader_vertex_metadata COMMAND $<TARGET_FILE:shader_vertex_metadata_tests>)
+	add_test(NAME shader_stages_en COMMAND $<TARGET_FILE:shader_stages_en_tests>)
+	add_test(NAME merged_geometry COMMAND $<TARGET_FILE:merged_geometry_tests>)
 	add_test(NAME shader_stage_runtime COMMAND $<TARGET_FILE:shader_stage_runtime_tests>)
 	add_test(NAME resource_tracking COMMAND $<TARGET_FILE:resource_tracking_tests>)
 	add_test(NAME event_queue_lifetime COMMAND $<TARGET_FILE:event_queue_lifetime_tests>)
@@ -586,6 +607,8 @@ if(BUILD_TESTING)
 		page_manager_tests
 		bit_array_tests
 		shader_vertex_metadata_tests
+		shader_stages_en_tests
+		merged_geometry_tests
 		shader_stage_runtime_tests
 		resource_tracking_tests
 		event_queue_lifetime_tests

--- a/src/graphics/guest_gpu/command_processor/pm4Dispatch.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Dispatch.cpp
@@ -160,8 +160,8 @@ constexpr auto MakeShaderDispatchTable() {
 	g_hw_sh_func[Pm4::SPI_SHADER_REQ_CTRL_PS]          = HwShIgnoreRegisters;
 	g_hw_sh_func[Pm4::SPI_SHADER_PGM_RSRC3_GS]         = HwShIgnoreRegisters;
 	g_hw_sh_func[Pm4::SPI_SHADER_PGM_RSRC4_GS]         = HwShIgnoreRegisters;
-	g_hw_sh_func[Pm4::SPI_SHADER_USER_DATA_ADDR_LO_GS] = HwShIgnoreRegisters;
-	g_hw_sh_func[Pm4::SPI_SHADER_USER_DATA_ADDR_HI_GS] = HwShIgnoreRegisters;
+	g_hw_sh_func[Pm4::SPI_SHADER_USER_DATA_ADDR_LO_GS] = HwShSetGsUserDataAddr;
+	g_hw_sh_func[Pm4::SPI_SHADER_USER_DATA_ADDR_HI_GS] = HwShSetGsUserDataAddr;
 	g_hw_sh_func[Pm4::SPI_SHADER_REQ_CTRL_ESGS]        = HwShIgnoreRegisters;
 	g_hw_sh_func[Pm4::SPI_SHADER_PGM_RSRC3_HS]         = HwShIgnoreRegisters;
 	g_hw_sh_func[Pm4::SPI_SHADER_PGM_RSRC4_HS]         = HwShIgnoreRegisters;

--- a/src/graphics/guest_gpu/command_processor/pm4Dispatch.h
+++ b/src/graphics/guest_gpu/command_processor/pm4Dispatch.h
@@ -98,6 +98,7 @@ uint32_t HwCtxSetViewportScaleOffset(CommandProcessor&, uint32_t, uint32_t, cons
                                      uint32_t);
 uint32_t HwShSetPsUserSgpr(CommandProcessor&, uint32_t, uint32_t, const uint32_t*, uint32_t);
 uint32_t HwShSetGsUserSgpr(CommandProcessor&, uint32_t, uint32_t, const uint32_t*, uint32_t);
+uint32_t HwShSetGsUserDataAddr(CommandProcessor&, uint32_t, uint32_t, const uint32_t*, uint32_t);
 uint32_t HwShSetHsUserSgpr(CommandProcessor&, uint32_t, uint32_t, const uint32_t*, uint32_t);
 uint32_t HwShSetCsUserSgpr(CommandProcessor&, uint32_t, uint32_t, const uint32_t*, uint32_t);
 uint32_t HwShSetPsUserAccumSgpr(CommandProcessor&, uint32_t, uint32_t, const uint32_t*, uint32_t);

--- a/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
@@ -1474,6 +1474,20 @@ KYTY_HW_SH_PARSER(HwShSetGsUserSgpr) {
 	return reg_num;
 }
 
+KYTY_HW_SH_PARSER(HwShSetGsUserDataAddr) {
+	EXIT_NOT_IMPLEMENTED(!(cmd_offset == Pm4::SPI_SHADER_USER_DATA_ADDR_LO_GS ||
+	                       cmd_offset == Pm4::SPI_SHADER_USER_DATA_ADDR_HI_GS));
+
+	auto       reg_num = (cmd_id >> 16u) & 0x3fffu;
+	const auto first   = cmd_offset - Pm4::SPI_SHADER_USER_DATA_ADDR_LO_GS;
+
+	for (uint32_t i = 0; i < reg_num && first + i < 2u; i++) {
+		cp.GetShCtx().SetGsUserDataAddr(first + i, buffer[i]);
+	}
+
+	return reg_num;
+}
+
 KYTY_HW_SH_PARSER(HwShSetGsUserAccumSgpr) {
 	EXIT_NOT_IMPLEMENTED(!(cmd_offset >= Pm4::SPI_SHADER_USER_ACCUM_ESGS_0 &&
 	                       cmd_offset <= Pm4::SPI_SHADER_USER_ACCUM_ESGS_3));
@@ -4143,10 +4157,10 @@ void GraphicsInitJmpTablesShIndirect() {
 		HwShIgnoreShaderRegister(cmd_offset, value);
 	};
 	g_hw_sh_indirect_func[Pm4::SPI_SHADER_USER_DATA_ADDR_LO_GS] = [](KYTY_HW_SH_INDIRECT_ARGS) {
-		HwShIgnoreShaderRegister(cmd_offset, value);
+		cp.GetShCtx().SetGsUserDataAddr(0, value);
 	};
 	g_hw_sh_indirect_func[Pm4::SPI_SHADER_USER_DATA_ADDR_HI_GS] = [](KYTY_HW_SH_INDIRECT_ARGS) {
-		HwShIgnoreShaderRegister(cmd_offset, value);
+		cp.GetShCtx().SetGsUserDataAddr(1, value);
 	};
 	g_hw_sh_indirect_func[Pm4::SPI_SHADER_REQ_CTRL_ESGS] = [](KYTY_HW_SH_INDIRECT_ARGS) {
 		HwShIgnoreShaderRegister(cmd_offset, value);

--- a/src/graphics/guest_gpu/hardwareContext.h
+++ b/src/graphics/guest_gpu/hardwareContext.h
@@ -661,6 +661,51 @@ struct ShaderRegisters {
 	}
 };
 
+// VGT_SHADER_STAGES_EN. Only bits established by measurement are named; the low stage-enable field
+// is kept opaque and compared against observed values rather than split into sub-fields. The W32
+// bits are execution width, never pipeline shape, so they must not take part in a shape test.
+struct ShaderStagesEn {
+	static constexpr uint32_t PRIMGEN_EN      = 1u << 13u;
+	static constexpr uint32_t HS_W32_EN       = 1u << 21u;
+	static constexpr uint32_t GS_W32_EN       = 1u << 22u;
+	static constexpr uint32_t VS_W32_EN       = 1u << 23u;
+	static constexpr uint32_t NGG_PASSTHROUGH = 1u << 25u;
+
+	static constexpr uint32_t STAGE_ENABLES_MASK  = 0x00001FFFu;
+	static constexpr uint32_t STAGE_ENABLES_NONE  = 0x00000000u;
+	static constexpr uint32_t STAGE_ENABLES_ES_GS = 0x00000030u;
+
+	uint32_t raw             = 0;
+	uint32_t stage_enables   = 0;
+	bool     primgen_en      = false;
+	bool     ngg_passthrough = false;
+	bool     hs_w32_en       = false;
+	bool     gs_w32_en       = false;
+	bool     vs_w32_en       = false;
+
+	[[nodiscard]] bool IsNggVertexOnly() const {
+		return primgen_en && ngg_passthrough && stage_enables == STAGE_ENABLES_NONE;
+	}
+
+	[[nodiscard]] bool IsNggMergedEsGs() const {
+		return primgen_en && !ngg_passthrough && stage_enables == STAGE_ENABLES_ES_GS;
+	}
+
+	[[nodiscard]] uint32_t VertexWaveSize() const { return gs_w32_en ? 32u : 64u; }
+};
+
+[[nodiscard]] inline ShaderStagesEn DecodeShaderStages(uint32_t raw) {
+	ShaderStagesEn s;
+	s.raw             = raw;
+	s.stage_enables   = raw & ShaderStagesEn::STAGE_ENABLES_MASK;
+	s.primgen_en      = (raw & ShaderStagesEn::PRIMGEN_EN) != 0u;
+	s.ngg_passthrough = (raw & ShaderStagesEn::NGG_PASSTHROUGH) != 0u;
+	s.hs_w32_en       = (raw & ShaderStagesEn::HS_W32_EN) != 0u;
+	s.gs_w32_en       = (raw & ShaderStagesEn::GS_W32_EN) != 0u;
+	s.vs_w32_en       = (raw & ShaderStagesEn::VS_W32_EN) != 0u;
+	return s;
+}
+
 enum class UserSgprType { Unknown, Region, Vsharp };
 
 struct UserSgprInfo {
@@ -770,6 +815,9 @@ public:
 
 	void                   SetShaderStages(uint32_t flags) { m_shader_stages = flags; }
 	[[nodiscard]] uint32_t GetShaderStages() const { return m_shader_stages; }
+	[[nodiscard]] ShaderStagesEn GetShaderStagesEn() const {
+		return DecodeShaderStages(m_shader_stages);
+	}
 
 	void SetDepthRenderTarget(const DepthRenderTarget& target) { m_depth_render_target = target; }
 	[[nodiscard]] const DepthRenderTarget& GetDepthRenderTarget() const {

--- a/src/graphics/guest_gpu/hardwareContext.h
+++ b/src/graphics/guest_gpu/hardwareContext.h
@@ -724,6 +724,9 @@ struct VertexShaderInfo {
 	GsStageRegisters gs_regs;
 	UserSgprInfo     hs_user_sgpr;
 	UserSgprInfo     gs_user_sgpr;
+	// SPI_SHADER_USER_DATA_ADDR_LO/HI_GS. A merged ES+GS wave starts with this address in
+	// s[0:1]; the GS half loads its own resource table from it.
+	uint32_t gs_user_data_addr[2] = {0, 0};
 };
 
 struct PixelShaderInfo {
@@ -1156,6 +1159,11 @@ public:
 		m_vs.hs_user_sgpr.type[id]  = type;
 		m_vs.hs_user_sgpr.count =
 		    ((id + 1) > m_vs.hs_user_sgpr.count ? (id + 1) : m_vs.hs_user_sgpr.count);
+	}
+	void SetGsUserDataAddr(uint32_t half, uint32_t value) {
+		if (half < 2) {
+			m_vs.gs_user_data_addr[half] = value;
+		}
 	}
 	void SetGsUserSgpr(uint32_t id, uint32_t value, UserSgprType type) {
 		m_vs.gs_user_sgpr.value[id] = value;

--- a/src/graphics/host_gpu/graphicContext.h
+++ b/src/graphics/host_gpu/graphicContext.h
@@ -32,6 +32,12 @@ struct GraphicContext {
 	bool                               rt_extensions_enabled                 = false;
 	bool                               compute_subgroup_size_control_enabled = false;
 	bool                               compute_wave64_supported              = false;
+	bool                               mesh_shader_enabled                   = false;
+	uint32_t                           max_mesh_work_group_invocations       = 0;
+	uint32_t                           max_mesh_output_vertices              = 0;
+	uint32_t                           max_mesh_output_primitives            = 0;
+	uint32_t                           max_mesh_shared_memory_size           = 0;
+	uint32_t                           max_mesh_work_group_count[3]          = {};
 	bool                               sample_rate_shading_enabled           = false;
 	uint32_t                           subgroup_size                         = 0;
 	uint32_t                           min_subgroup_size                     = 0;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1239,8 +1239,11 @@ vk::ImageView TextureCache::FindTexture(ImageId id, const ImageDesc& desc) {
 	std::scoped_lock lock {m_lock};
 	auto&            image = m_slot_images[id];
 	TouchImage(image);
+	const bool stencil_write =
+	    desc.type == BindingType::Storage && static_cast<bool>(image.depth_id);
 	if (!image.info.data.Empty()) {
-		if (!image.registered || image.depth_id || image.binding.needs_rebind) {
+		if (!image.registered || (image.depth_id && !stencil_write) ||
+		    image.binding.needs_rebind) {
 			EXIT("TextureCache: texture requires rediscovery before final acquisition\n");
 		}
 	}
@@ -1254,10 +1257,12 @@ vk::ImageView TextureCache::FindTexture(ImageId id, const ImageDesc& desc) {
 		case BindingType::Texture: break;
 		case BindingType::Storage:
 			if (!image.info.data.Empty()) {
-				if (!image.registered || image.depth_id) {
+				if (!image.registered) {
 					EXIT("TextureCache: cannot acquire an unavailable storage image\n");
 				}
-				CommitGpuWrite(image);
+				if (!stencil_write) {
+					CommitGpuWrite(image);
+				}
 			}
 			TrackImageDownload(id, image);
 			break;
@@ -1348,6 +1353,27 @@ void TextureCache::MarkGpuWritten(ImageId id) {
 	}
 	TrackImage(id);
 	CommitGpuWrite(image);
+}
+
+void TextureCache::FlushStencilWrite(ImageId id) {
+	std::scoped_lock lock {m_lock};
+	auto*            source = m_slot_images.try_get(id);
+	if (source == nullptr || !source->depth_id) {
+		EXIT("TextureCache: stencil write flush requires an associated image\n");
+	}
+	auto* depth = m_slot_images.try_get(source->depth_id);
+	if (depth == nullptr) {
+		EXIT("TextureCache: stencil write flush lost its depth image\n");
+	}
+	if (!depth->info.IsDepth() || !depth->info.HasStencil()) {
+		EXIT("TextureCache: stencil write flush target is not a depth/stencil image\n");
+	}
+	if (m_scheduler.Current().IsInvalid()) {
+		EXIT("TextureCache: stencil write flush requires a valid command buffer\n");
+	}
+	depth->CopyStencilFromColor(*source, m_buffer_cache.GetUtilityBuffer(MemoryUsage::DeviceLocal));
+	TouchImage(*depth);
+	CommitGpuWrite(*depth);
 }
 
 void TextureCache::CommitGpuWrite(Image& image) {

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -61,6 +61,7 @@ public:
 		return image;
 	}
 	void MarkGpuWritten(ImageId id);
+	void FlushStencilWrite(ImageId id);
 
 	[[nodiscard]] bool ClearImageFromBuffer(CommandBuffer& command, uint64_t address, uint64_t size,
 	                                        uint32_t packed_clear);

--- a/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <mutex>
 
 namespace Libs::Graphics {
 
@@ -100,8 +101,8 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 		EXIT("unsupported render-target sample configuration: samples=%u fragments=%u\n",
 		     rt.attrib.num_samples, rt.attrib.num_fragments);
 	}
-	const auto view = ResolveTargetViewInfo(
-	    rt.view.base_array_slice_index, rt.view.last_array_slice_index, render_target_slice_offset);
+	auto view = ResolveTargetViewInfo(rt.view.base_array_slice_index,
+	                                  rt.view.last_array_slice_index, render_target_slice_offset);
 	switch (view.type) {
 		case TargetViewType::Image2D:
 		case TargetViewType::Image2DArray: break;
@@ -315,10 +316,18 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 	const vk::Extent2D view_extent = {std::max(width >> rt.view.current_mip_level, 1u),
 	                                  std::max(height >> rt.view.current_mip_level, 1u)};
 	const uint32_t     view_depth  = std::max(depth >> rt.view.current_mip_level, 1u);
-	if (volume &&
-	    (view.base_layer >= view_depth || view.layer_count > view_depth - view.base_layer)) {
-		EXIT("3D render-target view exceeds mip depth: base=%u count=%u depth=%u mip=%u\n",
+	if (volume && view.base_layer >= view_depth) {
+		EXIT("3D render-target view starts past mip depth: base=%u count=%u depth=%u mip=%u\n",
 		     view.base_layer, view.layer_count, view_depth, rt.view.current_mip_level);
+	}
+	if (volume && view.layer_count > view_depth - view.base_layer) {
+		static std::once_flag warn_once;
+		std::call_once(warn_once, [&] {
+			LOGF("RenderColorTarget: clamping a 3D view of %u slices from base %u to a mip depth "
+			     "of %u\n",
+			     view.layer_count, view.base_layer, view_depth);
+		});
+		view.layer_count = view_depth - view.base_layer;
 	}
 
 	auto decision_log_id = g_render_color_log_count.fetch_add(1);

--- a/src/graphics/host_gpu/renderer/image/image.cpp
+++ b/src/graphics/host_gpu/renderer/image/image.cpp
@@ -531,6 +531,80 @@ void Image::CopyImageWithBuffer(Image& source, Buffer& buffer) {
 	        vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eTransferRead, {}, command);
 }
 
+void Image::CopyStencilFromColor(Image& source, Buffer& buffer) {
+	EXIT_IF(m_scheduler == nullptr || buffer.Handle() == nullptr);
+	const bool destination_has_stencil =
+	    static_cast<bool>(FullAspectMask(backing.format) & vk::ImageAspectFlagBits::eStencil);
+	if (!destination_has_stencil ||
+	    FullAspectMask(source.backing.format) != vk::ImageAspectFlagBits::eColor ||
+	    source.info.bytes_per_block != 1 || source.backing.samples != 1 || backing.samples != 1 ||
+	    source.backing.image == nullptr || backing.image == nullptr ||
+	    source.backing.mip_levels != 1 || backing.mip_levels != 1 ||
+	    source.backing.image_type != vk::ImageType::e2D ||
+	    backing.image_type != vk::ImageType::e2D ||
+	    source.backing.extent.width != backing.extent.width ||
+	    source.backing.extent.height != backing.extent.height) {
+		EXIT("unsupported stencil plane copy: source_format=%d source_bpb=%u source=%ux%u "
+		     "source_levels=%u source_samples=%u source_type=%d destination_format=%d "
+		     "destination=%ux%u destination_levels=%u destination_samples=%u destination_type=%d\n",
+		     static_cast<int>(source.backing.format), source.info.bytes_per_block,
+		     source.backing.extent.width, source.backing.extent.height, source.backing.mip_levels,
+		     source.backing.samples, static_cast<int>(source.backing.image_type),
+		     static_cast<int>(backing.format), backing.extent.width, backing.extent.height,
+		     backing.mip_levels, backing.samples, static_cast<int>(backing.image_type));
+	}
+	m_scheduler->EndRendering();
+
+	const auto     width         = backing.extent.width;
+	const auto     height        = backing.extent.height;
+	const auto     layers        = std::min(source.backing.layers, backing.layers);
+	const uint64_t row_size      = width;
+	const auto     rows_per_copy = CopyRows(row_size, height, buffer.Size());
+	EXIT_IF(layers == 0 || rows_per_copy == 0);
+
+	vk::BufferMemoryBarrier2 barrier {};
+	barrier.srcStageMask        = vk::PipelineStageFlagBits2::eTransfer;
+	barrier.srcAccessMask       = vk::AccessFlagBits2::eTransferRead;
+	barrier.dstStageMask        = vk::PipelineStageFlagBits2::eTransfer;
+	barrier.dstAccessMask       = vk::AccessFlagBits2::eTransferWrite;
+	barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	barrier.buffer              = buffer.Handle();
+	barrier.offset              = 0;
+	vk::DependencyInfo dependency {};
+	dependency.dependencyFlags          = vk::DependencyFlagBits::eByRegion;
+	dependency.bufferMemoryBarrierCount = 1;
+	dependency.pBufferMemoryBarriers    = &barrier;
+
+	auto command = m_scheduler->Current().Handle();
+	source.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead, {},
+	               command);
+	Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite, {}, command);
+	for (uint32_t layer = 0; layer < layers; layer++) {
+		for (uint32_t row = 0; row < height; row += rows_per_copy) {
+			const auto          copy_height = std::min(rows_per_copy, height - row);
+			vk::BufferImageCopy copy {};
+			copy.imageSubresource         = {vk::ImageAspectFlagBits::eColor, 0, layer, 1};
+			copy.imageOffset              = {0, static_cast<int32_t>(row), 0};
+			copy.imageExtent              = {width, copy_height, 1};
+			auto stencil_copy             = copy;
+			stencil_copy.imageSubresource = {vk::ImageAspectFlagBits::eStencil, 0, layer, 1};
+
+			barrier.size          = row_size * copy_height;
+			barrier.srcAccessMask = vk::AccessFlagBits2::eTransferRead;
+			barrier.dstAccessMask = vk::AccessFlagBits2::eTransferWrite;
+			command.pipelineBarrier2(dependency);
+			command.copyImageToBuffer(source.backing.image, vk::ImageLayout::eTransferSrcOptimal,
+			                          buffer.Handle(), copy);
+			barrier.srcAccessMask = vk::AccessFlagBits2::eTransferWrite;
+			barrier.dstAccessMask = vk::AccessFlagBits2::eTransferRead;
+			command.pipelineBarrier2(dependency);
+			command.copyBufferToImage(buffer.Handle(), backing.image,
+			                          vk::ImageLayout::eTransferDstOptimal, stencil_copy);
+		}
+	}
+}
+
 void Image::CopyMip(Image& source, uint32_t mip, uint32_t layer) {
 	EXIT_IF(m_scheduler == nullptr || source.backing.samples != backing.samples ||
 	        mip >= backing.mip_levels || layer >= backing.layers);

--- a/src/graphics/host_gpu/renderer/image/image.h
+++ b/src/graphics/host_gpu/renderer/image/image.h
@@ -40,6 +40,7 @@ struct ImageBinding {
 	bool needs_rebind  = false;
 	bool force_general = false;
 	bool shader_write  = false;
+	bool stencil_write = false;
 };
 
 class Image final {
@@ -65,6 +66,7 @@ public:
 	void Resolve(Image& source, const ImageSubresourceRange& source_range,
 	             const ImageSubresourceRange& destination_range);
 	void CopyImageWithBuffer(Image& source, Buffer& buffer);
+	void CopyStencilFromColor(Image& source, Buffer& buffer);
 	void CopyMip(Image& source, uint32_t mip, uint32_t layer);
 
 	void InvalidateCpuWrite(uint64_t vaddr, uint64_t size) {

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -131,6 +131,7 @@ static vk::ShaderStageFlags NativeShaderStage(ShaderType stage) {
 		case ShaderType::Vertex: return vk::ShaderStageFlagBits::eVertex;
 		case ShaderType::Pixel: return vk::ShaderStageFlagBits::eFragment;
 		case ShaderType::Compute: return vk::ShaderStageFlagBits::eCompute;
+		case ShaderType::Mesh: return vk::ShaderStageFlagBits::eMeshEXT;
 		default: EXIT("unknown native shader stage\n");
 	}
 }
@@ -807,7 +808,7 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	auto       id                  = texture_cache.FindImage(desc, shader_conversion);
 	auto*      image               = &texture_cache.GetImage(id);
 	const bool stencil_association = static_cast<bool>(image->depth_id);
-	if (stencil_association) {
+	if (stencil_association && !storage) {
 		id    = image->depth_id;
 		image = &texture_cache.GetImage(id);
 	} else if (image->info.IsDepth()) {
@@ -831,15 +832,7 @@ static vk::Sampler NativeSampler(RenderContext&                       context,
                                  const ShaderRecompiler::IR::DescriptorValue& value) {
 	ShaderSamplerResource descriptor;
 	CopyNativeDescriptor(value, descriptor.fields);
-	const bool depth_compare = std::any_of(program.info.sampled_pairs.begin(),
-	                                       program.info.sampled_pairs.end(), [&](const auto& pair) {
-		                                       return pair.sampler == index &&
-		                                              pair.image < program.info.images.size() &&
-		                                              program.info.images[pair.image].depth_compare;
-	                                       });
-	if (!depth_compare) {
-		descriptor.fields[0] &= ~(0x7u << 12u);
-	}
+	descriptor.fields[0] &= ~(0x7u << 12u);
 	if (program.info.samplers[index].force_point_filtering) {
 		descriptor.SetPointFiltering();
 	}
@@ -853,6 +846,31 @@ static BufferView NativeUpload(RenderContext& context, std::span<const uint32_t>
 	auto&      buffer = context.GetBufferCache().GetUtilityBuffer(MemoryUsage::Stream);
 	const auto offset = buffer.Copy(data.data(), data.size_bytes(), 256);
 	return {.buffer = buffer.Handle(), .offset = offset, .range = data.size_bytes()};
+}
+
+void RenderExecutor::SetMeshIndices(const void* index_addr, uint32_t index_type_and_size,
+                                    uint32_t index_count) {
+	EXIT_IF(index_addr == nullptr || index_count == 0);
+	m_mesh_index_scratch.resize(index_count);
+	switch (static_cast<Prospero::IndexType>(index_type_and_size)) {
+		case Prospero::IndexType::kIndex8: {
+			const auto* indices = static_cast<const uint8_t*>(index_addr);
+			std::copy_n(indices, index_count, m_mesh_index_scratch.begin());
+			break;
+		}
+		case Prospero::IndexType::kIndex16: {
+			const auto* indices = static_cast<const uint16_t*>(index_addr);
+			std::copy_n(indices, index_count, m_mesh_index_scratch.begin());
+			break;
+		}
+		case Prospero::IndexType::kIndex32: {
+			const auto* indices = static_cast<const uint32_t*>(index_addr);
+			std::copy_n(indices, index_count, m_mesh_index_scratch.begin());
+			break;
+		}
+		default: EXIT("unsupported mesh index type: %u\n", index_type_and_size);
+	}
+	m_mesh_index_view = NativeUpload(m_context, m_mesh_index_scratch);
 }
 
 void RenderExecutor::TrackImageBinding(ImageId id) {
@@ -884,10 +902,14 @@ void RenderExecutor::BindRenderTarget(ImageId id) {
 void RenderExecutor::ResetBindings() {
 	for (const auto id: m_bound_images) {
 		if (auto* image = m_context.GetTextureCache().m_slot_images.try_get(id); image != nullptr) {
+			if (image->binding.stencil_write) {
+				m_context.GetTextureCache().FlushStencilWrite(id);
+			}
 			image->binding = {};
 		}
 	}
 	m_bound_images.clear();
+	m_mesh_index_view = {};
 }
 
 PreparedBindings RenderExecutor::PrepareBindings(const ShaderStageRuntime& runtime) {
@@ -1081,10 +1103,17 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 	auto   vk_buffer        = buffer.Handle();
 	size_t descriptor_count = 0;
 	size_t write_count      = 0;
-	constexpr auto GraphicsStages =
-	    vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment;
+	constexpr auto GraphicsStages = vk::ShaderStageFlagBits::eVertex |
+	                                vk::ShaderStageFlagBits::eFragment |
+	                                vk::ShaderStageFlagBits::eMeshEXT;
+	vk::ShaderStageFlags graphics_stages {};
+	for (const auto* prepared: prepared_bindings) {
+		if (prepared != nullptr && prepared->program != nullptr) {
+			graphics_stages |= NativeShaderStage(prepared->program->stage);
+		}
+	}
 	const auto push_constant_stages = pipeline_bind_point == vk::PipelineBindPoint::eGraphics
-	                                      ? vk::ShaderStageFlags {GraphicsStages}
+	                                      ? graphics_stages
 	                                      : vk::ShaderStageFlags {vk::ShaderStageFlagBits::eCompute};
 	for (const auto* prepared: prepared_bindings) {
 		EXIT_IF(prepared == nullptr || prepared->program == nullptr ||
@@ -1129,21 +1158,27 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 			const ImageSubresourceRange range {view.base_level, view.level_count, view.base_layer,
 			                                   view.layer_count};
 			const bool storage = binding.desc.type == TextureCache::BindingType::Storage;
+			if (storage && image.depth_id) {
+				image.binding.stencil_write = true;
+			}
 			if (image.info.data.Empty()) {
 				image.Transit(vk::ImageLayout::eGeneral,
 				              storage ? vk::AccessFlagBits2::eShaderRead |
 				                            vk::AccessFlagBits2::eShaderWrite
 				                      : vk::AccessFlagBits2::eShaderRead,
 				              range, vk_buffer);
-			} else if ((image.binding.force_general || image.binding.is_target) &&
-			           !image.info.IsDepth()) {
+			} else if (image.binding.force_general || image.binding.is_target) {
 				const vk::AccessFlags2 storage_access = image.binding.shader_write
 				                                            ? vk::AccessFlagBits2::eShaderWrite
 				                                            : vk::AccessFlags2 {};
+				const auto attachment_access =
+				    image.info.IsDepth() ? vk::AccessFlagBits2::eDepthStencilAttachmentRead |
+				                               vk::AccessFlagBits2::eDepthStencilAttachmentWrite
+				                         : vk::AccessFlagBits2::eColorAttachmentRead |
+				                               vk::AccessFlagBits2::eColorAttachmentWrite;
 				image.Transit(vk::ImageLayout::eGeneral,
 				              vk::AccessFlagBits2::eShaderRead | storage_access |
-				                  vk::AccessFlagBits2::eColorAttachmentRead |
-				                  vk::AccessFlagBits2::eColorAttachmentWrite,
+				                  attachment_access,
 				              {}, vk_buffer);
 			} else if (storage) {
 				image.Transit(vk::ImageLayout::eGeneral,
@@ -1181,6 +1216,15 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 					                             ? cache.GetBdaPageTableBuffer()
 					                             : cache.GetFaultBuffer();
 					m_descriptor_buffers.emplace_back(bda_buffer->Handle(), 0, bda_buffer->Size());
+					break;
+				}
+				case BindingKind::MeshIndices: {
+					if (m_mesh_index_view.buffer == nullptr) {
+						EXIT("a mesh program declares an index buffer the draw never supplied\n");
+					}
+					m_descriptor_buffers.emplace_back(m_mesh_index_view.buffer,
+					                                  m_mesh_index_view.offset,
+					                                  m_mesh_index_view.range);
 					break;
 				}
 				case BindingKind::FlattenedSrt:

--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
@@ -106,6 +106,41 @@ struct PipelineCache::ProgramCache {
 		return handle;
 	}
 
+	// Mesh programs share ShaderVertexInputInfo with the vertex stage, so the stage cannot be
+	// deduced from the input type and the assembled code is only produced on a miss.
+	template <typename Assemble>
+	ShaderProgram GetMesh(const ShaderParams& params, ShaderVertexInputInfo& input_info,
+	                      Assemble&& assemble, std::string* error) {
+		BuildStageStaticKey(input_info, key_scratch);
+		auto& permutations = programs[{ShaderType::Mesh, params.hash}];
+		for (const auto& permutation: permutations) {
+			if (permutation.static_key == key_scratch &&
+			    MaterializeProgram(permutation.program, params, input_info)) {
+				return permutation.handle;
+			}
+		}
+
+		ShaderParams assembled = params;
+		if (!assemble(assembled)) {
+			return {};
+		}
+		const auto module = CompileMeshProgram(device, assembled, input_info, error);
+		if (module == nullptr) {
+			return {};
+		}
+		EXIT_IF(!input_info.stage);
+		uint64_t id =
+		    MixId(MixId(params.hash, static_cast<uint64_t>(ShaderType::Mesh)), permutations.size());
+		if (id == 0) {
+			id = 1;
+		}
+		const ShaderProgram handle {.id = id, .module = module};
+		permutations.push_back({key_scratch, input_info.stage.program, handle});
+
+		std::printf("Num compiled %u shaders\n", ++num_compiled);
+		return handle;
+	}
+
 	explicit ProgramCache(vk::Device device): device(device) {
 		key_scratch.reserve(MaxStaticKeyWords);
 	}
@@ -146,6 +181,26 @@ ShaderProgram PipelineCache::GetVertexProgram(const HW::VertexShaderInfo& regs,
 	const auto params = PrepareProgram(regs, sh, input_info);
 	Common::LockGuard lock(m_mutex);
 	return m_program_cache->Get(params, input_info);
+}
+
+ShaderProgram PipelineCache::GetMeshProgram(const HW::VertexShaderInfo& regs,
+                                            const HW::ShaderRegisters& sh,
+                                            const MeshDispatch&        dispatch,
+                                            MeshInputTopology topology, bool indexed,
+                                            ShaderVertexInputInfo& input_info,
+                                            std::string*           error) {
+	ShaderParams params;
+	if (!PrepareMeshProgram(regs, sh, dispatch, topology, indexed, input_info, params, error)) {
+		return {};
+	}
+	std::vector<uint32_t> code;
+	Common::LockGuard     lock(m_mutex);
+	return m_program_cache->GetMesh(
+	    params, input_info,
+	    [&](ShaderParams& assembled) {
+		    return AssembleMeshProgram(regs, code, assembled, error);
+	    },
+	    error);
 }
 
 ShaderProgram PipelineCache::GetPixelProgram(

--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
@@ -189,8 +189,11 @@ ShaderProgram PipelineCache::GetMeshProgram(const HW::VertexShaderInfo& regs,
                                             MeshInputTopology topology, bool indexed,
                                             ShaderVertexInputInfo& input_info,
                                             std::string*           error) {
-	ShaderParams params;
-	if (!PrepareMeshProgram(regs, sh, dispatch, topology, indexed, input_info, params, error)) {
+	// `user_data` and `code` back the spans in `params`, so both outlive the lookup below.
+	std::vector<uint32_t> user_data;
+	ShaderParams          params;
+	if (!PrepareMeshProgram(regs, sh, dispatch, topology, indexed, input_info, user_data, params,
+	                        error)) {
 		return {};
 	}
 	std::vector<uint32_t> code;

--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.h
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.h
@@ -137,6 +137,12 @@ public:
 	ShaderProgram GetComputeProgram(const HW::ComputeShaderInfo& regs,
 	                                const HW::ShaderRegisters& sh,
 	                                ShaderComputeInputInfo& input_info);
+	// Returns an empty program when the merged pair cannot be translated; the caller then
+	// falls back to the ordinary vertex path.
+	ShaderProgram GetMeshProgram(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
+	                             const MeshDispatch& dispatch, MeshInputTopology topology,
+	                             bool indexed, ShaderVertexInputInfo& input_info,
+	                             std::string* error);
 
 	GraphicsPipeline& CreateGraphicsPipeline(
 	    std::span<const RenderColorInfo> colors, const RenderDepthInfo& depth,

--- a/src/graphics/host_gpu/renderer/pipeline/shaderResourceBarrier.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaderResourceBarrier.cpp
@@ -19,6 +19,9 @@ vk::PipelineStageFlags ShaderPipelineStages(vk::ShaderStageFlags stages) {
 	if (stages & vk::ShaderStageFlagBits::eCompute) {
 		result |= vk::PipelineStageFlagBits::eComputeShader;
 	}
+	if (stages & vk::ShaderStageFlagBits::eMeshEXT) {
+		result |= vk::PipelineStageFlagBits::eMeshShaderEXT;
+	}
 	EXIT_IF(!result);
 	return result;
 }

--- a/src/graphics/host_gpu/renderer/pipeline/shaderResourceBarrier.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaderResourceBarrier.cpp
@@ -125,7 +125,7 @@ void ShaderWriteBarrier(vk::CommandBuffer vk_buffer, vk::PipelineStageFlags sour
 	    source_stages,
 	    vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eVertexInput |
 	        vk::PipelineStageFlagBits::eVertexShader | vk::PipelineStageFlagBits::eFragmentShader |
-	        vk::PipelineStageFlagBits::eTransfer |
+	        vk::PipelineStageFlagBits::eMeshShaderEXT | vk::PipelineStageFlagBits::eTransfer |
 	        vk::PipelineStageFlagBits::eColorAttachmentOutput,
 	    vk::DependencyFlags {}, 1, &barrier, 0, nullptr, 0, nullptr);
 }

--- a/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
@@ -467,7 +467,9 @@ void CreatePipelineInternal(
 	vert_shader_stage_info.sType               = vk::StructureType::ePipelineShaderStageCreateInfo;
 	vert_shader_stage_info.pNext               = nullptr;
 	vert_shader_stage_info.flags               = {};
-	vert_shader_stage_info.stage               = vk::ShaderStageFlagBits::eVertex;
+	vert_shader_stage_info.stage =
+	    vs_input_info.stage.program->stage == ShaderType::Mesh ? vk::ShaderStageFlagBits::eMeshEXT
+	                                                           : vk::ShaderStageFlagBits::eVertex;
 	vert_shader_stage_info.module              = vertex_module;
 	vert_shader_stage_info.pName               = "main";
 	vert_shader_stage_info.pSpecializationInfo = nullptr;
@@ -803,18 +805,20 @@ void CreatePipelineInternal(
 
 	EXIT_IF(!vs_input_info.stage);
 	std::vector<vk::DescriptorSetLayoutBinding> descriptor_bindings;
-	AddLayoutBindings(descriptor_bindings, *vs_input_info.stage.program,
-	                  vk::ShaderStageFlagBits::eVertex);
+	const auto first_stage = vs_input_info.stage.program->stage == ShaderType::Mesh
+	                             ? vk::ShaderStageFlagBits::eMeshEXT
+	                             : vk::ShaderStageFlagBits::eVertex;
+	AddLayoutBindings(descriptor_bindings, *vs_input_info.stage.program, first_stage);
 	if (ps_active) {
 		EXIT_IF(!ps_input_info->stage);
 		AddLayoutBindings(descriptor_bindings, *ps_input_info->stage.program,
 		                  vk::ShaderStageFlagBits::eFragment);
 	}
 	CreateDescriptorLayout(graphics, pipeline, descriptor_bindings);
-	constexpr auto GraphicsStages =
-	    vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment;
+	const auto graphics_stages =
+	    ps_active ? first_stage | vk::ShaderStageFlagBits::eFragment : first_stage;
 	const vk::PushConstantRange push_constants {
-	    GraphicsStages, 0, ShaderRecompiler::IR::NativePushConstantSize};
+	    graphics_stages, 0, ShaderRecompiler::IR::NativePushConstantSize};
 
 	vk::PipelineLayoutCreateInfo pipeline_layout_info {};
 	pipeline_layout_info.sType                  = vk::StructureType::ePipelineLayoutCreateInfo;
@@ -908,8 +912,9 @@ void CreatePipelineInternal(
 	pipeline_info.flags                    = {};
 	pipeline_info.stageCount               = shader_stage_count;
 	pipeline_info.pStages                  = shader_stages;
-	pipeline_info.pVertexInputState        = &vertex_input_info;
-	pipeline_info.pInputAssemblyState      = &input_assembly;
+	const bool mesh_stage = vs_input_info.stage.program->stage == ShaderType::Mesh;
+	pipeline_info.pVertexInputState        = mesh_stage ? nullptr : &vertex_input_info;
+	pipeline_info.pInputAssemblyState      = mesh_stage ? nullptr : &input_assembly;
 	vk::PipelineTessellationStateCreateInfo tessellation_state {};
 	tessellation_state.sType              = vk::StructureType::ePipelineTessellationStateCreateInfo;
 	tessellation_state.patchControlPoints = 3;

--- a/src/graphics/host_gpu/renderer/render.h
+++ b/src/graphics/host_gpu/renderer/render.h
@@ -146,6 +146,8 @@ public:
 	void CommitBindings(CommandBuffer& buffer, vk::PipelineBindPoint pipeline_bind_point,
 	                    const PipelineCache::Pipeline&     pipeline,
 	                    std::span<PreparedBindings* const> bindings);
+	void SetMeshIndices(const void* index_addr, uint32_t index_type_and_size,
+	                    uint32_t index_count);
 
 private:
 	struct GraphicsBindings {
@@ -190,6 +192,8 @@ private:
 	std::vector<vk::DescriptorImageInfo>  m_descriptor_images;
 	std::vector<vk::WriteDescriptorSet>   m_descriptor_writes;
 	std::vector<uint32_t>                 m_image_occurrences;
+	std::vector<uint32_t>                 m_mesh_index_scratch;
+	BufferView                            m_mesh_index_view {};
 	std::array<uint32_t, ShaderRecompiler::IR::NativePushConstantSize / sizeof(uint32_t)>
 	    m_push_constants {};
 

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -1456,7 +1456,8 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
 	}
 	vk::PipelineStageFlags shader_write_stages = {};
 	if (HasShaderBufferWrites(state.vs_input_info.stage)) {
-		shader_write_stages |= vk::PipelineStageFlagBits::eVertexShader;
+		shader_write_stages |= state.mesh.active ? vk::PipelineStageFlagBits::eMeshShaderEXT
+		                                         : vk::PipelineStageFlagBits::eVertexShader;
 	}
 	if (state.ps_active && HasShaderBufferWrites(state.ps_input_info.stage)) {
 		shader_write_stages |= vk::PipelineStageFlagBits::eFragmentShader;

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -23,6 +23,7 @@
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 #include "graphics/shader/recompiler/ir/passes/ResourceMaterialization.h"
 #include "graphics/shader/shader.h"
+#include "graphics/shader/shaderMergedGeometry.h"
 #include "kernel/eventQueue.h"
 #include "kernel/memory.h"
 #include "kernel/pthread.h"
@@ -421,7 +422,202 @@ static bool PixelShaderHasDepthOrCoverageSideEffects(const HW::ShaderRegisters& 
 	       db.shader_execute_on_noop;
 }
 
-static bool ShouldSkipGeShader(const CommandBuffer& buffer) {
+struct MeshDrawPlan {
+	bool         active = false;
+	MeshDispatch dispatch;
+	uint32_t          instance_count = 1;
+	MeshInputTopology topology       = MeshInputTopology::TriangleList;
+	bool        indexed     = false;
+	const void* index_addr  = nullptr;
+	uint32_t    index_type  = 0;
+	uint32_t    index_count = 0;
+};
+
+static bool IsSupportedMeshIndexType(uint32_t index_type_and_size) {
+	switch (static_cast<Prospero::IndexType>(index_type_and_size)) {
+		case Prospero::IndexType::kIndex8:
+		case Prospero::IndexType::kIndex16:
+		case Prospero::IndexType::kIndex32: return true;
+		default: return false;
+	}
+}
+
+static bool DrawIndicesAreIdentity(const void* index_addr, uint32_t index_type_and_size,
+                                   uint32_t index_count) {
+	if (index_addr == nullptr) {
+		return false;
+	}
+	switch (static_cast<Prospero::IndexType>(index_type_and_size)) {
+		case Prospero::IndexType::kIndex8: {
+			const auto* indices = static_cast<const uint8_t*>(index_addr);
+			for (uint32_t i = 0; i < index_count; i++) {
+				if (indices[i] != i) {
+					return false;
+				}
+			}
+			return index_count <= 0x100u;
+		}
+		case Prospero::IndexType::kIndex16: {
+			const auto* indices = static_cast<const uint16_t*>(index_addr);
+			for (uint32_t i = 0; i < index_count; i++) {
+				if (indices[i] != i) {
+					return false;
+				}
+			}
+			return index_count <= 0x10000u;
+		}
+		case Prospero::IndexType::kIndex32: {
+			const auto* indices = static_cast<const uint32_t*>(index_addr);
+			for (uint32_t i = 0; i < index_count; i++) {
+				if (indices[i] != i) {
+					return false;
+				}
+			}
+			return true;
+		}
+		default: return false;
+	}
+}
+
+static bool PlanMeshDraw(const CommandBuffer& buffer, const void* index_addr,
+                         uint32_t index_type_and_size, uint32_t index_count,
+                         uint32_t instance_count, uint32_t first_instance, int32_t vertex_offset,
+                         MeshDrawPlan& plan, std::string* reason) {
+	plan = {};
+
+	const auto& ctx = buffer.GetRegisters();
+	if (!ctx.GetShaderStagesEn().IsNggMergedEsGs()) {
+		return false; // Not a geometry draw at all; nothing to report.
+	}
+
+	const auto& graphics = buffer.GetContext().GetGraphics();
+	const auto& sh_regs  = ctx.GetShaderRegisters();
+	const auto& ge_cntl  = buffer.GetUserConfig().GetGeControl();
+	const auto& vs_regs  = buffer.GetShaders().GetVs();
+
+	const auto reject = [reason](const std::string& message) {
+		if (reason != nullptr) {
+			*reason = message;
+		}
+		return false;
+	};
+
+	if (!graphics.mesh_shader_enabled) {
+		return reject("VK_EXT_mesh_shader is unavailable");
+	}
+	if (vs_regs.es_regs.data_addr == 0 || vs_regs.gs_regs.data_addr == 0) {
+		return reject("the pair is missing one of its two programs");
+	}
+	if (ctx.GetShaderStagesEn().gs_w32_en) {
+		return reject("the merged pair is wave32, and only wave64 is translated");
+	}
+	if (static_cast<Prospero::GsOutputPrimitiveType>(sh_regs.m_vgtGsOutPrimType) !=
+	    Prospero::GsOutputPrimitiveType::kTriangles) {
+		return reject(fmt::format("output primitive type {} is not triangles",
+		                          sh_regs.m_vgtGsOutPrimType));
+	}
+	if (sh_regs.m_vgtGsMaxVertOut < 3) {
+		return reject(fmt::format("{} output vertices per primitive cannot form a triangle",
+		                          sh_regs.m_vgtGsMaxVertOut));
+	}
+	const auto prim_type = buffer.GetUserConfig().GetPrimType();
+	switch (prim_type) {
+		case Prospero::PrimitiveType::kTriList:
+			plan.topology = MeshInputTopology::TriangleList;
+			break;
+		case Prospero::PrimitiveType::kTriStrip:
+			plan.topology = MeshInputTopology::TriangleStrip;
+			break;
+		default:
+			return reject(fmt::format("input primitive type {} is not a triangle list or strip",
+			                          static_cast<uint32_t>(prim_type)));
+	}
+	if (prim_type == Prospero::PrimitiveType::kTriList && index_count % 3u != 0) {
+		return reject(fmt::format("{} indices do not divide into whole triangles", index_count));
+	}
+	if (vertex_offset != 0 || first_instance != 0) {
+		return reject(fmt::format("vertex offset {} / first instance {} are not folded into the "
+		                          "launch state",
+		                          vertex_offset, first_instance));
+	}
+	const bool identity_indices =
+	    index_addr == nullptr || DrawIndicesAreIdentity(index_addr, index_type_and_size,
+	                                                    index_count);
+	if (!identity_indices) {
+		if (!IsSupportedMeshIndexType(index_type_and_size)) {
+			return reject(
+			    fmt::format("index type {} is not a known index encoding", index_type_and_size));
+		}
+		plan.indexed    = true;
+		plan.index_addr = index_addr;
+		plan.index_type = index_type_and_size;
+	}
+	plan.index_count = index_count;
+
+	std::string error;
+	if (!ShaderComputeMeshDispatch(MeshPrimitiveCount(plan.topology, index_count), 3u,
+	                               sh_regs.m_vgtGsMaxVertOut, ge_cntl.vertex_group_size,
+	                               ge_cntl.primitive_group_size, sh_regs.m_geMaxOutputPerSubgroup,
+	                               plan.dispatch, &error)) {
+		return reject(error);
+	}
+	if (plan.dispatch.workgroup_count == 0) {
+		return reject("the draw has no whole primitives");
+	}
+	if (!ShaderValidateMeshLds(MeshLdsDwords(vs_regs.gs_regs.rsrc2.lds_size),
+	                           graphics.max_mesh_shared_memory_size, &error)) {
+		return reject(error);
+	}
+	if (plan.dispatch.output_vertices_per_workgroup > graphics.max_mesh_output_vertices ||
+	    plan.dispatch.output_primitives_per_workgroup > graphics.max_mesh_output_primitives ||
+	    MeshWaveLanes > graphics.max_mesh_work_group_invocations) {
+		return reject(fmt::format("a workgroup emitting {} vertices / {} primitives over {} "
+		                          "invocations exceeds the host mesh limits ({} / {} / {})",
+		                          plan.dispatch.output_vertices_per_workgroup,
+		                          plan.dispatch.output_primitives_per_workgroup, MeshWaveLanes,
+		                          graphics.max_mesh_output_vertices,
+		                          graphics.max_mesh_output_primitives,
+		                          graphics.max_mesh_work_group_invocations));
+	}
+
+	if (plan.dispatch.workgroup_count > graphics.max_mesh_work_group_count[0] ||
+	    instance_count > graphics.max_mesh_work_group_count[1]) {
+		return reject(fmt::format("a {}x{} workgroup grid exceeds the host's {}x{}",
+		                          plan.dispatch.workgroup_count, instance_count,
+		                          graphics.max_mesh_work_group_count[0],
+		                          graphics.max_mesh_work_group_count[1]));
+	}
+
+	plan.instance_count = instance_count;
+	plan.active         = true;
+
+	return true;
+}
+
+static void LogMergedGeometryRejection(const CommandBuffer& buffer, const std::string& reason,
+                                       uint32_t index_count) {
+	if (reason.empty() || !buffer.GetRegisters().GetShaderStagesEn().IsNggMergedEsGs()) {
+		return;
+	}
+	static std::mutex               seen_mutex;
+	static std::vector<std::string> seen;
+	{
+		std::scoped_lock lock(seen_mutex);
+		if (std::find(seen.begin(), seen.end(), reason) != seen.end()) {
+			return;
+		}
+		seen.push_back(reason);
+	}
+	const auto& hw     = buffer.GetRegisters();
+	const auto& target = hw.GetRenderTarget(render_target_first_bound_slot(buffer));
+	LOGF("Dropping merged geometry draw (%" PRIu32 " indices): %s\n"
+	     "  would target 0x%010" PRIx64 " %" PRIu32 "x%" PRIu32 " depth=%" PRIu32
+	     " dim=%" PRIu32 "\n",
+	     index_count, reason.c_str(), target.base.addr, target.attrib2.width + 1,
+	     target.attrib2.height + 1, target.attrib3.depth + 1, target.attrib3.dimension);
+}
+
+static bool ShouldSkipGeShader(const CommandBuffer& buffer, const MeshDrawPlan& mesh_plan) {
 	const auto& ctx         = buffer.GetRegisters();
 	const auto& ucfg        = buffer.GetUserConfig();
 	const auto& sh_ctx      = buffer.GetShaders();
@@ -459,6 +655,9 @@ static bool ShouldSkipGeShader(const CommandBuffer& buffer) {
 	    sh_regs.m_geMaxOutputPerSubgroup > 0x00000040;
 
 	if (unsupported_stage_mask || unsupported_gs_stage || ge_group_size || ge_shader_regs) {
+		if (mesh_plan.active) {
+			return false;
+		}
 		static std::once_flag warning_once;
 		std::call_once(warning_once, [] {
 			std::printf("Warning: game uses unsupported graphics pipelines; some draw calls were "
@@ -492,6 +691,7 @@ struct DrawRenderState {
 	ShaderPixelInputInfo  ps_input_info;
 	ShaderProgram         vertex_program;
 	ShaderProgram         pixel_program;
+	MeshDrawPlan          mesh;
 };
 
 struct DrawCallInfo {
@@ -664,7 +864,8 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 			EXIT("mixed color/depth sample counts are unsupported: %u and %u\n", attachment_samples,
 			     depth.samples);
 		}
-		const auto layout = depth_attachment_layout(depth);
+		const auto layout =
+		    image.binding.is_bound ? vk::ImageLayout::eGeneral : depth_attachment_layout(depth);
 		const auto writes = depth.AttachmentWriteAspects();
 		auto       access = vk::AccessFlags2 {vk::AccessFlagBits2::eDepthStencilAttachmentRead};
 		if (writes) {
@@ -993,7 +1194,7 @@ bool RenderExecutor::PrepareDrawRenderState(uint64_t submit_id, CommandBuffer& b
 	return true;
 }
 
-static void RefreshShaders(CommandBuffer& buffer, const DrawCallInfo& draw, bool log_phases,
+static bool RefreshShaders(CommandBuffer& buffer, const DrawCallInfo& draw, bool log_phases,
                            DrawRenderState& state) {
 	EXIT_IF(draw.name == nullptr);
 	auto& ctx    = buffer.GetRegisters();
@@ -1012,14 +1213,31 @@ static void RefreshShaders(CommandBuffer& buffer, const DrawCallInfo& draw, bool
 		target_export_mapping[state.color_info[i].target_slot] = state.color_info[i].export_mapping;
 	}
 	if (log_phases) {
-		LogDrawPhase(draw.name, "GetVertexProgram");
+		LogDrawPhase(draw.name, state.mesh.active ? "GetMeshProgram" : "GetVertexProgram");
 	}
 	auto& pipeline_cache = buffer.GetContext().GetPipelineCache();
-	state.vertex_program =
-	    pipeline_cache.GetVertexProgram(vertex_shader_info, shader_regs, state.vs_input_info);
+	if (state.mesh.active) {
+		std::string mesh_error;
+		state.vertex_program =
+		    pipeline_cache.GetMeshProgram(vertex_shader_info, shader_regs, state.mesh.dispatch,
+		                                  state.mesh.topology, state.mesh.indexed,
+		                                  state.vs_input_info, &mesh_error);
+		if (!state.vertex_program) {
+			static std::once_flag mesh_failure_once;
+			std::call_once(mesh_failure_once, [&mesh_error, &draw] {
+				LOGF("Dropping merged geometry draw (%s): mesh compile failed: %s\n", draw.name,
+				     mesh_error.c_str());
+			});
+			state.mesh.active = false;
+			return false;
+		}
+	} else {
+		state.vertex_program =
+		    pipeline_cache.GetVertexProgram(vertex_shader_info, shader_regs, state.vs_input_info);
+	}
 
 	if (!state.ps_active) {
-		return;
+		return true;
 	}
 	if (log_phases) {
 		LogDrawPhase(draw.name, "GetPixelProgram");
@@ -1027,6 +1245,7 @@ static void RefreshShaders(CommandBuffer& buffer, const DrawCallInfo& draw, bool
 	state.pixel_program =
 	    pipeline_cache.GetPixelProgram(pixel_shader_info, shader_regs, state.vs_input_info,
 	                                   target_export_mapping, state.ps_input_info);
+	return true;
 }
 
 static PreparedVertexBuffers PrepareVertexBuffers(uint64_t submit_id, CommandBuffer& buffer,
@@ -1169,8 +1388,11 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
 	LogDrawPhase(draw.name, "PrepareBindings");
 	auto bindings = PrepareGraphicsBindings(state.vs_input_info.stage, state.ps_input_info.stage,
 	                                        state.ps_active);
-	auto vertex_bindings = PrepareVertexBuffers(submit_id, buffer, draw, state.vs_input_info);
-	auto index_binding   = PrepareIndexBuffer(buffer, index_source);
+	auto vertex_bindings = state.mesh.active
+	                           ? PreparedVertexBuffers {}
+	                           : PrepareVertexBuffers(submit_id, buffer, draw, state.vs_input_info);
+	auto index_binding =
+	    state.mesh.active ? PreparedIndexBuffer {} : PrepareIndexBuffer(buffer, index_source);
 	state.rendering =
 	    AcquireRenderTargets(buffer, state.color_info, state.color_count, state.depth_info);
 
@@ -1203,6 +1425,9 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
 	if (bindings.pixel) {
 		descriptor_stages[1] = &*bindings.pixel;
 	}
+	if (state.mesh.active && state.mesh.indexed) {
+		SetMeshIndices(state.mesh.index_addr, state.mesh.index_type, state.mesh.index_count);
+	}
 	CommitBindings(buffer, vk::PipelineBindPoint::eGraphics, pipeline,
 	               std::span {descriptor_stages.data(), descriptor_stage_count});
 	CommitIndexBuffer(vk_buffer, index_binding);
@@ -1219,7 +1444,12 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
 	if (set_auto_debug) {
 		SetDrawDebugPhase(buffer, submit_id, draw, 0x500u);
 	}
-	EmitDrawPrimitives(ucfg, vk_buffer, state.vs_input_info, draw, emit);
+	if (state.mesh.active) {
+		vk_buffer.drawMeshTasksEXT(state.mesh.dispatch.workgroup_count, state.mesh.instance_count,
+		                           1);
+	} else {
+		EmitDrawPrimitives(ucfg, vk_buffer, state.vs_input_info, draw, emit);
+	}
 
 	if (set_auto_debug) {
 		SetDrawDebugPhase(buffer, submit_id, draw, 0x600u);
@@ -1271,7 +1501,14 @@ void RenderExecutor::DrawIndex(uint64_t submit_id, CommandBuffer& buffer,
 		return;
 	}
 
-	if (ShouldSkipGeShader(buffer)) {
+	MeshDrawPlan mesh_plan;
+	std::string  mesh_reject;
+	PlanMeshDraw(buffer, index_addr, index_type_and_size, index_count, instance_count,
+	             first_instance, static_cast<int32_t>(ucfg.GetIndexOffset()) + vertex_offset_add,
+	             mesh_plan, &mesh_reject);
+
+	if (ShouldSkipGeShader(buffer, mesh_plan)) {
+		LogMergedGeometryRejection(buffer, mesh_reject, index_count);
 		return;
 	}
 
@@ -1352,12 +1589,16 @@ void RenderExecutor::DrawIndex(uint64_t submit_id, CommandBuffer& buffer,
 	index_source.type = index_type;
 
 	DrawRenderState state {};
+	state.mesh = mesh_plan;
 	if (!PrepareDrawRenderState(submit_id, buffer, draw, render_target_slice_offset, true, state)) {
 		ResetBindings();
 		return;
 	}
 
-	RefreshShaders(buffer, draw, true, state);
+	if (!RefreshShaders(buffer, draw, true, state)) {
+		ResetBindings();
+		return;
+	}
 
 	LogDrawStateIfNeeded(buffer, draw, state, true, false, index_type_and_size, index_addr);
 
@@ -1402,7 +1643,13 @@ void RenderExecutor::DrawAuto(uint64_t submit_id, CommandBuffer& buffer, uint32_
 		return;
 	}
 
-	if (ShouldSkipGeShader(buffer)) {
+	MeshDrawPlan mesh_plan;
+	std::string  mesh_reject;
+	PlanMeshDraw(buffer, nullptr, 0, index_count, instance_count, first_instance, 0, mesh_plan,
+	             &mesh_reject);
+
+	if (ShouldSkipGeShader(buffer, mesh_plan)) {
+		LogMergedGeometryRejection(buffer, mesh_reject, index_count);
 		return;
 	}
 
@@ -1432,6 +1679,7 @@ void RenderExecutor::DrawAuto(uint64_t submit_id, CommandBuffer& buffer, uint32_
 	                         instance_count,  first_instance};
 
 	DrawRenderState state {};
+	state.mesh = mesh_plan;
 	if (!PrepareDrawRenderState(submit_id, buffer, draw, render_target_slice_offset, false,
 	                            state)) {
 		ResetBindings();
@@ -1443,7 +1691,10 @@ void RenderExecutor::DrawAuto(uint64_t submit_id, CommandBuffer& buffer, uint32_
 		ResetBindings();
 		return;
 	}
-	RefreshShaders(buffer, draw, false, state);
+	if (!RefreshShaders(buffer, draw, false, state)) {
+		ResetBindings();
+		return;
+	}
 
 	const bool rect_list = topology == vk::PrimitiveTopology::ePatchList;
 	if (rect_list && state.vs_input_info.buffers_num == 0 &&

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -469,9 +469,13 @@ static void VulkanInitSubgroupSizeControl(vk::PhysicalDevice physical_device,
 	subgroup_size_control.sType = vk::StructureType::ePhysicalDeviceSubgroupSizeControlProperties;
 	subgroup_size_control.pNext = nullptr;
 
+	vk::PhysicalDeviceMeshShaderPropertiesEXT mesh_properties {};
+	mesh_properties.sType = vk::StructureType::ePhysicalDeviceMeshShaderPropertiesEXT;
+	mesh_properties.pNext = &subgroup_size_control;
+
 	vk::PhysicalDeviceVulkan11Properties properties11 {};
 	properties11.sType = vk::StructureType::ePhysicalDeviceVulkan11Properties;
-	properties11.pNext = &subgroup_size_control;
+	properties11.pNext = &mesh_properties;
 
 	vk::PhysicalDeviceProperties2 properties2 {};
 	properties2.sType = vk::StructureType::ePhysicalDeviceProperties2;
@@ -500,6 +504,13 @@ static void VulkanInitSubgroupSizeControl(vk::PhysicalDevice physical_device,
 	    subgroup_size_control.maxSubgroupSize >= 64;
 	graphics.compute_wave64_supported =
 	    graphics.subgroup_size == 64u || graphics.compute_subgroup_size_control_enabled;
+	graphics.max_mesh_work_group_invocations = mesh_properties.maxMeshWorkGroupInvocations;
+	graphics.max_mesh_output_vertices        = mesh_properties.maxMeshOutputVertices;
+	graphics.max_mesh_output_primitives      = mesh_properties.maxMeshOutputPrimitives;
+	graphics.max_mesh_shared_memory_size     = mesh_properties.maxMeshSharedMemorySize;
+	for (uint32_t index = 0; index < 3u; index++) {
+		graphics.max_mesh_work_group_count[index] = mesh_properties.maxMeshWorkGroupCount[index];
+	}
 
 	LOGF("Vulkan subgroup: default=%u min=%u max=%u stages=0x%08x size_control=%s wave64=%s\n",
 	     graphics.subgroup_size, graphics.min_subgroup_size, graphics.max_subgroup_size,
@@ -579,10 +590,30 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 #endif
 	}
 
+	const auto mesh_shader_ext_enabled =
+	    HasExtension(device_extensions, VK_EXT_MESH_SHADER_EXTENSION_NAME);
+
+	vk::PhysicalDeviceMeshShaderFeaturesEXT supported_mesh_shader {};
+	supported_mesh_shader.sType = vk::StructureType::ePhysicalDeviceMeshShaderFeaturesEXT;
+	supported_mesh_shader.pNext = nullptr;
+	if (mesh_shader_ext_enabled) {
+		if (robustness2_ext_enabled) {
+			supported_robustness2.pNext = &supported_mesh_shader;
+		} else {
+#if defined(__APPLE__)
+			supported_features12.pNext = &supported_mesh_shader;
+#else
+			supported_fragment_barycentric.pNext = &supported_mesh_shader;
+#endif
+		}
+	}
+
 	vk::PhysicalDeviceFeatures2 supported_features2 {};
 	supported_features2.sType = vk::StructureType::ePhysicalDeviceFeatures2;
 	supported_features2.pNext = &supported_features13;
 	physical_device.getFeatures2(&supported_features2);
+	graphics.mesh_shader_enabled =
+	    mesh_shader_ext_enabled && supported_mesh_shader.meshShader == VK_TRUE;
 	const auto required_features13 = WindowContext::RequiredVulkan13Features();
 	EXIT_NOT_IMPLEMENTED(supported_features12.timelineSemaphore != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(required_features13.dynamicRendering == VK_TRUE &&
@@ -658,13 +689,21 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	features13.robustImageAccess   = supported_features13.robustImageAccess;
 	features13.subgroupSizeControl = subgroup_size_control_enabled ? VK_TRUE : VK_FALSE;
 
+	vk::PhysicalDeviceMeshShaderFeaturesEXT mesh_shader {};
+	if (graphics.mesh_shader_enabled) {
+		mesh_shader.sType      = vk::StructureType::ePhysicalDeviceMeshShaderFeaturesEXT;
+		mesh_shader.pNext      = &features13;
+		mesh_shader.meshShader = VK_TRUE;
+	}
+
 	LOGF("Vulkan robustness: robustImageAccess=%s robustImageAccess2=%s\n",
 	     features13.robustImageAccess == VK_TRUE ? "true" : "false",
 	     robustness2_ext_enabled && robustness2.robustImageAccess2 == VK_TRUE ? "true" : "false");
 
 	vk::DeviceCreateInfo create_info {};
 	create_info.sType                   = vk::StructureType::eDeviceCreateInfo;
-	create_info.pNext                   = &features13;
+	create_info.pNext = graphics.mesh_shader_enabled ? static_cast<const void*>(&mesh_shader)
+	                                                : static_cast<const void*>(&features13);
 	create_info.flags                   = {};
 	create_info.pQueueCreateInfos       = &queue_create_info;
 	create_info.queueCreateInfoCount    = 1;
@@ -1034,6 +1073,9 @@ void WindowContext::CreateVulkan() {
 		}
 		if (HasExtension(available_extensions, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
 			device_extensions.push_back(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+		}
+		if (HasExtension(available_extensions, VK_EXT_MESH_SHADER_EXTENSION_NAME)) {
+			device_extensions.push_back(VK_EXT_MESH_SHADER_EXTENSION_NAME);
 		}
 	}
 

--- a/src/graphics/shader/recompiler/ShaderRecompiler.cpp
+++ b/src/graphics/shader/recompiler/ShaderRecompiler.cpp
@@ -17,6 +17,7 @@
 #include "graphics/shader/recompiler/ir/passes/SharedMemoryBarrier.h"
 #include "graphics/shader/recompiler/ir/passes/SrtWalker.h"
 #include "graphics/shader/recompiler/ir/passes/SsaRewrite.h"
+#include "graphics/shader/shaderMergedGeometry.h"
 
 #include <algorithm>
 #include <array>
@@ -481,9 +482,9 @@ bool TryRecompile(std::span<const uint32_t> code, const CompileOptions& options,
 		return false;
 	}
 	if (options.stage != ShaderType::Compute && options.stage != ShaderType::Vertex &&
-	    options.stage != ShaderType::Pixel) {
+	    options.stage != ShaderType::Pixel && options.stage != ShaderType::Mesh) {
 		if (error != nullptr) {
-			*error = "shader recompiler supports compute, vertex, and pixel stages";
+			*error = "shader recompiler supports compute, vertex, pixel, and mesh stages";
 		}
 		return false;
 	}
@@ -565,6 +566,7 @@ bool TryRecompile(std::span<const uint32_t> code, const CompileOptions& options,
 	const ShaderPixelInputInfo*   pixel   = nullptr;
 	const ShaderComputeInputInfo* compute = nullptr;
 	switch (options.stage) {
+		case ShaderType::Mesh:
 		case ShaderType::Vertex: vertex = options.input_info.vertex; break;
 		case ShaderType::Pixel: pixel = options.input_info.pixel; break;
 		case ShaderType::Compute: compute = options.input_info.compute; break;
@@ -618,9 +620,16 @@ bool TryRecompile(std::span<const uint32_t> code, const CompileOptions& options,
 		IR::RemoveIdentities(ir.blocks);
 		IR::EliminateDeadCode(ir.blocks);
 	}
-	if (options.stage == ShaderType::Compute) {
-		const auto lds_barriers =
-		    IR::InsertSharedMemoryBarriers(ir, ir.wave_size, *compute);
+	if (options.stage == ShaderType::Compute || options.stage == ShaderType::Mesh) {
+		const bool mesh = options.stage == ShaderType::Mesh;
+		const auto threadgroup_size =
+		    mesh ? MeshWaveLanes
+		         : compute->threads_num[0] * compute->threads_num[1] * compute->threads_num[2];
+		const auto lds_size_dwords =
+		    mesh ? vertex->mesh_lds_size_dwords : compute->lds_size_dwords;
+		const auto needs_barriers = mesh || compute->needs_lds_barriers;
+		const auto lds_barriers   = IR::InsertSharedMemoryBarriers(
+		      ir, ir.wave_size, threadgroup_size, lds_size_dwords, needs_barriers);
 		if (lds_barriers.inserted_barriers != 0) {
 			LOGF("%s wave64 LDS synchronization: barriers=%" PRIu32 "\n", GetDumpLabel(options),
 			     lds_barriers.inserted_barriers);

--- a/src/graphics/shader/recompiler/backend/spirv/SpirvBuilder.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/SpirvBuilder.cpp
@@ -1,4 +1,5 @@
 #include "graphics/shader/recompiler/backend/spirv/SpirvBuilder.h"
+#include <algorithm>
 
 #include "common/debug.h"
 
@@ -35,6 +36,10 @@ void Builder::RequireCapability(uint32_t capability) {
 	if (m_required_capabilities.insert(capability).second) {
 		AddCapability({capability});
 	}
+}
+
+void Builder::RequireVersion(uint32_t version) {
+	m_version = std::max(m_version, version);
 }
 
 void Builder::RequireExtension(const char* name) {
@@ -133,6 +138,7 @@ uint32_t Builder::DefineGlobalVariable(uint32_t pointer_type, uint32_t storage_c
 
 void Builder::DefineGlobalVariable(uint32_t id, uint32_t pointer_type, uint32_t storage_class) {
 	AddType({59u, pointer_type, id, storage_class});
+	m_global_variables.push_back(id);
 }
 
 void Builder::AppendString(std::vector<uint32_t>& words, const char* text) {
@@ -187,10 +193,9 @@ void Builder::AddMemoryModel(std::initializer_list<uint32_t> operands) {
 
 void Builder::AddEntryPoint(uint32_t execution_model, uint32_t entry_point, const char* name,
                             const std::vector<uint32_t>& interfaces) {
-	std::vector<uint32_t> operands = {execution_model, entry_point};
-	AppendString(operands, name);
-	operands.insert(operands.end(), interfaces.begin(), interfaces.end());
-	AppendInstruction(m_entry_points, 15u, operands);
+	m_entry_point_prefix = {execution_model, entry_point};
+	AppendString(m_entry_point_prefix, name);
+	m_entry_point_interface = interfaces;
 }
 
 void Builder::AddExecutionMode(std::initializer_list<uint32_t> operands) {
@@ -241,9 +246,24 @@ void Builder::PatchDeferredPhi(DeferredPhi phi, size_t incoming, uint32_t value,
 std::vector<uint32_t> Builder::Build() const {
 	EXIT_IF(m_unpatched_phi_incomings != 0);
 
+	std::vector<uint32_t> entry_points;
+	if (!m_entry_point_prefix.empty()) {
+		auto operands = m_entry_point_prefix;
+		operands.insert(operands.end(), m_entry_point_interface.begin(),
+		                m_entry_point_interface.end());
+		if (m_version >= 0x00010400u) {
+			for (const auto id: m_global_variables) {
+				if (std::find(operands.begin(), operands.end(), id) == operands.end()) {
+					operands.push_back(id);
+				}
+			}
+		}
+		AppendInstruction(entry_points, 15u, operands);
+	}
+
 	std::vector<uint32_t> module;
 	module.reserve(5u + m_capabilities.size() + m_extensions.size() + m_ext_inst_imports.size() +
-	               m_memory_model.size() + m_entry_points.size() + m_execution_modes.size() +
+	               m_memory_model.size() + entry_points.size() + m_execution_modes.size() +
 	               m_debug.size() + m_annotations.size() + m_declarations.size() +
 	               m_functions.size());
 
@@ -257,7 +277,7 @@ std::vector<uint32_t> Builder::Build() const {
 	module.insert(module.end(), m_extensions.begin(), m_extensions.end());
 	module.insert(module.end(), m_ext_inst_imports.begin(), m_ext_inst_imports.end());
 	module.insert(module.end(), m_memory_model.begin(), m_memory_model.end());
-	module.insert(module.end(), m_entry_points.begin(), m_entry_points.end());
+	module.insert(module.end(), entry_points.begin(), entry_points.end());
 	module.insert(module.end(), m_execution_modes.begin(), m_execution_modes.end());
 	module.insert(module.end(), m_debug.begin(), m_debug.end());
 	module.insert(module.end(), m_annotations.begin(), m_annotations.end());

--- a/src/graphics/shader/recompiler/backend/spirv/SpirvBuilder.h
+++ b/src/graphics/shader/recompiler/backend/spirv/SpirvBuilder.h
@@ -29,6 +29,7 @@ public:
 
 	uint32_t AllocateId();
 	void     RequireCapability(uint32_t capability);
+	void     RequireVersion(uint32_t version);
 	void     RequireExtension(const char* name);
 	uint32_t Import(const char* name);
 	uint32_t Type(uint32_t opcode, std::initializer_list<uint32_t> operands = {});
@@ -72,6 +73,9 @@ private:
 	std::vector<uint32_t>                     m_ext_inst_imports;
 	std::vector<uint32_t>                     m_memory_model;
 	std::vector<uint32_t>                     m_entry_points;
+	std::vector<uint32_t>                     m_entry_point_prefix;
+	std::vector<uint32_t>                     m_entry_point_interface;
+	std::vector<uint32_t>                     m_global_variables;
 	std::vector<uint32_t>                     m_execution_modes;
 	std::vector<uint32_t>                     m_debug;
 	std::vector<uint32_t>                     m_annotations;

--- a/src/graphics/shader/recompiler/backend/spirv/SpirvEmitter.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/SpirvEmitter.cpp
@@ -82,6 +82,13 @@ bool ValidateNativeProgram(const IR::Program& program, std::string* error) {
 	if (uses_flattened_runtime) {
 		Expect(Kind::FlattenedSrt);
 	}
+	if (std::ranges::any_of(program.blocks, [](const IR::Block* block) {
+		    return std::ranges::any_of(*block, [](const auto& inst) {
+			    return inst.GetOpcode() == IR::ValueOpcode::ReadMeshIndex;
+		    });
+	    })) {
+		Expect(Kind::MeshIndices);
+	}
 	if (program.bindings.ShaderDataDwords() != 0 && program.bindings.push_constant_size == 0) {
 		Expect(Kind::UserData);
 	}
@@ -231,7 +238,8 @@ bool AnalyzeProgramRequirements(IR::Program& program, std::string* error) {
 				if (kind != IR::ResourceKind::Lds && kind != IR::ResourceKind::Gds) {
 					return Fail(error, "shared operation has invalid resource kind");
 				}
-				if (program.stage != ShaderType::Compute && kind == IR::ResourceKind::Lds) {
+				if (program.stage != ShaderType::Compute && program.stage != ShaderType::Mesh &&
+				    kind == IR::ResourceKind::Lds) {
 					requirements.function_lds = true;
 				}
 				if (shared_access == IR::SharedAccess::Append ||
@@ -304,8 +312,9 @@ bool EmitProgram(const IR::Program& program, const IR::ResourceSnapshot& resourc
 	using namespace Emitter;
 
 	if (program.stage != ShaderType::Compute && program.stage != ShaderType::Vertex &&
-	    program.stage != ShaderType::Pixel) {
-		SetError(error, "binary SPIR-V emitter supports compute, vertex, and pixel shaders");
+	    program.stage != ShaderType::Pixel && program.stage != ShaderType::Mesh) {
+		SetError(error,
+		         "binary SPIR-V emitter supports compute, vertex, pixel, and mesh shaders");
 		return false;
 	}
 	if (!program.srt_plan_complete || !program.resource_tracking_complete ||
@@ -329,6 +338,8 @@ bool EmitProgram(const IR::Program& program, const IR::ResourceSnapshot& resourc
 	EmitterState state(program, resources, input_info);
 	state.stage     = program.stage;
 	state.wave_size = program.wave_size;
+	state.logical_wave64 =
+	    program.stage == ShaderType::Mesh && program.wave_size == LogicalWave64Lanes;
 	state.inputs.reserve(program.info.inputs.size());
 	state.outputs.reserve(program.info.outputs.size());
 	state.interface_variables.reserve(program.info.inputs.size() + program.info.outputs.size());

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAnalysis.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAnalysis.cpp
@@ -336,6 +336,7 @@ uint32_t ExecutionModelForStage(ShaderType stage) {
 	switch (stage) {
 		case ShaderType::Vertex: return ExecutionModelVertex;
 		case ShaderType::Pixel: return ExecutionModelFragment;
+		case ShaderType::Mesh: return ExecutionModelMeshEXT;
 		default: return ExecutionModelGLCompute;
 	}
 }

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterFlow.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterFlow.cpp
@@ -419,6 +419,65 @@ void EmitExport(ValueEmitContext& ctx, const IR::Inst& inst) {
 		    {OpSelect, TypeU32(state), value, exec, ConstantU32(state, 1), ConstantU32(state, 0)});
 		state.builder.AddFunction({OpStore, state.pixel_valid_mask_variable, value});
 	}
+	if (exp.kind == IR::ExportTargetKind::Primitive && state.stage == ShaderType::Mesh) {
+		// The guest packs a triangle's connectivity into one dword, with 10-bit indices where the
+		// published GFX10.1 layout uses 9:
+		//   [9:0] index0 | [19:10] index1 | [29:20] index2 | bit 31 = cull this primitive
+		EmitIfCondition(state, exec, [&]() {
+			const auto packed = ExportRawComponent(ctx, ctx.Arg(inst, 0), 0);
+			const auto prim   = EmitCurrentLaneId(state);
+			const auto index  = [&](uint32_t shift) {
+				const auto shifted = state.builder.AllocateId();
+				const auto masked  = state.builder.AllocateId();
+				state.builder.AddFunction({OpShiftRightLogical, TypeU32(state), shifted, packed,
+				                           ConstantU32(state, shift)});
+				state.builder.AddFunction({OpBitwiseAnd, TypeU32(state), masked, shifted,
+				                           ConstantU32(state, 0x3ffu)});
+				return masked;
+			};
+			const auto triangle = state.builder.AllocateId();
+			state.builder.AddFunction({OpCompositeConstruct, TypeU32Vector(state, 3), triangle,
+			                           index(0), index(10), index(20)});
+			const auto pointer = state.builder.AllocateId();
+			state.builder.AddFunction(
+			    {OpAccessChain, TypePointer(state, StorageClassOutput, TypeU32Vector(state, 3)),
+			     pointer, state.mesh_prim_indices_variable, prim});
+			state.builder.AddFunction({OpStore, pointer, triangle});
+
+			// Bit 31 is the null-primitive encoding, which gl_CullPrimitiveEXT expresses.
+			const auto null_bit = state.builder.AllocateId();
+			const auto culled   = state.builder.AllocateId();
+			state.builder.AddFunction({OpBitwiseAnd, TypeU32(state), null_bit, packed,
+			                           ConstantU32(state, 0x80000000u)});
+			state.builder.AddFunction({OpINotEqual, TypeBool(state), culled, null_bit,
+			                           ConstantU32(state, 0)});
+			const auto cull_pointer = state.builder.AllocateId();
+			state.builder.AddFunction({OpAccessChain,
+			                           TypePointer(state, StorageClassOutput, TypeBool(state)),
+			                           cull_pointer, state.mesh_cull_variable, prim});
+			state.builder.AddFunction({OpStore, cull_pointer, culled});
+		});
+		return;
+	}
+	if (state.stage == ShaderType::Mesh && exp.kind == IR::ExportTargetKind::Position &&
+	    exp.index != 0) {
+		// POS1 packs (point size, edge flag, layer, viewport index); only the layer, in
+		// component z, is used here.
+		if ((exp.en & 4u) != 0u) {
+			EmitIfCondition(state, exec, [&]() {
+				const auto raw = ExportRawComponent(ctx, ctx.Arg(inst, 0), 2);
+				const auto layer = state.builder.AllocateId();
+				state.builder.AddFunction({OpBitcast, TypeI32(state), layer, raw});
+				const auto pointer = state.builder.AllocateId();
+				state.builder.AddFunction({OpAccessChain,
+				                           TypePointer(state, StorageClassOutput, TypeI32(state)),
+				                           pointer, state.mesh_layer_variable,
+				                           EmitCurrentLaneId(state)});
+				state.builder.AddFunction({OpStore, pointer, layer});
+			});
+		}
+		return;
+	}
 	if (exp.kind == IR::ExportTargetKind::Null || exp.kind == IR::ExportTargetKind::Primitive ||
 	    exp.en == 0u) {
 		return;
@@ -468,9 +527,22 @@ void EmitExport(ValueEmitContext& ctx, const IR::Inst& inst) {
 		}
 		if (exp.kind == IR::ExportTargetKind::Position) {
 			const auto pointer = state.builder.AllocateId();
+			if (state.stage == ShaderType::Mesh) {
+				state.builder.AddFunction(
+				    {OpAccessChain, TypePointer(state, StorageClassOutput, TypeF32Vector(state, 4)),
+				     pointer, variable, EmitCurrentLaneId(state), ConstantU32(state, 0)});
+			} else {
+				state.builder.AddFunction(
+				    {OpAccessChain, TypePointer(state, StorageClassOutput, TypeF32Vector(state, 4)),
+				     pointer, variable, ConstantU32(state, 0)});
+			}
+			state.builder.AddFunction({OpStore, pointer, value});
+		} else if (state.stage == ShaderType::Mesh &&
+		           exp.kind == IR::ExportTargetKind::Parameter) {
+			const auto pointer = state.builder.AllocateId();
 			state.builder.AddFunction(
-			    {OpAccessChain, TypePointer(state, StorageClassOutput, TypeF32Vector(state, 4)),
-			     pointer, variable, ConstantU32(state, 0)});
+			    {OpAccessChain, TypePointer(state, StorageClassOutput, vector_type), pointer,
+			     variable, EmitCurrentLaneId(state)});
 			state.builder.AddFunction({OpStore, pointer, value});
 		} else {
 			state.builder.AddFunction({OpStore, variable, value});
@@ -489,9 +561,24 @@ bool EmitValueFlow(ValueEmitContext& ctx, const IR::Inst& inst) {
 		case IR::ValueOpcode::ReferenceU32:
 		case IR::ValueOpcode::ControlNop:
 		case IR::ValueOpcode::Waitcnt:
-		case IR::ValueOpcode::Sendmsg:
 		case IR::ValueOpcode::TtraceData:
 		case IR::ValueOpcode::InstPrefetch: return true;
+		case IR::ValueOpcode::Sendmsg: {
+			if (state.stage != ShaderType::Mesh) {
+				return true;
+			}
+			// GS_ALLOC_REQ reserves the program's output space: m0 packs
+			// vertex_count[11:0] | primitive_count << 12.
+			const auto m0         = ctx.Arg(inst, 0);
+			const auto vertices   = state.builder.AllocateId();
+			const auto primitives = state.builder.AllocateId();
+			state.builder.AddFunction({OpBitwiseAnd, TypeU32(state), vertices, m0,
+			                           ConstantU32(state, 0xfffu)});
+			state.builder.AddFunction({OpShiftRightLogical, TypeU32(state), primitives, m0,
+			                           ConstantU32(state, 12)});
+			state.builder.AddFunction({OpSetMeshOutputsEXT, vertices, primitives});
+			return true;
+		}
 		case IR::ValueOpcode::Barrier: {
 			const auto semantics = MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
 			state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
@@ -521,19 +608,29 @@ bool EmitValueFlow(ValueEmitContext& ctx, const IR::Inst& inst) {
 			state.builder.AddFunction({OpUndef, ctx.TypeId(inst.GetType()), ctx.Result(inst)});
 			return true;
 		case IR::ValueOpcode::DppMoveU32: {
-			const auto flags    = inst.Flags<IR::DppMoveFlags>();
-			const auto target   = EmitDppTargetLane(state, flags.control);
-			const auto shuffled = state.builder.AllocateId();
-			state.builder.AddFunction({OpGroupNonUniformShuffle, TypeU32(state), shuffled,
-			                           ConstantU32(state, ScopeSubgroup), ctx.Arg(inst, 0),
-			                           target.lane});
+			const auto flags  = inst.Flags<IR::DppMoveFlags>();
+			const auto target = EmitDppTargetLane(state, flags.control);
+			uint32_t   shuffled = 0;
+			if (state.logical_wave64) {
+				shuffled = EmitLogicalReadLane(state, ctx.Arg(inst, 0), target.lane);
+			} else {
+				shuffled = state.builder.AllocateId();
+				state.builder.AddFunction({OpGroupNonUniformShuffle, TypeU32(state), shuffled,
+				                           ConstantU32(state, ScopeSubgroup), ctx.Arg(inst, 0),
+				                           target.lane});
+			}
 			if (flags.fetch_inactive) {
 				ctx.Define(inst, shuffled);
 				return true;
 			}
-			const auto ballot = state.builder.AllocateId();
-			state.builder.AddFunction({OpGroupNonUniformBallot, TypeU32Vector(state, 4), ballot,
-			                           ConstantU32(state, ScopeSubgroup), ctx.Arg(inst, 1)});
+			uint32_t ballot = 0;
+			if (state.logical_wave64) {
+				ballot = EmitLogicalBallot(state, ctx.Arg(inst, 1));
+			} else {
+				ballot = state.builder.AllocateId();
+				state.builder.AddFunction({OpGroupNonUniformBallot, TypeU32Vector(state, 4), ballot,
+				                           ConstantU32(state, ScopeSubgroup), ctx.Arg(inst, 1)});
+			}
 			const auto source_active = EmitBallotLaneActiveBool(state, ballot, target.lane);
 			const auto can_fetch     = state.builder.AllocateId();
 			state.builder.AddFunction(
@@ -554,13 +651,19 @@ bool EmitValueFlow(ValueEmitContext& ctx, const IR::Inst& inst) {
 			ctx.Define(inst, EmitWqm(ctx, ctx.Arg(inst, 0)));
 			return true;
 		case IR::ValueOpcode::LaneId:
-			ctx.Define(inst, EmitSubgroupLocalInvocationId(state));
+			ctx.Define(inst, state.logical_wave64 ? EmitLogicalLaneId(state)
+			                                      : EmitSubgroupLocalInvocationId(state));
 			return true;
 		case IR::ValueOpcode::Ballot:
+			if (state.logical_wave64) {
+				ctx.Define(inst, EmitLogicalBallot(state, ctx.Arg(inst, 0)));
+				return true;
+			}
 			ctx.Emit(inst, OpGroupNonUniformBallot, IR::Type::U32x4,
 			         {ConstantU32(state, ScopeSubgroup), ctx.Arg(inst, 0)});
 			return true;
 		case IR::ValueOpcode::ReadFirstLane: {
+			RejectUnsupportedLogicalWave64(state, "v_readfirstlane");
 			const auto ballot = state.builder.AllocateId();
 			const auto lane   = state.builder.AllocateId();
 			state.builder.AddFunction({OpGroupNonUniformBallot, TypeU32Vector(state, 4), ballot,
@@ -572,13 +675,17 @@ bool EmitValueFlow(ValueEmitContext& ctx, const IR::Inst& inst) {
 			return true;
 		}
 		case IR::ValueOpcode::ReadLane:
+			if (state.logical_wave64) {
+				ctx.Define(inst, EmitLogicalReadLane(state, ctx.Arg(inst, 0), ctx.Arg(inst, 1)));
+				return true;
+			}
 			ctx.Emit(inst, OpGroupNonUniformShuffle, IR::Type::U32,
 			         {ConstantU32(state, ScopeSubgroup), ctx.Arg(inst, 0), ctx.Arg(inst, 1)});
 			return true;
 		case IR::ValueOpcode::WriteLane: {
 			const auto hit = state.builder.AllocateId();
-			state.builder.AddFunction({OpIEqual, TypeBool(state), hit,
-			                           EmitSubgroupLocalInvocationId(state), ctx.Arg(inst, 2)});
+			state.builder.AddFunction(
+			    {OpIEqual, TypeBool(state), hit, EmitCurrentLaneId(state), ctx.Arg(inst, 2)});
 			ctx.Emit(inst, OpSelect, IR::Type::U32, {hit, ctx.Arg(inst, 1), ctx.Arg(inst, 0)});
 			return true;
 		}

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterFlow.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterFlow.cpp
@@ -408,6 +408,28 @@ void EmitAuxPositionExport(ValueEmitContext& ctx, uint32_t data, const IR::Expor
 	}
 }
 
+// All 64 invocations run, so lanes past the end of an output array must not store.
+static uint32_t MeshStoreCondition(EmitterState& state, uint32_t exec, uint32_t bound) {
+	if (state.stage != ShaderType::Mesh || bound == 0) {
+		return exec;
+	}
+	const auto in_range = state.builder.AllocateId();
+	state.builder.AddFunction({OpULessThan, TypeBool(state), in_range, EmitCurrentLaneId(state),
+	                           ConstantU32(state, bound)});
+	const auto both = state.builder.AllocateId();
+	state.builder.AddFunction({OpLogicalAnd, TypeBool(state), both, exec, in_range});
+	return both;
+}
+
+static uint32_t MeshVertexBound(const EmitterState& state) {
+	return state.input_info.vertex != nullptr ? state.input_info.vertex->mesh_output_vertices : 0u;
+}
+
+static uint32_t MeshPrimitiveBound(const EmitterState& state) {
+	return state.input_info.vertex != nullptr ? state.input_info.vertex->mesh_output_primitives
+	                                          : 0u;
+}
+
 void EmitExport(ValueEmitContext& ctx, const IR::Inst& inst) {
 	auto&       state = ctx.state;
 	const auto& exp   = ctx.Export(inst);
@@ -423,7 +445,7 @@ void EmitExport(ValueEmitContext& ctx, const IR::Inst& inst) {
 		// The guest packs a triangle's connectivity into one dword, with 10-bit indices where the
 		// published GFX10.1 layout uses 9:
 		//   [9:0] index0 | [19:10] index1 | [29:20] index2 | bit 31 = cull this primitive
-		EmitIfCondition(state, exec, [&]() {
+		EmitIfCondition(state, MeshStoreCondition(state, exec, MeshPrimitiveBound(state)), [&]() {
 			const auto packed = ExportRawComponent(ctx, ctx.Arg(inst, 0), 0);
 			const auto prim   = EmitCurrentLaneId(state);
 			const auto index  = [&](uint32_t shift) {
@@ -461,20 +483,36 @@ void EmitExport(ValueEmitContext& ctx, const IR::Inst& inst) {
 	}
 	if (state.stage == ShaderType::Mesh && exp.kind == IR::ExportTargetKind::Position &&
 	    exp.index != 0) {
-		// POS1 packs (point size, edge flag, layer, viewport index); only the layer, in
-		// component z, is used here.
-		if ((exp.en & 4u) != 0u) {
-			EmitIfCondition(state, exec, [&]() {
-				const auto raw = ExportRawComponent(ctx, ctx.Arg(inst, 0), 2);
-				const auto layer = state.builder.AllocateId();
-				state.builder.AddFunction({OpBitcast, TypeI32(state), layer, raw});
-				const auto pointer = state.builder.AllocateId();
-				state.builder.AddFunction({OpAccessChain,
-				                           TypePointer(state, StorageClassOutput, TypeI32(state)),
-				                           pointer, state.mesh_layer_variable,
-				                           EmitCurrentLaneId(state)});
-				state.builder.AddFunction({OpStore, pointer, layer});
-			});
+		// Only the layer has a mesh output; point size and clip/cull distances are not modelled.
+		if (state.mesh_layer_variable != 0) {
+			for (uint32_t component = 0; component < 4; component++) {
+				if ((exp.en & (1u << component)) == 0) {
+					continue;
+				}
+				const auto output = IR::DecodePositionExportComponent(
+				    state.input_info.vertex->pa_cl_vs_out_cntl, exp.index, component);
+				if (!output.layer) {
+					continue;
+				}
+				// Exported per vertex, but gl_Layer is per primitive, so primitive i takes
+				// vertex i's layer. Exact only where the two compactions agree.
+				EmitIfCondition(state, MeshStoreCondition(state, exec, MeshPrimitiveBound(state)),
+				                [&]() {
+					const auto raw    = ExportRawComponent(ctx, ctx.Arg(inst, 0), component);
+					const auto masked = state.builder.AllocateId();
+					const auto layer  = state.builder.AllocateId();
+					state.builder.AddFunction({OpBitwiseAnd, TypeU32(state), masked, raw,
+					                           ConstantU32(state, 0x7ffu)});
+					state.builder.AddFunction({OpBitcast, TypeI32(state), layer, masked});
+					const auto pointer = state.builder.AllocateId();
+					state.builder.AddFunction({OpAccessChain,
+					                           TypePointer(state, StorageClassOutput,
+					                                       TypeI32(state)),
+					                           pointer, state.mesh_layer_variable,
+					                           EmitCurrentLaneId(state)});
+					state.builder.AddFunction({OpStore, pointer, layer});
+				});
+			}
 		}
 		return;
 	}
@@ -482,7 +520,13 @@ void EmitExport(ValueEmitContext& ctx, const IR::Inst& inst) {
 	    exp.en == 0u) {
 		return;
 	}
-	EmitIfCondition(state, exec, [&]() {
+	const auto per_vertex_store = state.stage == ShaderType::Mesh &&
+	                              (exp.kind == IR::ExportTargetKind::Position ||
+	                               exp.kind == IR::ExportTargetKind::Parameter);
+	EmitIfCondition(state,
+	                per_vertex_store ? MeshStoreCondition(state, exec, MeshVertexBound(state))
+	                                 : exec,
+	                [&]() {
 		const auto data = ctx.Arg(inst, 0);
 		if (exp.kind == IR::ExportTargetKind::Position && exp.index != 0) {
 			EmitAuxPositionExport(ctx, data, exp);
@@ -567,15 +611,17 @@ bool EmitValueFlow(ValueEmitContext& ctx, const IR::Inst& inst) {
 			if (state.stage != ShaderType::Mesh) {
 				return true;
 			}
-			// GS_ALLOC_REQ reserves the program's output space: m0 packs
-			// vertex_count[11:0] | primitive_count << 12.
+			// m0 packs vertex_count[10:0] | primitive_count[22:12].
 			const auto m0         = ctx.Arg(inst, 0);
 			const auto vertices   = state.builder.AllocateId();
+			const auto shifted    = state.builder.AllocateId();
 			const auto primitives = state.builder.AllocateId();
 			state.builder.AddFunction({OpBitwiseAnd, TypeU32(state), vertices, m0,
-			                           ConstantU32(state, 0xfffu)});
-			state.builder.AddFunction({OpShiftRightLogical, TypeU32(state), primitives, m0,
+			                           ConstantU32(state, 0x7ffu)});
+			state.builder.AddFunction({OpShiftRightLogical, TypeU32(state), shifted, m0,
 			                           ConstantU32(state, 12)});
+			state.builder.AddFunction({OpBitwiseAnd, TypeU32(state), primitives, shifted,
+			                           ConstantU32(state, 0x7ffu)});
 			state.builder.AddFunction({OpSetMeshOutputsEXT, vertices, primitives});
 			return true;
 		}

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterHelpers.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterHelpers.cpp
@@ -91,7 +91,9 @@ DppTargetLane EmitDppMirrorTargetLane(EmitterState& state, uint32_t subid, bool 
 }
 
 DppTargetLane EmitDppTargetLane(EmitterState& state, uint32_t control) {
-	const auto subid = EmitSubgroupLocalInvocationId(state);
+	// EmitLogicalReadLane stores at the logical lane, so the target must be in that space too.
+	const auto subid =
+	    state.logical_wave64 ? EmitCurrentLaneId(state) : EmitSubgroupLocalInvocationId(state);
 	if (control <= 0xffu) {
 		return EmitDppQuadPermTargetLane(state, subid, control);
 	}

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
@@ -199,6 +199,46 @@ uint32_t FloatBits(ValueEmitContext& ctx, uint32_t value) {
 	return Unary(ctx.state, OpBitcast, TypeU32(ctx.state), value);
 }
 
+uint32_t DepthCompareOpcode(uint32_t compare_func) {
+	switch (compare_func) {
+		case 1: return OpFOrdLessThan;
+		case 2: return OpFOrdEqual;
+		case 3: return OpFOrdLessThanEqual;
+		case 4: return OpFOrdGreaterThan;
+		case 5: return OpFOrdNotEqual;
+		case 6: return OpFOrdGreaterThanEqual;
+		default: return 0;
+	}
+}
+
+uint32_t EmitDepthCompareTexel(EmitterState& state, uint32_t texel, uint32_t reference,
+                               uint32_t compare_func) {
+	const auto compare_op = DepthCompareOpcode(compare_func);
+	if (compare_op == 0) {
+		return ConstantF32Value(state, compare_func == 7u ? 1.0f : 0.0f);
+	}
+	const auto passed = state.builder.AllocateId();
+	state.builder.AddFunction({compare_op, TypeBool(state), passed, reference, texel});
+	const auto result = state.builder.AllocateId();
+	state.builder.AddFunction({OpSelect, TypeF32(state), result, passed,
+	                           ConstantF32Value(state, 1.0f), ConstantF32Value(state, 0.0f)});
+	return result;
+}
+
+uint32_t EmitDepthCompareGather(EmitterState& state, uint32_t sample, uint32_t reference,
+                                uint32_t compare_func) {
+	std::array<uint32_t, 4> components {};
+	for (uint32_t i = 0; i < components.size(); i++) {
+		const auto texel = state.builder.AllocateId();
+		state.builder.AddFunction({OpCompositeExtract, TypeF32(state), texel, sample, i});
+		components[i] = EmitDepthCompareTexel(state, texel, reference, compare_func);
+	}
+	const auto result = state.builder.AllocateId();
+	state.builder.AddFunction({OpCompositeConstruct, TypeF32Vector(state, 4), result, components[0],
+	                           components[1], components[2], components[3]});
+	return result;
+}
+
 uint32_t ResultVector(ValueEmitContext& ctx, uint32_t value, bool integer, bool dref,
                       const IR::MemoryInfo& mem, bool gather = false) {
 	if (mem.data_bits == 16u) {
@@ -615,25 +655,16 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		if (op == IR::ValueOpcode::ImageGatherRaw) {
 			const auto            sampled = MakeSampledImage(state, mem, pc, view);
 			const auto            sample  = state.builder.AllocateId();
-			std::vector<uint32_t> words =
-			    dref ? std::vector<uint32_t> {OpImageDrefGather,
-			                                  TypeF32Vector(state, 4),
-			                                  sample,
-			                                  sampled,
-			                                  coord,
-			                                  layout.dref != NoImageComponent
-			                                      ? AddressF32(ctx, mem, *address, layout.dref)
-			                                      : ZeroF32(state)}
-			         : std::vector<uint32_t> {
-			               OpImageGather,
-			               integer ? TypeU32Vector(state, 4) : TypeF32Vector(state, 4),
-			               sample,
-			               sampled,
-			               coord,
-			               ConstantU32(state, ImageConversionFormat(state, mem).format ==
-			                                          Prospero::BufferFormat::kInvalid
-			                                      ? ImageGatherComponent(mem.dmask)
-			                                      : 0u)};
+			std::vector<uint32_t> words {
+			    OpImageGather,
+			    integer && !dref ? TypeU32Vector(state, 4) : TypeF32Vector(state, 4),
+			    sample,
+			    sampled,
+			    coord,
+			    ConstantU32(state, dref || ImageConversionFormat(state, mem).format !=
+			                                   Prospero::BufferFormat::kInvalid
+			                           ? 0u
+			                           : ImageGatherComponent(mem.dmask))};
 			if (HasFlag(mem, Decoder::ImageSampleFlagGatherHorizontal)) {
 				words.push_back(ImageOperandsConstOffsetsMask);
 				words.push_back(HorizontalOffsets(state, view));
@@ -642,7 +673,17 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 				words.push_back(PackedOffset(ctx, mem, *address, layout, view));
 			}
 			state.builder.AddFunction(words);
-			ctx.Define(inst, ResultVector(ctx, UnpackImageGather(ctx, mem, sample),
+			const auto gathered =
+			    dref ? EmitDepthCompareGather(
+			               state, sample,
+			               layout.dref != NoImageComponent
+			                   ? AddressF32(ctx, mem, *address, layout.dref)
+			                   : ZeroF32(state),
+			               mem.sampler < state.program.info.samplers.size()
+			                   ? state.program.info.samplers[mem.sampler].depth_compare_func
+			                   : 0u)
+			         : sample;
+			ctx.Define(inst, ResultVector(ctx, UnpackImageGather(ctx, mem, gathered),
 			                              integer && !dref, false, mem, true));
 			return true;
 		}
@@ -650,11 +691,8 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		                          HasFlag(mem, Decoder::ImageSampleFlagLod) ||
 		                          HasFlag(mem, Decoder::ImageSampleFlagLevelZero) ||
 		                          state.stage != ShaderType::Pixel;
-		const auto opcode = explicit_lod
-		                        ? (dref ? OpImageSampleDrefExplicitLod : OpImageSampleExplicitLod)
-		                        : (dref ? OpImageSampleDrefImplicitLod : OpImageSampleImplicitLod);
-		const auto result_type =
-		    dref ? TypeF32(state) : (integer ? TypeU32Vector(state, 4) : TypeF32Vector(state, 4));
+		const auto opcode      = explicit_lod ? OpImageSampleExplicitLod : OpImageSampleImplicitLod;
+		const auto result_type = integer ? TypeU32Vector(state, 4) : TypeF32Vector(state, 4);
 		const auto dref_value =
 		    dref ? (layout.dref != NoImageComponent ? AddressF32(ctx, mem, *address, layout.dref)
 		                                            : ZeroF32(state))
@@ -681,9 +719,6 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			const auto            sampled = MakeSampledImage(state, mem, pc, view, resource);
 			const auto            sample  = state.builder.AllocateId();
 			std::vector<uint32_t> words {opcode, result_type, sample, sampled, coord};
-			if (dref) {
-				words.push_back(dref_value);
-			}
 			if (operand_mask != 0u) {
 				words.push_back(operand_mask);
 				words.insert(words.end(), operands.begin(), operands.end());
@@ -691,10 +726,21 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			state.builder.AddFunction(words);
 			return sample;
 		};
+		const auto EmitDepthCompare = [&](uint32_t sample) {
+			const auto texel = state.builder.AllocateId();
+			state.builder.AddFunction({OpCompositeExtract, TypeF32(state), texel, sample, 0u});
+			return EmitDepthCompareTexel(
+			    state, texel, dref_value,
+			    mem.sampler < state.program.info.samplers.size()
+			        ? state.program.info.samplers[mem.sampler].depth_compare_func
+			        : 0u);
+		};
 		const auto& image = state.program.info.images[mem.resource];
 		if (image.indirect_root != mem.resource) {
 			const auto sample = EmitSample(mem.resource);
-			ctx.Define(inst, ResultVector(ctx, dref ? sample : UnpackImageTexel(ctx, mem, sample),
+			ctx.Define(inst, ResultVector(ctx,
+			                              dref ? EmitDepthCompare(sample)
+			                                   : UnpackImageTexel(ctx, mem, sample),
 			                              integer, dref, mem));
 			return true;
 		}
@@ -787,7 +833,9 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		EmitLabel(state, merge_label);
 		state.builder.AddFunction(phi_words);
 		ctx.Define(inst,
-		           ResultVector(ctx, dref ? phi_words[2] : UnpackImageTexel(ctx, mem, phi_words[2]),
+		           ResultVector(ctx,
+		                        dref ? EmitDepthCompare(phi_words[2])
+		                             : UnpackImageTexel(ctx, mem, phi_words[2]),
 		                        integer, dref, mem));
 		return true;
 	}

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
@@ -300,6 +300,7 @@ enum : uint32_t {
 	GlslSqrt            = 31,
 	GlslInverseSqrt     = 32,
 	GlslFMin            = 37,
+	GlslUMin            = 38,
 	GlslFMax            = 40,
 	GlslFClamp          = 43,
 	GlslLdexp           = 53,

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
@@ -25,14 +25,20 @@
 
 namespace Libs::Graphics::ShaderRecompiler::Spirv::Emitter {
 
+inline constexpr uint32_t SpirvVersion15 = 0x00010500u;
+
 enum : uint32_t {
 	ExecutionModelVertex                     = 0,
+	ExecutionModelMeshEXT                    = 5365,
 	ExecutionModelFragment                   = 4,
 	ExecutionModelGLCompute                  = 5,
 	ExecutionModeOriginUpperLeft             = 7,
 	ExecutionModeEarlyFragmentTests          = 9,
 	ExecutionModeDepthReplacing              = 12,
 	ExecutionModeLocalSize                   = 17,
+	ExecutionModeOutputVertices              = 26,
+	ExecutionModeOutputPrimitivesEXT         = 5270,
+	ExecutionModeOutputTrianglesEXT          = 5298,
 	ExecutionModeSignedZeroInfNanPreserve    = 4461,
 	ExecutionModeDerivativeGroupQuadsKHR     = 5289,
 	AddressingModelLogical                   = 0,
@@ -40,12 +46,14 @@ enum : uint32_t {
 	MemoryModelGLSL450                       = 1,
 	CapabilityShader                         = 1,
 	CapabilityInt64                          = 11,
+	CapabilityMeshShadingEXT                 = 5283,
 	CapabilityImageGatherExtended            = 25,
 	CapabilityClipDistance                   = 32,
 	CapabilityCullDistance                   = 33,
 	CapabilitySampled1D                      = 43,
 	CapabilityImage1D                        = 44,
 	CapabilityImageQuery                     = 50,
+	CapabilityShaderLayer                    = 69,
 	CapabilityStorageImageWriteWithoutFormat = 56,
 	CapabilityGroupNonUniform                = 61,
 	CapabilityGroupNonUniformBallot          = 64,
@@ -72,6 +80,7 @@ enum : uint32_t {
 enum : uint32_t {
 	DecorationBlock         = 2,
 	DecorationBuiltIn       = 11,
+	DecorationPerPrimitiveEXT = 5271,
 	DecorationNoPerspective = 13,
 	DecorationFlat          = 14,
 	DecorationLocation      = 30,
@@ -88,6 +97,8 @@ enum : uint32_t {
 	BuiltInClipDistance              = 3,
 	BuiltInCullDistance              = 4,
 	BuiltInLayer                     = 9,
+	BuiltInPrimitiveTriangleIndicesEXT = 5296,
+	BuiltInCullPrimitiveEXT            = 5299,
 	BuiltInFragCoord                 = 15,
 	BuiltInFrontFacing               = 17,
 	BuiltInSampleMask                = 20,
@@ -242,6 +253,7 @@ enum : uint32_t {
 	OpBitReverse                   = 204,
 	OpBitCount                     = 205,
 	OpControlBarrier               = 224,
+	OpSetMeshOutputsEXT            = 5295,
 	OpMemoryBarrier                = 225,
 	OpAtomicLoad                   = 227,
 	OpAtomicExchange               = 229,
@@ -357,6 +369,14 @@ struct EmitterState {
 	const IR::SpirvRequirements& requirements;
 	ShaderType                   stage                   = ShaderType::Unknown;
 	uint32_t                     wave_size               = 64;
+	bool                         logical_wave64          = false;
+	uint32_t                     local_invocation_index_variable = 0;
+	uint32_t                     wave_exchange_variable          = 0;
+	uint32_t                     wave_ballot_variable            = 0;
+	uint32_t                     mesh_vertices_variable          = 0;
+	uint32_t                     mesh_prim_indices_variable      = 0;
+	uint32_t                     mesh_layer_variable             = 0;
+	uint32_t                     mesh_cull_variable              = 0;
 	uint32_t                     storage_buffer_variable = 0;
 	std::array<uint32_t, IR::ShaderInfo::MaxBuffers>      memory_byte_offsets {};
 	uint32_t                                             bda_pagetable_variable = 0;
@@ -367,6 +387,7 @@ struct EmitterState {
 	uint32_t                                             push_constant_variable  = 0;
 	uint32_t                                             vsharp_storage_variable = 0;
 	uint32_t                                             flattened_srt_variable  = 0;
+	uint32_t                                             mesh_index_variable     = 0;
 	uint32_t                                             lds_variable            = 0;
 	uint32_t                                             scratch_variable        = 0;
 	std::array<uint32_t, 2u * SampledImageViewKindCount> sampled_image_variables {};
@@ -734,6 +755,16 @@ uint32_t EmitVertexParameterComponentU32(EmitterState& state, const InputBinding
 uint32_t EmitInputComponentU32(EmitterState& state, IR::StageInputKind kind, uint32_t component);
 
 uint32_t EmitLocalInvocationIndex(EmitterState& state);
+
+inline constexpr uint32_t LogicalWave64Lanes = 64;
+
+void     PrepareLogicalWave64Storage(EmitterState& state);
+uint32_t EmitLogicalLaneId(EmitterState& state);
+uint32_t EmitCurrentLaneId(EmitterState& state);
+void     RejectUnsupportedLogicalWave64(const EmitterState& state, const char* operation);
+uint32_t EmitLogicalBallot(EmitterState& state, uint32_t condition);
+uint32_t EmitLogicalReadLane(EmitterState& state, uint32_t value, uint32_t lane);
+void     EmitLogicalWaveBarrier(EmitterState& state);
 
 uint32_t EmitBallotLaneActiveBool(EmitterState& state, uint32_t ballot, uint32_t lane);
 

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
@@ -1092,10 +1092,23 @@ bool EmitValueMemory(ValueEmitContext& ctx, const IR::Inst& inst) {
 			ctx.Fail(inst, "requires the mesh index descriptor");
 			return true;
 		}
+		auto        index = ctx.Arg(inst, 0);
+		const auto* mesh  = state.input_info.vertex;
+		if (mesh != nullptr) {
+			const uint64_t total = static_cast<uint64_t>(mesh->mesh_last_group_index) *
+			                           mesh->mesh_vertices_per_workgroup +
+			                       mesh->mesh_last_vertices;
+			if (total > 0) {
+				const auto clamped = state.builder.AllocateId();
+				state.builder.AddFunction(
+				    {OpExtInst, TypeU32(state), clamped, GlslStd450(state), GlslUMin, index,
+				     ConstantU32(state, static_cast<uint32_t>(total - 1))});
+				index = clamped;
+			}
+		}
 		const auto pointer = state.builder.AllocateId();
 		state.builder.AddFunction({OpAccessChain, TypeStorageBufferElementPointer(state), pointer,
-		                           state.mesh_index_variable, ConstantU32(state, 0),
-		                           ctx.Arg(inst, 0)});
+		                           state.mesh_index_variable, ConstantU32(state, 0), index});
 		ctx.Emit(inst, OpLoad, IR::Type::U32, {pointer});
 		return true;
 	}

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
@@ -1087,6 +1087,18 @@ bool EmitValueMemory(ValueEmitContext& ctx, const IR::Inst& inst) {
 	    ctx.Memory(inst).planning_only) {
 		return true;
 	}
+	if (op == IR::ValueOpcode::ReadMeshIndex) {
+		if (state.mesh_index_variable == 0) {
+			ctx.Fail(inst, "requires the mesh index descriptor");
+			return true;
+		}
+		const auto pointer = state.builder.AllocateId();
+		state.builder.AddFunction({OpAccessChain, TypeStorageBufferElementPointer(state), pointer,
+		                           state.mesh_index_variable, ConstantU32(state, 0),
+		                           ctx.Arg(inst, 0)});
+		ctx.Emit(inst, OpLoad, IR::Type::U32, {pointer});
+		return true;
+	}
 	if (op == IR::ValueOpcode::ReadConst) {
 		if (state.flattened_srt_variable == 0) {
 			ctx.Fail(inst, "requires the flattened SRT descriptor");

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemoryHelpers.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemoryHelpers.cpp
@@ -64,14 +64,20 @@ void EmitMemoryOffsets(EmitterState& state) {
 }
 
 uint32_t LdsDwordCount(const EmitterState& state) {
-	return state.stage == ShaderType::Compute ? state.input_info.compute->lds_size_dwords : 8192u;
+	if (state.stage == ShaderType::Compute) {
+		return state.input_info.compute->lds_size_dwords;
+	}
+	if (state.stage == ShaderType::Mesh) {
+		return state.input_info.vertex->mesh_lds_size_dwords;
+	}
+	return 8192u;
 }
 
 static void EnsureLdsStorage(EmitterState& state) {
 	if (state.lds_variable != 0) {
 		return;
 	}
-	if (state.stage != ShaderType::Compute) {
+	if (state.stage != ShaderType::Compute && state.stage != ShaderType::Mesh) {
 		EXIT("function LDS was not prepared before SPIR-V function emission\n");
 	}
 	state.lds_variable = state.builder.DefineGlobalVariable(
@@ -153,9 +159,11 @@ uint32_t EmitMemoryElementPointer(EmitterState& state, const MemoryResourceAcces
                                   uint32_t index) {
 	const auto pointer = state.builder.AllocateId();
 	if (access.kind == IR::ResourceKind::Lds || access.kind == IR::ResourceKind::Scratch) {
+		const auto shared_lds =
+		    state.stage == ShaderType::Compute || state.stage == ShaderType::Mesh;
 		const auto storage_class = access.kind == IR::ResourceKind::Scratch ? StorageClassFunction
-		                           : state.stage == ShaderType::Compute     ? StorageClassWorkgroup
-		                                                                    : StorageClassFunction;
+		                           : shared_lds                            ? StorageClassWorkgroup
+		                                                                   : StorageClassFunction;
 		state.builder.AddFunction({OpAccessChain, TypeU32ElementPointer(state, storage_class),
 		                           pointer, access.object_pointer, index});
 	} else {

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterModule.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterModule.cpp
@@ -187,6 +187,10 @@ void DefineDescriptorVariables(EmitterState& state) {
 		state.flattened_srt_variable = state.builder.DefineGlobalVariable(
 		    TypeStorageBufferPointer(state), StorageClassStorageBuffer);
 	}
+	if (DescriptorBinding(state, IR::DescriptorBindingKind::MeshIndices) != nullptr) {
+		state.mesh_index_variable = state.builder.DefineGlobalVariable(
+		    TypeStorageBufferPointer(state), StorageClassStorageBuffer);
+	}
 	for (uint32_t i = 0; i < state.sampled_image_variables.size(); i++) {
 		const auto view    = static_cast<ImageViewKind>(i % SampledImageViewKindCount);
 		const bool integer = i >= SampledImageViewKindCount;
@@ -424,6 +428,11 @@ void AllocateInputVariables(EmitterState& state) {
 		state.subgroup_local_invocation_id_variable = state.builder.AllocateId();
 		state.interface_variables.push_back(state.subgroup_local_invocation_id_variable);
 	}
+	if (state.logical_wave64 &&
+	    InputVariableForKind(state, IR::StageInputKind::LocalInvocationIndex) == 0) {
+		state.local_invocation_index_variable = state.builder.AllocateId();
+		state.interface_variables.push_back(state.local_invocation_index_variable);
+	}
 }
 
 static uint32_t AllocateInterfaceVariable(EmitterState& state) {
@@ -461,6 +470,9 @@ void AllocateOutputVariables(EmitterState& state) {
 				state.cull_distance_count = std::max(state.cull_distance_count, binding.index + 1);
 				break;
 			case IR::StageOutputKind::Layer:
+				if (state.stage == ShaderType::Mesh) {
+					break;
+				}
 				binding.variable_id = AllocateSharedOutputVariable(state, state.layer_variable);
 				break;
 			case IR::StageOutputKind::Depth:
@@ -476,6 +488,20 @@ void AllocateOutputVariables(EmitterState& state) {
 				break;
 		}
 	}
+	if (state.stage == ShaderType::Mesh) {
+		state.mesh_prim_indices_variable = AllocateInterfaceVariable(state);
+		state.mesh_layer_variable = AllocateInterfaceVariable(state);
+		state.mesh_cull_variable  = AllocateInterfaceVariable(state);
+		AllocateSharedOutputVariable(state, state.per_vertex_variable);
+	}
+}
+
+uint32_t MeshOutputVertices(const EmitterState& state) {
+	return std::max(state.input_info.vertex->mesh_output_vertices, 1u);
+}
+
+uint32_t MeshOutputPrimitives(const EmitterState& state) {
+	return std::max(state.input_info.vertex->mesh_output_primitives, 1u);
 }
 
 uint32_t BuiltInForInput(IR::StageInputKind kind) {
@@ -534,6 +560,21 @@ void AddInputAnnotationsAndNames(EmitterState& state) {
 }
 
 void AddOutputAnnotationsAndNames(EmitterState& state) {
+	if (state.mesh_prim_indices_variable != 0) {
+		state.builder.AddName(state.mesh_prim_indices_variable, "gl_PrimitiveTriangleIndicesEXT");
+		state.builder.AddAnnotation({OpDecorate, state.mesh_prim_indices_variable,
+		                             DecorationBuiltIn, BuiltInPrimitiveTriangleIndicesEXT});
+		state.builder.AddName(state.mesh_layer_variable, "gl_Layer");
+		state.builder.AddAnnotation(
+		    {OpDecorate, state.mesh_layer_variable, DecorationBuiltIn, BuiltInLayer});
+		state.builder.AddAnnotation(
+		    {OpDecorate, state.mesh_layer_variable, DecorationPerPrimitiveEXT});
+		state.builder.AddName(state.mesh_cull_variable, "gl_CullPrimitiveEXT");
+		state.builder.AddAnnotation(
+		    {OpDecorate, state.mesh_cull_variable, DecorationBuiltIn, BuiltInCullPrimitiveEXT});
+		state.builder.AddAnnotation(
+		    {OpDecorate, state.mesh_cull_variable, DecorationPerPrimitiveEXT});
+	}
 	if (state.per_vertex_variable != 0) {
 		state.builder.AddName(PerVertexType(state), "gl_PerVertex");
 		state.builder.AddName(state.per_vertex_variable, "outPerVertex");
@@ -640,6 +681,10 @@ void AddDescriptorAnnotationsAndNames(EmitterState& state) {
 	if (state.gds_variable != 0) {
 		Decorate(state.gds_variable, "gds", IR::DescriptorBindingKind::Gds);
 	}
+	if (state.mesh_index_variable != 0) {
+		Decorate(state.mesh_index_variable, "mesh_indices",
+		         IR::DescriptorBindingKind::MeshIndices);
+	}
 	if (state.flattened_srt_variable != 0) {
 		Decorate(state.flattened_srt_variable, "flattened_srt",
 		         IR::DescriptorBindingKind::FlattenedSrt);
@@ -712,6 +757,12 @@ void DefineModule(EmitterState& state) {
 		state.builder.RequireCapability(CapabilityFragmentBarycentricKHR);
 		state.builder.RequireExtension("SPV_KHR_fragment_shader_barycentric");
 	}
+	if (state.stage == ShaderType::Mesh) {
+		state.builder.RequireVersion(SpirvVersion15);
+		state.builder.RequireCapability(CapabilityMeshShadingEXT);
+		state.builder.RequireCapability(CapabilityShaderLayer);
+		state.builder.RequireExtension("SPV_EXT_mesh_shader");
+	}
 	state.builder.RequireExtension("SPV_KHR_float_controls");
 	state.builder.AddMemoryModel(
 	    {state.program.info.uses_dma ? AddressingModelPhysicalStorageBuffer64
@@ -732,6 +783,15 @@ void DefineModule(EmitterState& state) {
 		local_z             = cs->threads_num[2] != 0u ? cs->threads_num[2] : local_z;
 		state.builder.AddExecutionMode(
 		    {state.main_func, ExecutionModeLocalSize, local_x, local_y, local_z});
+	}
+	if (state.stage == ShaderType::Mesh) {
+		state.builder.AddExecutionMode(
+		    {state.main_func, ExecutionModeLocalSize, state.wave_size, 1u, 1u});
+		state.builder.AddExecutionMode(
+		    {state.main_func, ExecutionModeOutputVertices, MeshOutputVertices(state)});
+		state.builder.AddExecutionMode(
+		    {state.main_func, ExecutionModeOutputPrimitivesEXT, MeshOutputPrimitives(state)});
+		state.builder.AddExecutionMode({state.main_func, ExecutionModeOutputTrianglesEXT});
 	}
 	if (state.stage == ShaderType::Pixel) {
 		state.builder.AddExecutionMode({state.main_func, ExecutionModeOriginUpperLeft});
@@ -804,9 +864,29 @@ void DefineModule(EmitterState& state) {
 		state.builder.DefineGlobalVariable(input.variable_id, ptr_type, StorageClassInput);
 	}
 	if (state.per_vertex_variable != 0) {
-		state.builder.DefineGlobalVariable(
-		    state.per_vertex_variable, TypePointer(state, StorageClassOutput, PerVertexType(state)),
-		    StorageClassOutput);
+		const auto per_vertex =
+		    state.stage == ShaderType::Mesh
+		        ? state.builder.Type(OpTypeArray, {PerVertexType(state),
+		                                           ConstantU32(state, MeshOutputVertices(state))})
+		        : PerVertexType(state);
+		state.builder.DefineGlobalVariable(state.per_vertex_variable,
+		                                   TypePointer(state, StorageClassOutput, per_vertex),
+		                                   StorageClassOutput);
+	}
+	if (state.mesh_prim_indices_variable != 0) {
+		const auto count   = ConstantU32(state, MeshOutputPrimitives(state));
+		const auto indices = state.builder.Type(OpTypeArray, {TypeU32Vector(state, 3), count});
+		state.builder.DefineGlobalVariable(state.mesh_prim_indices_variable,
+		                                   TypePointer(state, StorageClassOutput, indices),
+		                                   StorageClassOutput);
+		const auto layers = state.builder.Type(OpTypeArray, {TypeI32(state), count});
+		state.builder.DefineGlobalVariable(state.mesh_layer_variable,
+		                                   TypePointer(state, StorageClassOutput, layers),
+		                                   StorageClassOutput);
+		const auto culls = state.builder.Type(OpTypeArray, {TypeBool(state), count});
+		state.builder.DefineGlobalVariable(state.mesh_cull_variable,
+		                                   TypePointer(state, StorageClassOutput, culls),
+		                                   StorageClassOutput);
 	}
 	if (state.point_size_variable != 0) {
 		state.builder.DefineGlobalVariable(
@@ -835,12 +915,18 @@ void DefineModule(EmitterState& state) {
 	for (const auto& binding: state.outputs) {
 		if (binding.kind == IR::StageOutputKind::Parameter ||
 		    binding.kind == IR::StageOutputKind::Mrt) {
-			const auto pointer_type =
+			auto value_type =
 			    binding.kind == IR::StageOutputKind::Mrt && MrtUsesUintOutput(state, binding.index)
-			        ? TypePointer(state, StorageClassOutput, TypeU32Vector(state, 4))
-			        : TypePointer(state, StorageClassOutput, TypeF32Vector(state, 4));
-			state.builder.DefineGlobalVariable(binding.variable_id, pointer_type,
-			                                   StorageClassOutput);
+			        ? TypeU32Vector(state, 4)
+			        : TypeF32Vector(state, 4);
+			if (state.stage == ShaderType::Mesh &&
+			    binding.kind == IR::StageOutputKind::Parameter) {
+				value_type = state.builder.Type(
+				    OpTypeArray, {value_type, ConstantU32(state, MeshOutputVertices(state))});
+			}
+			state.builder.DefineGlobalVariable(
+			    binding.variable_id, TypePointer(state, StorageClassOutput, value_type),
+			    StorageClassOutput);
 		}
 	}
 	if (state.depth_variable != 0) {

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterWave64.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterWave64.cpp
@@ -1,0 +1,156 @@
+#include "graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h"
+
+
+namespace Libs::Graphics::ShaderRecompiler::Spirv::Emitter {
+
+namespace {
+
+uint32_t Binary(EmitterState& state, uint32_t opcode, uint32_t type, uint32_t lhs, uint32_t rhs) {
+	const auto id = state.builder.AllocateId();
+	state.builder.AddFunction({opcode, type, id, lhs, rhs});
+	return id;
+}
+
+uint32_t Select(EmitterState& state, uint32_t type, uint32_t condition, uint32_t when_true,
+                uint32_t when_false) {
+	const auto id = state.builder.AllocateId();
+	state.builder.AddFunction({OpSelect, type, id, condition, when_true, when_false});
+	return id;
+}
+
+} // namespace
+
+void PrepareLogicalWave64Storage(EmitterState& state) {
+	if (!state.logical_wave64 || state.wave_exchange_variable != 0) {
+		return;
+	}
+	state.wave_exchange_variable = state.builder.DefineGlobalVariable(
+	    TypeU32ArrayPointer(state, StorageClassWorkgroup, LogicalWave64Lanes),
+	    StorageClassWorkgroup);
+	state.builder.AddName(state.wave_exchange_variable, "wave_exchange");
+
+	state.wave_ballot_variable = state.builder.DefineGlobalVariable(
+	    TypeU32ArrayPointer(state, StorageClassWorkgroup, 2), StorageClassWorkgroup);
+	state.builder.AddName(state.wave_ballot_variable, "wave_ballot");
+}
+
+void EmitLogicalWaveBarrier(EmitterState& state) {
+	const auto semantics = MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
+	state.builder.AddFunction({OpControlBarrier, ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, semantics)});
+}
+
+void RejectUnsupportedLogicalWave64(const EmitterState& state, const char* operation) {
+	if (!state.logical_wave64) {
+		return;
+	}
+	EXIT("logical wave64: %s is not lowered for a 64-lane workgroup (shader hash=0x%016" PRIx64
+	     "). It would resolve against one 32-lane host subgroup and silently return a wrong "
+	     "result.\n",
+	     operation, state.program.shader_hash);
+}
+
+uint32_t EmitCurrentLaneId(EmitterState& state) {
+	return state.logical_wave64 ? EmitLogicalLaneId(state) : EmitSubgroupLocalInvocationId(state);
+}
+
+uint32_t EmitLogicalLaneId(EmitterState& state) {
+	if (state.local_invocation_index_variable == 0) {
+		if (InputVariableForKind(state, IR::StageInputKind::LocalInvocationIndex) != 0) {
+			return EmitLocalInvocationIndex(state);
+		}
+		EXIT("LocalInvocationIndex was not declared before SPIR-V function emission\n");
+	}
+	const auto value = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpLoad, TypeU32(state), value, state.local_invocation_index_variable});
+	return value;
+}
+
+static uint32_t ExchangeSlot(EmitterState& state, uint32_t index) {
+	const auto pointer = state.builder.AllocateId();
+	state.builder.AddFunction({OpAccessChain,
+	                           TypeU32ElementPointer(state, StorageClassWorkgroup), pointer,
+	                           state.wave_exchange_variable, index});
+	return pointer;
+}
+
+static uint32_t BallotSlot(EmitterState& state, uint32_t index) {
+	const auto pointer = state.builder.AllocateId();
+	state.builder.AddFunction({OpAccessChain, TypeU32ElementPointer(state, StorageClassWorkgroup),
+	                           pointer, state.wave_ballot_variable, index});
+	return pointer;
+}
+
+uint32_t EmitLogicalBallot(EmitterState& state, uint32_t condition) {
+	PrepareLogicalWave64Storage(state);
+
+	const auto lane = EmitLogicalLaneId(state);
+
+	const auto is_first =
+	    Binary(state, OpIEqual, TypeBool(state), lane, ConstantU32(state, 0));
+	const auto clear_label = state.builder.AllocateId();
+	const auto merge_label = state.builder.AllocateId();
+	state.builder.AddFunction({OpSelectionMerge, merge_label, SelectionControlNone});
+	state.builder.AddFunction({OpBranchConditional, is_first, clear_label, merge_label});
+	EmitLabel(state, clear_label);
+	state.builder.AddFunction({OpStore, BallotSlot(state, ConstantU32(state, 0)),
+	                           ConstantU32(state, 0)});
+	state.builder.AddFunction({OpStore, BallotSlot(state, ConstantU32(state, 1)),
+	                           ConstantU32(state, 0)});
+	state.builder.AddFunction({OpBranch, merge_label});
+	EmitLabel(state, merge_label);
+
+	EmitLogicalWaveBarrier(state);
+
+	const auto half = Binary(state, OpShiftRightLogical, TypeU32(state), lane,
+	                         ConstantU32(state, 5));
+	const auto bit_index =
+	    Binary(state, OpBitwiseAnd, TypeU32(state), lane, ConstantU32(state, 31));
+	const auto bit = Binary(state, OpShiftLeftLogical, TypeU32(state), ConstantU32(state, 1),
+	                        bit_index);
+	const auto contribution = Select(state, TypeU32(state), condition, bit,
+	                                 ConstantU32(state, 0));
+
+	const auto atomic_semantics = MemorySemanticsAcquireRelease | MemorySemanticsWorkgroupMemory;
+	const auto discard          = state.builder.AllocateId();
+	state.builder.AddFunction({OpAtomicOr, TypeU32(state), discard, BallotSlot(state, half),
+	                           ConstantU32(state, ScopeWorkgroup),
+	                           ConstantU32(state, atomic_semantics), contribution});
+
+	EmitLogicalWaveBarrier(state);
+
+	const auto low  = state.builder.AllocateId();
+	const auto high = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpLoad, TypeU32(state), low, BallotSlot(state, ConstantU32(state, 0))});
+	state.builder.AddFunction(
+	    {OpLoad, TypeU32(state), high, BallotSlot(state, ConstantU32(state, 1))});
+
+	EmitLogicalWaveBarrier(state);
+
+	const auto result = state.builder.AllocateId();
+	state.builder.AddFunction({OpCompositeConstruct, TypeU32Vector(state, 4), result, low, high,
+	                           ConstantU32(state, 0), ConstantU32(state, 0)});
+	return result;
+}
+
+uint32_t EmitLogicalReadLane(EmitterState& state, uint32_t value, uint32_t lane) {
+	PrepareLogicalWave64Storage(state);
+
+	const auto self = EmitLogicalLaneId(state);
+	state.builder.AddFunction({OpStore, ExchangeSlot(state, self), value});
+
+	EmitLogicalWaveBarrier(state);
+
+	const auto index = Binary(state, OpBitwiseAnd, TypeU32(state), lane,
+	                          ConstantU32(state, LogicalWave64Lanes - 1));
+	const auto result = state.builder.AllocateId();
+	state.builder.AddFunction({OpLoad, TypeU32(state), result, ExchangeSlot(state, index)});
+
+	EmitLogicalWaveBarrier(state);
+	return result;
+}
+
+} // namespace Libs::Graphics::ShaderRecompiler::Spirv::Emitter

--- a/src/graphics/shader/recompiler/frontend/decode/MemoryOps.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/MemoryOps.cpp
@@ -211,7 +211,129 @@ bool IsFlatStoreOpcode(Opcode opcode) {
 	}
 }
 
+bool IsDsNonReturningAtomicOpcode(Opcode opcode) {
+	switch (opcode) {
+		case Opcode::DS_ADD_U32:
+		case Opcode::DS_SUB_U32:
+		case Opcode::DS_MIN_I32:
+		case Opcode::DS_MAX_I32:
+		case Opcode::DS_MIN_U32:
+		case Opcode::DS_MAX_U32:
+		case Opcode::DS_AND_B32:
+		case Opcode::DS_OR_B32:
+		case Opcode::DS_XOR_B32:
+		case Opcode::DS_MIN_F32:
+		case Opcode::DS_MAX_F32: return true;
+		default: return false;
+	}
+}
+
+bool IsBufferStoreOpcode(Opcode opcode) {
+	switch (opcode) {
+		case Opcode::BUFFER_STORE_FORMAT_X:
+		case Opcode::BUFFER_STORE_FORMAT_XY:
+		case Opcode::BUFFER_STORE_FORMAT_XYZ:
+		case Opcode::BUFFER_STORE_FORMAT_XYZW:
+		case Opcode::BUFFER_STORE_BYTE:
+		case Opcode::BUFFER_STORE_SHORT:
+		case Opcode::BUFFER_STORE_DWORD:
+		case Opcode::BUFFER_STORE_DWORDX2:
+		case Opcode::BUFFER_STORE_DWORDX3:
+		case Opcode::BUFFER_STORE_DWORDX4:
+		case Opcode::TBUFFER_STORE_FORMAT_X:
+		case Opcode::TBUFFER_STORE_FORMAT_XY:
+		case Opcode::TBUFFER_STORE_FORMAT_XYZ:
+		case Opcode::TBUFFER_STORE_FORMAT_XYZW: return true;
+		default: return false;
+	}
+}
+
+bool IsBufferAtomicOpcode(Opcode opcode) {
+	switch (opcode) {
+		case Opcode::BUFFER_ATOMIC_SWAP:
+		case Opcode::BUFFER_ATOMIC_ADD:
+		case Opcode::BUFFER_ATOMIC_SUB:
+		case Opcode::BUFFER_ATOMIC_SMIN:
+		case Opcode::BUFFER_ATOMIC_UMIN:
+		case Opcode::BUFFER_ATOMIC_SMAX:
+		case Opcode::BUFFER_ATOMIC_UMAX:
+		case Opcode::BUFFER_ATOMIC_AND:
+		case Opcode::BUFFER_ATOMIC_OR:
+		case Opcode::BUFFER_ATOMIC_XOR:
+		case Opcode::BUFFER_ATOMIC_FMIN:
+		case Opcode::BUFFER_ATOMIC_FMAX: return true;
+		default: return false;
+	}
+}
+
+bool IsImageAtomicOpcode(Opcode opcode) {
+	switch (opcode) {
+		case Opcode::IMAGE_ATOMIC_ADD:
+		case Opcode::IMAGE_ATOMIC_UMIN:
+		case Opcode::IMAGE_ATOMIC_UMAX:
+		case Opcode::IMAGE_ATOMIC_AND:
+		case Opcode::IMAGE_ATOMIC_OR:
+		case Opcode::IMAGE_ATOMIC_XOR: return true;
+		default: return false;
+	}
+}
+
 } // namespace
+
+bool InstructionWritesDestination(const Instruction& inst) {
+	switch (inst.family) {
+		case Family::DS:
+			return !IsDsWriteOpcode(inst.opcode) && !IsDsNonReturningAtomicOpcode(inst.opcode);
+		case Family::MUBUF:
+		case Family::MTBUF:
+			return !IsBufferStoreOpcode(inst.opcode) &&
+			       (!IsBufferAtomicOpcode(inst.opcode) || inst.glc);
+		case Family::FLAT: return !IsFlatStoreOpcode(inst.opcode);
+		case Family::MIMG:
+			return inst.opcode != Opcode::IMAGE_STORE && inst.opcode != Opcode::IMAGE_STORE_MIP &&
+			       (!IsImageAtomicOpcode(inst.opcode) || inst.glc);
+		default: return true;
+	}
+}
+
+uint32_t InstructionSourceRegisterCount(const Instruction& inst, uint32_t index) {
+	switch (inst.family) {
+		case Family::SMEM:
+			if (index != 0) {
+				return 1;
+			}
+			switch (inst.opcode) {
+				case Opcode::S_BUFFER_LOAD_DWORD:
+				case Opcode::S_BUFFER_LOAD_DWORDX2:
+				case Opcode::S_BUFFER_LOAD_DWORDX4:
+				case Opcode::S_BUFFER_LOAD_DWORDX8:
+				case Opcode::S_BUFFER_LOAD_DWORDX16: return 4;
+				default: return 2;
+			}
+		case Family::MUBUF:
+		case Family::MTBUF:
+			return index == 1 ? 4u : 1u;
+		case Family::MIMG:
+			if (index == 1) {
+				return inst.image_r128 ? 4u : 8u;
+			}
+			return index == 2 ? 4u : 1u;
+		default: return 1;
+	}
+}
+
+bool InstructionReadsDestination(const Instruction& inst) {
+	switch (inst.family) {
+		case Family::MUBUF:
+		case Family::MTBUF:
+			return IsBufferStoreOpcode(inst.opcode) || IsBufferAtomicOpcode(inst.opcode);
+		case Family::FLAT: return IsFlatStoreOpcode(inst.opcode);
+		case Family::MIMG:
+			return inst.opcode == Opcode::IMAGE_STORE || inst.opcode == Opcode::IMAGE_STORE_MIP ||
+			       IsImageAtomicOpcode(inst.opcode);
+		default: return false;
+	}
+}
 
 void DecodeSmem(uint32_t pc, std::span<const uint32_t> code, uint32_t word_index,
                 Instruction& inst) {

--- a/src/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp
@@ -39,6 +39,7 @@ constexpr OpcodeMap SOP1_OPCODE_LIST[] = {
     {0x04u, Opcode::S_MOV_B64},
     {0x07u, Opcode::S_NOT_B32},
     {0x08u, Opcode::S_NOT_B64},
+    {0x09u, Opcode::S_WQM_B32},
     {0x0au, Opcode::S_WQM_B64},
     {0x0bu, Opcode::S_BREV_B32},
     {0x0fu, Opcode::S_BCNT1_I32_B32},
@@ -199,9 +200,14 @@ bool DecodeSopk(uint32_t pc, std::span<const uint32_t> code, uint32_t word_index
 	inst.family          = Family::SOPK;
 	inst.opcode_id       = opcode;
 	inst.opcode          = Detail::LookupOpcode(SOPK_OPS, opcode);
+	// The unsigned SOPK compares zero-extend SIMM16; only the signed forms sign-extend it.
+	const bool zero_extended =
+	    inst.opcode == Opcode::S_CMP_EQ_U32 || inst.opcode == Opcode::S_CMP_LG_U32 ||
+	    inst.opcode == Opcode::S_CMP_GT_U32 || inst.opcode == Opcode::S_CMP_GE_U32 ||
+	    inst.opcode == Opcode::S_CMP_LT_U32 || inst.opcode == Opcode::S_CMP_LE_U32;
 	inst.src0.kind       = OperandKind::IntegerInlineConstant;
-	inst.src0.signed_val = imm;
-	inst.src0.value      = static_cast<uint32_t>(imm);
+	inst.src0.signed_val = zero_extended ? static_cast<int32_t>(word & 0xffffu) : imm;
+	inst.src0.value      = zero_extended ? (word & 0xffffu) : static_cast<uint32_t>(imm);
 	inst.src_count       = 1;
 	SetRawWords(inst, code, word_index, 1);
 

--- a/src/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp
@@ -37,6 +37,8 @@ constexpr OpcodeMap SOP2_OPCODE_LIST[] = {
 constexpr OpcodeMap SOP1_OPCODE_LIST[] = {
     {0x03u, Opcode::S_MOV_B32},
     {0x04u, Opcode::S_MOV_B64},
+    {0x05u, Opcode::S_CMOV_B32},
+    {0x06u, Opcode::S_CMOV_B64},
     {0x07u, Opcode::S_NOT_B32},
     {0x08u, Opcode::S_NOT_B64},
     {0x09u, Opcode::S_WQM_B32},

--- a/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.cpp
@@ -504,6 +504,7 @@ std::string InstructionToString(const Instruction& inst) {
 		case Opcode::S_FF1_I32_B32:
 		case Opcode::S_FF1_I32_B64:
 		case Opcode::S_NOT_B64:
+		case Opcode::S_WQM_B32:
 		case Opcode::S_WQM_B64:
 		case Opcode::S_QUADMASK_B64:
 		case Opcode::S_AND_SAVEEXEC_B32:

--- a/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.cpp
@@ -494,6 +494,8 @@ std::string InstructionToString(const Instruction& inst) {
 	switch (inst.opcode) {
 		case Opcode::S_MOV_B32:
 		case Opcode::S_MOV_B64:
+		case Opcode::S_CMOV_B32:
+		case Opcode::S_CMOV_B64:
 			return WithUnsupportedReason(inst, fmt::format("0x{:08x}: {} {}, {}", inst.pc,
 			                                               magic_enum::enum_name(inst.opcode),
 			                                               OperandToString(inst.dst).c_str(),

--- a/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.h
+++ b/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.h
@@ -57,6 +57,7 @@ enum class Opcode {
 	S_ANDN1_SAVEEXEC_B64,
 	S_NOT_B32,
 	S_NOT_B64,
+	S_WQM_B32,
 	S_WQM_B64,
 	S_ADD_U32,
 	S_ADDC_U32,
@@ -698,6 +699,10 @@ Family GetInstructionFamily(uint32_t word);
 bool DecodeInstruction(std::span<const uint32_t> code, uint32_t word_index, Instruction& inst,
                        std::string* error);
 bool DecodeProgram(std::span<const uint32_t> code, Program& program, std::string* error);
+
+bool InstructionWritesDestination(const Instruction& inst);
+uint32_t InstructionSourceRegisterCount(const Instruction& inst, uint32_t index);
+bool InstructionReadsDestination(const Instruction& inst);
 
 bool DecodeScalarSource(uint32_t code, uint32_t pc, Operand& operand, std::string* error);
 bool DecodeScalarDestination(uint32_t code, uint32_t pc, Operand& operand, std::string* error);

--- a/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.h
+++ b/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.h
@@ -38,6 +38,8 @@ enum class Opcode {
 
 	S_MOV_B32,
 	S_MOV_B64,
+	S_CMOV_B32,
+	S_CMOV_B64,
 	S_MOVK_I32,
 	S_ABS_I32,
 	S_BREV_B32,

--- a/src/graphics/shader/recompiler/frontend/decode/VectorAluOps.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/VectorAluOps.cpp
@@ -1267,6 +1267,8 @@ uint32_t NativeVop3SourceCount(Opcode opcode) {
 		case Opcode::V_LDEXP_F32:
 		case Opcode::V_BFM_B32:
 		case Opcode::V_BCNT_U32_B32:
+		case Opcode::V_MBCNT_LO_U32_B32:
+		case Opcode::V_MBCNT_HI_U32_B32:
 		case Opcode::V_CVT_PKNORM_I16_F32:
 		case Opcode::V_CVT_PKNORM_U16_F32:
 		case Opcode::V_CVT_PK_U16_U32:

--- a/src/graphics/shader/recompiler/frontend/translate/Control.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Control.cpp
@@ -179,7 +179,16 @@ void Translator::S_BARRIER() {
 	ir.Emit(IR::ValueOpcode::Barrier);
 }
 
-void Translator::S_SENDMSG() {
+void Translator::S_SENDMSG(const Decoder::Instruction& inst) {
+	// Only the allocation request reaches the mesh output; the other messages address hardware
+	// the mesh stage does not have, so emitting them would export a primitive that is not there.
+	constexpr uint32_t GsAllocReq = 9;
+	const auto&        message    = inst.src0;
+	const bool         immediate  = message.kind == Decoder::OperandKind::LiteralConstant ||
+	                        message.kind == Decoder::OperandKind::IntegerInlineConstant;
+	if (immediate && (message.value & 0xfu) != GsAllocReq) {
+		return;
+	}
 	ir.Emit(IR::ValueOpcode::Sendmsg, {ir.GetM0()});
 }
 

--- a/src/graphics/shader/recompiler/frontend/translate/Control.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Control.cpp
@@ -229,19 +229,37 @@ bool Translator::S_GETPC_B64(const Decoder::Instruction& inst, std::string* erro
 }
 
 void Translator::S_CSELECT_B32(const Decoder::Instruction& inst) {
-	const auto result = ir.Select(ir.GetScc(), ReadU32(inst.src0), ReadU32(inst.src1));
-	WriteOperand(DestinationOperand(inst), result);
+	SelectOn32(inst, inst.src1);
 }
 
 void Translator::S_CSELECT_B64(const Decoder::Instruction& inst) {
+	SelectOn64(inst, inst.src1);
+}
+
+// S_CMOV leaves the destination untouched when SCC is clear, so it is the same select with the
+// destination itself standing in as the false operand.
+void Translator::S_CMOV_B32(const Decoder::Instruction& inst) {
+	SelectOn32(inst, inst.dst);
+}
+
+void Translator::S_CMOV_B64(const Decoder::Instruction& inst) {
+	SelectOn64(inst, inst.dst);
+}
+
+void Translator::SelectOn32(const Decoder::Instruction& inst, const Decoder::Operand& if_false) {
+	const auto result = ir.Select(ir.GetScc(), ReadU32(inst.src0), ReadU32(if_false));
+	WriteOperand(DestinationOperand(inst), result);
+}
+
+void Translator::SelectOn64(const Decoder::Instruction& inst, const Decoder::Operand& if_false) {
 	const auto condition     = ir.GetScc();
 	const auto lhs           = ReadU32Pair(inst.src0);
-	const auto rhs           = ReadU32Pair(inst.src1);
+	const auto rhs           = ReadU32Pair(if_false);
 	const auto selected_mask = IR::U1(
-	    ir.Emit(IR::ValueOpcode::SelectU1, {condition, ReadMask(inst.src0), ReadMask(inst.src1)}));
+	    ir.Emit(IR::ValueOpcode::SelectU1, {condition, ReadMask(inst.src0), ReadMask(if_false)}));
 	const auto selected_mask_valid =
 	    IR::U1(ir.Emit(IR::ValueOpcode::SelectU1,
-	                   {condition, ReadMaskValid(inst.src0), ReadMaskValid(inst.src1)}));
+	                   {condition, ReadMaskValid(inst.src0), ReadMaskValid(if_false)}));
 	if (IsExecOrVcc(inst.dst)) {
 		WriteMask64(inst.dst, selected_mask);
 		return;

--- a/src/graphics/shader/recompiler/frontend/translate/Control.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Control.cpp
@@ -13,6 +13,16 @@ bool IsExecOrVcc(const Decoder::Operand& operand) {
 	}
 }
 
+// A 32-bit move only names the whole lane mask through its low half; naming the high half is a
+// plain raw copy, so it must not be widened into a mask move.
+bool IsExecOrVccLo(const Decoder::Operand& operand) {
+	switch (operand.kind) {
+		case Decoder::OperandKind::ExecLo:
+		case Decoder::OperandKind::VccLo: return true;
+		default: return false;
+	}
+}
+
 Decoder::Operand ConditionOperand(Decoder::OperandKind kind) {
 	Decoder::Operand operand;
 	operand.kind = kind;
@@ -23,6 +33,34 @@ Decoder::Operand ConditionOperand(Decoder::OperandKind kind) {
 
 void Translator::S_SAVEEXEC(const Decoder::Instruction& inst, IR::ValueOpcode operation,
                             bool negate_exec, bool negate_source, bool write_64) {
+	if (current_logical_wave64) {
+		// The logical wave is wider than the host subgroup, so the mask lives in the raw
+		// EXEC halves rather than in a per-invocation bit.
+		const auto old_low  = ir.GetExecLo();
+		const auto old_high = ir.GetExecHi();
+		const auto src_low  = ReadRawU32(inst.src0);
+		const auto src_high =
+		    write_64 ? ReadRawU32(OffsetOperand(inst.src0, 1)) : IR::U32(IR::Value(0u));
+		const auto apply = [&](IR::U32 old_value, IR::U32 src_value) {
+			const auto lhs = negate_exec ? ir.BitwiseNot(old_value) : old_value;
+			const auto rhs = negate_source ? ir.BitwiseNot(src_value) : src_value;
+			return operation == IR::ValueOpcode::LogicalOr ? ir.BitwiseOr(lhs, rhs)
+			                                               : ir.BitwiseAnd(lhs, rhs);
+		};
+		const auto result_low  = apply(old_low, src_low);
+		const auto result_high = write_64 ? apply(old_high, src_high) : old_high;
+		if (write_64) {
+			WriteU32Pair(inst.dst, {old_low, old_high});
+		} else {
+			WriteOperand(inst.dst, old_low);
+		}
+		ir.SetExecLo(result_low);
+		ir.SetExecHi(result_high);
+		ir.SetExec(ThreadBit(result_low, result_high));
+		const auto nonzero = write_64 ? ir.BitwiseOr(result_low, result_high) : result_low;
+		ir.SetScc(ir.INotEqual(nonzero, IR::U32(IR::Value(0u))));
+		return;
+	}
 	const auto old    = ir.GetExec();
 	const auto src    = ReadMask(inst.src0);
 	const auto lhs    = negate_exec ? ir.LogicalNot(old) : old;
@@ -142,7 +180,7 @@ void Translator::S_BARRIER() {
 }
 
 void Translator::S_SENDMSG() {
-	ir.Emit(IR::ValueOpcode::Sendmsg);
+	ir.Emit(IR::ValueOpcode::Sendmsg, {ir.GetM0()});
 }
 
 void Translator::S_TTRACEDATA() {
@@ -218,7 +256,7 @@ void Translator::S_CSELECT_B64(const Decoder::Instruction& inst) {
 }
 
 void Translator::MOV_B32(const Decoder::Instruction& inst, bool apply_float_modifiers) {
-	if (IsExecOrVcc(inst.src0) && IsExecOrVcc(inst.dst)) {
+	if (IsExecOrVccLo(inst.src0) && IsExecOrVccLo(inst.dst)) {
 		WriteMask(inst.dst, ReadMask(inst.src0));
 	} else if (apply_float_modifiers && (inst.src0.negate || inst.src0.absolute)) {
 		WriteOperand(DestinationOperand(inst), ReadOperand(inst.src0, IR::Type::F32));

--- a/src/graphics/shader/recompiler/frontend/translate/Integer.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Integer.cpp
@@ -150,8 +150,15 @@ bool Translator::SimpleInteger(const Decoder::Instruction& inst, IR::ValueOpcode
 		const auto arg_type = IR::ArgTypeOf(opcode, index);
 		const auto operand  = SourceAt(inst, reverse && index < 2u ? 1u - index : index);
 		args[index]         = ReadOperand(operand, arg_type == IR::Type::Void ? type : arg_type);
+		// The hardware takes the shift count modulo the operand width; SPIR-V leaves a shift of
+		// the width or more undefined.
 		if (mask_shift_count && index == 1u) {
 			args[index] = ir.BitwiseAnd(IR::U32(args[index]), IR::U32(IR::Value(31u)));
+		}
+		if (index == 1u && (opcode == IR::ValueOpcode::ShiftLeftLogical64 ||
+		                    opcode == IR::ValueOpcode::ShiftRightLogical64 ||
+		                    opcode == IR::ValueOpcode::ShiftRightArithmetic64)) {
+			args[index] = ir.BitwiseAnd(IR::U32(args[index]), IR::U32(IR::Value(63u)));
 		}
 	}
 	IR::Value result;

--- a/src/graphics/shader/recompiler/frontend/translate/Scalar.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Scalar.cpp
@@ -13,6 +13,8 @@ bool Translator::EmitScalar(const Decoder::Instruction& inst, std::string* error
 		case O::S_SETPC_B64: return true;
 		case O::S_CSELECT_B32: S_CSELECT_B32(inst); return true;
 		case O::S_CSELECT_B64: S_CSELECT_B64(inst); return true;
+		case O::S_CMOV_B32: S_CMOV_B32(inst); return true;
+		case O::S_CMOV_B64: S_CMOV_B64(inst); return true;
 		case O::S_SETREG_B32: EmitControlNop(); return true;
 		case O::S_WAITCNT: EmitWaitcnt(); return true;
 

--- a/src/graphics/shader/recompiler/frontend/translate/Scalar.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Scalar.cpp
@@ -205,7 +205,7 @@ bool Translator::EmitScalar(const Decoder::Instruction& inst, std::string* error
 		case O::S_TRAP: EmitControlNop(); return true;
 		case O::S_WAITCNT_DEPCTR: EmitWaitcnt(); return true;
 		case O::S_BARRIER: S_BARRIER(); return true;
-		case O::S_SENDMSG: S_SENDMSG(); return true;
+		case O::S_SENDMSG: S_SENDMSG(inst); return true;
 		case O::S_TTRACEDATA: S_TTRACEDATA(); return true;
 		case O::S_INST_PREFETCH: S_INST_PREFETCH(); return true;
 		case O::S_BRANCH:

--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -1,5 +1,6 @@
 #include "graphics/shader/recompiler/frontend/translate/Translator.h"
 #include "graphics/shader/shader.h"
+#include "graphics/shader/shaderMergedGeometry.h"
 
 #include <algorithm>
 #include <array>
@@ -111,8 +112,12 @@ Decoder::Operand Translator::PlainOperand(const Decoder::Operand& operand) {
 }
 
 std::array<IR::U32, 2> Translator::BallotMask(IR::U1 value) {
-	return {ir.Select(value, IR::U32(IR::Value(1u)), IR::U32(IR::Value(0u))),
-	        IR::U32(IR::Value(0u))};
+	if (!current_logical_wave64) {
+		return {ir.Select(value, IR::U32(IR::Value(1u)), IR::U32(IR::Value(0u))),
+		        IR::U32(IR::Value(0u))};
+	}
+	const auto ballot = ir.Emit(IR::ValueOpcode::Ballot, {value});
+	return {IR::U32(ir.CompositeExtract(ballot, 0)), IR::U32(ir.CompositeExtract(ballot, 1))};
 }
 
 IR::U32 Translator::ReadRawU32(const Decoder::Operand& operand) {
@@ -286,7 +291,7 @@ void Translator::WriteRawU32(const Decoder::Operand& operand, IR::U32 value) {
 		case Decoder::OperandKind::Sgpr: {
 			const auto reg = static_cast<IR::ScalarReg>(operand.reg);
 			ir.SetScalarReg(reg, value);
-			ir.SetThreadBitScalarReg(reg, ThreadBit(value));
+			ir.SetThreadBitScalarReg(reg, ir.INotEqual(value, IR::U32(IR::Value(0u))));
 			ir.SetScalarMaskTag(reg, IR::U1(IR::Value(false)));
 			if (IR::RegIndex(reg) > 0u) {
 				ir.SetScalarMaskTag(static_cast<IR::ScalarReg>(IR::RegIndex(reg) - 1u),
@@ -315,20 +320,20 @@ void Translator::WriteRawU32(const Decoder::Operand& operand, IR::U32 value) {
 		}
 		case Decoder::OperandKind::VccLo:
 			ir.SetVccLo(IR::U32(value));
-			ir.SetVcc(ThreadBit(IR::U32(value)));
+			ir.SetVcc(ThreadBit(IR::U32(value), ir.GetVccHi()));
 			break;
 		case Decoder::OperandKind::VccHi:
 			ir.SetVccHi(IR::U32(value));
-			ir.SetVcc(ThreadBit(ir.GetVccLo()));
+			ir.SetVcc(ThreadBit(ir.GetVccLo(), IR::U32(value)));
 			break;
 		case Decoder::OperandKind::M0: ir.SetM0(IR::U32(value)); break;
 		case Decoder::OperandKind::ExecLo:
 			ir.SetExecLo(IR::U32(value));
-			ir.SetExec(ThreadBit(IR::U32(value)));
+			ir.SetExec(ThreadBit(IR::U32(value), ir.GetExecHi()));
 			break;
 		case Decoder::OperandKind::ExecHi:
 			ir.SetExecHi(IR::U32(value));
-			ir.SetExec(ThreadBit(ir.GetExecLo()));
+			ir.SetExec(ThreadBit(ir.GetExecLo(), IR::U32(value)));
 			break;
 		case Decoder::OperandKind::Scc:
 			ir.SetScc(ir.INotEqual(value, IR::U32(IR::Value(0u))));
@@ -583,7 +588,7 @@ void Translator::WriteU32Pair(const Decoder::Operand&       operand,
 	if (operand.kind == Decoder::OperandKind::Null) {
 		return;
 	}
-	const auto thread_bit = ThreadBit(value[0]);
+	const auto thread_bit = ThreadBit(value[0], value[1]);
 	switch (operand.kind) {
 		case Decoder::OperandKind::ExecLo:
 			ir.SetExec(thread_bit);
@@ -602,8 +607,21 @@ void Translator::WriteU32Pair(const Decoder::Operand&       operand,
 	WriteRawU32(OffsetOperand(operand, 1), value[1]);
 }
 
-IR::U1 Translator::ThreadBit(IR::U32 low) {
-	return ir.INotEqual(low, IR::U32(IR::Value(0u)));
+IR::U1 Translator::ThreadBit(IR::U32 low, IR::U32 high) {
+	if (!current_logical_wave64) {
+		return ir.INotEqual(low, IR::U32(IR::Value(0u)));
+	}
+	const auto lane = IR::U32(ir.Emit(IR::ValueOpcode::LaneId));
+	auto       word = low;
+	if (current_wave_size == 64u) {
+		const auto high_lane =
+		    IR::U1(ir.Emit(IR::ValueOpcode::UGreaterThanEqual32, {lane, IR::Value(32u)}));
+		word = ir.Select(high_lane, high, low);
+	}
+	const auto bit =
+	    ir.BitwiseAnd(ir.ShiftRightLogical(word, ir.BitwiseAnd(lane, IR::U32(IR::Value(31u)))),
+	                  IR::U32(IR::Value(1u)));
+	return ir.INotEqual(bit, IR::U32(IR::Value(0u)));
 }
 
 IR::U1 Translator::ReadCondition(const Decoder::Operand& operand) {
@@ -628,6 +646,15 @@ IR::U1 Translator::ReadMask(const Decoder::Operand& operand) {
 	switch (operand.kind) {
 		case Decoder::OperandKind::Sgpr: {
 			const auto reg = static_cast<IR::ScalarReg>(operand.reg);
+			if (current_logical_wave64) {
+				// The logical mask spans two scalar registers, so read the pair rather than the
+				// per-invocation bit the host subgroup would carry.
+				const auto high =
+				    current_wave_size == 64u && IR::RegIndex(reg) + 1u < IR::NumScalarRegs
+				        ? ir.GetScalarReg(static_cast<IR::ScalarReg>(IR::RegIndex(reg) + 1u))
+				        : IR::U32(IR::Value(0u));
+				return ThreadBit(ir.GetScalarReg(reg), high);
+			}
 			return ir.GetThreadBitScalarReg(reg);
 		}
 		case Decoder::OperandKind::ExecLo:
@@ -771,15 +798,26 @@ bool Translator::AddBranchCondition(const CFG::BasicBlock& source, IR::BlockInfo
 	}
 	// EXEC and VCC are invocation-local Boolean masks. Branching on that Boolean lets inactive
 	// invocations leave the region without reconstructing a host-subgroup mask.
-	IR::U1 condition;
+	IR::U1     condition;
+	const auto mask_non_zero = [&](IR::U1 value) -> IR::U1 {
+		if (!current_logical_wave64) {
+			return value;
+		}
+		const auto mask = BallotMask(value);
+		return ir.INotEqual(ir.BitwiseOr(mask[0], mask[1]), IR::U32(IR::Value(0u)));
+	};
 	switch (source.terminator.condition) {
 		case CFG::BranchCondition::Always: condition = IR::U1(IR::Value(true)); break;
 		case CFG::BranchCondition::SccZero: condition = ir.LogicalNot(ir.GetScc()); break;
 		case CFG::BranchCondition::SccNonZero: condition = ir.GetScc(); break;
-		case CFG::BranchCondition::VccZero: condition = ir.LogicalNot(ir.GetVcc()); break;
-		case CFG::BranchCondition::VccNonZero: condition = ir.GetVcc(); break;
-		case CFG::BranchCondition::ExecZero: condition = ir.LogicalNot(ir.GetExec()); break;
-		case CFG::BranchCondition::ExecNonZero: condition = ir.GetExec(); break;
+		case CFG::BranchCondition::VccZero:
+			condition = ir.LogicalNot(mask_non_zero(ir.GetVcc()));
+			break;
+		case CFG::BranchCondition::VccNonZero: condition = mask_non_zero(ir.GetVcc()); break;
+		case CFG::BranchCondition::ExecZero:
+			condition = ir.LogicalNot(mask_non_zero(ir.GetExec()));
+			break;
+		case CFG::BranchCondition::ExecNonZero: condition = mask_non_zero(ir.GetExec()); break;
 		case CFG::BranchCondition::GotoVariable:
 			if (source.terminator.goto_variable == UINT32_MAX) {
 				return Fail(error,
@@ -968,6 +1006,11 @@ bool TranslateProgram(const Decoder::Program& decoded, const CFG::Graph& cfg,
 		result.info.vertex_offset_sgpr = options.embedded_fetch->vertex_offset_sgpr;
 	}
 
+	// A merged geometry wave is 64 lanes wide whatever the host subgroup is, so its masks have to
+	// be carried in the raw EXEC/VCC halves rather than in a per-invocation bit.
+	const bool logical_wave64 =
+	    options.stage == ShaderType::Mesh && options.wave_size == 64u;
+
 	uint32_t vector_limit = 1u;
 	for (const auto& cfg_block: cfg.blocks) {
 		for (uint32_t index = cfg_block.inst_begin; index < cfg_block.inst_end; index++) {
@@ -1041,8 +1084,83 @@ bool TranslateProgram(const Decoder::Program& decoded, const CFG::Graph& cfg,
 			entry_ir.SetScalarMaskTag(reg, IR::U1(IR::Value(false)));
 		}
 		entry_ir.SetExec(IR::U1(IR::Value(true)));
-		entry_ir.SetExecLo(IR::U32(IR::Value(1u)));
-		entry_ir.SetExecHi(IR::U32(IR::Value(0u)));
+		entry_ir.SetExecLo(IR::U32(IR::Value(logical_wave64 ? 0xffffffffu : 1u)));
+		entry_ir.SetExecHi(
+		    IR::U32(IR::Value(logical_wave64 && options.wave_size > 32u ? 0xffffffffu : 0u)));
+		if (options.stage == ShaderType::Mesh) {
+			// s3 is the merged wave info: [7:0] ES vertex count, [15:8] GS primitive count,
+			// [27:24] wave id, [31:28] waves in the workgroup.
+			const auto* vs = options.vertex;
+			if (vs == nullptr || vs->mesh_vertices_per_workgroup == 0 ||
+			    vs->mesh_primitives_per_workgroup == 0) {
+				return Fail(error, "mesh stage reached without a dispatch split: the draw must "
+				                   "supply per-workgroup vertex and primitive counts");
+			}
+			if (vs->mesh_vertices_per_workgroup % vs->mesh_primitives_per_workgroup != 0) {
+				return Fail(
+				    error, "a mesh workgroup's vertices must divide evenly among its primitives");
+			}
+			const auto group   = builtin(IR::StageInputKind::WorkgroupId, 0);
+			const auto is_last = entry_ir.IEqual(group, IR::U32(IR::Value(vs->mesh_last_group_index)));
+			const auto vertex_count =
+			    entry_ir.Select(is_last, IR::U32(IR::Value(vs->mesh_last_vertices)),
+			                    IR::U32(IR::Value(vs->mesh_vertices_per_workgroup)));
+			const auto primitive_count =
+			    entry_ir.Select(is_last, IR::U32(IR::Value(vs->mesh_last_primitives)),
+			                    IR::U32(IR::Value(vs->mesh_primitives_per_workgroup)));
+			entry_ir.SetScalarReg(
+			    static_cast<IR::ScalarReg>(3),
+			    entry_ir.BitwiseOr(
+			        entry_ir.BitwiseOr(
+			            vertex_count,
+			            entry_ir.ShiftLeftLogical(primitive_count, IR::U32(IR::Value(8u)))),
+			        IR::U32(IR::Value(1u << 28u))));
+
+			const auto lane = builtin(IR::StageInputKind::LocalInvocationIndex);
+			const auto slot = entry_ir.IAdd(
+			    entry_ir.IMul(group, IR::U32(IR::Value(vs->mesh_vertices_per_workgroup))), lane);
+
+			const auto verts_per_prim =
+			    vs->mesh_vertices_per_workgroup / vs->mesh_primitives_per_workgroup;
+			IR::U32 index_position = slot;
+			if (static_cast<MeshInputTopology>(vs->mesh_topology) ==
+			    MeshInputTopology::TriangleStrip) {
+				const auto prim = entry_ir.UDiv(slot, IR::U32(IR::Value(verts_per_prim)));
+				const auto corner =
+				    entry_ir.ISub(slot, entry_ir.IMul(prim, IR::U32(IR::Value(verts_per_prim))));
+				const auto swap    = entry_ir.BitwiseAnd(prim, IR::U32(IR::Value(1u)));
+				const auto swapped = entry_ir.Select(entry_ir.IEqual(corner, IR::U32(IR::Value(2u))),
+				                                     corner, entry_ir.BitwiseXor(corner, swap));
+				index_position     = entry_ir.IAdd(prim, swapped);
+			}
+			const auto vertex_index =
+			    vs->mesh_indexed
+			        ? IR::U32(entry_ir.Emit(IR::ValueOpcode::ReadMeshIndex, {index_position}))
+			        : index_position;
+			entry_ir.SetVectorReg(static_cast<IR::VectorReg>(5), vertex_index);
+
+			entry_ir.SetVectorReg(static_cast<IR::VectorReg>(8),
+			                      builtin(IR::StageInputKind::WorkgroupId, 1));
+
+			// v0/v1 name the input vertices lane `p` assembles: a vertex sits at bit 2 of each
+			// 16-bit half, the hardware's ES vertex offset in dwords.
+			const auto first_slot = entry_ir.IMul(lane, IR::U32(IR::Value(verts_per_prim)));
+			// Two vertices to a register, low half then high half, as gs_vtx_offset0/1/2.
+			for (uint32_t reg = 0; reg * 2u < verts_per_prim; reg++) {
+				IR::U32 packed {IR::Value(0u)};
+				for (uint32_t half = 0; half < 2u; half++) {
+					const auto vertex = reg * 2u + half;
+					if (vertex >= verts_per_prim) {
+						break;
+					}
+					const auto vertex_slot = entry_ir.IAdd(first_slot, IR::U32(IR::Value(vertex)));
+					const auto field =
+					    entry_ir.ShiftLeftLogical(vertex_slot, IR::U32(IR::Value(half * 16u + 2u)));
+					packed = half == 0 ? field : entry_ir.BitwiseOr(packed, field);
+				}
+				entry_ir.SetVectorReg(static_cast<IR::VectorReg>(reg), packed);
+			}
+		}
 		if (options.stage == ShaderType::Compute) {
 			const auto* cs = options.compute;
 			const auto  thread_ids =
@@ -1116,7 +1234,8 @@ bool TranslateProgram(const Decoder::Program& decoded, const CFG::Graph& cfg,
 	}
 	for (const auto& cfg_block: cfg.blocks) {
 		const auto         typed_index = block_indices.at(cfg_block.id);
-		Translator translator(result, result.blocks[typed_index], vector_limit, options.wave_size);
+		Translator translator(result, result.blocks[typed_index], vector_limit, options.wave_size,
+		                      logical_wave64);
 		for (uint32_t index = cfg_block.inst_begin; index < cfg_block.inst_end; index++) {
 			const auto& instruction = decoded.instructions[index];
 			if (IsCodeTableLoad(cfg, instruction.pc)) {

--- a/src/graphics/shader/recompiler/frontend/translate/Translator.h
+++ b/src/graphics/shader/recompiler/frontend/translate/Translator.h
@@ -224,7 +224,7 @@ private:
 	void EmitControlNop();
 	void EmitWaitcnt();
 	void S_BARRIER();
-	void S_SENDMSG();
+	void S_SENDMSG(const Decoder::Instruction& inst);
 	void S_TTRACEDATA();
 	void S_INST_PREFETCH();
 	bool S_GETPC_B64(const Decoder::Instruction& inst, std::string* error);

--- a/src/graphics/shader/recompiler/frontend/translate/Translator.h
+++ b/src/graphics/shader/recompiler/frontend/translate/Translator.h
@@ -9,9 +9,10 @@ namespace Libs::Graphics::ShaderRecompiler::Frontend {
 
 class Translator {
 public:
-	Translator(IR::Program& program, IR::Block* block, uint32_t vector_limit, uint32_t wave_size)
+	Translator(IR::Program& program, IR::Block* block, uint32_t vector_limit, uint32_t wave_size,
+	           bool logical_wave64 = false)
 	    : program(program), ir(block), current_vector_limit(vector_limit),
-	      current_wave_size(wave_size) {}
+	      current_wave_size(wave_size), current_logical_wave64(logical_wave64) {}
 
 	bool TranslateInstruction(const Decoder::Instruction& inst, std::string* error);
 	bool TranslateEmbeddedFetch(const Decoder::Instruction& inst, uint32_t attribute,
@@ -29,7 +30,7 @@ private:
 	IR::U32                ReadScalarCode(uint32_t code);
 	IR::U32                ApplyBitSourceModifiers(const Decoder::Operand& operand, IR::U32 value);
 	IR::Value              ReadOperand(const Decoder::Operand& operand, IR::Type type);
-	IR::U1                 ThreadBit(IR::U32 low);
+	IR::U1                 ThreadBit(IR::U32 low, IR::U32 high);
 	void                   WriteRawU32(const Decoder::Operand& operand, IR::U32 value);
 	IR::F32                ApplyF32ResultModifiers(const Decoder::Operand& operand, IR::F32 value);
 	void                   WriteOperand(const Decoder::Operand& operand, IR::Value value);
@@ -250,10 +251,11 @@ private:
 
 	IR::Program&    program;
 	IR::IREmitter   ir;
-	Decoder::Opcode current_opcode       = Decoder::Opcode::UNKNOWN;
-	uint32_t        current_pc           = 0;
-	uint32_t        current_vector_limit = 1;
-	uint32_t        current_wave_size    = 64;
+	Decoder::Opcode current_opcode         = Decoder::Opcode::UNKNOWN;
+	uint32_t        current_pc             = 0;
+	uint32_t        current_vector_limit   = 1;
+	uint32_t        current_wave_size      = 64;
+	bool            current_logical_wave64 = false;
 };
 
 } // namespace Libs::Graphics::ShaderRecompiler::Frontend

--- a/src/graphics/shader/recompiler/frontend/translate/Translator.h
+++ b/src/graphics/shader/recompiler/frontend/translate/Translator.h
@@ -230,6 +230,10 @@ private:
 	bool S_GETPC_B64(const Decoder::Instruction& inst, std::string* error);
 	void S_CSELECT_B32(const Decoder::Instruction& inst);
 	void S_CSELECT_B64(const Decoder::Instruction& inst);
+	void S_CMOV_B32(const Decoder::Instruction& inst);
+	void S_CMOV_B64(const Decoder::Instruction& inst);
+	void SelectOn32(const Decoder::Instruction& inst, const Decoder::Operand& if_false);
+	void SelectOn64(const Decoder::Instruction& inst, const Decoder::Operand& if_false);
 	void MOV_B32(const Decoder::Instruction& inst, bool apply_float_modifiers);
 	void S_MOV_B64(const Decoder::Instruction& inst);
 	void S_WQM_B64(const Decoder::Instruction& inst);

--- a/src/graphics/shader/recompiler/ir/IREmitter.cpp
+++ b/src/graphics/shader/recompiler/ir/IREmitter.cpp
@@ -170,6 +170,10 @@ U32 IREmitter::IMul(U32 lhs, U32 rhs) {
 	return U32(Emit(ValueOpcode::IMul32, {lhs, rhs}));
 }
 
+U32 IREmitter::UDiv(U32 lhs, U32 rhs) {
+	return U32(Emit(ValueOpcode::UDiv32, {lhs, rhs}));
+}
+
 U32 IREmitter::ShiftLeftLogical(U32 value, U32 shift) {
 	return U32(Emit(ValueOpcode::ShiftLeftLogical32, {value, shift}));
 }

--- a/src/graphics/shader/recompiler/ir/IREmitter.h
+++ b/src/graphics/shader/recompiler/ir/IREmitter.h
@@ -62,6 +62,7 @@ public:
 	U32 IAdd(U32 lhs, U32 rhs);
 	U32 ISub(U32 lhs, U32 rhs);
 	U32 IMul(U32 lhs, U32 rhs);
+	U32 UDiv(U32 lhs, U32 rhs);
 	U32 ShiftLeftLogical(U32 value, U32 shift);
 	U32 ShiftRightLogical(U32 value, U32 shift);
 	U32 ShiftRightArithmetic(U32 value, U32 shift);

--- a/src/graphics/shader/recompiler/ir/ShaderIR.h
+++ b/src/graphics/shader/recompiler/ir/ShaderIR.h
@@ -164,6 +164,7 @@ struct SamplerResource {
 	uint32_t source                = 0;
 	uint32_t first_use_pc          = 0;
 	bool     force_point_filtering = false;
+	uint32_t depth_compare_func    = 0;
 
 	bool operator==(const SamplerResource& other) const = default;
 };
@@ -311,6 +312,7 @@ enum class DescriptorBindingKind {
 	FaultBuffer,
 	FlattenedSrt,
 	UserData,
+	MeshIndices,
 	Count,
 };
 

--- a/src/graphics/shader/recompiler/ir/opcodes/ValueOpcodes.cpp
+++ b/src/graphics/shader/recompiler/ir/opcodes/ValueOpcodes.cpp
@@ -90,6 +90,7 @@ bool HasSideEffects(ValueOpcode opcode) {
 		case ValueOpcode::Reference:
 		case ValueOpcode::ReferenceU32:
 		case ValueOpcode::SetAttribute:
+		case ValueOpcode::Sendmsg:
 		case ValueOpcode::Barrier: return true;
 		default: return false;
 	}

--- a/src/graphics/shader/recompiler/ir/opcodes/ValueOpcodes.inc
+++ b/src/graphics/shader/recompiler/ir/opcodes/ValueOpcodes.inc
@@ -80,6 +80,7 @@ VALUE_OPCODE(BitFieldUExtract, U32, U32, U32, U32)
 VALUE_OPCODE(BitFieldSExtract, U32, U32, U32, U32)
 VALUE_OPCODE(DppMoveU32, U32, U32, U1)
 VALUE_OPCODE(DppUpdateU32, U32, U32, U32, U1)
+VALUE_OPCODE(WqmU32, U32, U32)
 VALUE_OPCODE(WqmU64, U64, U64)
 VALUE_OPCODE(WqmMask, U1, U1)
 
@@ -200,6 +201,11 @@ VALUE_OPCODE(GetSamplerResource, SamplerResource, U32, U32, U32, U32)
 VALUE_OPCODE(MakeImageAddress, ImageAddress, U32, U32, U32, U32, U32, U32, U32, U32, U32, U32, U32,
              U32, U32)
 
+// One entry of the draw's index buffer, widened to a dword. Only a mesh program's synthesized
+// prologue emits this: the geometry engine would have read the index buffer to decide which guest
+// vertex each ES lane fetches, and a mesh dispatch has to do that read itself.
+VALUE_OPCODE(ReadMeshIndex, U32, U32)
+
 VALUE_OPCODE(ReadConst, U32, SrtResource, U32)
 VALUE_OPCODE(ReadConstBuffer, U32, BufferResource, U32)
 VALUE_OPCODE(LoadAddressU8, U8, AddressResource, U32, U32, U1)
@@ -280,7 +286,7 @@ VALUE_OPCODE(SetAttribute, Void, U32x4, U1)
 VALUE_OPCODE(ControlNop, Void)
 VALUE_OPCODE(Waitcnt, Void)
 VALUE_OPCODE(Barrier, Void)
-VALUE_OPCODE(Sendmsg, Void)
+VALUE_OPCODE(Sendmsg, Void, U32)
 VALUE_OPCODE(TtraceData, Void)
 VALUE_OPCODE(InstPrefetch, Void)
 VALUE_OPCODE(SelectU32, U32, U1, U32, U32)

--- a/src/graphics/shader/recompiler/ir/passes/BindingLayout.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/BindingLayout.cpp
@@ -66,6 +66,17 @@ bool UsesGds(const Program& program, bool& uses_gds) {
 	return true;
 }
 
+bool UsesMeshIndices(const Program& program) {
+	for (const auto* block: program.blocks) {
+		for (const auto& inst: *block) {
+			if (inst.GetOpcode() == ValueOpcode::ReadMeshIndex) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 } // namespace
 
 bool AllocateBindings(Program& program, uint32_t push_constant_offset, std::string* error) {
@@ -167,6 +178,9 @@ bool AllocateBindings(Program& program, uint32_t push_constant_offset, std::stri
 	    });
 	if (uses_flattened_runtime) {
 		AddBinding(next, DescriptorBindingKind::FlattenedSrt);
+	}
+	if (UsesMeshIndices(program)) {
+		AddBinding(next, DescriptorBindingKind::MeshIndices);
 	}
 
 	const auto push_dwords = (NativePushConstantSize - push_constant_offset) / sizeof(uint32_t);

--- a/src/graphics/shader/recompiler/ir/passes/ConstantPropagation.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ConstantPropagation.cpp
@@ -341,6 +341,15 @@ void FoldInstruction(Inst& inst) {
 				ReplaceBinaryIdentity(inst, Type::U64, 1u);
 			}
 			return;
+		case ValueOpcode::WqmU32: {
+			const auto value = Arg(inst, 0);
+			if (IsImmediate(value, Type::U32)) {
+				auto quads = value.U32() | (value.U32() >> 1u);
+				quads |= quads >> 2u;
+				Replace(inst, Value((quads & 0x11111111u) * 0x0fu));
+			}
+			return;
+		}
 		case ValueOpcode::WqmU64: {
 			const auto value = Arg(inst, 0);
 			if (IsImmediate(value, Type::U64)) {

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -864,6 +864,10 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 		bool native     = false;
 		bool point_only = false;
 	};
+	for (uint32_t i = 0; i < next.samplers.size(); i++) {
+		next.samplers[i].depth_compare_func = (next_snapshot.samplers[i].dwords[0] >> 12u) & 0x7u;
+	}
+
 	std::vector<SamplerUsage> sampler_usage(next.samplers.size());
 	for (const auto& pair: next.sampled_pairs) {
 		if (pair.image >= next.images.size() || pair.sampler >= next.samplers.size()) {

--- a/src/graphics/shader/recompiler/ir/passes/ShaderInfoCollection.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ShaderInfoCollection.cpp
@@ -42,6 +42,7 @@ bool ValidateOptions(const Program& program, const ShaderInfoOptions& options, s
 		return false;
 	};
 	switch (program.stage) {
+		case ShaderType::Mesh:
 		case ShaderType::Vertex:
 			if (options.vertex->resources_num < 0 ||
 			    options.vertex->resources_num > ShaderVertexInputInfo::RES_MAX) {
@@ -380,7 +381,12 @@ bool CollectShaderInfo(Program& program, const ShaderInfoOptions& options, std::
 		case ShaderType::Vertex: CollectVertexInputs(program, options.vertex, next); break;
 		case ShaderType::Pixel: CollectPixelInputs(program, options.pixel, next); break;
 		case ShaderType::Compute: CollectComputeInputs(options.compute, next); break;
-		default: return false;
+		case ShaderType::Mesh: break;
+		default:
+			if (error != nullptr) {
+				*error = "unsupported shader stage for input collection";
+			}
+			return false;
 	}
 	CollectBuiltinInputs(program, next);
 	if (!CollectOutputs(program, options.vertex, options.pixel, next, error)) {

--- a/src/graphics/shader/recompiler/ir/passes/SharedMemoryBarrier.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/SharedMemoryBarrier.cpp
@@ -95,12 +95,10 @@ uint32_t InsertMergeBarrier(Block& block) {
 } // namespace
 
 SharedMemoryBarrierStats InsertSharedMemoryBarriers(Program& program, uint32_t wave_size,
-	                                                 const ShaderComputeInputInfo& compute_info) {
+                                                    uint32_t threadgroup_size,
+                                                    uint32_t lds_size_dwords, bool needs_barriers) {
 	SharedMemoryBarrierStats stats;
-	const auto threadgroup_size = compute_info.threads_num[0] * compute_info.threads_num[1] *
-	                              compute_info.threads_num[2];
-	if (wave_size != 64u || !compute_info.needs_lds_barriers ||
-	    compute_info.lds_size_dwords == 0u || threadgroup_size != 64u) {
+	if (wave_size != 64u || !needs_barriers || lds_size_dwords == 0u || threadgroup_size != 64u) {
 		return stats;
 	}
 	if (program.blocks.size() != program.block_info.size()) {

--- a/src/graphics/shader/recompiler/ir/passes/SharedMemoryBarrier.h
+++ b/src/graphics/shader/recompiler/ir/passes/SharedMemoryBarrier.h
@@ -9,7 +9,7 @@ struct SharedMemoryBarrierStats {
 };
 
 [[nodiscard]] SharedMemoryBarrierStats
-InsertSharedMemoryBarriers(Program& program, uint32_t wave_size,
-	                       const ShaderComputeInputInfo& compute_info);
+InsertSharedMemoryBarriers(Program& program, uint32_t wave_size, uint32_t threadgroup_size,
+                           uint32_t lds_size_dwords, bool needs_barriers);
 
 } // namespace Libs::Graphics::ShaderRecompiler::IR

--- a/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
@@ -21,6 +21,7 @@ const char* StageName(ShaderType stage) {
 		case ShaderType::Pixel: return "pixel";
 		case ShaderType::Fetch: return "fetch";
 		case ShaderType::Compute: return "compute";
+		case ShaderType::Mesh: return "mesh";
 		default: return "unknown";
 	}
 }
@@ -565,7 +566,10 @@ private:
 		uint32_t word = 0;
 		if (m_runtime.read_memory != nullptr) {
 			if (!m_runtime.read_memory(m_runtime.userdata, address, &word)) {
-				return Fail(error, fmt::format("constant read failed at 0x{:016x}", address));
+				return Fail(error,
+				            fmt::format("constant read failed at 0x{:016x} (descriptor base "
+				                        "0x{:012x}, dword offset 0x{:x})",
+				                        address, base, address - base));
 			}
 		} else {
 			std::memcpy(&word, reinterpret_cast<const void*>(address), sizeof(word));

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -1289,8 +1289,8 @@ static vk::ShaderModule CompileModule(vk::Device device, const ShaderParams& par
 	std::string                     recompile_error;
 	if (!ShaderRecompiler::TryRecompile(params.code, options, result, &recompile_error)) {
 		if (error != nullptr) {
-			return ShaderError::Fail(error, fmt::format("recompile failed: {}", recompile_error)),
-			       nullptr;
+			*error = fmt::format("recompile failed: {}", recompile_error);
+			return nullptr;
 		}
 		ExitShaderRecompilerFailure(label, options.shader_hash, recompile_error.c_str());
 	}
@@ -1299,7 +1299,8 @@ static vk::ShaderModule CompileModule(vk::Device device, const ShaderParams& par
 	if (!SpirvValidateBinary(label, options.shader_hash, result.spirv)) {
 		DumpShaderRecompilerSpirv(stage_name, options.shader_hash, result.spirv);
 		if (error != nullptr) {
-			return ShaderError::Fail(error, "SPIR-V validation failed"), nullptr;
+			*error = "SPIR-V validation failed";
+			return nullptr;
 		}
 		ExitShaderRecompilerFailure(label, options.shader_hash, "SPIR-V validation failed");
 	}
@@ -1330,14 +1331,32 @@ static vk::ShaderModule CompileModule(vk::Device device, const ShaderParams& par
 	return module;
 }
 
-// A merged ES+GS pair is assembled from two guest programs rather than read straight out of
-// guest memory, so the caller owns the assembled words and `params.code` views them. The
-// launch state the pair was planned for is folded into `input_info`, and lands in the static
-// key below so two dispatches of the same pair do not share one permutation.
-static std::span<const uint32_t> MergedGeometryUserData(const HW::VertexShaderInfo& regs) {
-	const auto count =
-	    std::max(static_cast<uint32_t>(regs.gs_regs.rsrc2.user_sgpr), regs.gs_user_sgpr.count);
-	return {regs.gs_user_sgpr.value, count};
+// A merged ES+GS wave does not start its user data at s0: the SPI reserves s0..s7 for the
+// launch state it hands the pair. s[0:1] is the address the guest wrote to
+// SPI_SHADER_USER_DATA_ADDR_LO/HI_GS, and the GS half loads its own resource table from it,
+// so the recompiler has to see the whole window from s0 rather than only the guest's user
+// SGPRs at s8.
+struct MergedGeometryScalars {
+	static constexpr uint32_t LaunchSgprCount = 8;
+
+	std::array<uint32_t, LaunchSgprCount + HW::UserSgprInfo::SGPRS_MAX> value {};
+	uint32_t                                                           count = 0;
+
+	[[nodiscard]] std::span<const uint32_t> Span() const { return {value.data(), count}; }
+};
+
+static MergedGeometryScalars MergedGeometryUserData(const HW::VertexShaderInfo& regs) {
+	MergedGeometryScalars out;
+	const auto            user_count = std::min<uint32_t>(
+	               std::max(static_cast<uint32_t>(regs.gs_regs.rsrc2.user_sgpr), regs.gs_user_sgpr.count),
+	               HW::UserSgprInfo::SGPRS_MAX);
+	out.value[0] = regs.gs_user_data_addr[0];
+	out.value[1] = regs.gs_user_data_addr[1];
+	for (uint32_t i = 0; i < user_count; i++) {
+		out.value[MergedGeometryScalars::LaunchSgprCount + i] = regs.gs_user_sgpr.value[i];
+	}
+	out.count = MergedGeometryScalars::LaunchSgprCount + user_count;
+	return out;
 }
 
 static bool ShaderTryGetMappedData(uint64_t addr, ShaderMappedData& data) {
@@ -1354,9 +1373,11 @@ static bool ShaderTryGetMappedData(uint64_t addr, ShaderMappedData& data) {
 
 bool PrepareMeshProgram(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
                         const MeshDispatch& dispatch, MeshInputTopology topology, bool indexed,
-                        ShaderVertexInputInfo& info, ShaderParams& params, std::string* error) {
+                        ShaderVertexInputInfo& info, std::vector<uint32_t>& user_data,
+                        ShaderParams& params, std::string* error) {
 	KYTY_PROFILER_FUNCTION();
 
+	user_data.clear();
 	params = {};
 
 	if (regs.es_regs.data_addr == 0 || regs.gs_regs.data_addr == 0) {
@@ -1385,7 +1406,11 @@ bool PrepareMeshProgram(const HW::VertexShaderInfo& regs, const HW::ShaderRegist
 	info.mesh_indexed                  = indexed;
 	info.mesh_lds_size_dwords          = MeshLdsDwords(regs.gs_regs.rsrc2.lds_size);
 
-	params.user_data     = MergedGeometryUserData(regs);
+	// The launch window is synthesised rather than read out of a register file, so the caller
+	// owns it and `params` only views it.
+	const auto scalars = MergedGeometryUserData(regs);
+	user_data.assign(scalars.Span().begin(), scalars.Span().end());
+	params.user_data     = user_data;
 	params.hash          = regs.gs_regs.chksum;
 	// The assembled words live on the host heap, so key the permutation on the ES address the
 	// guest actually launched instead of wherever the assembly happened to land.
@@ -1422,10 +1447,12 @@ bool AssembleMeshProgram(const HW::VertexShaderInfo& regs, std::vector<uint32_t>
 vk::ShaderModule CompileMeshProgram(vk::Device device, const ShaderParams& params,
                                     ShaderVertexInputInfo& input_info, std::string* error) {
 	KYTY_PROFILER_FUNCTION(profiler::colors::Amber300);
-	auto options              = MakeCompileOptions(params, ShaderType::Mesh);
-	options.wave_size         = input_info.wave_size;
-	options.user_data_base    = 8;
+	auto options           = MakeCompileOptions(params, ShaderType::Mesh);
+	options.wave_size      = input_info.wave_size;
+	// `params.user_data` already starts at the SPI's launch window, so the pair sees s0.
+	options.user_data_base    = 0;
 	options.scratch_dwords    = input_info.scratch_size_dwords;
+	options.read_memory       = ReadShaderMappedMemory;
 	options.input_info.vertex = &input_info;
 	const auto module         = CompileModule(device, params, options, input_info.stage, error);
 	if (module == nullptr) {

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -1,4 +1,5 @@
 #include "graphics/shader/shader.h"
+#include "graphics/shader/shaderMergedGeometry.h"
 
 #include "common/assert.h"
 #include "common/common.h"
@@ -11,6 +12,7 @@
 #include "graphics/guest_gpu/gpu_defs.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/guest_gpu/hardwareContext.h"
+#include "graphics/host_gpu/hostMemory.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
 #include "graphics/shader/recompiler/ShaderRecompiler.h"
 #include "graphics/shader/recompiler/frontend/decode/ShaderDecoder.h"
@@ -53,6 +55,20 @@ namespace {
 bool ReadShaderGuestMemory(void*, uint64_t address, uint32_t* value) {
 	return value != nullptr &&
 	       Libs::LibKernel::Memory::TryReadGpuCleanBacking(address, value, sizeof(*value));
+}
+
+bool ReadShaderMappedMemory(void*, uint64_t address, uint32_t* value) {
+	if (value == nullptr) {
+		return false;
+	}
+	if (Libs::LibKernel::Memory::HasGuestAddressSpace()) {
+		return Libs::LibKernel::Memory::TryReadBacking(address, value, sizeof(*value));
+	}
+	if (!HostMemoryRangeIsReadable(address, sizeof(*value))) {
+		return false;
+	}
+	std::memcpy(value, reinterpret_cast<const void*>(address), sizeof(*value));
+	return true;
 }
 
 } // namespace
@@ -925,6 +941,19 @@ void BuildStageStaticKey(const ShaderVertexInputInfo& info, std::vector<uint32_t
 			key.push_back(buffer.attr_offsets[j]);
 		}
 	}
+
+	// A mesh permutation bakes its launch state into the program, so two dispatches of the
+	// same ES+GS pair with different geometry are different programs.
+	key.push_back(info.mesh_vertices_per_workgroup);
+	key.push_back(info.mesh_primitives_per_workgroup);
+	key.push_back(info.mesh_last_group_index);
+	key.push_back(info.mesh_last_vertices);
+	key.push_back(info.mesh_last_primitives);
+	key.push_back(info.mesh_output_vertices);
+	key.push_back(info.mesh_output_primitives);
+	key.push_back(info.mesh_topology);
+	key.push_back(static_cast<uint32_t>(info.mesh_indexed));
+	key.push_back(info.mesh_lds_size_dwords);
 }
 
 void BuildStageStaticKey(const ShaderPixelInputInfo& info, std::vector<uint32_t>& key) {
@@ -1219,6 +1248,7 @@ static const char* ShaderStageName(ShaderType stage) {
 		case ShaderType::Vertex: return "vs";
 		case ShaderType::Pixel: return "ps";
 		case ShaderType::Compute: return "cs";
+		case ShaderType::Mesh: return "ms";
 		default: EXIT("invalid shader stage\n");
 	}
 }
@@ -1228,6 +1258,7 @@ static const char* ShaderStageLabel(ShaderType stage) {
 		case ShaderType::Vertex: return "ShaderRecompiler VS";
 		case ShaderType::Pixel: return "ShaderRecompiler PS";
 		case ShaderType::Compute: return "ShaderRecompiler CS";
+		case ShaderType::Mesh: return "ShaderRecompiler MS";
 		default: EXIT("invalid shader stage\n");
 	}
 }
@@ -1247,20 +1278,29 @@ static ShaderRecompiler::CompileOptions MakeCompileOptions(const ShaderParams& p
 	return options;
 }
 
+// `error` makes a failed recompile recoverable: mesh draws fall back to the ES/GS path
+// instead of terminating the emulator. Every other stage passes nullptr and exits.
 static vk::ShaderModule CompileModule(vk::Device device, const ShaderParams& params,
                                       ShaderRecompiler::CompileOptions options,
-                                      ShaderStageRuntime& stage) {
+                                      ShaderStageRuntime& stage, std::string* error = nullptr) {
 	const auto* stage_name = ShaderStageName(options.stage);
 	const auto* label      = ShaderStageLabel(options.stage);
 	ShaderRecompiler::CompileResult result;
-	std::string                     error;
-	if (!ShaderRecompiler::TryRecompile(params.code, options, result, &error)) {
-		ExitShaderRecompilerFailure(label, options.shader_hash, error.c_str());
+	std::string                     recompile_error;
+	if (!ShaderRecompiler::TryRecompile(params.code, options, result, &recompile_error)) {
+		if (error != nullptr) {
+			return ShaderError::Fail(error, fmt::format("recompile failed: {}", recompile_error)),
+			       nullptr;
+		}
+		ExitShaderRecompilerFailure(label, options.shader_hash, recompile_error.c_str());
 	}
 
 	DumpShaderRecompilerOriginal(stage_name, options.shader_hash, params.code, result.decoded_dump);
 	if (!SpirvValidateBinary(label, options.shader_hash, result.spirv)) {
 		DumpShaderRecompilerSpirv(stage_name, options.shader_hash, result.spirv);
+		if (error != nullptr) {
+			return ShaderError::Fail(error, "SPIR-V validation failed"), nullptr;
+		}
 		ExitShaderRecompilerFailure(label, options.shader_hash, "SPIR-V validation failed");
 	}
 	DumpShaderRecompilerSpirv(stage_name, options.shader_hash, result.spirv);
@@ -1287,6 +1327,111 @@ static vk::ShaderModule CompileModule(vk::Device device, const ShaderParams& par
 		LOGF("%s SPIR-V words=%" PRIu64 " wave_size=%u\n", label,
 		     static_cast<uint64_t>(result.spirv.size()), options.wave_size);
 	}
+	return module;
+}
+
+// A merged ES+GS pair is assembled from two guest programs rather than read straight out of
+// guest memory, so the caller owns the assembled words and `params.code` views them. The
+// launch state the pair was planned for is folded into `input_info`, and lands in the static
+// key below so two dispatches of the same pair do not share one permutation.
+static std::span<const uint32_t> MergedGeometryUserData(const HW::VertexShaderInfo& regs) {
+	const auto count =
+	    std::max(static_cast<uint32_t>(regs.gs_regs.rsrc2.user_sgpr), regs.gs_user_sgpr.count);
+	return {regs.gs_user_sgpr.value, count};
+}
+
+static bool ShaderTryGetMappedData(uint64_t addr, ShaderMappedData& data) {
+	EXIT_IF(g_shader_map == nullptr);
+
+	std::scoped_lock lock(g_shader_map_mutex);
+
+	if (auto iter = g_shader_map->find(addr); iter != g_shader_map->end()) {
+		data = iter->second;
+		return true;
+	}
+	return false;
+}
+
+bool PrepareMeshProgram(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
+                        const MeshDispatch& dispatch, MeshInputTopology topology, bool indexed,
+                        ShaderVertexInputInfo& info, ShaderParams& params, std::string* error) {
+	KYTY_PROFILER_FUNCTION();
+
+	params = {};
+
+	if (regs.es_regs.data_addr == 0 || regs.gs_regs.data_addr == 0) {
+		return ShaderError::Fail(error, "a merged geometry pair needs both an ES and a GS address");
+	}
+
+	ShaderMappedData es_data;
+	ShaderMappedData gs_data;
+	if (!ShaderTryGetMappedData(regs.es_regs.data_addr, es_data) ||
+	    !ShaderTryGetMappedData(regs.gs_regs.data_addr, gs_data)) {
+		return ShaderError::Fail(error, "the ES or GS program is missing from ShaderMap");
+	}
+
+	if (!ShaderGetStaticInputInfoVS(regs, sh, es_data, info)) {
+		return ShaderError::Fail(error, "could not read the ES half's resource bindings");
+	}
+	info.wave_size                     = 64;
+	info.mesh_vertices_per_workgroup   = dispatch.vertices_per_workgroup;
+	info.mesh_primitives_per_workgroup = dispatch.primitives_per_workgroup;
+	info.mesh_last_group_index         = dispatch.workgroup_count - 1;
+	info.mesh_last_vertices            = dispatch.last_vertices;
+	info.mesh_last_primitives          = dispatch.last_primitives;
+	info.mesh_output_vertices          = dispatch.output_vertices_per_workgroup;
+	info.mesh_output_primitives        = dispatch.output_primitives_per_workgroup;
+	info.mesh_topology                 = static_cast<uint32_t>(topology);
+	info.mesh_indexed                  = indexed;
+	info.mesh_lds_size_dwords          = MeshLdsDwords(regs.gs_regs.rsrc2.lds_size);
+
+	params.user_data     = MergedGeometryUserData(regs);
+	params.hash          = regs.gs_regs.chksum;
+	// The assembled words live on the host heap, so key the permutation on the ES address the
+	// guest actually launched instead of wherever the assembly happened to land.
+	params.base_override = regs.es_regs.data_addr;
+	return true;
+}
+
+bool AssembleMeshProgram(const HW::VertexShaderInfo& regs, std::vector<uint32_t>& code,
+                         ShaderParams& params, std::string* error) {
+	KYTY_PROFILER_FUNCTION();
+
+	ShaderMappedData es_data;
+	ShaderMappedData gs_data;
+	if (!ShaderTryGetMappedData(regs.es_regs.data_addr, es_data) ||
+	    !ShaderTryGetMappedData(regs.gs_regs.data_addr, gs_data)) {
+		return ShaderError::Fail(error, "the ES or GS program is missing from ShaderMap");
+	}
+
+	MergedGeometryProgram merged;
+	if (!ShaderAssembleMergedGeometry(
+	        {reinterpret_cast<const uint32_t*>(regs.es_regs.data_addr),
+	         es_data.code_size_bytes / sizeof(uint32_t)},
+	        {reinterpret_cast<const uint32_t*>(regs.gs_regs.data_addr),
+	         gs_data.code_size_bytes / sizeof(uint32_t)},
+	        merged, error)) {
+		return false;
+	}
+
+	code        = std::move(merged.code);
+	params.code = code;
+	return true;
+}
+
+vk::ShaderModule CompileMeshProgram(vk::Device device, const ShaderParams& params,
+                                    ShaderVertexInputInfo& input_info, std::string* error) {
+	KYTY_PROFILER_FUNCTION(profiler::colors::Amber300);
+	auto options              = MakeCompileOptions(params, ShaderType::Mesh);
+	options.wave_size         = input_info.wave_size;
+	options.user_data_base    = 8;
+	options.scratch_dwords    = input_info.scratch_size_dwords;
+	options.input_info.vertex = &input_info;
+	const auto module         = CompileModule(device, params, options, input_info.stage, error);
+	if (module == nullptr) {
+		return nullptr;
+	}
+	ApplyVertexOutputs(input_info, *input_info.stage.program);
 	return module;
 }
 

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -33,7 +33,10 @@ struct ComputeShaderInfo;
 struct ShaderRegisters;
 } // namespace HW
 
-enum class ShaderType { Unknown, Vertex, Pixel, Fetch, Compute };
+enum class ShaderType { Unknown, Vertex, Pixel, Fetch, Compute, Mesh };
+
+struct MeshDispatch;
+enum class MeshInputTopology;
 
 namespace ShaderRecompiler::IR {
 struct Program;
@@ -86,6 +89,20 @@ struct ShaderVertexInputInfo {
 	uint32_t                pa_cl_vs_out_cntl    = 0;
 	bool                    fetch_external      = false;
 	bool                    fetch_embedded      = false;
+	// Guest wave size for this stage, decoded from VGT_SHADER_STAGES_EN. Part of the shader id,
+	// so a wave32 and a wave64 build of one program never share a pipeline.
+	uint32_t                wave_size           = 64;
+
+	uint32_t                mesh_vertices_per_workgroup   = 0;
+	uint32_t                mesh_primitives_per_workgroup = 0;
+	uint32_t                mesh_last_group_index         = 0;
+	uint32_t                mesh_last_vertices            = 0;
+	uint32_t                mesh_last_primitives          = 0;
+	uint32_t                mesh_output_vertices          = 0;
+	uint32_t                mesh_output_primitives        = 0;
+	uint32_t                mesh_topology                 = 0;
+	bool                    mesh_indexed                  = false;
+	uint32_t                mesh_lds_size_dwords          = 0;
 };
 
 struct ShaderComputeInputInfo {

--- a/src/graphics/shader/shaderCompiler.h
+++ b/src/graphics/shader/shaderCompiler.h
@@ -58,8 +58,8 @@ vk::ShaderModule CompileProgram(vk::Device device, const ShaderParams& params,
 // ordinary vertex path instead of terminating the emulator.
 bool PrepareMeshProgram(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
                         const MeshDispatch& dispatch, MeshInputTopology topology, bool indexed,
-                        ShaderVertexInputInfo& input_info, ShaderParams& params,
-                        std::string* error);
+                        ShaderVertexInputInfo& input_info, std::vector<uint32_t>& user_data,
+                        ShaderParams& params, std::string* error);
 bool AssembleMeshProgram(const HW::VertexShaderInfo& regs, std::vector<uint32_t>& code,
                          ShaderParams& params, std::string* error);
 vk::ShaderModule CompileMeshProgram(vk::Device device, const ShaderParams& params,

--- a/src/graphics/shader/shaderCompiler.h
+++ b/src/graphics/shader/shaderCompiler.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace Libs::Graphics {
@@ -14,9 +15,12 @@ struct ShaderParams {
 	std::span<const uint32_t> code;
 	std::span<const uint32_t> user_data;
 	uint64_t                  hash = 0;
+	// Set when `code` is assembled on the host rather than viewed in guest memory, so the
+	// program is still identified by the guest address the shader was launched from.
+	uint64_t                  base_override = 0;
 
 	[[nodiscard]] uint64_t Base() const {
-		return reinterpret_cast<uint64_t>(code.data());
+		return base_override != 0 ? base_override : reinterpret_cast<uint64_t>(code.data());
 	}
 };
 
@@ -47,6 +51,19 @@ vk::ShaderModule CompileProgram(vk::Device device, const ShaderParams& params,
                                 ShaderPixelInputInfo& input_info);
 vk::ShaderModule CompileProgram(vk::Device device, const ShaderParams& params,
                                 ShaderComputeInputInfo& input_info);
+
+// A merged NGG ES+GS pair compiles to a mesh stage. Preparing the params is enough to look the
+// program up; the two halves are only assembled on a cache miss, and `code` must then outlive
+// the `params` that view it. Every step is fallible: an unsupported pair leaves the draw to the
+// ordinary vertex path instead of terminating the emulator.
+bool PrepareMeshProgram(const HW::VertexShaderInfo& regs, const HW::ShaderRegisters& sh,
+                        const MeshDispatch& dispatch, MeshInputTopology topology, bool indexed,
+                        ShaderVertexInputInfo& input_info, ShaderParams& params,
+                        std::string* error);
+bool AssembleMeshProgram(const HW::VertexShaderInfo& regs, std::vector<uint32_t>& code,
+                         ShaderParams& params, std::string* error);
+vk::ShaderModule CompileMeshProgram(vk::Device device, const ShaderParams& params,
+                                    ShaderVertexInputInfo& input_info, std::string* error);
 
 } // namespace Libs::Graphics
 

--- a/src/graphics/shader/shaderMergedGeometry.cpp
+++ b/src/graphics/shader/shaderMergedGeometry.cpp
@@ -1,0 +1,291 @@
+#include "graphics/shader/shaderMergedGeometry.h"
+
+#include "graphics/shader/recompiler/frontend/decode/ShaderDecoder.h"
+
+#include <algorithm>
+#include <fmt/format.h>
+
+namespace Libs::Graphics {
+
+namespace {
+
+using ShaderRecompiler::Decoder::Opcode;
+
+// The IR layer that used to answer this was removed upstream, but the scan still has to know
+// which scalar results claim a register pair.
+bool ScalarResultIs64Bit(Opcode opcode) {
+	switch (opcode) {
+		case Opcode::S_AND_B64:
+		case Opcode::S_ANDN2_B64:
+		case Opcode::S_NOT_B64:
+		case Opcode::S_OR_B64:
+		case Opcode::S_ORN2_B64:
+		case Opcode::S_XOR_B64:
+		case Opcode::S_NAND_B64:
+		case Opcode::S_NOR_B64:
+		case Opcode::S_XNOR_B64:
+		case Opcode::S_LSHL_B64:
+		case Opcode::S_LSHR_B64:
+		case Opcode::S_BFE_U64:
+		case Opcode::S_WQM_B64:
+		case Opcode::S_QUADMASK_B64: return true;
+		default: return false;
+	}
+}
+
+bool Fail(std::string* error, const std::string& message) {
+	if (error != nullptr) {
+		*error = message;
+	}
+	return false;
+}
+
+bool FindGsEnd(std::span<const uint32_t> gs_code, uint32_t& end_word, std::string* error) {
+	uint32_t word_index = 0;
+	while (word_index < gs_code.size()) {
+		ShaderRecompiler::Decoder::Instruction inst {};
+		std::string                            decode_error;
+		if (!ShaderRecompiler::Decoder::DecodeInstruction(gs_code, word_index, inst,
+		                                                 &decode_error)) {
+			return Fail(error, fmt::format("GS decode failed at word {}: {}", word_index,
+			                               decode_error));
+		}
+		word_index += std::max(inst.word_count, 1u);
+		if (inst.opcode == Opcode::S_ENDPGM) {
+			end_word = word_index;
+			return true;
+		}
+	}
+	return Fail(error, fmt::format("GS has no s_endpgm in {} words", gs_code.size()));
+}
+
+bool FindEsExit(std::span<const uint32_t> es_code, uint32_t& exit_word, std::string* error) {
+	uint32_t word_index = 0;
+	uint32_t decoded    = 0;
+	while (word_index < es_code.size()) {
+		ShaderRecompiler::Decoder::Instruction inst {};
+		std::string                            decode_error;
+		if (!ShaderRecompiler::Decoder::DecodeInstruction(es_code, word_index, inst,
+		                                                 &decode_error)) {
+			return Fail(error, fmt::format("ES decode failed at word {}: {}", word_index,
+			                               decode_error));
+		}
+		if (inst.opcode == Opcode::S_SETPC_B64) {
+			exit_word = word_index;
+			return true;
+		}
+		decoded++;
+		word_index += std::max(inst.word_count, 1u);
+	}
+	return Fail(error, fmt::format("ES has no s_setpc_b64 in {} decoded instructions ({} words): "
+	                               "it does not end the way a merged ES+GS pair does",
+	                               decoded, es_code.size()));
+}
+
+using ShaderRecompiler::Decoder::Operand;
+using ShaderRecompiler::Decoder::OperandKind;
+
+} // namespace
+
+std::string MergedGeometryLaunchState::Describe() const {
+	std::string text;
+	for (uint32_t i = 0; i < ScalarCount; i++) {
+		if (scalar[i]) {
+			text += fmt::format("{}s{}", text.empty() ? "" : " ", i);
+		}
+	}
+	for (uint32_t i = 0; i < VectorCount; i++) {
+		if (vector[i]) {
+			text += fmt::format("{}v{}", text.empty() ? "" : " ", i);
+		}
+	}
+	if (reads_m0) {
+		text += text.empty() ? "m0" : " m0";
+	}
+	if (scalar_out_of_range || vector_out_of_range) {
+		text += " (registers outside the tracked window were used)";
+	}
+	return text.empty() ? "none" : text;
+}
+
+bool ShaderAnalyzeMergedLaunchState(std::span<const uint32_t> code,
+                                    MergedGeometryLaunchState& out, std::string* error) {
+	out = {};
+	bool written_scalar[MergedGeometryLaunchState::ScalarCount] = {};
+	bool written_vector[MergedGeometryLaunchState::VectorCount] = {};
+
+	uint32_t word_index = 0;
+	while (word_index < code.size()) {
+		ShaderRecompiler::Decoder::Instruction inst {};
+		std::string                            decode_error;
+		if (!ShaderRecompiler::Decoder::DecodeInstruction(code, word_index, inst, &decode_error)) {
+			return Fail(error, fmt::format("launch-state scan failed at word {}: {}", word_index,
+			                               decode_error));
+		}
+
+		const auto note_read = [&](const Operand& src, uint32_t reg_count) {
+			for (uint32_t i = 0; i < reg_count; i++) {
+				const auto reg = src.reg + i;
+				if (src.kind == OperandKind::Sgpr) {
+					if (reg < MergedGeometryLaunchState::ScalarCount) {
+						if (!written_scalar[reg]) {
+							out.scalar[reg] = true;
+						}
+					} else {
+						out.scalar_out_of_range = true;
+					}
+				}
+				if (src.kind == OperandKind::Vgpr) {
+					if (reg < MergedGeometryLaunchState::VectorCount) {
+						if (!written_vector[reg]) {
+							out.vector[reg] = true;
+						}
+					} else {
+						out.vector_out_of_range = true;
+					}
+				}
+			}
+			if (src.kind == OperandKind::M0) {
+				out.reads_m0 = true;
+			}
+		};
+
+		const Operand* sources[] = {&inst.src0, &inst.src1, &inst.src2, &inst.src3};
+		for (uint32_t i = 0; i < inst.src_count && i < std::size(sources); i++) {
+			note_read(*sources[i], ShaderRecompiler::Decoder::InstructionSourceRegisterCount(inst, i));
+		}
+		if (ShaderRecompiler::Decoder::InstructionReadsDestination(inst)) {
+			note_read(inst.dst, std::max(inst.data_dwords, 1u));
+		}
+
+		if (inst.opcode == Opcode::S_ENDPGM) {
+			break;
+		}
+
+		bool vector_sourced = false;
+		for (uint32_t i = 0; i < inst.src_count && i < std::size(sources); i++) {
+			vector_sourced = vector_sourced || sources[i]->kind == OperandKind::Vgpr;
+		}
+		const bool writes_lane_mask = inst.dst.kind == OperandKind::Sgpr && vector_sourced;
+		const bool     writes_dst    = ShaderRecompiler::Decoder::InstructionWritesDestination(inst);
+		const uint32_t load_dst_regs = std::max(inst.data_dwords, 1u);
+		const uint32_t scalar_dst_regs =
+		    std::max(load_dst_regs, (ScalarResultIs64Bit(inst.opcode) ||
+		                             writes_lane_mask)
+		                                ? 2u
+		                                : 1u);
+		if (writes_dst && inst.dst.kind == OperandKind::Sgpr) {
+			for (uint32_t i = 0; i < scalar_dst_regs; i++) {
+				const auto reg = inst.dst.reg + i;
+				if (reg < MergedGeometryLaunchState::ScalarCount) {
+					written_scalar[reg] = true;
+				}
+			}
+		}
+		if (writes_dst && inst.dst.kind == OperandKind::Vgpr) {
+			for (uint32_t i = 0; i < load_dst_regs; i++) {
+				const auto reg = inst.dst.reg + i;
+				if (reg < MergedGeometryLaunchState::VectorCount) {
+					written_vector[reg] = true;
+				}
+			}
+		}
+		if (inst.dst2.kind == OperandKind::Sgpr &&
+		    inst.dst2.reg < MergedGeometryLaunchState::ScalarCount) {
+			written_scalar[inst.dst2.reg] = true;
+		}
+
+		word_index += std::max(inst.word_count, 1u);
+	}
+	return true;
+}
+
+bool ShaderValidateMeshLds(uint32_t lds_dwords, uint32_t max_bytes, std::string* error) {
+	const uint64_t bytes = static_cast<uint64_t>(lds_dwords) * sizeof(uint32_t);
+	if (max_bytes == 0) {
+		return Fail(error, "the host reported no mesh shared memory at all");
+	}
+	if (bytes > max_bytes) {
+		return Fail(error, fmt::format("the merged wave wants {} bytes of LDS but a mesh workgroup "
+		                               "may use {}",
+		                               bytes, max_bytes));
+	}
+	return true;
+}
+
+bool ShaderComputeMeshDispatch(uint32_t total_primitives, uint32_t vertices_per_primitive,
+                               uint32_t output_vertices_per_primitive, uint32_t vertex_group_size,
+                               uint32_t primitive_group_size, uint32_t max_output_per_subgroup,
+                               MeshDispatch& out, std::string* error) {
+	out = {};
+	if (vertices_per_primitive == 0) {
+		return Fail(error, "a primitive needs at least one vertex");
+	}
+	if (output_vertices_per_primitive == 0) {
+		return Fail(error, "a primitive that emits no vertices cannot be drawn");
+	}
+	if (vertex_group_size == 0 || primitive_group_size == 0) {
+		return Fail(error, "the GE group sizes must both be non-zero");
+	}
+
+	if (total_primitives == 0) {
+		return true; // Nothing to draw; zero workgroups is the right answer.
+	}
+
+	uint32_t primitives = std::min(primitive_group_size, MeshWaveLanes);
+	primitives          = std::min(primitives, vertex_group_size / vertices_per_primitive);
+	primitives          = std::min(primitives, MeshWaveLanes / vertices_per_primitive);
+	if (max_output_per_subgroup != 0) {
+		primitives = std::min(primitives, max_output_per_subgroup / output_vertices_per_primitive);
+	}
+	if (primitives == 0) {
+		return Fail(error, fmt::format("no primitive fits a workgroup: vert_group={} prim_group={} "
+		                               "max_out={} verts_per_prim={}",
+		                               vertex_group_size, primitive_group_size,
+		                               max_output_per_subgroup, vertices_per_primitive));
+	}
+
+	out.primitives_per_workgroup = primitives;
+	out.vertices_per_workgroup   = primitives * vertices_per_primitive;
+	out.output_vertices_per_workgroup = primitives * output_vertices_per_primitive;
+	out.output_primitives_per_workgroup =
+	    primitives * MeshOutputPrimitivesPerPrimitive(output_vertices_per_primitive);
+	out.workgroup_count = (total_primitives + primitives - 1) / primitives;
+
+	const uint32_t remainder = total_primitives % primitives;
+	out.last_primitives       = remainder == 0 ? primitives : remainder;
+	out.last_vertices         = out.last_primitives * vertices_per_primitive;
+
+	if (out.vertices_per_workgroup > 0xFFu || out.primitives_per_workgroup > 0xFFu) {
+		return Fail(error, fmt::format("workgroup counts do not fit the merged wave info: {} "
+		                               "vertices, {} primitives",
+		                               out.vertices_per_workgroup, out.primitives_per_workgroup));
+	}
+	return true;
+}
+
+bool ShaderAssembleMergedGeometry(std::span<const uint32_t> es_code,
+                                  std::span<const uint32_t> gs_code,
+                                  MergedGeometryProgram& out, std::string* error) {
+	if (es_code.empty() || gs_code.empty()) {
+		return Fail(error, "merged geometry needs both an ES and a GS program");
+	}
+
+	uint32_t exit_word = 0;
+	if (!FindEsExit(es_code, exit_word, error)) {
+		return false;
+	}
+	uint32_t gs_end_word = 0;
+	if (!FindGsEnd(gs_code, gs_end_word, error)) {
+		return false;
+	}
+
+	out.code.clear();
+	out.code.reserve(exit_word + gs_end_word);
+	out.code.insert(out.code.end(), es_code.begin(), es_code.begin() + exit_word);
+	out.gs_word_offset = exit_word;
+	out.code.insert(out.code.end(), gs_code.begin(), gs_code.begin() + gs_end_word);
+	return true;
+}
+
+} // namespace Libs::Graphics

--- a/src/graphics/shader/shaderMergedGeometry.cpp
+++ b/src/graphics/shader/shaderMergedGeometry.cpp
@@ -238,6 +238,11 @@ bool ShaderComputeMeshDispatch(uint32_t total_primitives, uint32_t vertices_per_
 	if (max_output_per_subgroup != 0) {
 		primitives = std::min(primitives, max_output_per_subgroup / output_vertices_per_primitive);
 	}
+	// One output vertex and one output primitive per lane, so the emitted output has to fit the
+	// lane budget. GE_MAX_OUTPUT_PER_SUBGROUP is a maximum, so a smaller split is always legal.
+	primitives = std::min(primitives, MeshWaveLanes / output_vertices_per_primitive);
+	primitives = std::min(primitives,
+	                      MeshWaveLanes / MeshOutputPrimitivesPerPrimitive(output_vertices_per_primitive));
 	if (primitives == 0) {
 		return Fail(error, fmt::format("no primitive fits a workgroup: vert_group={} prim_group={} "
 		                               "max_out={} verts_per_prim={}",

--- a/src/graphics/shader/shaderMergedGeometry.h
+++ b/src/graphics/shader/shaderMergedGeometry.h
@@ -1,0 +1,78 @@
+#ifndef EMULATOR_SRC_GRAPHICS_SHADER_SHADERMERGEDGEOMETRY_H_
+#define EMULATOR_SRC_GRAPHICS_SHADER_SHADERMERGEDGEOMETRY_H_
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace Libs::Graphics {
+
+struct MergedGeometryProgram {
+	std::vector<uint32_t> code;
+	uint32_t gs_word_offset = 0;
+};
+
+bool ShaderAssembleMergedGeometry(std::span<const uint32_t> es_code,
+                                  std::span<const uint32_t> gs_code,
+                                  MergedGeometryProgram& out, std::string* error);
+
+struct MergedGeometryLaunchState {
+	static constexpr uint32_t ScalarCount = 32;
+	static constexpr uint32_t VectorCount = 16;
+
+	bool scalar[ScalarCount] = {};
+	bool vector[VectorCount] = {};
+	bool reads_m0            = false;
+	bool scalar_out_of_range = false;
+	bool vector_out_of_range = false;
+
+	[[nodiscard]] std::string Describe() const;
+};
+
+bool ShaderAnalyzeMergedLaunchState(std::span<const uint32_t> code,
+                                    MergedGeometryLaunchState& out, std::string* error);
+
+inline constexpr uint32_t MeshWaveLanes = 64;
+
+enum class MeshInputTopology { TriangleList, TriangleStrip };
+
+[[nodiscard]] inline uint32_t MeshPrimitiveCount(MeshInputTopology topology, uint32_t index_count) {
+	switch (topology) {
+		case MeshInputTopology::TriangleList: return index_count / 3u;
+		case MeshInputTopology::TriangleStrip: return index_count >= 3u ? index_count - 2u : 0u;
+	}
+	return 0;
+}
+
+struct MeshDispatch {
+	uint32_t workgroup_count = 0;
+	uint32_t vertices_per_workgroup   = 0;
+	uint32_t primitives_per_workgroup = 0;
+	uint32_t last_vertices   = 0;
+	uint32_t last_primitives = 0;
+	uint32_t output_vertices_per_workgroup   = 0;
+	uint32_t output_primitives_per_workgroup = 0;
+};
+
+[[nodiscard]] inline uint32_t MeshOutputPrimitivesPerPrimitive(uint32_t output_vertices) {
+	return output_vertices >= 3u ? output_vertices - 2u : 1u;
+}
+
+// SPI_SHADER_PGM_RSRC2_GS.LDS_SIZE counts 128-dword granules, the same unit compute uses.
+inline constexpr uint32_t MeshLdsGranuleDwords = 128;
+
+[[nodiscard]] inline uint32_t MeshLdsDwords(uint32_t rsrc2_lds_size) {
+	return rsrc2_lds_size * MeshLdsGranuleDwords;
+}
+
+bool ShaderValidateMeshLds(uint32_t lds_dwords, uint32_t max_bytes, std::string* error);
+
+bool ShaderComputeMeshDispatch(uint32_t total_primitives, uint32_t vertices_per_primitive,
+                               uint32_t output_vertices_per_primitive, uint32_t vertex_group_size,
+                               uint32_t primitive_group_size, uint32_t max_output_per_subgroup,
+                               MeshDispatch& out, std::string* error);
+
+} // namespace Libs::Graphics
+
+#endif // EMULATOR_SRC_GRAPHICS_SHADER_SHADERMERGEDGEOMETRY_H_

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -862,6 +862,10 @@ bool TryWriteBacking(uint64_t vaddr, const void* data, uint64_t size) {
 	       g_guest_address_space->TryWriteBacking(vaddr, data, size);
 }
 
+bool HasGuestAddressSpace() {
+	return g_guest_address_space != nullptr;
+}
+
 bool TryReadBacking(uint64_t vaddr, void* data, uint64_t size) {
 	return g_guest_address_space != nullptr &&
 	       g_guest_address_space->TryReadBacking(vaddr, data, size);

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -108,6 +108,7 @@ static_assert(sizeof(KernelMemoryPoolBlockStats) == 16,
 void                   RegisterCallbacks(callback_func_t alloc_func, callback_func_t free_func);
 void                   SetFlexibleMemorySize(uint64_t size);
 bool                   TryWriteBacking(uint64_t vaddr, const void* data, uint64_t size);
+bool                   HasGuestAddressSpace();
 bool                   TryReadBacking(uint64_t vaddr, void* data, uint64_t size);
 bool                   TryReadGpuCleanBacking(uint64_t vaddr, void* data, uint64_t size);
 bool                   TryReadPrtBacking(uint64_t vaddr, void* data, uint64_t size);

--- a/tests/MergedGeometryTests.cpp
+++ b/tests/MergedGeometryTests.cpp
@@ -1,0 +1,323 @@
+#include "graphics/shader/shaderMergedGeometry.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+void Check(bool value, const char *text) {
+  if (!value) {
+    std::fprintf(stderr, "MergedGeometryTests: failed: %s\n", text);
+    std::abort();
+  }
+}
+
+// SOP1: [31:23] opcode class, [22:16] SDST, [15:8] OP, [7:0] SSRC0.
+// s_setpc_b64 s[6:7] is OP 0x20 reading s6, which is how every merged ES half ends.
+constexpr uint32_t SetPcB64S6 = 0xBE800000u | (0x20u << 8u) | 6u;
+// SOPP: s_endpgm is OP 1.
+constexpr uint32_t EndPgm = 0xBF810000u | (1u << 16u);
+// s_nop, used here only as filler that decodes cleanly.
+constexpr uint32_t Nop = 0xBF800000u;
+
+void JoinsAtTheEsExit() {
+  const std::vector<uint32_t> es {Nop, Nop, SetPcB64S6, Nop, Nop}; // trailing words are padding
+  const std::vector<uint32_t> gs {Nop, EndPgm};
+
+  Libs::Graphics::MergedGeometryProgram merged;
+  std::string error;
+  // Sequenced deliberately: building the message inside the Check call would read `error` before
+  // the call that fills it, since argument evaluation order is unspecified.
+  const bool assembled = Libs::Graphics::ShaderAssembleMergedGeometry(es, gs, merged, &error);
+  const std::string message = "assembly succeeds: " + error;
+  Check(assembled, message.c_str());
+
+  // The ES contributes everything before its setpc, and nothing after it.
+  Check(merged.gs_word_offset == 2, "the GS half starts where the ES setpc was");
+  Check(merged.code.size() == 2 + gs.size(), "padding after the setpc is dropped");
+  Check(merged.code[0] == Nop && merged.code[1] == Nop, "the ES body is preserved");
+  Check(merged.code[2] == gs[0] && merged.code[3] == gs[1], "the GS body follows immediately");
+
+  // The setpc itself must not survive: it would jump to launch state we no longer honour.
+  for (const auto word : merged.code) {
+    Check(word != SetPcB64S6, "the setpc is dropped rather than carried into the merged program");
+  }
+}
+
+void RejectsAnEsWithoutTheMergedExit() {
+  const std::vector<uint32_t> es {Nop, EndPgm};
+  const std::vector<uint32_t> gs {Nop, EndPgm};
+
+  Libs::Graphics::MergedGeometryProgram merged;
+  std::string error;
+  Check(!Libs::Graphics::ShaderAssembleMergedGeometry(es, gs, merged, &error),
+        "an ES that does not end in s_setpc_b64 is rejected");
+  Check(!error.empty(), "the rejection explains itself");
+}
+
+void RejectsEmptyHalves() {
+  Libs::Graphics::MergedGeometryProgram merged;
+  std::string error;
+  const std::vector<uint32_t> code {Nop, SetPcB64S6};
+  Check(!Libs::Graphics::ShaderAssembleMergedGeometry({}, code, merged, &error),
+        "a missing ES is rejected");
+  Check(!Libs::Graphics::ShaderAssembleMergedGeometry(code, {}, merged, &error),
+        "a missing GS is rejected");
+}
+
+// The register values Stray and Silent Hill actually emit: both group sizes 0x40, and
+// GE_MAX_OUTPUT_PER_SUBGROUP 0xc0. Triangles, so three vertices per primitive.
+constexpr uint32_t GroupSize = 0x40;
+constexpr uint32_t MaxOut = 0xc0;
+constexpr uint32_t TriVerts = 3;
+
+Libs::Graphics::MeshDispatch DispatchFor(uint32_t index_count) {
+  Libs::Graphics::MeshDispatch dispatch;
+  std::string error;
+  const uint32_t primitives = Libs::Graphics::MeshPrimitiveCount(
+      Libs::Graphics::MeshInputTopology::TriangleList, index_count);
+  const bool ok = Libs::Graphics::ShaderComputeMeshDispatch(
+      primitives, TriVerts, TriVerts, GroupSize, GroupSize, MaxOut, dispatch, &error);
+  const std::string message = "dispatch computed: " + error;
+  Check(ok, message.c_str());
+  return dispatch;
+}
+
+void AWorkgroupNeverOverrunsAWave() {
+  const auto dispatch = DispatchFor(3 * 1000);
+
+  // The vertex bound is what binds: 64 primitives would need 192 input vertices, but only 64
+  // lanes exist to hold them, so 21 primitives at three vertices each is the most that fits.
+  Check(dispatch.primitives_per_workgroup == 21, "21 primitives fit one workgroup");
+  Check(dispatch.vertices_per_workgroup == 63, "which is 63 vertices");
+  Check(dispatch.vertices_per_workgroup <= Libs::Graphics::MeshWaveLanes,
+        "vertices never exceed one lane each");
+  Check(dispatch.primitives_per_workgroup <= Libs::Graphics::MeshWaveLanes,
+        "primitives never exceed one lane each");
+}
+
+void EveryPrimitiveIsCoveredExactlyOnce() {
+  // A partial final workgroup is the normal case, so the split has to account for it exactly.
+  for (uint32_t primitives = 1; primitives <= 200; primitives++) {
+    const auto dispatch = DispatchFor(primitives * TriVerts);
+    const uint32_t covered =
+        (dispatch.workgroup_count - 1) * dispatch.primitives_per_workgroup +
+        dispatch.last_primitives;
+    Check(covered == primitives, "the workgroups cover every primitive exactly once");
+    Check(dispatch.last_primitives >= 1 &&
+              dispatch.last_primitives <= dispatch.primitives_per_workgroup,
+          "the final workgroup is non-empty and no larger than a full one");
+    Check(dispatch.last_vertices == dispatch.last_primitives * TriVerts,
+          "the final vertex count matches its primitive count");
+  }
+}
+
+void AnExactMultipleHasAFullFinalWorkgroup() {
+  const auto dispatch = DispatchFor(21 * TriVerts * 4);
+  Check(dispatch.workgroup_count == 4, "four full workgroups");
+  Check(dispatch.last_primitives == dispatch.primitives_per_workgroup,
+        "the final workgroup is full, not empty");
+}
+
+void AnEmptyDrawDispatchesNothing() {
+  const auto dispatch = DispatchFor(0);
+  Check(dispatch.workgroup_count == 0, "an empty draw needs no workgroups");
+}
+
+void ImpossibleConfigurationsAreRejected() {
+  Libs::Graphics::MeshDispatch dispatch;
+  std::string error;
+  // A primitive wider than the group can hold has no valid split.
+  Check(!Libs::Graphics::ShaderComputeMeshDispatch(100, 100, 100, GroupSize, GroupSize, MaxOut,
+                                                   dispatch, &error),
+        "a primitive too wide for a workgroup is rejected");
+  Check(!Libs::Graphics::ShaderComputeMeshDispatch(100, 0, TriVerts, GroupSize, GroupSize, MaxOut,
+                                                   dispatch, &error),
+        "a primitive with no vertices is rejected");
+  Check(!Libs::Graphics::ShaderComputeMeshDispatch(100, TriVerts, 0, GroupSize, GroupSize, MaxOut,
+                                                   dispatch, &error),
+        "a primitive that emits no vertices is rejected");
+  Check(!Libs::Graphics::ShaderComputeMeshDispatch(100, TriVerts, TriVerts, 0, GroupSize, MaxOut,
+                                                   dispatch, &error),
+        "a zero group size is rejected");
+}
+
+void LdsIsSizedFromTheGranuleCount() {
+  // Two real geometry shaders, each with its declared granule count and the highest LDS offset
+  // it addresses, read from the same run so the pairing is real. A 128-dword granule covers both
+  // with little to spare, which is what a compiler sizing LDS precisely looks like.
+  struct Sample { uint32_t granules; uint32_t highest_offset; };
+  constexpr Sample Samples[] = {{17, 7456}, {31, 15456}};
+
+  for (const auto &sample : Samples) {
+    const uint32_t bytes = Libs::Graphics::MeshLdsDwords(sample.granules) * 4;
+    Check(bytes > sample.highest_offset, "the allocation covers what the shader addresses");
+    // Half the granule would not reach the offsets these shaders use, which is what fixes the
+    // granule at 128 dwords rather than something smaller.
+    Check(bytes / 2 <= sample.highest_offset, "and a smaller granule would not");
+  }
+
+  Check(Libs::Graphics::MeshLdsDwords(17) * 4 == 8704, "17 granules is 8704 bytes");
+  Check(Libs::Graphics::MeshLdsDwords(31) * 4 == 15872, "31 granules is 15872 bytes");
+}
+
+void BothRealGeometryShadersFitTheHost() {
+  constexpr uint32_t MaxBytes = 28672; // maxMeshSharedMemorySize on the RTX 2000 Ada
+  std::string error;
+  for (const uint32_t granules : {17u, 31u}) {
+    Check(Libs::Graphics::ShaderValidateMeshLds(Libs::Graphics::MeshLdsDwords(granules), MaxBytes,
+                                                &error),
+          "a real geometry shader's LDS fits a mesh workgroup");
+  }
+  // A doubled granule would push the larger shader past the host limit even though it only needs
+  // about 15 KB - the reason the granule size has to be right rather than merely generous.
+  Check(31u * 256u * 4u > MaxBytes, "an over-sized granule would reject a shader that fits");
+}
+
+void LdsBeyondTheHostLimitIsRejected() {
+  constexpr uint32_t MaxBytes = 28672; // maxMeshSharedMemorySize on the RTX 2000 Ada
+  std::string error;
+
+  Check(Libs::Graphics::ShaderValidateMeshLds(Libs::Graphics::MeshLdsDwords(17), MaxBytes, &error),
+        "Stray's 8704 bytes fit");
+  Check(Libs::Graphics::ShaderValidateMeshLds(MaxBytes / 4, MaxBytes, &error),
+        "exactly the limit fits");
+  Check(!Libs::Graphics::ShaderValidateMeshLds(MaxBytes / 4 + 1, MaxBytes, &error),
+        "one dword over the limit is rejected");
+  Check(!error.empty(), "the rejection says how much was wanted and how much is allowed");
+  Check(!Libs::Graphics::ShaderValidateMeshLds(1, 0, &error),
+        "a host reporting no mesh shared memory is rejected");
+}
+
+// A store keeps its data register in the destination field of the encoding, and an LDS store
+// leaves that field naming nothing at all. Both shapes appear in every merged geometry program,
+// and reading the field as a written register is what hid the primitive connectivity these
+// programs receive at launch.
+void AStoreDoesNotWriteItsDestinationField() {
+  // ds_write_b32 v3, v2 - addr in v3, data in v2, and the unused vdst field left at zero, which
+  // names v0. Then a read of v0, which the hardware really does supply.
+  constexpr uint32_t DsWriteWord0 = 0xD8000000u | (0x0du << 18u);
+  constexpr uint32_t DsWriteWord1 = (2u << 8u) | 3u; // data0 = v2, addr = v3
+  // v_mov_b32 v4, v0
+  constexpr uint32_t VMovV4FromV0 = 0x7E000000u | (4u << 17u) | (1u << 9u) | 256u;
+
+  const std::vector<uint32_t> code {DsWriteWord0, DsWriteWord1, VMovV4FromV0, EndPgm};
+
+  Libs::Graphics::MergedGeometryLaunchState launch;
+  std::string error;
+  const bool ok = Libs::Graphics::ShaderAnalyzeMergedLaunchState(code, launch, &error);
+  const std::string message = "the scan succeeds: " + error;
+  Check(ok, message.c_str());
+
+  Check(launch.vector[0], "v0 is launch state: the store's unused vdst field did not write it");
+  Check(launch.vector[2], "the store's data register is a read");
+  Check(launch.vector[3], "so is its address register");
+  Check(!launch.vector[4], "a register the program writes is not launch state");
+}
+
+void ABufferStoreReadsItsDataRegister() {
+  // buffer_store_dword v7, v1, s[4:7], 0 - vdata is v7, and it is data the store reads.
+  // soffset 128 is the inline constant zero, so no SGPR read comes from it.
+  constexpr uint32_t BufferStoreWord0 = 0xE0000000u | (0x1cu << 18u);
+  constexpr uint32_t BufferStoreWord1 =
+      (128u << 24u) | (1u << 16u) | (7u << 8u) | 1u; // srsrc s[4:7], vdata v7, vaddr v1
+  const std::vector<uint32_t> code {BufferStoreWord0, BufferStoreWord1, EndPgm};
+
+  Libs::Graphics::MergedGeometryLaunchState launch;
+  std::string error;
+  Check(Libs::Graphics::ShaderAnalyzeMergedLaunchState(code, launch, &error),
+        "the scan succeeds");
+  Check(launch.vector[7], "the stored data register is read, not written");
+  Check(launch.vector[1], "the address register is read");
+  // A buffer descriptor is four consecutive registers. Counting only the named one would leave
+  // s5-s7 looking like registers the program never touches.
+  Check(launch.scalar[4] && launch.scalar[5] && launch.scalar[6] && launch.scalar[7],
+        "the whole four-register descriptor is read, not just its base");
+  Check(!launch.scalar[8], "and not one register more");
+}
+
+// A strip shares vertices between consecutive primitives, so the same indices describe a different
+// number of triangles than a list does. The split is driven by that count, not by the index count.
+void AStripCountsItsPrimitivesDifferently() {
+  using Libs::Graphics::MeshInputTopology;
+  using Libs::Graphics::MeshPrimitiveCount;
+
+  Check(MeshPrimitiveCount(MeshInputTopology::TriangleList, 18) == 6, "18 indices are 6 triangles");
+  // The shape both Stray and Silent Hill draw: a four-vertex quad as two strip triangles.
+  Check(MeshPrimitiveCount(MeshInputTopology::TriangleStrip, 4) == 2,
+        "4 strip indices are 2 triangles");
+  Check(MeshPrimitiveCount(MeshInputTopology::TriangleStrip, 3) == 1, "3 are the minimum strip");
+  Check(MeshPrimitiveCount(MeshInputTopology::TriangleStrip, 2) == 0, "2 cannot form a triangle");
+  Check(MeshPrimitiveCount(MeshInputTopology::TriangleList, 2) == 0, "nor can 2 as a list");
+
+  // A strip still spends three ES lanes per primitive: the shared vertices are fetched twice
+  // rather than deduplicated, which is what keeps the slot mapping a closed form.
+  Libs::Graphics::MeshDispatch dispatch;
+  std::string error;
+  Check(Libs::Graphics::ShaderComputeMeshDispatch(
+            MeshPrimitiveCount(MeshInputTopology::TriangleStrip, 4), TriVerts, TriVerts, GroupSize,
+            GroupSize, MaxOut, dispatch, &error),
+        "a four-index strip splits");
+  Check(dispatch.workgroup_count == 1, "into one workgroup");
+  Check(dispatch.last_primitives == 2 && dispatch.last_vertices == 6,
+        "of two primitives over six slots");
+}
+
+// Silent Hill issues a GS with VGT_GS_MAX_VERT_OUT of 24 - eight triangles out of one in. The
+// output arrays and the subgroup bound have to be sized by what it emits, not by what it reads;
+// those are the same number only for the 1:1 triangle GS that hid the distinction.
+void AnAmplifyingGsIsSizedByWhatItEmits() {
+  constexpr uint32_t Amplified = 24;
+  Libs::Graphics::MeshDispatch dispatch;
+  std::string error;
+  Check(Libs::Graphics::ShaderComputeMeshDispatch(100, TriVerts, Amplified, GroupSize, GroupSize,
+                                                   MaxOut, dispatch, &error),
+        "an amplifying GS splits");
+
+  // GE_MAX_OUTPUT_PER_SUBGROUP counts emitted vertices: 192 of them at 24 each is 8 primitives.
+  Check(dispatch.primitives_per_workgroup == MaxOut / Amplified,
+        "the subgroup output bound divides by what a primitive emits");
+  Check(dispatch.vertices_per_workgroup == dispatch.primitives_per_workgroup * TriVerts,
+        "its input vertices still come three to a primitive");
+  Check(dispatch.output_vertices_per_workgroup == dispatch.primitives_per_workgroup * Amplified,
+        "and its output vertices come 24 to a primitive");
+  // A GS emits a strip, so 24 vertices are 22 triangles.
+  Check(dispatch.output_primitives_per_workgroup == dispatch.primitives_per_workgroup * 22,
+        "24 emitted vertices are 22 triangles");
+
+  // The 1:1 case is where the two counts coincide, which is worth pinning so a future change
+  // cannot quietly reintroduce the conflation.
+  Libs::Graphics::MeshDispatch plain;
+  Check(Libs::Graphics::ShaderComputeMeshDispatch(100, TriVerts, TriVerts, GroupSize, GroupSize,
+                                                   MaxOut, plain, &error),
+        "a 1:1 GS splits");
+  Check(plain.output_vertices_per_workgroup == plain.vertices_per_workgroup,
+        "a 1:1 GS emits exactly the vertices it reads");
+  Check(plain.output_primitives_per_workgroup == plain.primitives_per_workgroup,
+        "and one triangle per primitive");
+}
+
+} // namespace
+
+int main() {
+  LdsIsSizedFromTheGranuleCount();
+  BothRealGeometryShadersFitTheHost();
+  LdsBeyondTheHostLimitIsRejected();
+  JoinsAtTheEsExit();
+  RejectsAnEsWithoutTheMergedExit();
+  RejectsEmptyHalves();
+  AWorkgroupNeverOverrunsAWave();
+  EveryPrimitiveIsCoveredExactlyOnce();
+  AnExactMultipleHasAFullFinalWorkgroup();
+  AnEmptyDrawDispatchesNothing();
+  ImpossibleConfigurationsAreRejected();
+  AStoreDoesNotWriteItsDestinationField();
+  ABufferStoreReadsItsDataRegister();
+  AStripCountsItsPrimitivesDifferently();
+  AnAmplifyingGsIsSizedByWhatItEmits();
+
+  std::printf("MergedGeometryTests: ok\n");
+  return 0;
+}

--- a/tests/MergedGeometryTests.cpp
+++ b/tests/MergedGeometryTests.cpp
@@ -276,9 +276,12 @@ void AnAmplifyingGsIsSizedByWhatItEmits() {
                                                    MaxOut, dispatch, &error),
         "an amplifying GS splits");
 
-  // GE_MAX_OUTPUT_PER_SUBGROUP counts emitted vertices: 192 of them at 24 each is 8 primitives.
-  Check(dispatch.primitives_per_workgroup == MaxOut / Amplified,
-        "the subgroup output bound divides by what a primitive emits");
+  // The subgroup bound alone allows eight primitives; 64 lanes can only write two.
+  Check(MaxOut / Amplified == 8, "the subgroup output bound alone would allow eight primitives");
+  Check(dispatch.primitives_per_workgroup == 2, "but the lane budget clamps it to two");
+  Check(dispatch.output_vertices_per_workgroup <= 64 &&
+            dispatch.output_primitives_per_workgroup <= 64,
+        "so the emitted output fits the lanes that have to write it");
   Check(dispatch.vertices_per_workgroup == dispatch.primitives_per_workgroup * TriVerts,
         "its input vertices still come three to a primitive");
   Check(dispatch.output_vertices_per_workgroup == dispatch.primitives_per_workgroup * Amplified,

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -12501,6 +12501,54 @@ TestCase ScalarMinMaxSccComparisonEdges() {
            O::BUFFER_STORE_DWORD, O::S_ENDPGM}};
 }
 
+// S_CMOV writes the source only when SCC is set; when SCC is clear the
+// destination has to keep its previous value rather than take the source or
+// get zeroed. The merged ES+GS prologues Pathless ships open with
+// s_cmov_b64 exec, -1, so the 64-bit form has to preserve the mask too.
+TestCase ScalarCmovPreservesDestinationWhenSccClear() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  auto set_scc = [&](bool value) {
+    code.push_back(EncodeSopc(0x06, InlineU32(1), InlineU32(value ? 1u : 0u)));
+  };
+
+  // 32-bit: SCC clear keeps 7, SCC set takes 9.
+  code.push_back(EncodeSMovB32(20, InlineU32(7)));
+  set_scc(false);
+  code.push_back(EncodeSop1(0x05, 20, InlineU32(9)));
+
+  code.push_back(EncodeSMovB32(21, InlineU32(7)));
+  set_scc(true);
+  code.push_back(EncodeSop1(0x05, 21, InlineU32(9)));
+
+  // 64-bit: s[2:3] is the source pair, s[22:23] and s[24:25] the destinations.
+  code.push_back(EncodeSMovB32(2, InlineU32(9)));
+  code.push_back(EncodeSMovB32(3, InlineU32(11)));
+
+  code.push_back(EncodeSMovB32(22, InlineU32(7)));
+  code.push_back(EncodeSMovB32(23, InlineU32(5)));
+  set_scc(false);
+  code.push_back(EncodeSop1(0x06, 22, 2));
+
+  code.push_back(EncodeSMovB32(24, InlineU32(7)));
+  code.push_back(EncodeSMovB32(25, InlineU32(5)));
+  set_scc(true);
+  code.push_back(EncodeSop1(0x06, 24, 2));
+
+  for (u32 i = 0; i < 6u; i++) {
+    AppendStoreSgpr(&code, 20u + i, i);
+  }
+  AppendEnd(&code);
+
+  return {"ScalarCmovPreservesDestinationWhenSccClear",
+          code,
+          {},
+          {7, 9, 7, 5, 9, 11},
+          {O::S_MOV_B32, O::S_CMP_EQ_U32, O::S_CMOV_B32, O::S_CMOV_B64,
+           O::V_MOV_B32, O::BUFFER_STORE_DWORD, O::S_ENDPGM}};
+}
+
 TestCase ScalarAbsI32UpdatesScc() {
   using O = ShaderOpcode;
 
@@ -20335,6 +20383,7 @@ std::vector<TestCase> MakeCases() {
   AddCase(ScalarExtendedArithmetic);
   AddCase(ScalarArithmeticSccCarryBorrowOverflow);
   AddCase(ScalarMinMaxSccComparisonEdges);
+  AddCase(ScalarCmovPreservesDestinationWhenSccClear);
   AddCase(ScalarAbsI32UpdatesScc);
   AddCase(ScalarShiftLeftAddSccCarryEdges);
   AddCase(ScalarCompareOps);

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -9024,12 +9024,21 @@ public:
       auto storage_redirected =
           executor.PrepareBindings(stencil_storage_runtime);
       executor.RebindImages(storage_redirected);
-      Require(
-          name, "storage stencil acquisition",
-          storage_redirected.resources.images[0].image_id == depth_id &&
-              storage_redirected.resources.images[0].image_view != nullptr &&
-              texture_cache.GetImage(depth_id).usage.storage,
-          "storage stencil binding did not acquire the associated depth owner");
+      // A storage binding is the one case that must NOT redirect to the depth owner: a depth
+      // image is never created with VK_IMAGE_USAGE_STORAGE_BIT, so the shader writes the plane's
+      // own colour image and the result is copied into the depth image's stencil aspect
+      // afterwards.
+      const auto storage_stencil_id =
+          storage_redirected.resources.images[0].image_id;
+      Require(name, "storage stencil acquisition",
+              storage_stencil_id != depth_id &&
+                  storage_redirected.resources.images[0].image_view !=
+                      nullptr &&
+                  texture_cache.GetImage(storage_stencil_id).depth_id ==
+                      depth_id &&
+                  texture_cache.GetImage(storage_stencil_id).usage.storage &&
+                  !texture_cache.GetImage(depth_id).usage.storage,
+              "storage stencil binding did not stay on the plane's own image");
       RenderExecutorTestAccess::ResetBindings(executor);
       resources.UnmapMemory(base, allocation_size);
       scheduler.Finish();
@@ -19325,7 +19334,7 @@ TestCase ImageSampleA16CompareBiasRdna2AddressOrder() {
   test.code = code;
   test.opcodes = {O::V_MOV_B32, O::IMAGE_SAMPLE, O::BUFFER_STORE_DWORD,
                   O::S_ENDPGM};
-  test.required_spirv = {"OpImageSampleDrefExplicitLod", "UnpackHalf2x16"};
+  test.required_spirv = {"OpImageSampleExplicitLod", "UnpackHalf2x16"};
   test.compile_only = true;
   return test;
 }
@@ -19369,7 +19378,7 @@ TestCase ImageGatherCompareOpcodes() {
       O::V_MOV_B32,         O::IMAGE_GATHER4_C,      O::IMAGE_GATHER4_C_LZ,
       O::IMAGE_GATHER4_C_O, O::IMAGE_GATHER4_C_LZ_O, O::BUFFER_STORE_DWORD,
       O::S_ENDPGM};
-  test.required_spirv = {"OpImageDrefGather", "OpBitFieldSExtract"};
+  test.required_spirv = {"OpImageGather", "OpBitFieldSExtract"};
   test.compile_only = true;
   return test;
 }

--- a/tests/ShaderStagesEnTests.cpp
+++ b/tests/ShaderStagesEnTests.cpp
@@ -1,0 +1,118 @@
+#include "graphics/guest_gpu/hardwareContext.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <initializer_list>
+
+namespace {
+
+void Check(bool value, const char *text) {
+  if (!value) {
+    std::fprintf(stderr, "ShaderStagesEnTests: failed: %s\n", text);
+    std::abort();
+  }
+}
+
+using Libs::Graphics::HW::DecodeShaderStages;
+using Libs::Graphics::HW::ShaderStagesEn;
+
+// Every stage word below was observed in a census over five titles, so these are values the
+// hardware really produces rather than constructed examples.
+
+void OrdinaryNggVertexDrawIsVertexOnly() {
+  // The majority of PS5 draws: PRIMGEN_EN plus passthrough, no stage enables.
+  const auto s = DecodeShaderStages(0x02002000u);
+
+  Check(s.primgen_en, "0x02002000 sets PRIMGEN_EN");
+  Check(s.ngg_passthrough, "0x02002000 sets the NGG passthrough bit");
+  Check(s.stage_enables == ShaderStagesEn::STAGE_ENABLES_NONE,
+        "0x02002000 enables no stage");
+  Check(s.IsNggVertexOnly(), "0x02002000 is a vertex-only NGG draw");
+  Check(!s.IsNggMergedEsGs(), "0x02002000 is not a merged ES+GS draw");
+  Check(s.VertexWaveSize() == 64u, "0x02002000 is a wave64 vertex draw");
+}
+
+void WaveSizeBitsDoNotChangePipelineShape() {
+  // The regression the decode exists to prevent: an exact match against 0x02002000 rejected
+  // these outright, costing Dead Space 14.8% of its early draws.
+  const auto plain = DecodeShaderStages(0x02002000u);
+  const auto wave32 = DecodeShaderStages(0x02402000u);
+
+  Check(wave32.IsNggVertexOnly(), "0x02402000 is still a vertex-only NGG draw");
+  Check(wave32.gs_w32_en, "0x02402000 sets GS_W32_EN");
+  Check(wave32.VertexWaveSize() == 32u, "0x02402000 is a wave32 vertex draw");
+  Check(plain.stage_enables == wave32.stage_enables,
+        "the wave-size bit leaves the stage enables untouched");
+  Check(plain.IsNggVertexOnly() == wave32.IsNggVertexOnly(),
+        "the wave-size bit does not change the classification");
+
+  // The other two width bits must be equally inert.
+  for (const uint32_t bit : {ShaderStagesEn::HS_W32_EN, ShaderStagesEn::VS_W32_EN}) {
+    const auto s = DecodeShaderStages(0x02002000u | bit);
+    Check(s.IsNggVertexOnly(), "a width bit alone does not disqualify a vertex draw");
+    Check(s.stage_enables == ShaderStagesEn::STAGE_ENABLES_NONE,
+          "a width bit does not leak into the stage enables");
+  }
+}
+
+void MergedEsGsIsRecognised() {
+  // Stray and Silent Hill both emit this word. It does not set the passthrough bit, which is
+  // what separates a real geometry program from a vertex-only wave.
+  const auto s = DecodeShaderStages(0x00002030u);
+
+  Check(s.primgen_en, "0x00002030 sets PRIMGEN_EN");
+  Check(!s.ngg_passthrough, "0x00002030 does not set the NGG passthrough bit");
+  Check(s.stage_enables == ShaderStagesEn::STAGE_ENABLES_ES_GS,
+        "0x00002030 enables ES and GS");
+  Check(s.IsNggMergedEsGs(), "0x00002030 is a merged ES+GS draw");
+  Check(!s.IsNggVertexOnly(), "0x00002030 is not a vertex-only draw");
+}
+
+void TheTwoConfigurationsAreDisjoint() {
+  // A word can never satisfy both predicates, whatever the width bits say.
+  for (const uint32_t raw : {0x02002000u, 0x02402000u, 0x00002030u, 0x00000000u,
+                             0x02002030u, 0x00002000u}) {
+    const auto s = DecodeShaderStages(raw);
+    Check(!(s.IsNggVertexOnly() && s.IsNggMergedEsGs()),
+          "no stage word is both vertex-only and merged ES+GS");
+  }
+}
+
+void UnrecognisedWordsAreNeitherConfiguration() {
+  // Neither a zero word nor a contradictory one may be mistaken for a supported config.
+  const auto zero = DecodeShaderStages(0x00000000u);
+  Check(!zero.IsNggVertexOnly(), "a zero stage word is not a vertex-only draw");
+  Check(!zero.IsNggMergedEsGs(), "a zero stage word is not a merged ES+GS draw");
+
+  const auto contradictory = DecodeShaderStages(0x02002030u);
+  Check(!contradictory.IsNggVertexOnly(),
+        "passthrough with stage enables is not a vertex-only draw");
+  Check(!contradictory.IsNggMergedEsGs(),
+        "passthrough with stage enables is not a merged ES+GS draw");
+
+  // PRIMGEN alone, without passthrough and without stage enables.
+  const auto primgen_only = DecodeShaderStages(0x00002000u);
+  Check(!primgen_only.IsNggVertexOnly(),
+        "PRIMGEN without passthrough is not a vertex-only draw");
+  Check(!primgen_only.IsNggMergedEsGs(),
+        "PRIMGEN without stage enables is not a merged ES+GS draw");
+}
+
+void RawValueIsPreserved() {
+  const auto s = DecodeShaderStages(0x02402000u);
+  Check(s.raw == 0x02402000u, "the raw register value is carried through the decode");
+}
+
+} // namespace
+
+int main() {
+  OrdinaryNggVertexDrawIsVertexOnly();
+  WaveSizeBitsDoNotChangePipelineShape();
+  MergedEsGsIsRecognised();
+  TheTwoConfigurationsAreDisjoint();
+  UnrecognisedWordsAreNeitherConfiguration();
+  RawValueIsPreserved();
+
+  std::printf("ShaderStagesEnTests: ok\n");
+  return 0;
+}

--- a/tests/shaderCfgTests.cpp
+++ b/tests/shaderCfgTests.cpp
@@ -4858,20 +4858,28 @@ void TestNewShaderRecompilerPixelImageSampleLodSelection() {
               1,
           "pixel IMAGE_SAMPLE_LZ must use explicit lod");
   }
+  // A shadow lookup is an ordinary sample followed by the comparison in the shader: a host
+  // comparison sampler is only legal against a depth-format view, which a guest shadow map is
+  // not unless it also happens to be a depth target.
   {
     const auto result = compile(0x28, 0x1); // image_sample_c
     Check(SpirvInstructionOpcodeCount(result.spirv,
-                                      OpImageSampleDrefImplicitLod) == 1,
-          "pixel IMAGE_SAMPLE_C must use OpImageSampleDrefImplicitLod");
-    Check(SpirvInstructionOpcodeCount(result.spirv,
-                                      OpImageSampleDrefExplicitLod) == 0,
-          "pixel IMAGE_SAMPLE_C unexpectedly used explicit dref lod");
+                                      OpImageSampleDrefImplicitLod) == 0 &&
+              SpirvInstructionOpcodeCount(result.spirv,
+                                          OpImageSampleDrefExplicitLod) == 0,
+          "pixel IMAGE_SAMPLE_C must not build a hardware comparison sample");
+    Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleImplicitLod) ==
+              1,
+          "pixel IMAGE_SAMPLE_C must sample with implicit lod");
   }
   {
     const auto result = compile(0x2f, 0x1); // image_sample_c_lz
     Check(SpirvInstructionOpcodeCount(result.spirv,
-                                      OpImageSampleDrefExplicitLod) == 1,
-          "pixel IMAGE_SAMPLE_C_LZ must use explicit dref lod");
+                                      OpImageSampleDrefExplicitLod) == 0,
+          "pixel IMAGE_SAMPLE_C_LZ must not build a hardware comparison sample");
+    Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleExplicitLod) ==
+              1,
+          "pixel IMAGE_SAMPLE_C_LZ must sample with explicit lod");
   }
 }
 
@@ -5164,8 +5172,9 @@ void TestNewShaderRecompilerImageGatherVariants() {
         "SPIR-V binary does not request ImageGatherExtended");
   Check(SpirvContainsOpcode(result.spirv, 96),
         "SPIR-V binary does not contain OpImageGather");
-  Check(SpirvContainsOpcode(result.spirv, 97),
-        "SPIR-V binary does not contain OpImageDrefGather");
+  // A shadow gather is an ordinary gather now, with the four texels compared in the shader.
+  Check(!SpirvContainsOpcode(result.spirv, 97),
+        "SPIR-V binary must not build a hardware comparison gather");
   Check(SpirvContainsOpcode(result.spirv, 202),
         "SPIR-V binary does not contain packed gather offset extraction");
   Check(SpirvContainsOpcode(result.spirv, 81),
@@ -11805,17 +11814,15 @@ void TestSharedMemoryBarrierSafety() {
     return ir.INotEqual(local_id, U32(Value(0u)));
   };
 
-  ShaderComputeInputInfo compute_info{};
-  compute_info.needs_lds_barriers = true;
-  compute_info.lds_size_dwords = 128;
-  compute_info.threads_num[0] = 64;
-  compute_info.threads_num[1] = 1;
-  compute_info.threads_num[2] = 1;
+  // The pass takes the facts directly now, so a mesh program - one guest wave64 as a
+  // 64-invocation workgroup - can use it too.
+  constexpr uint32_t kThreadgroup = 64;
+  constexpr uint32_t kLdsDwords   = 128;
 
   auto phases = make_program(1);
   append_write(*phases.blocks[0]);
   append_read(*phases.blocks[0]);
-  const auto phase_stats = InsertSharedMemoryBarriers(phases, 64u, compute_info);
+  const auto phase_stats = InsertSharedMemoryBarriers(phases, 64u, kThreadgroup, kLdsDwords, true);
   std::vector<ValueOpcode> phase_opcodes;
   for (const auto& inst : *phases.blocks[0]) {
     phase_opcodes.push_back(inst.GetOpcode());
@@ -11835,7 +11842,7 @@ void TestSharedMemoryBarrierSafety() {
   append_write(*selection.blocks[1]);
   append_read(*selection.blocks[2]);
   const auto selection_stats =
-      InsertSharedMemoryBarriers(selection, 64u, compute_info);
+      InsertSharedMemoryBarriers(selection, 64u, kThreadgroup, kLdsDwords, true);
   Check(selection_stats.inserted_barriers == 2 &&
             count_barriers(*selection.blocks[1]) == 0 &&
             selection.blocks[2]->begin()->GetOpcode() ==
@@ -11848,7 +11855,7 @@ void TestSharedMemoryBarrierSafety() {
   loop.block_info[0].condition = divergent_condition(loop, 0);
   append_write(*loop.blocks[0]);
   append_read(*loop.blocks[0]);
-  const auto loop_stats = InsertSharedMemoryBarriers(loop, 64u, compute_info);
+  const auto loop_stats = InsertSharedMemoryBarriers(loop, 64u, kThreadgroup, kLdsDwords, true);
   Check(loop_stats.inserted_barriers == 0 &&
             count_barriers(*loop.blocks[0]) == 0,
         "workgroup barrier was inserted into divergent loop control");


### PR DESCRIPTION
Compile a merged ES+GS pair as a mesh shader instead of dropping the draw. Includes the wave64 lane-mask handling it needs, plus fixes for SRT constant reads, shadow sampling, stencil plane writes and depth target layouts.

## Summary

- Decode VGT_SHADER_STAGES_EN for if the draw is a merged ES GS pair and concatenates them together.
- I run the wave64 guest program as a 64 invocation workgroup 
- The launch state the hardware would have supplied is synthesized, because a mesh dispatch has no geometry engine: the merged wave info in s3, the vertex and instance indices, and the primitive connectivity.
- Geometry exports are lowered onto the mesh outputs. The packed connectivity dword becomes gl_PrimitiveTriangleIndicesEXT with its null-primitive bit as gl_CullPrimitiveEXT, POS1's layer field becomes a per-primitive gl_Layer, and GS_ALLOC_REQ becomes OpSetMeshOutputsEXT.
- A draw the mesh path cannot take is refused with a named reason and dropped.

This should probably be discussed/tested more before merging.

PR follows contribution guidelines and the Windows build is verified.