### PR TITLE
loader: rebind pending imports after module load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,8 @@ if(BUILD_TESTING)
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --alignbyte-only)
 	add_test(NAME virtual_memory_allocation
 		COMMAND $<TARGET_FILE:virtual_memory_allocation_tests>)
+	add_test(NAME import_rebind_classifier
+		COMMAND $<TARGET_FILE:virtual_memory_allocation_tests> --import-rebind-only)
 	add_test(NAME guest_red_zone_patcher
 		COMMAND $<TARGET_FILE:virtual_memory_allocation_tests> --red-zone-patcher-only)
 	add_test(NAME command_scheduler_timeline

--- a/src/libs/libKernel.cpp
+++ b/src/libs/libKernel.cpp
@@ -1252,6 +1252,9 @@ static KYTY_SYSV_ABI KernelModule KernelLoadStartModule(const char* module_file_
 	program->dbg_print_reloc = true;
 
 	rt->RelocateProgram(program);
+	// The module's exports may satisfy imports that were left pending in programs loaded earlier.
+	// Rebinding is intentionally selective so live, valid relocation targets remain untouched.
+	rt->RebindPendingImports();
 
 	int result = rt->StartModule(program, args, argp, nullptr);
 

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -1073,6 +1073,88 @@ static void RelocateRecords(Elf64_Rela* records, uint64_t size, Program* program
 	}
 }
 
+// Loading a shared module can make imports from already-relocated programs resolvable. Only
+// replace values that still carry one of the linker's pending-import sentinels; guest code may
+// legitimately update other relocation slots after startup.
+static bool IsPendingImportTarget(uint64_t patch_vaddr, uint64_t current, SymbolType type,
+                                  uint64_t initial_no_type_value, uint64_t invalid_memory,
+                                  const std::vector<StubbedImportRecord>& stubs) {
+	if (current == 0 || current == invalid_memory) {
+		return true;
+	}
+
+	if (type == SymbolType::NoType && current == initial_no_type_value) {
+		return true;
+	}
+
+	return std::any_of(stubs.begin(), stubs.end(), [=](const auto& record) {
+		return record.patch_vaddr == patch_vaddr && record.thunk_vaddr == current;
+	});
+}
+
+#if defined(KYTY_VIRTUAL_MEMORY_ALLOCATION_TESTS)
+bool TestPendingImportTargetClassifier() {
+	constexpr uint64_t patch_vaddr           = 0x1000;
+	constexpr uint64_t thunk_vaddr           = 0x2000;
+	constexpr uint64_t invalid_memory        = 0x3000;
+	constexpr uint64_t initial_no_type_value = 0x4000;
+	constexpr uint64_t resolved_vaddr        = 0x5000;
+	const std::vector<StubbedImportRecord> stubs = {
+	    {.patch_vaddr = patch_vaddr, .thunk_vaddr = thunk_vaddr}};
+
+	return IsPendingImportTarget(patch_vaddr, 0, SymbolType::Object, 0, invalid_memory, stubs) &&
+	       IsPendingImportTarget(patch_vaddr, invalid_memory, SymbolType::Object, 0,
+	                             invalid_memory, stubs) &&
+	       IsPendingImportTarget(patch_vaddr, thunk_vaddr, SymbolType::Func, 0, invalid_memory,
+	                             stubs) &&
+	       IsPendingImportTarget(patch_vaddr, initial_no_type_value, SymbolType::NoType,
+	                             initial_no_type_value, invalid_memory, stubs) &&
+	       !IsPendingImportTarget(patch_vaddr + 8, thunk_vaddr, SymbolType::Func, 0,
+	                              invalid_memory, stubs) &&
+	       !IsPendingImportTarget(patch_vaddr, initial_no_type_value, SymbolType::Object,
+	                              initial_no_type_value, invalid_memory, stubs) &&
+	       !IsPendingImportTarget(patch_vaddr, resolved_vaddr, SymbolType::Func, 0,
+	                              invalid_memory, stubs);
+}
+#endif
+
+static uint32_t RebindPendingRecords(Elf64_Rela* records, uint64_t size, Program* program) {
+	if (records == nullptr || size == 0) {
+		return 0;
+	}
+
+	uint32_t rebound = 0;
+	uint32_t index   = 0;
+	for (auto* r = records;
+	     reinterpret_cast<uint8_t*>(r) < reinterpret_cast<uint8_t*>(records) + size; r++, index++) {
+		auto ri = GetRelocationInfo(r, program);
+		if (!ri.resolved || ri.bind_self ||
+		    (ri.bind != BindType::Global && ri.bind != BindType::Weak)) {
+			continue;
+		}
+
+		uint64_t current = 0;
+		std::memcpy(&current, reinterpret_cast<const void*>(ri.vaddr), sizeof(current));
+		const uint64_t initial_no_type_value =
+		    ri.type == SymbolType::NoType
+		        ? RuntimeLinker::ReadFromElf(program, ri.vaddr) + ri.base_vaddr
+		        : 0;
+		if (!IsPendingImportTarget(ri.vaddr, current, ri.type, initial_no_type_value,
+		                           g_invalid_memory, g_stubbed_imports)) {
+			continue;
+		}
+
+		if (PatchGuestMemory64(ri.vaddr, ri.value)) {
+			rebound++;
+			LOGF("Rebound pending import [%u] [0x%016" PRIx64 "] <- 0x%016" PRIx64
+			     ", %s, %s, %s\n",
+			     index, ri.vaddr, ri.value, ri.name.c_str(), Common::EnumName(ri.type).c_str(),
+			     Common::PathToString(program->file_name).c_str());
+		}
+	}
+	return rebound;
+}
+
 __attribute__((naked)) static KYTY_SYSV_ABI void RelocateHandlerReturnStub() {
 	asm volatile("addq $8, %rsp\n\t"
 	             "retq\n");
@@ -1286,6 +1368,28 @@ void RuntimeLinker::RelocateProgram(Program* program) {
 	EXIT_IF(std::find(m_programs.begin(), m_programs.end(), program) == m_programs.end());
 
 	Relocate(program);
+}
+
+void RuntimeLinker::RebindPendingImports() {
+	Common::LockGuard lock(m_mutex);
+
+	uint32_t rebound = 0;
+	for (auto* program: m_programs) {
+		if (program == nullptr || !program->relocated) {
+			continue;
+		}
+
+		// Relocation tables describe every candidate slot, while IsPendingImportTarget keeps
+		// already-valid and guest-modified values intact.
+		rebound += RebindPendingRecords(program->dynamic_info->rela_table,
+		                                program->dynamic_info->rela_table_total_size, program);
+		rebound += RebindPendingRecords(program->dynamic_info->jmprela_table,
+		                                program->dynamic_info->jmprela_table_size, program);
+	}
+
+	if (rebound != 0) {
+		LOGF("Rebound %u pending imports after module load\n", rebound);
+	}
 }
 
 void RuntimeLinker::UnloadProgram(Program* program) {

--- a/src/loader/runtimeLinker.h
+++ b/src/loader/runtimeLinker.h
@@ -158,6 +158,8 @@ public:
 
 	void RelocateAll();
 	void RelocateProgram(Program* program);
+	// Resolve only import slots that still contain a linker-owned pending value.
+	void RebindPendingImports();
 
 	void  Execute(const std::filesystem::path& game_patch = {});
 	int   StartModule(Program* program, size_t args, const void* argp, module_func_t func);
@@ -212,6 +214,7 @@ private:
 #if defined(KYTY_VIRTUAL_MEMORY_ALLOCATION_TESTS)
 bool TestMainEntryUsesGuestStack();
 bool TestModuleRelocationUsesWritableHostMapping();
+bool TestPendingImportTargetClassifier();
 #endif
 
 } // namespace Loader

--- a/tests/VirtualMemoryAllocationTests.cpp
+++ b/tests/VirtualMemoryAllocationTests.cpp
@@ -2506,9 +2506,21 @@ void TestModuleRelocationUsesWritableHostMapping() {
 	std::printf("[host]    %-48s ok\n", test);
 }
 
+void TestPendingImportTargetClassifier() {
+	const char* test = "PendingImportTargetClassifier";
+	Check(test, Loader::TestPendingImportTargetClassifier(),
+	      "valid import targets were not kept distinct from linker-owned pending values");
+	std::printf("[host]    %-48s ok\n", test);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
+	if (argc == 2 && std::strcmp(argv[1], "--import-rebind-only") == 0) {
+		RunTest(TestPendingImportTargetClassifier);
+		return g_failed_tests == 0 ? 0 : 1;
+	}
+
 	InitSubsystems();
 	if (argc == 2 && std::strcmp(argv[1], "--red-zone-patcher-only") == 0) {
 		RunTest(TestWindowsGuestRedZoneStaticPatcher);
@@ -2563,6 +2575,7 @@ int main(int argc, char** argv) {
 	RunTest(TestMemoryPoolCommitDecommitQueryFlags);
 	RunTest(TestProgramMemoryAllocationAndProtection);
 	RunTest(TestModuleRelocationUsesWritableHostMapping);
+	RunTest(TestPendingImportTargetClassifier);
 
 	if (g_failed_tests != 0) {
 		std::printf("VirtualMemoryAllocationTests: %d case(s) failed\n", g_failed_tests);


### PR DESCRIPTION
## Summary

- Revisit imports in already-relocated programs after sceKernelLoadStartModule loads a shared module.
- Patch only linker-owned pending values: null, the invalid-object sentinel, a registered import thunk, or the original ELF value used by unresolved STT_NOTYPE imports.
- Preserve self/local bindings, valid resolved targets, and relocation slots modified by guest code.

## Why

Late function thunks can resolve on first call, but unresolved object and STT_NOTYPE imports have no equivalent call path. Re-running RelocateAll would rewrite every live import slot. This change handles newly available exports without disturbing valid runtime state.

## Implementation

- Add RuntimeLinker::RebindPendingImports and invoke it after relocating a newly loaded module.
- Centralize pending-target classification in a documented helper.
- Scan both RELA and PLT tables only for already-relocated programs.
- Log each changed slot and the final rebound count.
- Add focused positive and negative classifier coverage.

## Verification

- Build of virtual_memory_allocation_tests: passed.
- Focused executable test: passed.
- CTest import_rebind_classifier: passed (1/1).
- Full virtual_memory_allocation_tests could not reach its cases on this Windows host: InitSubsystems aborts in memoryAddressSpace.inc:662 because the required host reservation is unavailable. The focused classifier runs before subsystem initialization and is unaffected.

Adapted from the external development branch and expanded with stricter classification, documentation, and negative coverage. Original work is retained through the commit co-author trailer.