### PR TITLE
emulator: run cleanup handlers on the quick_exit path

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -200,6 +200,10 @@ void Run(const RunOptions& options) {
 	int ok = atexit(KytyClose);
 	EXIT_NOT_IMPLEMENTED(ok != 0);
 
+	// Guest threads are still running, so skip KytyClose() and only flush emergency state.
+	ok = at_quick_exit(Common::Subsystems::EmergencyShutdownActive);
+	EXIT_NOT_IMPLEMENTED(ok != 0);
+
 	Libs::LibKernel::FileSystem::Mount(options.app0_dir, "/app0");
 	Libs::LibKernel::FileSystem::Mount(options.app0_dir, "/hostapp");
 


### PR DESCRIPTION
## Problem

`Run()` registers a cleanup handler with `atexit()`:

```c
int ok = atexit(KytyClose);
```

but `Execute()` terminates the process with:

```c
std::quick_exit(0);
```

`std::quick_exit` invokes `at_quick_exit` handlers only. It does not run `atexit` handlers, and it does not flush open C streams. Nothing in `src/` registers an `at_quick_exit` handler, so `KytyClose` never runs on a normal exit.

Because `KytyClose` is what calls `Subsystems::EmergencyShutdownActive()`, none of the emergency handlers run either:

- `FileSystem::EmergencyShutdown` â†’ `g_files->CloseAll()` â€” open guest files are never closed
- `Log::Shutdown` â€” the log is never flushed or closed
- `Profiler::Shutdown` â€” the capture is never ended

This is easy to confirm without a debugger: `KytyClose` logs `done!` as its last action, and `done!` does not appear anywhere in a log from a normal exit. I checked a 276 MB log from a full play session and the count is zero.

The severity depends on the platform, because the file backends differ:

- **Windows** (`sysWindowsFileIO.cpp`) uses `WriteFile`, so writes have already reached the OS and survive process termination.
- **Linux / macOS** (`sysLinuxFileIO.cpp`) uses `fopen`/`fwrite`. Since `quick_exit` does not flush C streams, buffered guest writes are dropped â€” a save written shortly before quitting can be lost.

Truncated logs have the same root cause, which matters given that the issue template asks for the complete log file.

## Fix

Register a handler on the path the process actually takes.

The new handler runs `Subsystems::EmergencyShutdownActive()` and deliberately does **not** call `RuntimeLinker::Clear()`.

I tried the obvious version first â€” registering `KytyClose` itself with `at_quick_exit` â€” and it **hung the emulator on exit**. Guest threads are still live at `quick_exit` time, and `rt->Clear()` deadlocks against a thread parked in a condition wait. The log tail showed it stuck in `PthreadCondWait`. That is very likely why this code ended up on `quick_exit` in the first place.

The emergency handlers are the correct subset here: closing files and flushing the log is exactly what they exist for, and it is already what the fatal-error path in `assert.cpp` uses.

## Testing

Windows 11 25H2, clang-cl 20.1.8, Qt 6.10.3, RTX 2060 (driver 596.36). Tested against a commercial title (Tetris Forever, PPSA25646) booted through to gameplay and then quit.

- **`ctest`: 31/31 pass.**
- **Handler verified to fire.** I temporarily added a log line to the new handler and confirmed it appears exactly once, immediately after the quit keypress, then the process exits. Removed before submitting.
- **No hang.** Exit is clean, unlike the `KytyClose` variant described above.
- **No shutdown regression.** Timed from a `WM_CLOSE` to process termination, two runs each:

  | Build | Run 1 | Run 2 |
  |---|---|---|
  | `main` (c52bf45) | 1.53 s | 1.64 s |
  | this branch | 1.63 s | 1.47 s |

I did not find a practical way to cover this in the existing test suite. Verifying it requires observing real process termination, and `quick_exit` ends the process, so it would need a subprocess harness that `tests/` does not currently have. Happy to add one if you would like it.

**Only Windows is verified.** The bug is worse on Linux and macOS because of the buffered `fwrite` backend, but I have no machine to test those on. A second pair of eyes there would be welcome.

## AI use

This change was developed with AI assistance (Claude). The AI traced the `atexit` / `quick_exit` mismatch, proposed the fix, and ran the builds, tests and timing measurements described above on my machine.

I reviewed the diff and understand why it is correct: `atexit` handlers are not invoked by `std::quick_exit`, only `at_quick_exit` handlers are, so the existing registration could never fire on this exit path. I also understand why `RuntimeLinker::Clear()` has to stay out of the quick-exit handler â€” I saw the hang it causes when it is included. I ran the emulator before and after the change and confirmed the exit behaviour myself.
