### PR TITLE
The pathless boot/stability fixes

### DIFF
--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -54,13 +54,6 @@ struct ConfigOptions {
 	bool                   readback_linear_images      = false;
 	bool                   playgo_hack_enabled         = false;
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
-	// Off by default. Windows dispatches every exception by building its frame on the faulting
-	// thread's own stack, reaching to within sixteen bytes of rsp, and guest code is System V
-	// and keeps live data in the 128 bytes below rsp — so a GPU page-tracking fault taken at
-	// the guest's own stack pointer destroys that data. Measured: a fault at 0x90267ba56 with
-	// rsp=0x7ec2a2e88 zeroed [rsp-0x10], and the next instruction to reload that slot
-	// dereferenced the resulting null. The patcher below fixes that, but it rewrites tens of
-	// thousands of guest instructions, so it stays opt-in via --redzone.
 	bool red_zone_protection_enabled = false;
 #endif
 	Keymap keymap;

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -54,6 +54,13 @@ struct ConfigOptions {
 	bool                   readback_linear_images      = false;
 	bool                   playgo_hack_enabled         = false;
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	// Off by default. Windows dispatches every exception by building its frame on the faulting
+	// thread's own stack, reaching to within sixteen bytes of rsp, and guest code is System V
+	// and keeps live data in the 128 bytes below rsp — so a GPU page-tracking fault taken at
+	// the guest's own stack pointer destroys that data. Measured: a fault at 0x90267ba56 with
+	// rsp=0x7ec2a2e88 zeroed [rsp-0x10], and the next instruction to reload that slot
+	// dereferenced the resulting null. The patcher below fixes that, but it rewrites tens of
+	// thousands of guest instructions, so it stays opt-in via --redzone.
 	bool red_zone_protection_enabled = false;
 #endif
 	Keymap keymap;

--- a/src/common/hostException.cpp
+++ b/src/common/hostException.cpp
@@ -2,6 +2,10 @@
 
 #include <atomic>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <utility>
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 #include <windows.h> // IWYU pragma: keep
@@ -33,6 +37,186 @@ static_assert(decltype(g_install_state)::is_always_lock_free);
 #endif
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+
+// A fault the guest handler declines is fatal, and Windows tears the process down without
+// printing anything, which leaves a truncated log and no way to tell where it died. Report
+// the faulting instruction before letting the search continue. The report is capped because
+// this also sees first-chance faults that somebody else's __except may go on to handle.
+static std::atomic_uint32_t g_unhandled_reports {0};
+
+static void DumpExceptionRing() noexcept;
+
+static void ReportUnhandledFault(PEXCEPTION_POINTERS exception, const ExceptionInfo& info) noexcept {
+	if (g_unhandled_reports.fetch_add(1, std::memory_order_relaxed) >= 4) {
+		return;
+	}
+
+	const char* access = "unknown";
+	switch (info.access_violation_type) {
+		case AccessViolationType::Read: access = "read"; break;
+		case AccessViolationType::Write: access = "write"; break;
+		case AccessViolationType::Execute: access = "execute"; break;
+		default: break;
+	}
+
+	const auto module_base = reinterpret_cast<uint64_t>(GetModuleHandleW(nullptr));
+	printf("\nUnhandled host fault: code=0x%08" PRIx32 " %s at 0x%016" PRIx64 "\n",
+	       info.native_code, access, info.access_violation_vaddr);
+	printf("\t rip = 0x%016" PRIx64 " (kyty_emulator.exe base 0x%016" PRIx64 ")\n",
+	       info.exception_address, module_base);
+	printf("\t rsp = 0x%016" PRIx64 ", rbp = 0x%016" PRIx64 "\n", info.rsp, info.rbp);
+	printf("\t thread = %" PRIu32 "\n", static_cast<uint32_t>(GetCurrentThreadId()));
+
+	printf("\t rax=%016" PRIx64 " rcx=%016" PRIx64 " rdx=%016" PRIx64 " rbx=%016" PRIx64 "\n",
+	       info.rax, info.rcx, info.rdx, info.rbx);
+	printf("\t rsi=%016" PRIx64 " rdi=%016" PRIx64 " r8 =%016" PRIx64 " r9 =%016" PRIx64 "\n",
+	       info.rsi, info.rdi, info.r8, info.r9);
+	printf("\t r10=%016" PRIx64 " r11=%016" PRIx64 " r12=%016" PRIx64 " r13=%016" PRIx64 "\n",
+	       info.r10, info.r11, info.r12, info.r13);
+	printf("\t r14=%016" PRIx64 " r15=%016" PRIx64 "\n", info.r14, info.r15);
+
+	// Everything below rsp has already been overwritten by the exception frame this very fault
+	// pushed, so it cannot say who clobbered the red zone. What is still original is the memory
+	// *above* rsp: the callee-saved registers this frame pushed and the caller frames. If a guest
+	// stack was recycled and zero-filled under the running thread, those read back as zeroes while
+	// the live registers do not; if only the red zone was hit, they are intact.
+	constexpr int64_t DumpBelow = 0xc0;
+	constexpr int64_t DumpAbove = 0x200;
+	MEMORY_BASIC_INFORMATION region {};
+	const auto  low  = reinterpret_cast<const uint8_t*>(info.rsp - DumpBelow);
+	const auto  high = reinterpret_cast<const uint8_t*>(info.rsp + DumpAbove);
+	const bool  readable =
+	    VirtualQuery(low, &region, sizeof(region)) == sizeof(region) &&
+	    region.State == MEM_COMMIT &&
+	    high <= static_cast<const uint8_t*>(region.BaseAddress) + region.RegionSize;
+	printf("\t stack window [rsp-0x%" PRIx64 " .. rsp+0x%" PRIx64 ") readable=%d\n",
+	       static_cast<uint64_t>(DumpBelow), static_cast<uint64_t>(DumpAbove),
+	       static_cast<int>(readable));
+	if (readable) {
+		for (int64_t offset = -DumpBelow; offset < DumpAbove; offset += 32) {
+			uint64_t words[4] {};
+			memcpy(words, reinterpret_cast<const void*>(info.rsp + offset), sizeof(words));
+			printf("\t rsp%c0x%03" PRIx64 ": %016" PRIx64 " %016" PRIx64 " %016" PRIx64
+			       " %016" PRIx64 "\n",
+			       offset < 0 ? '-' : '+', static_cast<uint64_t>(offset < 0 ? -offset : offset),
+			       words[0], words[1], words[2], words[3]);
+		}
+		uint64_t saved[8] {};
+		memcpy(saved, reinterpret_cast<const void*>(info.rsp), sizeof(saved));
+		int zero_words = 0;
+		for (const uint64_t word: saved) {
+			zero_words += static_cast<int>(word == 0);
+		}
+		printf("\t saved-frame words above rsp zero=%d of 8 (a zero-filled guest stack shows 8)\n",
+		       zero_words);
+	}
+
+	void* frames[32] {};
+	const auto count = CaptureStackBackTrace(0, 32, frames, nullptr);
+	for (USHORT i = 0; i < count; i++) {
+		printf("\t [%02d] 0x%016" PRIx64 "\n", i, reinterpret_cast<uint64_t>(frames[i]));
+	}
+	DumpExceptionRing();
+	fflush(stdout);
+}
+
+// Direct measurement of the hazard this patcher exists to remove, rather than of the rare crash it
+// eventually causes. Set KYTY_FAULT_WATCH=lo-hi (hex guest addresses) to have every fault taken
+// inside that range reported with the stack pointer it was taken at. An instruction the red zone
+// patcher covered faults with rsp already biased down by 128; an uncovered one faults at the
+// guest's own rsp, which is precisely when the kernel's exception frame lands on live data.
+static void ReportWatchedFault(uint64_t rip, uint64_t rsp) noexcept {
+	static const auto range = [] {
+		std::pair<uint64_t, uint64_t> value {1, 0};
+		if (const char* env = std::getenv("KYTY_FAULT_WATCH"); env != nullptr) {
+			char*      end = nullptr;
+			const auto lo  = std::strtoull(env, &end, 16);
+			if (end != env && *end == '-') {
+				const char* second = end + 1;
+				const auto  hi     = std::strtoull(second, &end, 16);
+				if (end != second) {
+					value = {lo, hi};
+				}
+			}
+		}
+		return value;
+	}();
+	if (rip < range.first || rip >= range.second) {
+		return;
+	}
+
+	static std::atomic_uint64_t seen {0};
+	const auto count = seen.fetch_add(1, std::memory_order_relaxed) + 1;
+	if (count <= 64 || count % 256 == 0) {
+		printf("FAULTWATCH n=%" PRIu64 " rip=0x%016" PRIx64 " rsp=0x%016" PRIx64 "\n", count, rip,
+		       rsp);
+		fflush(stdout);
+	}
+}
+
+// Every exception the process takes, per thread, in a small ring. Windows dispatches a fault by
+// building its exception frame on the faulting thread's own stack, below rsp, so a fault taken
+// while a System V guest frame holds live data in its 128-byte red zone destroys that data. The
+// ring makes the destroying fault visible after the fact: at the crash it names the instruction
+// and the stack pointer of the last faults this thread took.
+struct ExceptionRingEntry {
+	uint32_t serial = 0;
+	uint32_t code   = 0;
+	uint64_t rip    = 0;
+	uint64_t rsp    = 0;
+	uint64_t vaddr  = 0;
+};
+
+constexpr uint32_t                  EXCEPTION_RING_SIZE = 24;
+static thread_local ExceptionRingEntry g_exception_ring[EXCEPTION_RING_SIZE] {};
+static thread_local uint32_t           g_exception_ring_next = 0;
+static thread_local uint32_t           g_exception_serial    = 0;
+
+// Where the kernel put the frame it built for this fault, relative to the stack pointer the guest
+// was running on. Windows has no red zone, so the frame is free to start immediately below rsp;
+// System V guest code keeps live data in the 128 bytes below rsp. Reported once so a run can be
+// read without guessing.
+static void ReportFrameExtentOnce(PEXCEPTION_POINTERS exception, uint64_t rsp) noexcept {
+	static std::atomic_flag reported = ATOMIC_FLAG_INIT;
+	if (reported.test_and_set(std::memory_order_relaxed)) {
+		return;
+	}
+	const auto record  = reinterpret_cast<uint64_t>(exception->ExceptionRecord);
+	const auto context = reinterpret_cast<uint64_t>(exception->ContextRecord);
+	const auto record_top  = record + sizeof(EXCEPTION_RECORD);
+	const auto context_top = context + sizeof(CONTEXT);
+	const auto top         = record_top > context_top ? record_top : context_top;
+	printf("FRAMEEXTENT rsp=0x%016" PRIx64 " record=0x%016" PRIx64 " context=0x%016" PRIx64
+	       " frame_top=0x%016" PRIx64 " bytes_of_red_zone_destroyed=%" PRId64 "\n",
+	       rsp, record, context, top, static_cast<int64_t>(rsp) - static_cast<int64_t>(top) >= 128
+	                                      ? 0
+	                                      : 128 - (static_cast<int64_t>(rsp) - static_cast<int64_t>(top)));
+	fflush(stdout);
+}
+
+static void RecordException(uint32_t code, uint64_t rip, uint64_t rsp, uint64_t vaddr) noexcept {
+	auto& entry  = g_exception_ring[g_exception_ring_next++ % EXCEPTION_RING_SIZE];
+	entry.serial = ++g_exception_serial;
+	entry.code   = code;
+	entry.rip    = rip;
+	entry.rsp    = rsp;
+	entry.vaddr  = vaddr;
+}
+
+static void DumpExceptionRing() noexcept {
+	printf("\t last faults on this thread (%" PRIu32 " total); a fault taken at the guest's own "
+	       "rsp destroys its red zone\n",
+	       g_exception_serial);
+	for (uint32_t i = 0; i < EXCEPTION_RING_SIZE; i++) {
+		const auto& entry = g_exception_ring[(g_exception_ring_next + i) % EXCEPTION_RING_SIZE];
+		if (entry.serial == 0) {
+			continue;
+		}
+		printf("\t FAULT n=%" PRIu32 " code=0x%08" PRIx32 " rip=0x%016" PRIx64 " rsp=0x%016" PRIx64
+		       " at=0x%016" PRIx64 "\n",
+		       entry.serial, entry.code, entry.rip, entry.rsp, entry.vaddr);
+	}
+}
 
 static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) noexcept {
 	auto* exception_record = exception->ExceptionRecord;
@@ -67,6 +251,13 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) noexcept {
 		return EXCEPTION_CONTINUE_SEARCH;
 	}
 
+	ReportWatchedFault(reinterpret_cast<uint64_t>(exception_record->ExceptionAddress),
+	                   exception->ContextRecord->Rsp);
+	ReportFrameExtentOnce(exception, exception->ContextRecord->Rsp);
+	RecordException(exception_record->ExceptionCode,
+	                reinterpret_cast<uint64_t>(exception_record->ExceptionAddress),
+	                exception->ContextRecord->Rsp, info.access_violation_vaddr);
+
 	info.rax = exception->ContextRecord->Rax;
 	info.rbx = exception->ContextRecord->Rbx;
 	info.rcx = exception->ContextRecord->Rcx;
@@ -87,6 +278,12 @@ static LONG WINAPI ExceptionFilter(PEXCEPTION_POINTERS exception) noexcept {
 	const auto handler = g_handler.load(std::memory_order_acquire);
 	if (handler != nullptr && handler(info)) {
 		return EXCEPTION_CONTINUE_EXECUTION;
+	}
+	// Breakpoints and single-steps also land here whenever a handler declines the
+	// event, and those are routine; only a genuine fault is worth reporting.
+	if (info.type == ExceptionType::AccessViolation ||
+	    info.type == ExceptionType::IllegalInstruction) {
+		ReportUnhandledFault(exception, info);
 	}
 	return EXCEPTION_CONTINUE_SEARCH;
 }

--- a/src/graphics/host_gpu/memoryTracker.h
+++ b/src/graphics/host_gpu/memoryTracker.h
@@ -23,6 +23,20 @@ public:
 
 	KYTY_CLASS_NO_COPY(MemoryTracker);
 
+	// Diagnostics: the region belief for one page, without creating a region.
+	[[nodiscard]] bool DescribePage(uint64_t vaddr, RegionManager::PageDiagnostics* out) const {
+		const auto index = vaddr / TRACKER_REGION_SIZE;
+		if (index >= REGION_COUNT) {
+			return false;
+		}
+		const auto* manager = m_regions[index].load(std::memory_order_acquire);
+		if (manager == nullptr) {
+			return false;
+		}
+		*out = manager->DescribePage(vaddr);
+		return true;
+	}
+
 	[[nodiscard]] bool IsRegionCpuModified(uint64_t vaddr, uint64_t size);
 	[[nodiscard]] bool IsRegionGpuModified(uint64_t vaddr, uint64_t size);
 	void               MarkRegionAsCpuModified(uint64_t vaddr, uint64_t size);

--- a/src/graphics/host_gpu/pageManager.cpp
+++ b/src/graphics/host_gpu/pageManager.cpp
@@ -331,6 +331,23 @@ uint64_t PageManager::GetPageSize() const {
 	return PAGE_SIZE;
 }
 
+PageManager::PageDiagnostics PageManager::DescribePage(uint64_t vaddr) const {
+	PageDiagnostics result {};
+	auto*           region = m_impl->FindRegion(vaddr);
+	if (region == nullptr) {
+		return result;
+	}
+	const auto region_base = vaddr / REGION_SIZE * REGION_SIZE;
+	const auto index       = static_cast<size_t>((PageStart(vaddr) - region_base) / PAGE_SIZE);
+	SpinGuard  lock(region->lock);
+	const auto& page = region->pages[index];
+	result.known               = true;
+	result.write_watchers      = page.write_watchers;
+	result.access_watchers     = page.access_watchers;
+	result.expected_protection = page.Perms();
+	return result;
+}
+
 template <bool track>
 void PageManager::UpdatePageWatchers(uint64_t vaddr, uint64_t size) {
 	m_impl->UpdatePageWatchers<track, false>(vaddr, size);

--- a/src/graphics/host_gpu/pageManager.h
+++ b/src/graphics/host_gpu/pageManager.h
@@ -20,6 +20,16 @@ public:
 
 	[[nodiscard]] uint64_t GetPageSize() const;
 
+	// Diagnostics: the watcher state this manager believes a page has, and the protection that
+	// state implies. Compared against the real host protection it shows tracker/OS divergence.
+	struct PageDiagnostics {
+		bool     known               = false;
+		uint32_t write_watchers      = 0;
+		uint32_t access_watchers     = 0;
+		uint32_t expected_protection = 0;
+	};
+	[[nodiscard]] PageDiagnostics DescribePage(uint64_t vaddr) const;
+
 	template <bool track>
 	void UpdatePageWatchers(uint64_t vaddr, uint64_t size);
 	template <bool track, bool is_read = false>

--- a/src/graphics/host_gpu/regionManager.h
+++ b/src/graphics/host_gpu/regionManager.h
@@ -84,6 +84,29 @@ public:
 	KYTY_CLASS_NO_COPY(RegionManager);
 
 	[[nodiscard]] uint64_t GetCpuAddr() const { return m_cpu_addr; }
+
+	// Diagnostics: this region's per-page belief about a single page. `writable`/`readable` are
+	// what the region thinks the host protection already is; a mismatch with the real protection
+	// means a protection update was skipped by the mask.None() early-out.
+	struct PageDiagnostics {
+		bool cpu_dirty = false;
+		bool gpu_dirty = false;
+		bool writable  = false;
+		bool readable  = false;
+	};
+	[[nodiscard]] PageDiagnostics DescribePage(uint64_t vaddr) const {
+		PageDiagnostics result {};
+		if (vaddr < m_cpu_addr || vaddr - m_cpu_addr >= TRACKER_REGION_SIZE) {
+			return result;
+		}
+		const auto index = static_cast<size_t>((vaddr - m_cpu_addr) / TRACKER_PAGE_SIZE);
+		result.cpu_dirty = m_cpu_dirty.Get(index);
+		result.gpu_dirty = m_gpu_dirty.Get(index);
+		result.writable  = m_writable.Get(index);
+		result.readable  = m_readable.Get(index);
+		return result;
+	}
+
 	template <DirtySource source>
 	[[nodiscard]] bool IsModified(uint64_t offset, uint64_t size) const {
 		const auto [start, end] = GetPageRange(m_cpu_addr + offset, size);

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.h
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.h
@@ -38,6 +38,12 @@ public:
 	~BufferCache();
 	KYTY_CLASS_NO_COPY(BufferCache);
 
+	// Diagnostics: what this cache's tracker believes about a single page.
+	[[nodiscard]] bool DescribeTrackerPage(uint64_t vaddr,
+	                                       RegionManager::PageDiagnostics* out) const {
+		return m_memory_tracker.DescribePage(vaddr, out);
+	}
+
 	void                   InvalidateMemory(uint64_t vaddr, uint64_t size);
 	void                   ReadMemory(uint64_t vaddr, uint64_t size, bool is_write = false);
 	[[nodiscard]] Buffer&  GetBuffer(BufferId id) { return m_slot_buffers[id]; }

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -3,7 +3,93 @@
 #include "common/assert.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/host_gpu/renderer/commandScheduler.h"
+#include "kernel/memory.h"
+
+#include <cinttypes>
+#include <cstdio>
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#undef min
+#undef max
+#endif
+
 namespace Libs::Graphics {
+
+namespace {
+
+// The real host protection of a page, so a claimed-but-unresolved fault can be told apart from a
+// genuine repeat. A tracker that believes a page is writable while the OS reports read-only is the
+// signature of a protection update that the mask.None() early-out skipped.
+uint32_t QueryHostProtection(uint64_t vaddr) noexcept {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	MEMORY_BASIC_INFORMATION info {};
+	if (VirtualQuery(reinterpret_cast<const void*>(vaddr), &info, sizeof(info)) == 0) {
+		return 0;
+	}
+	return info.State == MEM_COMMIT ? info.Protect : 0;
+#else
+	(void)vaddr;
+	return 0;
+#endif
+}
+
+} // namespace
+
+// Safety net, not a fix. A fault this manager claims must actually be resolved: the filter resumes
+// the guest instruction, which re-executes the same store. If the caches leave the page protected
+// the store faults again immediately and the thread makes no progress at all -- a livelock that is
+// indistinguishable from a hang and that no amount of waiting escapes. Whenever a single page is
+// claimed this many times in a row without another page intervening, force the host protection
+// open so the thread advances, and report the tracker state that caused it. A redundant
+// VirtualProtect costs microseconds; a livelocked render thread costs the process.
+void GpuResourceManager::ResolveRepeatedFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept {
+	// Far above any legitimate consecutive-repeat burst (a page reprotected between two guest
+	// stores repeats a handful of times), far below the tens of millions a real livelock reaches.
+	constexpr uint64_t UNRESOLVED_FAULT_LIMIT = 4096;
+	constexpr uint64_t MAX_REPORTS            = 16;
+
+	static thread_local uint64_t last_page = 0;
+	static thread_local uint64_t repeats   = 0;
+	static thread_local uint64_t reported  = 0;
+
+	const auto page = fault_vaddr & ~(TRACKER_PAGE_SIZE - 1);
+	if (page != last_page) {
+		last_page = page;
+		repeats   = 1;
+		return;
+	}
+	if (++repeats < UNRESOLVED_FAULT_LIMIT) {
+		return;
+	}
+	repeats = 1;
+
+	if (reported < MAX_REPORTS) {
+		reported++;
+		const auto page_state   = m_page_manager.DescribePage(page);
+		const auto host_protect = QueryHostProtection(page);
+		printf("FAULTLOOP page=0x%016" PRIx64 " at=0x%016" PRIx64 " access=%d claimed %" PRIu64
+		       " times without progress; tracker(write_watchers=%" PRIu32 " access_watchers=%" PRIu32
+		       " known=%d expected_protect=0x%02" PRIx32 ") host_protect=0x%08" PRIx32 "\n",
+		       page, fault_vaddr, static_cast<int>(access), UNRESOLVED_FAULT_LIMIT,
+		       page_state.write_watchers, page_state.access_watchers,
+		       static_cast<int>(page_state.known), page_state.expected_protection, host_protect);
+		RegionManager::PageDiagnostics region {};
+		if (m_buffer_cache.DescribeTrackerPage(page, &region)) {
+			printf("\t BUFFER REGION cpu_dirty=%d gpu_dirty=%d writable=%d readable=%d\n",
+			       static_cast<int>(region.cpu_dirty), static_cast<int>(region.gpu_dirty),
+			       static_cast<int>(region.writable), static_cast<int>(region.readable));
+		}
+		m_texture_cache.DescribePageImages(page);
+		fflush(stdout);
+	}
+
+	(void)LibKernel::Memory::ProtectGuestHostMemory(page, TRACKER_PAGE_SIZE,
+	                                                Common::VirtualMemory::Mode::ReadWrite);
+}
 
 GpuResourceManager::GpuResourceManager(GraphicContext& graphics, CommandScheduler& scheduler)
     : m_scheduler(scheduler), m_buffer_cache(graphics, scheduler, m_page_manager, m_texture_cache),
@@ -22,6 +108,7 @@ bool GpuResourceManager::HandleFault(PageFaultAccess access, uint64_t fault_vadd
 	} else {
 		m_buffer_cache.ReadMemory(fault_vaddr, fault_size);
 	}
+	ResolveRepeatedFault(access, fault_vaddr);
 	return true;
 }
 

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
@@ -26,6 +26,7 @@ public:
 	void                        SetGpu(GuestGpu* gpu) noexcept { m_gpu = gpu; }
 
 	[[nodiscard]] bool HandleFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept;
+	void               ResolveRepeatedFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept;
 	[[nodiscard]] bool InvalidateMemory(uint64_t vaddr, uint64_t size);
 	[[nodiscard]] bool IsMapped(uint64_t vaddr, uint64_t size) const noexcept;
 	void               MapMemory(uint64_t vaddr, uint64_t size);

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1441,6 +1441,23 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t address
 	return true;
 }
 
+void TextureCache::DescribePageImages(uint64_t address) {
+	const auto       page = address & ~(TRACKER_PAGE_SIZE - 1);
+	std::scoped_lock lock {m_lock};
+	for (const auto id: FindImagesInRegion(page, TRACKER_PAGE_SIZE, true)) {
+		const auto* image = m_slot_images.try_get(id);
+		if (image == nullptr) {
+			continue;
+		}
+		printf("\t IMAGE id=%u data=[0x%016" PRIx64 ",0x%016" PRIx64 ") track=[0x%016" PRIx64
+		       ",0x%016" PRIx64 ") registered=%d gpu_modified=%d has_depth=%d\n",
+		       id.index, image->info.data.address, image->info.data.End(), image->track_addr,
+		       image->track_addr_end, static_cast<int>(image->registered),
+		       static_cast<int>(image->IsGpuModified()),
+		       static_cast<int>(static_cast<bool>(image->depth_id)));
+	}
+}
+
 void TextureCache::InvalidateMemory(uint64_t address, uint64_t size) {
 	if (!GuestRange {address, size}.Valid()) {
 		EXIT("TextureCache: invalid memory-invalidation range\n");
@@ -1745,9 +1762,14 @@ void TextureCache::InvalidateCpuAliases(uint64_t address, uint64_t size) {
 	const auto page_end   = (address + size + TRACKER_PAGE_SIZE - 1) & ~(TRACKER_PAGE_SIZE - 1);
 	for (const auto id: FindImagesInRegion(address, size, true)) {
 		auto owner = m_slot_images.try_get(id);
-		if (owner == nullptr || owner->depth_id) {
+		if (owner == nullptr) {
 			continue;
 		}
+		// A stencil association owns no contents, but RefreshImage still installs page watchers
+		// over its guest range. Skipping it here left the watcher in place forever: the guest
+		// store that raised the fault was resumed onto a still-read-only page and re-faulted
+		// immediately, livelocking the faulting thread. Invalidate it like any other image so the
+		// watcher is dropped and the plane is re-imported on its next binding.
 		if (owner->Overlaps(address, size)) {
 			owner->InvalidateCpuWrite(address, size);
 			UntrackImage(id);

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -64,6 +64,8 @@ public:
 
 	[[nodiscard]] bool ClearImageFromBuffer(CommandBuffer& command, uint64_t address, uint64_t size,
 	                                        uint32_t packed_clear);
+	// Diagnostics: describe every image whose tracked range covers a page, for fault triage.
+	void               DescribePageImages(uint64_t address);
 	void               InvalidateMemory(uint64_t address, uint64_t size);
 	void               InvalidateMemoryFromGPU(uint64_t address, uint64_t size);
 	[[nodiscard]] RegionInfo QueryRegion(uint64_t address, uint64_t size);

--- a/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
@@ -13,13 +13,36 @@
 #include "graphics/host_gpu/renderer/renderContext.h"
 #include "graphics/host_gpu/vulkanCommon.h"
 
+#include <vulkan/vulkan_format_traits.hpp>
+
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <string_view>
 
 namespace Libs::Graphics {
 
 static std::atomic<uint32_t> g_render_color_log_count = 0;
+
+// The fixed DCC clear codes (0x40/0x80/0xc0) encode a literal 0.0 or 1.0 per channel, so unlike
+// the register-backed code they need no packed decode and are not tied to a particular bit layout.
+// Any format whose Vulkan clear value is expressed through the float union can materialize them;
+// integer targets cannot, because their clear must be written through uint32/int32 instead.
+[[nodiscard]] static bool SupportsFixedDccClear(vk::Format format) {
+	const auto components = vk::componentCount(format);
+	if (components == 0 || vk::isCompressed(format)) {
+		return false;
+	}
+	for (uint8_t component = 0; component < components; component++) {
+		const std::string_view numeric = vk::componentNumericFormat(format, component);
+		if (numeric != "UNORM" && numeric != "SNORM" && numeric != "USCALED" &&
+		    numeric != "SSCALED" && numeric != "SFLOAT" && numeric != "UFLOAT" &&
+		    numeric != "SRGB") {
+			return false;
+		}
+	}
+	return true;
+}
 
 static void ResolveDccClearInfo(RenderColorInfo& info, vk::Format format, bool has_dcc,
                                 uint32_t packed_clear) {
@@ -27,17 +50,7 @@ static void ResolveDccClearInfo(RenderColorInfo& info, vk::Format format, bool h
 	// formats here; unsupported encodings remain tracked without unsafe materialization.
 	info.metadata_clear_supported =
 	    has_dcc && DecodePackedColorClear(format, packed_clear, info.color_clear_value);
-	switch (format) {
-		case vk::Format::eR8G8B8A8Unorm:
-		case vk::Format::eR8G8B8A8Srgb:
-		case vk::Format::eB8G8R8A8Unorm:
-		case vk::Format::eB8G8R8A8Srgb:
-		case vk::Format::eA2B10G10R10UnormPack32:
-		case vk::Format::eA2R10G10B10UnormPack32:
-			info.metadata_fixed_clear_supported = has_dcc;
-			break;
-		default: info.metadata_fixed_clear_supported = false; break;
-	}
+	info.metadata_fixed_clear_supported = has_dcc && SupportsFixedDccClear(format);
 	if (!info.metadata_clear_supported) {
 		info.color_clear_value = {};
 	}

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -1,5 +1,6 @@
 #include "common/assert.h"
 #include "common/common.h"
+
 #include "common/emulatorConfig.h"
 #include "common/file.h"
 #include "common/logging/log.h"
@@ -17,6 +18,7 @@
 #include "graphics/host_gpu/renderer/render.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
 #include "graphics/host_gpu/vulkanCommon.h"
+#include "graphics/shader/recompiler/ir/Block.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 #include "graphics/shader/recompiler/ir/passes/ResourceMaterialization.h"
 #include "graphics/shader/shader.h"
@@ -74,6 +76,34 @@ bool RenderExecutor::TryConsumeComputeMetaClear(const ShaderComputeInputInfo& in
 	return false;
 }
 
+static bool ResolveConstantDwordStore(const ShaderRecompiler::IR::Program& program,
+                                      uint32_t&                            clear) {
+	constexpr size_t StoreValueArg = 4;
+	bool             found         = false;
+	for (const auto* block: program.blocks) {
+		for (const auto& inst: *block) {
+			const auto op = inst.GetOpcode();
+			if (op != ShaderRecompiler::IR::ValueOpcode::StoreBufferU32) {
+				if (ShaderRecompiler::IR::BufferAccessOf(op) !=
+				    ShaderRecompiler::IR::BufferAccess::None) {
+					return false; // some other buffer traffic: not a plain fill
+				}
+				continue;
+			}
+			if (found || inst.NumArgs() <= StoreValueArg) {
+				return false; // more than one store, or an unexpected shape
+			}
+			const auto value = inst.Arg(StoreValueArg);
+			if (!value.IsImmediate()) {
+				return false; // the fill value is computed, not a constant we can name
+			}
+			clear = value.U32();
+			found = true;
+		}
+	}
+	return found;
+}
+
 bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t group_x,
                               uint32_t group_y, uint32_t group_z, uint32_t mode,
                               ShaderBufferResource& resolved_descriptor, uint32_t& resolved_clear,
@@ -88,12 +118,15 @@ bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t grou
 	const auto& resource   = program.info.buffers.front();
 	const auto& raw        = resources.buffers.front();
 	const auto  descriptor = DecodeNativeDescriptor<ShaderBufferResource>(raw);
+	const bool quad_fill = resource.max_byte_extent == 16 && descriptor.Stride() == 16 &&
+	                       descriptor.Format() == Prospero::BufferFormat::k32_32_32_32UInt;
+	const bool dword_fill = resource.max_byte_extent == 4 && descriptor.Stride() == 4 &&
+	                        descriptor.Format() == Prospero::BufferFormat::k32UInt;
 	if (!resource.formatted || !resource.written || resource.read || resource.atomic ||
-	    resource.scalar || resource.max_byte_extent != 16 || descriptor.Stride() != 16 ||
-	    descriptor.Format() != Prospero::BufferFormat::k32_32_32_32UInt ||
-	    descriptor.SwizzleEnabled() || descriptor.IndexStride() != 0 || descriptor.AddTid() ||
+	    resource.scalar || (!quad_fill && !dword_fill) || descriptor.SwizzleEnabled() ||
+	    descriptor.IndexStride() != 0 || descriptor.AddTid() ||
 	    resource.packed_stride != descriptor.PackedStride() || raw.dword_count != 4 ||
-	    program.user_data_base != 0 || resources.user_data.size() != 8) {
+	    program.user_data_base != 0 || resources.user_data.size() < raw.dword_count) {
 		return false;
 	}
 	for (uint32_t i = 0; i < raw.dword_count; i++) {
@@ -101,19 +134,34 @@ bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t grou
 			return false;
 		}
 	}
-	const uint32_t clear = resources.user_data[4];
-	if (resources.user_data[5] != clear || resources.user_data[6] != clear ||
-	    resources.user_data[7] != clear) {
+	uint32_t clear = 0;
+	if (quad_fill) {
+		if (resources.user_data.size() != 8) {
+			return false;
+		}
+		clear = resources.user_data[4];
+		if (resources.user_data[5] != clear || resources.user_data[6] != clear ||
+		    resources.user_data[7] != clear) {
+			return false;
+		}
+	} else if (!ResolveConstantDwordStore(program, clear)) {
 		return false;
 	}
+	// group_x is a thread count for the quad shape and a group count for the dword one.
+	const bool common =
+	    input.threads_num[0] == 64 && input.threads_num[1] == 1 && input.threads_num[2] == 1 &&
+	    group_x != 0 && group_y == 1 && group_z == 1 && input.group_id[0] && !input.group_id[1] &&
+	    !input.group_id[2] && input.thread_ids_num == 1 && input.wave_size == 64 &&
+	    !input.tg_size_en;
 	const bool full_dispatch =
-	    input.dispatch_thread_dimensions && input.threads_num[0] == 64 &&
-	    input.threads_num[1] == 1 && input.threads_num[2] == 1 && group_x != 0 && group_y == 1 &&
-	    group_z == 1 && input.dispatch_threads_num[0] == group_x &&
-	    input.dispatch_threads_num[1] == 1 && input.dispatch_threads_num[2] == 1 &&
-	    input.group_id[0] && !input.group_id[1] && !input.group_id[2] &&
-	    input.thread_ids_num == 1 && input.wave_size == 64 && !input.tg_size_en && mode == 0x61u &&
-	    group_x % input.threads_num[0] == 0 && descriptor.NumRecords() == group_x;
+	    common &&
+	    (quad_fill ? (input.dispatch_thread_dimensions && mode == 0x61u &&
+	                  input.dispatch_threads_num[0] == group_x &&
+	                  input.dispatch_threads_num[1] == 1 && input.dispatch_threads_num[2] == 1 &&
+	                  group_x % input.threads_num[0] == 0 && descriptor.NumRecords() == group_x)
+	               : (!input.dispatch_thread_dimensions &&
+	                  descriptor.NumRecords() ==
+	                      static_cast<uint64_t>(group_x) * input.threads_num[0]));
 	const auto size = BufferDescriptorSize(descriptor);
 	if (!full_dispatch || size == 0) {
 		return false;
@@ -135,7 +183,9 @@ static bool TryConsumeComputeImageClear(const ShaderComputeInputInfo& input, Com
 		return false;
 	}
 	auto& cache = command.GetContext().GetTextureCache();
-	if (!cache.ClearImageFromBuffer(command, descriptor.Base48(), size, packed_clear)) {
+	const bool image_cleared = cache.ClearImageFromBuffer(command, descriptor.Base48(), size,
+	                                                      packed_clear);
+	if (!image_cleared) {
 		// Recognized metadata-fill shaders access DCC as an ordinary storage buffer and may run
 		// before the render target is bound. TryConsumeDccFill either consumes registered state
 		// or retains a PendingDcc fill while allowing the dispatch to run.

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -23,6 +23,7 @@
 #include "graphics/shader/recompiler/ir/passes/ResourceMaterialization.h"
 #include "graphics/shader/shader.h"
 #include "kernel/eventQueue.h"
+#include "kernel/memory.h"
 #include "kernel/pthread.h"
 #include "libs/errno.h"
 
@@ -76,32 +77,91 @@ bool RenderExecutor::TryConsumeComputeMetaClear(const ShaderComputeInputInfo& in
 	return false;
 }
 
-static bool ResolveConstantDwordStore(const ShaderRecompiler::IR::Program& program,
-                                      uint32_t&                            clear) {
+// Locate the single dword store of a fill shader and name the value it writes.
+//
+// A fast-clear shader either stores an immediate or loads the clear code from a small read-only
+// constant buffer. The latter is resolved out of guest memory: the guest has already written that
+// constant by the time it issues the dispatch, so reading it here yields the value the shader is
+// about to store. Constant reads are tolerated; anything else touching a buffer is not, so a
+// shader that computes its value per lane is still rejected.
+static bool ResolveConstantDwordStore(const ShaderComputeInputInfo& input, uint32_t fill_resource,
+                                      uint32_t& clear) {
+	using namespace ShaderRecompiler;
 	constexpr size_t StoreValueArg = 4;
-	bool             found         = false;
+	const auto&      program       = *input.stage.program;
+	const auto&      resources     = *input.stage.resources;
+	const auto       memory_of     = [&program](const IR::Inst& inst) -> const IR::MemoryInfo* {
+        const auto index = inst.template Flags<IR::MemoryFlags>().index;
+        if (index >= program.memory_info.size()) {
+            return nullptr;
+        }
+        return &program.memory_info[index];
+	};
+
+	const IR::Inst* store = nullptr;
 	for (const auto* block: program.blocks) {
 		for (const auto& inst: *block) {
-			const auto op = inst.GetOpcode();
-			if (op != ShaderRecompiler::IR::ValueOpcode::StoreBufferU32) {
-				if (ShaderRecompiler::IR::BufferAccessOf(op) !=
-				    ShaderRecompiler::IR::BufferAccess::None) {
-					return false; // some other buffer traffic: not a plain fill
-				}
+			const auto op     = inst.GetOpcode();
+			const auto access = IR::BufferAccessOf(op);
+			if (access == IR::BufferAccess::None) {
 				continue;
 			}
-			if (found || inst.NumArgs() <= StoreValueArg) {
-				return false; // more than one store, or an unexpected shape
+			if (access == IR::BufferAccess::Read) {
+				continue; // reading a constant is how the clear code reaches the shader
 			}
-			const auto value = inst.Arg(StoreValueArg);
-			if (!value.IsImmediate()) {
-				return false; // the fill value is computed, not a constant we can name
+			if (op != IR::ValueOpcode::StoreBufferU32 || store != nullptr) {
+				return false;
 			}
-			clear = value.U32();
-			found = true;
+			store = &inst;
 		}
 	}
-	return found;
+	if (store == nullptr || store->NumArgs() <= StoreValueArg) {
+		return false;
+	}
+	const auto* store_memory = memory_of(*store);
+	if (store_memory == nullptr || store_memory->kind != IR::ResourceKind::Buffer ||
+	    store_memory->resource != fill_resource) {
+		return false;
+	}
+
+	const auto value = store->Arg(StoreValueArg);
+	if (value.IsImmediate()) {
+		clear = value.U32();
+		return true;
+	}
+
+	const auto* source = value.ResolveInstruction();
+	if (source == nullptr) {
+		return false;
+	}
+	if (source->GetOpcode() != IR::ValueOpcode::ReadConstBuffer || source->NumArgs() < 2 ||
+	    !source->Arg(1).IsImmediate()) {
+		return false;
+	}
+	const auto* source_memory = memory_of(*source);
+	// A constant load carries ResourceKind::ScalarBuffer; only a vector access is ::Buffer.
+	if (source_memory == nullptr ||
+	    (source_memory->kind != IR::ResourceKind::Buffer &&
+	     source_memory->kind != IR::ResourceKind::ScalarBuffer) ||
+	    source_memory->resource >= program.info.buffers.size() ||
+	    source_memory->resource >= resources.buffers.size() ||
+	    source_memory->resource == fill_resource ||
+	    program.info.buffers[source_memory->resource].written) {
+		return false;
+	}
+	const auto descriptor =
+	    DecodeNativeDescriptor<ShaderBufferResource>(resources.buffers[source_memory->resource]);
+	const uint64_t offset = static_cast<uint64_t>(source_memory->offset) + source->Arg(1).U32();
+	if (offset > BufferDescriptorSize(descriptor) - sizeof(uint32_t)) {
+		return false;
+	}
+	uint32_t loaded = 0;
+	if (!Libs::LibKernel::Memory::TryReadBacking(descriptor.Base48() + offset, &loaded,
+	                                             sizeof(loaded))) {
+		return false;
+	}
+	clear = loaded;
+	return true;
 }
 
 bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t group_x,
@@ -110,13 +170,31 @@ bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t grou
                               uint64_t& resolved_size) {
 	const auto& program   = *input.stage.program;
 	const auto& resources = *input.stage.resources;
-	if (program.info.buffers.size() != 1 || resources.buffers.size() != 1 ||
+	if (resources.buffers.size() != program.info.buffers.size() || program.info.buffers.empty() ||
 	    !program.info.images.empty() || !program.info.samplers.empty() || program.info.uses_dma ||
 	    !resources.images.empty() || !resources.samplers.empty()) {
 		return false;
 	}
-	const auto& resource   = program.info.buffers.front();
-	const auto& raw        = resources.buffers.front();
+	// Exactly one buffer is filled. A fast-clear shader may additionally bind small read-only
+	// constant buffers that hold the clear code, so tolerate those and nothing else: any second
+	// written buffer, atomic, or formatted read means this is real compute work, not a fill.
+	uint32_t fill_index = UINT32_MAX;
+	for (uint32_t i = 0; i < program.info.buffers.size(); i++) {
+		const auto& candidate = program.info.buffers[i];
+		if (candidate.written) {
+			if (fill_index != UINT32_MAX) {
+				return false;
+			}
+			fill_index = i;
+		} else if (candidate.atomic || candidate.formatted || !candidate.scalar) {
+			return false;
+		}
+	}
+	if (fill_index == UINT32_MAX) {
+		return false;
+	}
+	const auto& resource   = program.info.buffers[fill_index];
+	const auto& raw        = resources.buffers[fill_index];
 	const auto  descriptor = DecodeNativeDescriptor<ShaderBufferResource>(raw);
 	const bool quad_fill = resource.max_byte_extent == 16 && descriptor.Stride() == 16 &&
 	                       descriptor.Format() == Prospero::BufferFormat::k32_32_32_32UInt;
@@ -129,14 +207,26 @@ bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t grou
 	    program.user_data_base != 0 || resources.user_data.size() < raw.dword_count) {
 		return false;
 	}
-	for (uint32_t i = 0; i < raw.dword_count; i++) {
-		if (raw.dwords[i] != resources.user_data[i]) {
-			return false;
+	// The descriptor must have reached the shader verbatim through user data, so that the address
+	// we are about to clear is the one the guest named. Which slot it occupies depends on how the
+	// shader lays its resources out, so find it rather than assuming a fixed position.
+	bool descriptor_from_user_data = false;
+	for (size_t base = 0;
+	     !descriptor_from_user_data && base + raw.dword_count <= resources.user_data.size();
+	     base += 4) {
+		bool match = true;
+		for (uint32_t i = 0; i < raw.dword_count && match; i++) {
+			match = raw.dwords[i] == resources.user_data[base + i];
 		}
+		descriptor_from_user_data = match;
+	}
+	if (!descriptor_from_user_data) {
+		return false;
 	}
 	uint32_t clear = 0;
 	if (quad_fill) {
-		if (resources.user_data.size() != 8) {
+		// The quad shape carries its clear value inline, immediately after the sole descriptor.
+		if (program.info.buffers.size() != 1 || resources.user_data.size() != 8) {
 			return false;
 		}
 		clear = resources.user_data[4];
@@ -144,7 +234,7 @@ bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t grou
 		    resources.user_data[7] != clear) {
 			return false;
 		}
-	} else if (!ResolveConstantDwordStore(program, clear)) {
+	} else if (!ResolveConstantDwordStore(input, fill_index, clear)) {
 		return false;
 	}
 	// group_x is a thread count for the quad shape and a group count for the dword one.

--- a/src/graphics/presentation/window/window.cpp
+++ b/src/graphics/presentation/window/window.cpp
@@ -40,6 +40,7 @@
 #include "loader/systemContent.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -988,6 +989,18 @@ void WindowContext::UpdateTitle() {
 	    (has_title ? title : ""), (has_title ? ", " : ""), (has_title_id ? title_id : ""),
 	    (has_title_id ? ", " : ""), (has_app_ver ? app_ver : ""), (has_app_ver ? " " : ""),
 	    device_name, processor_name, frame_num, current_fps);
+
+	// The title is the only live progress signal, and a headless or scripted run never sees it.
+	// KYTY_FLIP_LOG=<n> mirrors it to stdout every n flips so a run's progress is measurable from
+	// its log alone. Unset, this costs one comparison per flip.
+	static const uint64_t flip_log_interval = [] {
+		const char* env = std::getenv("KYTY_FLIP_LOG");
+		return env != nullptr ? std::strtoull(env, nullptr, 10) : 0;
+	}();
+	if (flip_log_interval != 0 && frame_num % flip_log_interval == 0) {
+		printf("FLIP frame=%" PRIu64 " fps=%.2f\n", frame_num, current_fps);
+		fflush(stdout);
+	}
 
 #if defined(__APPLE__)
 	// AppKit traps on title changes off the main thread; fire-and-forget keeps present pacing.

--- a/src/launcher/src/mainDialog.cpp
+++ b/src/launcher/src/mainDialog.cpp
@@ -221,9 +221,7 @@ static QStringList CreateEmulatorArgs(const Configuration& info) {
 	args << "--profiler-direction" << EnumToText(info.profiler_direction);
 	args << "--spirv-debug-printf" << "false";
 #if defined(_WIN32)
-	if (info.red_zone_protection_enabled) {
-		args << "--redzone";
-	}
+	args << (info.red_zone_protection_enabled ? "--redzone" : "--no-redzone");
 #endif
 	for (const auto& binding: info.host_input_mapping) {
 		args << "--keymap" << binding;

--- a/src/libs/libC.cpp
+++ b/src/libs/libC.cpp
@@ -25,6 +25,7 @@
 #include <fmt/format.h>
 #include <list>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -76,6 +77,68 @@ static KYTY_SYSV_ABI void exit(int code) {
 	PRINT_NAME();
 
 	::exit(code);
+}
+
+// Titles keep their own fatal-error text in static buffers that outlive the throwaway string the
+// error printer builds, so a post-mortem can still read them here. The addresses are title
+// specific, hence the environment variables: KYTY_ABORT_WIDE is a comma separated list of guest
+// addresses holding NUL terminated UTF-16 text (UE4's GErrorHist, for example), and
+// KYTY_ABORT_BYTE the same for single byte flags (GIsCriticalError, GIsGuarded).
+static void PrintAbortWideBuffer(const char* name, uint64_t addr) {
+	if (!Graphics::HostMemoryIsReadable(addr)) {
+		LOGF("\t %s @ 0x%016" PRIx64 " is unreadable\n", name, addr);
+		return;
+	}
+
+	constexpr size_t MAX_CHARS = 16384;
+
+	std::string text;
+	const auto* ptr = reinterpret_cast<const uint16_t*>(static_cast<uintptr_t>(addr));
+
+	for (size_t i = 0;
+	     i < MAX_CHARS && Graphics::HostMemoryIsReadable(addr + i * sizeof(uint16_t) + 1); i++) {
+		const auto c = ptr[i];
+		if (c == 0) {
+			break;
+		}
+		if (c == '\n') {
+			text += "\n\t   ";
+		} else if (c == '\r' || c == '\t') {
+			text += ' ';
+		} else if (c >= 0x20 && c < 0x7f) {
+			text += static_cast<char>(c);
+		} else {
+			text += fmt::format("\\u{:04x}", c);
+		}
+	}
+
+	LOGF("\t %s @ 0x%016" PRIx64 " = \"%s\"\n", name, addr, text.c_str());
+}
+
+static void PrintAbortEnvBuffers() {
+	if (const auto* wide = std::getenv("KYTY_ABORT_WIDE"); wide != nullptr) {
+		for (const auto& part: Common::Split(wide, ',')) {
+			const auto addr = std::strtoull(part.c_str(), nullptr, 0);
+			if (addr != 0) {
+				PrintAbortWideBuffer("KYTY_ABORT_WIDE", addr);
+			}
+		}
+	}
+
+	if (const auto* flags = std::getenv("KYTY_ABORT_BYTE"); flags != nullptr) {
+		for (const auto& part: Common::Split(flags, ',')) {
+			const auto addr = std::strtoull(part.c_str(), nullptr, 0);
+			if (addr == 0) {
+				continue;
+			}
+			if (!Graphics::HostMemoryIsReadable(addr)) {
+				LOGF("\t KYTY_ABORT_BYTE @ 0x%016" PRIx64 " is unreadable\n", addr);
+				continue;
+			}
+			LOGF("\t KYTY_ABORT_BYTE @ 0x%016" PRIx64 " = 0x%02" PRIx8 "\n", addr,
+			     *reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(addr)));
+		}
+	}
 }
 
 static void PrintAbortStringCandidate(const char* name, uint64_t addr) {
@@ -250,6 +313,8 @@ static void PrintAbortPointerArrayCandidate(const char* name, uint64_t addr) {
 			PrintAbortPointerArrayCandidate(fmt::format("stack[{:02d}]", i).c_str(), value);
 		}
 	}
+
+	PrintAbortEnvBuffers();
 
 	EXIT("Guest abort()\n");
 	std::abort();

--- a/src/loader/redZonePatcher.cpp
+++ b/src/loader/redZonePatcher.cpp
@@ -10,7 +10,10 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
+#include <cinttypes>
 #include <climits>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <map>
@@ -21,6 +24,7 @@
 #include <unordered_set>
 #include <vector>
 #if defined(_WIN32)
+#include <windows.h> // IWYU pragma: keep
 #include <xbyak/xbyak.h>
 #include <xbyak/xbyak_util.h>
 #endif
@@ -129,11 +133,13 @@ struct DecodedCodeInstruction {
 	bool                                                     changes_stack_pointer {};
 	bool                                                     replaces_stack_pointer {};
 	std::optional<s64>                                       stack_pointer_delta;
+	std::array<std::optional<s64>, 16>                       stack_registers {};
 };
 
 struct DecodedFunction {
 	std::map<uintptr_t, DecodedCodeInstruction> instructions;
 	std::set<uintptr_t>                         branch_targets;
+	std::map<uintptr_t, std::vector<uintptr_t>> indirect_targets;
 	bool                                        uses_red_zone {};
 	bool                                        has_indirect_branch {};
 	bool                                        requires_conservative_red_zone_tracking {};
@@ -239,36 +245,235 @@ DecodedCodeInstruction DecodeCodeInstruction(uintptr_t address, uintptr_t end) {
 		           decoded.instruction.mnemonic == ZYDIS_MNEMONIC_PUSHFD ||
 		           decoded.instruction.mnemonic == ZYDIS_MNEMONIC_PUSHFQ) {
 			decoded.stack_pointer_delta = -static_cast<s64>(sizeof(u64));
-		} else if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POP ||
-		           decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPF ||
-		           decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPFD ||
-		           decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPFQ) {
+		} else if ((decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POP ||
+		            decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPF ||
+		            decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPFD ||
+		            decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPFQ) &&
+		           !(operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
+		             IsStackPointerRegister(operands[0].reg.value))) {
+			// `pop rsp` loads a new stack pointer rather than advancing it by eight.
 			decoded.stack_pointer_delta = sizeof(u64);
+		}
+	}
+
+	return decoded;
+}
+
+// Offset of every general purpose register from the stack pointer the function was entered with,
+// for the registers that provably hold a stack address. Index 4 (RSP) doubles as the current
+// stack depth. A register with no value either does not hold a stack address or was merged from
+// paths that disagree.
+constexpr size_t GprCount    = 16;
+constexpr size_t RspGprIndex = 4;
+using StackRegisterState     = std::array<std::optional<s64>, GprCount>;
+
+std::optional<size_t> GprIndex(ZydisRegister reg) {
+	if (reg == ZYDIS_REGISTER_NONE) {
+		return std::nullopt;
+	}
+	const auto full = ZydisRegisterGetLargestEnclosing(ZYDIS_MACHINE_MODE_LONG_64, reg);
+	if (ZydisRegisterGetClass(full) != ZYDIS_REGCLASS_GPR64) {
+		return std::nullopt;
+	}
+	const auto id = ZydisRegisterGetId(full);
+	if (id < 0 || static_cast<size_t>(id) >= GprCount) {
+		return std::nullopt;
+	}
+	return static_cast<size_t>(id);
+}
+
+// Segment overrides other than the implicit stack/data segments never address the stack.
+bool IsStackAddressableSegment(const ZydisDecodedOperand& operand) {
+	return operand.mem.segment == ZYDIS_REGISTER_SS || operand.mem.segment == ZYDIS_REGISTER_DS ||
+	       operand.mem.segment == ZYDIS_REGISTER_NONE;
+}
+
+StackRegisterState TransferStackRegisters(const DecodedCodeInstruction& decoded,
+                                          const StackRegisterState&     state_in) {
+	StackRegisterState state_out = state_in;
+
+	// The only forms that hand a stack address to another register.
+	std::optional<std::pair<size_t, std::optional<s64>>> propagated;
+	const auto&                                          operands = decoded.operands;
+	if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_MOV &&
+	    operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
+	    operands[1].type == ZYDIS_OPERAND_TYPE_REGISTER && operands[0].size == 64 &&
+	    operands[1].size == 64) {
+		const auto destination = GprIndex(operands[0].reg.value);
+		const auto source      = GprIndex(operands[1].reg.value);
+		if (destination && source) {
+			propagated = {*destination, state_in[*source]};
+		}
+	} else if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_LEA &&
+	           operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER && operands[0].size == 64 &&
+	           operands[1].type == ZYDIS_OPERAND_TYPE_MEMORY &&
+	           operands[1].mem.index == ZYDIS_REGISTER_NONE &&
+	           IsStackAddressableSegment(operands[1])) {
+		const auto destination = GprIndex(operands[0].reg.value);
+		const auto base        = GprIndex(operands[1].mem.base);
+		if (destination) {
+			std::optional<s64> value;
+			if (base && state_in[*base]) {
+				value = *state_in[*base] + operands[1].mem.disp.value;
+			}
+			propagated = {*destination, value};
+		}
+	}
+
+	for (u8 index = 0; index < decoded.instruction.operand_count; ++index) {
+		const auto& operand = decoded.operands[index];
+		if (operand.type != ZYDIS_OPERAND_TYPE_REGISTER ||
+		    (operand.actions & ZYDIS_OPERAND_ACTION_MASK_WRITE) == 0) {
+			continue;
+		}
+		if (const auto gpr = GprIndex(operand.reg.value)) {
+			state_out[*gpr] = std::nullopt;
+		}
+	}
+	if (propagated) {
+		state_out[propagated->first] = propagated->second;
+	}
+
+	const bool pops_stack_pointer =
+	    (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POP ||
+	     decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPF ||
+	     decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPFD ||
+	     decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPFQ) &&
+	    operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
+	    IsStackPointerRegister(operands[0].reg.value);
+	if (propagated && propagated->first == RspGprIndex) {
+		// `mov rsp, reg` / `lea rsp, [reg + disp]` already produced the new depth.
+	} else if (pops_stack_pointer) {
+		state_out[RspGprIndex] = std::nullopt;
+	} else if (decoded.stack_pointer_delta.has_value()) {
+		state_out[RspGprIndex] = state_in[RspGprIndex].has_value()
+		                             ? std::optional<s64>(*state_in[RspGprIndex] +
+		                                                  *decoded.stack_pointer_delta)
+		                             : std::nullopt;
+	} else if (decoded.changes_stack_pointer) {
+		state_out[RspGprIndex] = std::nullopt;
+	} else {
+		// Everything else, calls included: a call restores the stack pointer before the next
+		// instruction of this function runs.
+		state_out[RspGprIndex] = state_in[RspGprIndex];
+	}
+
+	// Zydis models a call's register effects as RIP and RSP only, so nothing above would drop the
+	// registers the callee is free to destroy. Believing a clobbered register still holds a stack
+	// address would classify a genuine heap dereference as a stack access and silently leave it
+	// unprotected.
+	if (decoded.instruction.meta.category == ZYDIS_CATEGORY_CALL) {
+		constexpr std::array<size_t, 9> CallerSavedGprs = {0, 1, 2, 6, 7, 8, 9, 10, 11};
+		for (const size_t gpr: CallerSavedGprs) {
+			state_out[gpr] = std::nullopt;
+		}
+	}
+	return state_out;
+}
+
+// Recompute the memory classification of one instruction now that the stack pointer relationship
+// of every base register is known. This is what lets a frame-pointer function be seen at all: its
+// red zone slots are addressed as [rbp - n], never as [rsp - n].
+void ClassifyStackOperands(DecodedCodeInstruction& decoded, const StackRegisterState& state) {
+	decoded.red_zone_use.reset();
+	decoded.red_zone_def.reset();
+	decoded.has_red_zone_operand           = false;
+	decoded.has_unmodeled_red_zone_operand = false;
+	decoded.accesses_memory                = false;
+
+	// Offset of the operand's address from the current stack pointer, when it is knowable. A base
+	// of RSP needs no dataflow at all, so a function whose stack depth stops being tracked (an
+	// alloca, an `and rsp, -16`) keeps the protection it had before the frame registers were
+	// modelled.
+	const bool addresses_are_64_bit = decoded.instruction.address_width == 64;
+	const auto stack_relative_offset =
+	    [&state, addresses_are_64_bit](const ZydisDecodedOperand& operand) -> std::optional<s64> {
+		if (!IsStackAddressableSegment(operand) || !addresses_are_64_bit) {
+			return std::nullopt;
+		}
+		if (IsStackPointerRegister(operand.mem.base)) {
+			return operand.mem.disp.value;
+		}
+		const auto base = GprIndex(operand.mem.base);
+		if (!base || !state[*base] || !state[RspGprIndex]) {
+			return std::nullopt;
+		}
+		return *state[*base] + operand.mem.disp.value - *state[RspGprIndex];
+	};
+	// A 0x67 prefix truncates the effective address to 32 bits, so `[ebp + n]` is not the frame
+	// slot it looks like; treat nothing as stack relative in that case.
+	const auto is_stack_register = [&state, addresses_are_64_bit](ZydisRegister reg) {
+		if (!addresses_are_64_bit) {
+			return false;
+		}
+		if (IsStackPointerRegister(reg)) {
+			return true;
+		}
+		const auto gpr = GprIndex(reg);
+		return gpr.has_value() && state[*gpr].has_value();
+	};
+
+	for (u8 index = 0; index < decoded.instruction.operand_count; ++index) {
+		const auto& operand = decoded.operands[index];
+		if (operand.type != ZYDIS_OPERAND_TYPE_MEMORY) {
+			continue;
+		}
+		// Only the base decides. A tracked register appearing as a *scaled* index is an array
+		// subscript, not a stack address, and treating it as one would drop protection from a
+		// genuinely faultable access.
+		const bool stack_relative =
+		    IsStackAddressableSegment(operand) && is_stack_register(operand.mem.base);
+		constexpr ZydisOperandActions MemoryAccessMask =
+		    ZYDIS_OPERAND_ACTION_MASK_READ | ZYDIS_OPERAND_ACTION_MASK_WRITE;
+		if (decoded.instruction.mnemonic != ZYDIS_MNEMONIC_LEA &&
+		    decoded.instruction.mnemonic != ZYDIS_MNEMONIC_NOP && !stack_relative &&
+		    (operand.actions & MemoryAccessMask) != 0) {
+			decoded.accesses_memory = true;
 		}
 	}
 
 	for (u8 index = 0; index < decoded.instruction.operand_count_visible; ++index) {
 		const auto& operand = decoded.operands[index];
-		if (operand.type != ZYDIS_OPERAND_TYPE_MEMORY ||
-		    !IsStackPointerRegister(operand.mem.base) || operand.mem.disp.size == 0 ||
-		    operand.mem.disp.value >= 0) {
+		if (operand.type != ZYDIS_OPERAND_TYPE_MEMORY) {
+			continue;
+		}
+		const auto offset_from_stack_pointer = stack_relative_offset(operand);
+		if (!offset_from_stack_pointer.has_value()) {
+			// A frame register whose depth is no longer tracked still addresses the frame, so the
+			// red zone traffic of this function can no longer be seen precisely.
+			decoded.has_unmodeled_red_zone_operand |= is_stack_register(operand.mem.base);
+			continue;
+		}
+		if (operand.mem.index != ZYDIS_REGISTER_NONE) {
+			// An indexed access whose base already sits below the stack pointer can land anywhere
+			// in the red zone; give up on precise liveness rather than assume it misses. A base at
+			// or above the stack pointer is an ordinary local array and is left alone, because
+			// making every one of those conservative floods the trampoline arena.
+			decoded.has_unmodeled_red_zone_operand |= *offset_from_stack_pointer < 0;
 			continue;
 		}
 
-		decoded.has_red_zone_operand = true;
+		const s64 access_start = *offset_from_stack_pointer;
 		if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_LEA) {
-			if (decoded.stack_pointer_delta.has_value()) {
-				decoded.has_red_zone_operand = false;
+			// `lea rsp, [rsp - n]` is the stack adjustment itself, not a red zone reference.
+			if (decoded.stack_pointer_delta.has_value() || access_start >= 0) {
 				continue;
 			}
+			// The address escapes into a register and may be dereferenced anywhere, including
+			// through memory or a callee, so stop trusting the liveness of this function.
+			decoded.has_red_zone_operand           = true;
 			decoded.has_unmodeled_red_zone_operand = true;
 			continue;
 		}
 
-		const s64 access_start = operand.mem.disp.value;
-		const s64 access_size  = std::max<s64>(operand.size / 8, 1);
-		const s64 range_start  = std::max(access_start, -static_cast<s64>(GuestRedZoneSize));
-		const s64 range_end    = std::min(access_start + access_size, 0LL);
+		const s64 access_size = std::max<s64>(operand.size / 8, 1);
+		const s64 range_start = std::max(access_start, -static_cast<s64>(GuestRedZoneSize));
+		const s64 range_end   = std::min(access_start + access_size, 0LL);
+		if (range_start >= range_end) {
+			continue;
+		}
+
+		decoded.has_red_zone_operand = true;
 		for (s64 offset = range_start; offset < range_end; ++offset) {
 			const size_t bit = static_cast<size_t>(offset + static_cast<s64>(GuestRedZoneSize));
 			if ((operand.actions & ZYDIS_OPERAND_ACTION_MASK_READ) != 0) {
@@ -279,7 +484,94 @@ DecodedCodeInstruction DecodeCodeInstruction(uintptr_t address, uintptr_t end) {
 			}
 		}
 	}
-	return decoded;
+}
+
+// Successors of one instruction inside the function, including the targets of an indirect branch
+// once its jump table has been resolved.
+template <typename Fn>
+void ForEachSuccessor(const DecodedFunction& function, const DecodedCodeInstruction& decoded,
+                      Fn&& fn) {
+	const uintptr_t next_address  = decoded.address + decoded.instruction.length;
+	const uintptr_t branch_target = GetRelativeTarget(decoded);
+	if (decoded.instruction.meta.category == ZYDIS_CATEGORY_COND_BR) {
+		fn(next_address);
+		fn(branch_target);
+		return;
+	}
+	if (decoded.instruction.meta.category == ZYDIS_CATEGORY_UNCOND_BR) {
+		if (branch_target != 0) {
+			fn(branch_target);
+			return;
+		}
+		const auto resolved = function.indirect_targets.find(decoded.address);
+		if (resolved != function.indirect_targets.end()) {
+			for (const uintptr_t target: resolved->second) {
+				fn(target);
+			}
+		}
+		return;
+	}
+	if (!IsControlFlowTerminator(decoded.instruction)) {
+		fn(next_address);
+	}
+}
+
+// Forward dataflow over the decoded CFG, recording for every instruction which registers hold a
+// known offset from the stack pointer the function was entered with.
+void AnalyzeStackRegisters(DecodedFunction& function, uintptr_t function_start) {
+	const auto entry = function.instructions.find(function_start);
+	if (entry == function.instructions.end()) {
+		return;
+	}
+
+	std::vector<DecodedCodeInstruction*> instructions;
+	instructions.reserve(function.instructions.size());
+	std::map<uintptr_t, size_t> indices;
+	for (auto& [address, decoded]: function.instructions) {
+		indices.emplace(address, instructions.size());
+		instructions.push_back(&decoded);
+	}
+
+	std::vector<StackRegisterState> state_in(instructions.size());
+	std::vector<bool>               reached(instructions.size(), false);
+	const size_t                    entry_index = indices.at(function_start);
+	state_in[entry_index][RspGprIndex]          = 0;
+	reached[entry_index]                        = true;
+
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		for (size_t index = 0; index < instructions.size(); ++index) {
+			if (!reached[index]) {
+				continue;
+			}
+			const auto state_out = TransferStackRegisters(*instructions[index], state_in[index]);
+			ForEachSuccessor(function, *instructions[index], [&](uintptr_t address) {
+				const auto successor = indices.find(address);
+				if (successor == indices.end()) {
+					return;
+				}
+				const size_t target = successor->second;
+				if (!reached[target]) {
+					reached[target]  = true;
+					state_in[target] = state_out;
+					changed          = true;
+					return;
+				}
+				for (size_t gpr = 0; gpr < GprCount; ++gpr) {
+					if (state_in[target][gpr].has_value() &&
+					    state_in[target][gpr] != state_out[gpr]) {
+						state_in[target][gpr] = std::nullopt;
+						changed               = true;
+					}
+				}
+			});
+		}
+	}
+
+	for (size_t index = 0; index < instructions.size(); ++index) {
+		instructions[index]->stack_registers = state_in[index];
+	}
 }
 
 bool IsSameRegister(ZydisRegister lhs, ZydisRegister rhs) {
@@ -296,6 +588,62 @@ bool WritesRegister(const DecodedCodeInstruction& decoded, ZydisRegister reg) {
 		           (operand.actions & ZYDIS_OPERAND_ACTION_MASK_WRITE) != 0 &&
 		           IsSameRegister(operand.reg.value, reg);
 	    });
+}
+
+// A jump table usually lives in a read-only data segment, not in the executable one, and a guest
+// module can contain segments that are deliberately left unreadable. Check before dereferencing.
+bool IsReadableRange(uintptr_t address, size_t size) {
+	MEMORY_BASIC_INFORMATION region {};
+	if (VirtualQuery(reinterpret_cast<const void*>(address), &region, sizeof(region)) !=
+	    sizeof(region)) {
+		return false;
+	}
+	constexpr DWORD ReadableProtection = PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
+	                                     PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE |
+	                                     PAGE_EXECUTE_WRITECOPY;
+	if (region.State != MEM_COMMIT || (region.Protect & ReadableProtection) == 0 ||
+	    (region.Protect & (PAGE_GUARD | PAGE_NOACCESS)) != 0) {
+		return false;
+	}
+	const auto region_end = reinterpret_cast<uintptr_t>(region.BaseAddress) + region.RegionSize;
+	return address + size <= region_end;
+}
+
+// clang bounds checks a switch index in its narrow form and then widens it, as in
+//     cmp al, 6 / ja default / movzx eax, al / movsxd rax, [table + rax*4]
+// so a redefinition of the index register that only changes its width still carries the bound and
+// must not abandon the search for the compare.
+bool IsWidthChangeOfRegister(const DecodedCodeInstruction& decoded, ZydisRegister reg,
+                             bool* widened) {
+	switch (decoded.instruction.mnemonic) {
+		case ZYDIS_MNEMONIC_MOV:
+		case ZYDIS_MNEMONIC_MOVZX:
+		case ZYDIS_MNEMONIC_MOVSX:
+		case ZYDIS_MNEMONIC_MOVSXD: break;
+		// `and reg, imm` is how a compiler bounds an index *without* a compare, so stepping over
+		// one would let the scan latch onto an older and larger bound.
+		default: return false;
+	}
+	if (decoded.instruction.operand_count_visible != 2 ||
+	    decoded.operands[0].type != ZYDIS_OPERAND_TYPE_REGISTER ||
+	    decoded.operands[1].type != ZYDIS_OPERAND_TYPE_REGISTER ||
+	    !IsSameRegister(decoded.operands[0].reg.value, reg) ||
+	    !IsSameRegister(decoded.operands[1].reg.value, reg) ||
+	    decoded.operands[0].size < decoded.operands[1].size) {
+		return false;
+	}
+	// A high-byte source is a different half of the register, not a narrower view of the value.
+	switch (decoded.operands[1].reg.value) {
+		case ZYDIS_REGISTER_AH:
+		case ZYDIS_REGISTER_CH:
+		case ZYDIS_REGISTER_DH:
+		case ZYDIS_REGISTER_BH: return false;
+		default: break;
+	}
+	if (widened != nullptr && decoded.operands[0].size > decoded.operands[1].size) {
+		*widened = true;
+	}
+	return true;
 }
 
 std::optional<std::vector<uintptr_t>>
@@ -362,7 +710,8 @@ ResolveBoundedJumpTable(const DecodedFunction& function, uintptr_t branch_addres
 	constexpr size_t         MaxPatternInstructions = 64;
 	std::optional<size_t>    table_size;
 	std::optional<uintptr_t> guarded_path_start;
-	auto                     cursor = load;
+	bool                     index_was_widened = false;
+	auto                     cursor            = load;
 	for (size_t count = 0; count < MaxPatternInstructions; ++count) {
 		cursor = previous_contiguous(cursor);
 		if (cursor == function.instructions.end()) {
@@ -384,6 +733,12 @@ ResolveBoundedJumpTable(const DecodedFunction& function, uintptr_t branch_addres
 			if (bound < 0) {
 				return std::nullopt;
 			}
+			// A bound taken on an 8 or 16 bit alias only carries to the register the table is
+			// indexed with if something explicitly widened it in between; a 32 bit compare is
+			// already carried by the implicit zero extension of every 32 bit write.
+			if (decoded.operands[0].size < 32 && !index_was_widened) {
+				return std::nullopt;
+			}
 			if (bounds_branch->second.instruction.mnemonic == ZYDIS_MNEMONIC_JNBE) {
 				table_size = static_cast<size_t>(bound) + 1;
 			} else if (bounds_branch->second.instruction.mnemonic == ZYDIS_MNEMONIC_JNB) {
@@ -394,7 +749,8 @@ ResolveBoundedJumpTable(const DecodedFunction& function, uintptr_t branch_addres
 			guarded_path_start = next_address + bounds_branch->second.instruction.length;
 			break;
 		}
-		if (WritesRegister(decoded, index_reg)) {
+		if (WritesRegister(decoded, index_reg) &&
+		    !IsWidthChangeOfRegister(decoded, index_reg, &index_was_widened)) {
 			return std::nullopt;
 		}
 	}
@@ -456,7 +812,8 @@ ResolveBoundedJumpTable(const DecodedFunction& function, uintptr_t branch_addres
 	std::optional<std::vector<uintptr_t>> resolved_targets;
 	for (const uintptr_t table_address: table_candidates) {
 		if (table_address < segment_start || table_address > segment_end ||
-		    *table_size > (segment_end - table_address) / sizeof(s32)) {
+		    *table_size > (segment_end - table_address) / sizeof(s32) ||
+		    !IsReadableRange(table_address, *table_size * sizeof(s32))) {
 			continue;
 		}
 
@@ -510,11 +867,6 @@ DecodedFunction DecodeFunction(uintptr_t function_start, uintptr_t function_end,
 					break;
 				}
 
-				function.uses_red_zone |= decoded.has_red_zone_operand;
-				function.requires_conservative_red_zone_tracking |=
-				    decoded.has_unmodeled_red_zone_operand ||
-				    (decoded.changes_stack_pointer && !decoded.stack_pointer_delta.has_value());
-
 				const uintptr_t next_address  = address + decoded.instruction.length;
 				const uintptr_t branch_target = GetRelativeTarget(decoded);
 				if (branch_target >= function_start && branch_target < function_end) {
@@ -551,6 +903,7 @@ DecodedFunction DecodeFunction(uintptr_t function_start, uintptr_t function_end,
 				continue;
 			}
 			resolved_indirect_branches.insert(branch_address);
+			function.indirect_targets[branch_address] = *targets;
 			for (const uintptr_t target: *targets) {
 				function.branch_targets.insert(target);
 				if (!visited.contains(target)) {
@@ -564,6 +917,15 @@ DecodedFunction DecodeFunction(uintptr_t function_start, uintptr_t function_end,
 		}
 	}
 	function.has_indirect_branch = indirect_branches.size() != resolved_indirect_branches.size();
+
+	AnalyzeStackRegisters(function, function_start);
+	for (auto& [address, decoded]: function.instructions) {
+		ClassifyStackOperands(decoded, decoded.stack_registers);
+		function.uses_red_zone |= decoded.has_red_zone_operand;
+		function.requires_conservative_red_zone_tracking |=
+		    decoded.has_unmodeled_red_zone_operand ||
+		    (decoded.changes_stack_pointer && !decoded.stack_pointer_delta.has_value());
+	}
 	return function;
 }
 
@@ -619,16 +981,7 @@ void AnalyzeRedZoneLiveness(DecodedFunction& function) {
 				}
 			};
 
-			const uintptr_t next_address  = decoded.address + decoded.instruction.length;
-			const uintptr_t branch_target = GetRelativeTarget(decoded);
-			if (decoded.instruction.meta.category == ZYDIS_CATEGORY_COND_BR) {
-				add_successor(next_address);
-				add_successor(branch_target);
-			} else if (decoded.instruction.meta.category == ZYDIS_CATEGORY_UNCOND_BR) {
-				add_successor(branch_target);
-			} else if (!IsControlFlowTerminator(decoded.instruction)) {
-				add_successor(next_address);
-			}
+			ForEachSuccessor(function, decoded, add_successor);
 
 			const RedZoneMask translated_live_out =
 			    decoded.stack_pointer_delta.has_value()
@@ -741,6 +1094,72 @@ bool GenerateProtectedIndirectCall(const DecodedCodeInstruction& decoded,
 }
 } // namespace
 
+namespace {
+
+// Debug aid: set KYTY_RZ_DUMP to a comma separated list of hex guest addresses to have the
+// containing function's decode and classification printed once during patching.
+const std::vector<uintptr_t>& GetDumpAddresses() {
+	static const std::vector<uintptr_t> addresses = [] {
+		std::vector<uintptr_t> value;
+		const char*            env = std::getenv("KYTY_RZ_DUMP");
+		if (env == nullptr) {
+			return value;
+		}
+		const char* cursor = env;
+		while (*cursor != '\0') {
+			char*      end   = nullptr;
+			const auto parsed = std::strtoull(cursor, &end, 16);
+			if (end == cursor) {
+				break;
+			}
+			value.push_back(static_cast<uintptr_t>(parsed));
+			cursor = end;
+			while (*cursor == ',' || *cursor == ' ') {
+				cursor++;
+			}
+		}
+		return value;
+	}();
+	return addresses;
+}
+
+void DumpFunction(uintptr_t function_start, uintptr_t function_end, const DecodedFunction& function,
+                  const std::map<uintptr_t, InstructionRewrite>& rewrite_sites) {
+	static ZydisFormatter formatter = [] {
+		ZydisFormatter value {};
+		ZydisFormatterInit(&value, ZYDIS_FORMATTER_STYLE_INTEL);
+		return value;
+	}();
+
+	printf("RZDUMP function 0x%016" PRIx64 " .. 0x%016" PRIx64
+	       " instructions=%zu uses_red_zone=%d indirect=%d conservative=%d\n",
+	       static_cast<u64>(function_start), static_cast<u64>(function_end),
+	       function.instructions.size(), static_cast<int>(function.uses_red_zone),
+	       static_cast<int>(function.has_indirect_branch),
+	       static_cast<int>(function.requires_conservative_red_zone_tracking));
+	for (const auto& [address, decoded]: function.instructions) {
+		char text[256] {};
+		ZydisFormatterFormatInstruction(&formatter, &decoded.instruction, decoded.operands.data(),
+		                                decoded.instruction.operand_count_visible, text,
+		                                sizeof(text), address, nullptr);
+		const auto rewrite = rewrite_sites.find(address);
+		printf("RZDUMP   0x%016" PRIx64 " len=%u mem=%d rsp=%d rz_op=%d use=%d def=%d live=%d "
+		       "patch=%d | %s\n",
+		       static_cast<u64>(address), decoded.instruction.length,
+		       static_cast<int>(decoded.accesses_memory),
+		       static_cast<int>(decoded.uses_stack_pointer),
+		       static_cast<int>(decoded.has_red_zone_operand),
+		       static_cast<int>(decoded.red_zone_use.any()),
+		       static_cast<int>(decoded.red_zone_def.any()),
+		       static_cast<int>(decoded.red_zone_live.any()),
+		       static_cast<int>(rewrite != rewrite_sites.end() && rewrite->second.protect_red_zone),
+		       text);
+	}
+	fflush(stdout);
+}
+
+} // namespace
+
 RedZonePatchResult PatchRedZoneMemoryInstructions(u64 segment_addr, u64 segment_size,
                                                   std::span<const uintptr_t> function_starts) {
 	RedZonePatchResult result {};
@@ -771,7 +1190,11 @@ RedZonePatchResult PatchRedZoneMemoryInstructions(u64 segment_addr, u64 segment_
 		}
 
 		++result.function_count;
-		auto function = DecodeFunction(function_start, function_end, segment_addr, segment_end);
+		// Jump tables are emitted into read-only data, which is a different segment from the code
+		// being patched, so table addresses are validated against the whole module.
+		auto function = DecodeFunction(function_start, function_end,
+		                               reinterpret_cast<uintptr_t>(module->start),
+		                               reinterpret_cast<uintptr_t>(module->end));
 		AnalyzeRedZoneLiveness(function);
 		result.instruction_count += function.instructions.size();
 
@@ -812,6 +1235,13 @@ RedZonePatchResult PatchRedZoneMemoryInstructions(u64 segment_addr, u64 segment_
 				rewrite_sites[address].protect_red_zone = true;
 			}
 		}
+		for (const uintptr_t dump_address: GetDumpAddresses()) {
+			if (dump_address >= function_start && dump_address < function_end) {
+				DumpFunction(function_start, function_end, function, rewrite_sites);
+				break;
+			}
+		}
+
 		if (rewrite_sites.empty()) {
 			continue;
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,8 @@ static void PrintUsage() {
 	    "  --readback-linear-images <true|false> Read back writable linear images on submit.\n");
 	::printf("  --playgo-hack                       Use the supplied PlayGo stub fallback.\n");
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
-	::printf("  --redzone                            Protect the guest SysV red zone.\n");
+	::printf("  --redzone                            Protect the guest SysV red zone (default).\n");
+	::printf("  --no-redzone                         Leave the guest SysV red zone unprotected.\n");
 #endif
 	::printf("  --keymap <Control=Input>             DualSense mapping; may be repeated.\n");
 	::printf("  --rd                                 Enable RenderDoc capture.\n");
@@ -152,6 +153,11 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 		if (arg == "--redzone") {
 			options.config.red_zone_protection_enabled = true;
+			continue;
+		}
+
+		if (arg == "--no-redzone") {
+			options.config.red_zone_protection_enabled = false;
 			continue;
 		}
 #endif

--- a/tests/VirtualMemoryAllocationTests.cpp
+++ b/tests/VirtualMemoryAllocationTests.cpp
@@ -154,35 +154,23 @@ LONG CALLBACK RedZoneFaultHandler(EXCEPTION_POINTERS* exception) {
 	return EXCEPTION_CONTINUE_EXECUTION;
 }
 
-void TestWindowsGuestRedZoneStaticPatcher() {
-	const char* test = "WindowsGuestRedZoneStaticPatcher";
-	constexpr uint64_t SENTINEL = 0x1122334455667788ull;
+struct RedZonePatchCase {
+	bool                       unpatched_was_corrupted = false;
+	bool                       patched_preserved       = false;
+	bool                       freed                   = false;
+	Loader::RedZonePatchResult result {};
+};
+
+// Run one guest function twice through a fault on `rdi`: once unpatched, to confirm the harness
+// really does destroy the red zone slot the function parked a sentinel in, and once after the
+// static patcher has run. The function must return 1 when the sentinel survived.
+RedZonePatchCase RunRedZonePatchCase(const char* test, const std::vector<uint8_t>& code) {
 	constexpr uint64_t CODE_SIZE = 0x4000;
 	constexpr uint64_t TRAMPOLINE_SIZE = 0x4000;
 	const auto mapping = Libs::LibKernel::Memory::AllocateProgramMemory(
 	    0x0000000902000000ull, CODE_SIZE + TRAMPOLINE_SIZE,
 	    Common::VirtualMemory::Mode::ExecuteReadWrite, "red_zone_patcher_test");
 	Check(test, mapping != 0, "failed to allocate patch test code");
-
-	std::vector<uint8_t> code;
-	const auto emit = [&code](std::initializer_list<uint8_t> bytes) {
-		code.insert(code.end(), bytes.begin(), bytes.end());
-	};
-	const auto emit64 = [&code](uint64_t value) {
-		const auto offset = code.size();
-		code.resize(offset + sizeof(value));
-		std::memcpy(code.data() + offset, &value, sizeof(value));
-	};
-	emit({0x48, 0xb8});
-	emit64(SENTINEL);                         // movabs rax, sentinel
-	emit({0x48, 0x89, 0x44, 0x24, 0xe8});     // mov [rsp-0x18], rax
-	emit({0x48, 0x8b, 0x07});                 // mov rax, [rdi] (faultable, 3 bytes)
-	emit({0x48, 0x8b, 0x44, 0x24, 0xe8});     // mov rax, [rsp-0x18]
-	emit({0x48, 0xb9});
-	emit64(SENTINEL);                         // movabs rcx, sentinel
-	emit({0x48, 0x39, 0xc8});                 // cmp rax, rcx
-	emit({0x0f, 0x94, 0xc0});                 // sete al
-	emit({0x0f, 0xb6, 0xc0, 0xc3});           // movzx eax, al; ret
 	Check(test, code.size() < CODE_SIZE, "generated patch test code is too large");
 	std::memcpy(reinterpret_cast<void*>(mapping), code.data(), code.size());
 	Check(test, Common::VirtualMemory::FlushInstructionCache(mapping, code.size()),
@@ -216,18 +204,94 @@ void TestWindowsGuestRedZoneStaticPatcher() {
 	g_red_zone_fault_page = nullptr;
 	const bool freed = Libs::LibKernel::Memory::FreeGuestMemory(mapping, CODE_SIZE + TRAMPOLINE_SIZE);
 
-	Check(test, unpatched_was_corrupted, "test harness did not reproduce red-zone corruption");
-	Check(test, result.red_zone_function_count == 1 && result.memory_instruction_count >= 1 &&
-	                result.patched_memory_instruction_count >= 1 &&
-	                result.unrelocatable_memory_instruction_count == 0,
+	return {.unpatched_was_corrupted = unpatched_was_corrupted,
+	        .patched_preserved       = patched_preserved,
+	        .freed                   = freed,
+	        .result                  = result};
+}
+
+void CheckRedZonePatchCase(const char* test, const RedZonePatchCase& patch_case) {
+	Check(test, patch_case.unpatched_was_corrupted,
+	      "test harness did not reproduce red-zone corruption");
+	Check(test,
+	      patch_case.result.red_zone_function_count == 1 &&
+	          patch_case.result.memory_instruction_count >= 1 &&
+	          patch_case.result.patched_memory_instruction_count >= 1 &&
+	          patch_case.result.unrelocatable_memory_instruction_count == 0,
 	      "static patcher did not cover the faultable instruction");
-	Check(test, patched_preserved, "patched fault still corrupted the guest red zone");
-	Check(test, freed, "failed to free patch test code");
+	Check(test, patch_case.patched_preserved, "patched fault still corrupted the guest red zone");
+	Check(test, patch_case.freed, "failed to free patch test code");
 	std::printf("[host]    %-48s ok\n", test);
+}
+
+void TestWindowsGuestRedZoneStaticPatcher() {
+	const char*        test     = "WindowsGuestRedZoneStaticPatcher";
+	constexpr uint64_t SENTINEL = 0x1122334455667788ull;
+
+	std::vector<uint8_t> code;
+	const auto emit = [&code](std::initializer_list<uint8_t> bytes) {
+		code.insert(code.end(), bytes.begin(), bytes.end());
+	};
+	const auto emit64 = [&code](uint64_t value) {
+		const auto offset = code.size();
+		code.resize(offset + sizeof(value));
+		std::memcpy(code.data() + offset, &value, sizeof(value));
+	};
+	emit({0x48, 0xb8});
+	emit64(SENTINEL);                         // movabs rax, sentinel
+	emit({0x48, 0x89, 0x44, 0x24, 0xe8});     // mov [rsp-0x18], rax
+	emit({0x48, 0x8b, 0x07});                 // mov rax, [rdi] (faultable, 3 bytes)
+	emit({0x48, 0x8b, 0x44, 0x24, 0xe8});     // mov rax, [rsp-0x18]
+	emit({0x48, 0xb9});
+	emit64(SENTINEL);                         // movabs rcx, sentinel
+	emit({0x48, 0x39, 0xc8});                 // cmp rax, rcx
+	emit({0x0f, 0x94, 0xc0});                 // sete al
+	emit({0x0f, 0xb6, 0xc0, 0xc3});           // movzx eax, al; ret
+
+	CheckRedZonePatchCase(test, RunRedZonePatchCase(test, code));
+}
+
+// The shape that a frame-pointer build actually produces: the prologue establishes rbp, pushes
+// callee-saved registers and never subtracts from rsp, so the locals below rsp are reached as
+// [rbp - n] and never as [rsp - n]. A patcher that only recognises RSP-relative operands leaves
+// such a function completely unprotected.
+void TestWindowsGuestRedZoneFramePointerPatcher() {
+	const char*        test     = "WindowsGuestRedZoneFramePointerPatcher";
+	constexpr uint64_t SENTINEL = 0x1122334455667788ull;
+
+	std::vector<uint8_t> code;
+	const auto emit = [&code](std::initializer_list<uint8_t> bytes) {
+		code.insert(code.end(), bytes.begin(), bytes.end());
+	};
+	const auto emit64 = [&code](uint64_t value) {
+		const auto offset = code.size();
+		code.resize(offset + sizeof(value));
+		std::memcpy(code.data() + offset, &value, sizeof(value));
+	};
+	emit({0x55});                             // push rbp
+	emit({0x48, 0x89, 0xe5});                 // mov rbp, rsp
+	emit({0x53});                             // push rbx           (rsp = rbp-8, no sub rsp)
+	emit({0x48, 0xb8});
+	emit64(SENTINEL);                         // movabs rax, sentinel
+	emit({0x48, 0x89, 0x45, 0xe0});           // mov [rbp-0x20], rax   == [rsp-0x18], red zone
+	emit({0x48, 0x8b, 0x07});                 // mov rax, [rdi] (faultable, 3 bytes)
+	emit({0x48, 0x8b, 0x45, 0xe0});           // mov rax, [rbp-0x20]
+	emit({0x48, 0xb9});
+	emit64(SENTINEL);                         // movabs rcx, sentinel
+	emit({0x48, 0x39, 0xc8});                 // cmp rax, rcx
+	emit({0x0f, 0x94, 0xc0});                 // sete al
+	emit({0x0f, 0xb6, 0xc0});                 // movzx eax, al
+	emit({0x5b, 0x5d, 0xc3});                 // pop rbx; pop rbp; ret
+
+	CheckRedZonePatchCase(test, RunRedZonePatchCase(test, code));
 }
 #else
 void TestWindowsGuestRedZoneStaticPatcher() {
 	std::printf("[host]    %-48s skipped\n", "WindowsGuestRedZoneStaticPatcher");
+}
+
+void TestWindowsGuestRedZoneFramePointerPatcher() {
+	std::printf("[host]    %-48s skipped\n", "WindowsGuestRedZoneFramePointerPatcher");
 }
 #endif
 
@@ -2512,10 +2576,12 @@ int main(int argc, char** argv) {
 	InitSubsystems();
 	if (argc == 2 && std::strcmp(argv[1], "--red-zone-patcher-only") == 0) {
 		RunTest(TestWindowsGuestRedZoneStaticPatcher);
+		RunTest(TestWindowsGuestRedZoneFramePointerPatcher);
 		return g_failed_tests == 0 ? 0 : 1;
 	}
 
 	RunTest(TestWindowsGuestRedZoneStaticPatcher);
+	RunTest(TestWindowsGuestRedZoneFramePointerPatcher);
 	RunTest(TestProsperoArgumentAndInfoSizeContracts);
 	RunTest(TestGuestAddressSpaceOwnsReservationsBeforeBacking);
 	RunTest(TestPrtBackingReadPreservesSparseResidency);


### PR DESCRIPTION
multiple fixes to make the pathless boot and reach the main menu stabily.

## Summary

- Extended the redzon patcher so it covers leaf functions that keep their red zone at [rbp-k] instead of [rsp-k]
- Added diagnostics for host faults 
- InvalidateCpuAliases skipped no longer skip every image with depth_id set which caused stencil association write watchers to not release.
- Added recognition for d-word granular meta data fills.
- Added recognition for fills whose clear code is loaded from a constant buffer.
- The clear codes are no longer gated by a format whitelist which caused them to be thrown away. Now any float/normalized format is valid.

PR follows contribution guidelines and the Windows build is verified.