### PR TITLE
launcher: add 1440p option and improve toolbar contrast

### DIFF
--- a/src/launcher/include/configuration.h
+++ b/src/launcher/include/configuration.h
@@ -54,6 +54,7 @@ public:
 	enum class Resolution {
 		R1280X720,
 		R1920X1080,
+		R2560X1440,
 	};
 	Q_ENUM(Resolution)
 

--- a/src/launcher/src/configurationListWidget.cpp
+++ b/src/launcher/src/configurationListWidget.cpp
@@ -163,11 +163,12 @@ static void ApplyGameListStyle(Ui::ConfigurationListWidget* ui) {
 	    "#267bd8; }"
 	    "QLineEdit:focus { border-color: rgba(80,160,255,180); }"));
 	ui->global_settings_button->setStyleSheet(QStringLiteral(
-	    "QToolButton { background: rgba(255,255,255,18); border: 1px solid transparent; "
-	    "border-radius: 5px; padding: 3px; }"
-	    "QToolButton:hover { background: rgba(255,255,255,45); border-color: rgba(255,255,255,70); "
-	    "}"
-	    "QToolButton:disabled { background: transparent; }"));
+	    "QToolButton { background: #202733; border: 1px solid #4b5c73; border-radius: 5px; "
+	    "padding: 3px; }"
+	    "QToolButton:hover { background: #267bd8; border-color: #70b5ff; }"
+	    "QToolButton:pressed { background: #185d9f; border-color: #9bcaff; }"
+	    "QToolButton:focus { border: 2px solid #70b5ff; padding: 2px; }"
+	    "QToolButton:disabled { background: #59616d; border-color: #737d8a; }"));
 	ui->edit_button->setStyleSheet(ui->global_settings_button->styleSheet());
 	ui->delete_button->setStyleSheet(ui->global_settings_button->styleSheet());
 	ui->input_mapping_button->setStyleSheet(ui->global_settings_button->styleSheet());


### PR DESCRIPTION
## Summary

- add 2560x1440 to the launcher resolution choices
- give toolbar actions explicit normal, hover, pressed, focus, and disabled states
- keep both changes within the existing enum-driven launcher flow

## Validation

- `cmake --build _Build/launcher-usability --target launcher --parallel 2`
- launched the resulting Windows executable and verified the toolbar visually
- opened Global settings and confirmed the resolution list contains 1280x720, 1920x1080, and 2560x1440
- closed the dialog without saving, so local user settings were not changed

## Scope

Launcher-only usability change; emulator rendering and game compatibility paths are unchanged.