### PR TITLE
graphics: add structured PM4 submission inspector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,6 +488,14 @@ add_executable(image_page_table_tests EXCLUDE_FROM_ALL
 target_link_libraries(image_page_table_tests common fmt::fmt)
 target_include_directories(image_page_table_tests PRIVATE ${inc_headers})
 
+add_executable(pm4_inspector_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/Pm4InspectorTests.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/guest_gpu/pm4.cpp"
+	"${KYTY_SOURCE_DIR}/graphics/guest_gpu/pm4Inspector.cpp"
+)
+target_link_libraries(pm4_inspector_tests common fmt::fmt nlohmann_json::nlohmann_json)
+target_include_directories(pm4_inspector_tests PRIVATE ${inc_headers})
+
 add_kyty_full_emulator_test(shader_recompiler_compute_tests "${KYTY_TESTS_DIR}/ShaderRecompilerComputeTests.cpp")
 
 set(gpu_test_generated_dir "${PROJECT_BINARY_DIR}/gpu_test_shaders")
@@ -528,6 +536,7 @@ if(BUILD_TESTING)
 	add_test(NAME shader_cfg COMMAND $<TARGET_FILE:shader_cfg_tests>)
 	add_test(NAME scalar_provenance COMMAND $<TARGET_FILE:scalar_provenance_tests>)
 	add_test(NAME image_page_table COMMAND $<TARGET_FILE:image_page_table_tests>)
+	add_test(NAME pm4_inspector COMMAND $<TARGET_FILE:pm4_inspector_tests>)
 	add_test(NAME memory_tracker COMMAND $<TARGET_FILE:memory_tracker_tests>)
 	add_test(NAME page_manager COMMAND $<TARGET_FILE:page_manager_tests>)
 	add_test(NAME bit_array COMMAND $<TARGET_FILE:bit_array_tests>)
@@ -582,6 +591,7 @@ if(BUILD_TESTING)
 		shader_cfg_tests
 		scalar_provenance_tests
 		image_page_table_tests
+		pm4_inspector_tests
 		memory_tracker_tests
 		page_manager_tests
 		bit_array_tests

--- a/docs/pm4-inspector.md
+++ b/docs/pm4-inspector.md
@@ -1,0 +1,26 @@
+# PM4 submission inspector
+
+Enable **Command Buffer Dump** in the launcher, or pass:
+
+```text
+--command-buffer-dump true --command-buffer-dump-folder _Buffers
+```
+
+Kyty continues to create its existing text dumps and additionally writes one
+`*.json` file per submitted graphics DCB or asynchronous-compute ACB.
+
+Each JSON trace contains:
+
+- The queue, frame, source address, and copied root packet stream.
+- Readable nested indirect command buffers captured at submission time.
+- Readable indirect context, shader, and uconfig register pairs.
+- Register-state deltas and a persistent tracked-state hash per queue.
+- Packet classifications: `Known`, `Partial`, `Inferred`, `Unknown`, `Unsupported`, or
+  `UnreadableAtCaptureTime`.
+
+`Known` describes the inspector's structural understanding. It does not claim that every
+runtime behavior or register semantic is implemented. Resource-registration metadata and
+general descriptor memory are not captured yet; the JSON records those limits explicitly.
+
+The JSON uses `dcb` for graphics submissions and `acb` for asynchronous-compute submissions.
+The older internal `constant_commands` stream is intentionally not relabeled or inspected.

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -10,6 +10,7 @@
 #include "graphics/guest_gpu/command_processor/pm4Dispatch.h"
 #include "graphics/guest_gpu/hardwareContext.h"
 #include "graphics/guest_gpu/pm4.h"
+#include "graphics/guest_gpu/pm4Inspector.h"
 #include "graphics/host_gpu/renderer/render.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
 #include "graphics/host_gpu/renderer/sync.h"
@@ -26,6 +27,7 @@
 #include <atomic>
 #include <cstdio>
 #include <deque>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <semaphore>
@@ -66,10 +68,48 @@ static bool GraphicsRunDebugDumpEnabled() {
 	       Config::GetPrintfDirection() != Config::OutputDirection::Silent;
 }
 
+static bool ReadGuestWordsForInspector(uint64_t address, uint32_t size_dw,
+                                       std::vector<uint32_t>* words) {
+	EXIT_IF(words == nullptr);
+	words->clear();
+	if (size_dw == 0) {
+		return true;
+	}
+
+	// Validate every mapped segment before copying. An indirect command buffer can cross guest
+	// allocation boundaries, so checking only its first address is insufficient.
+	constexpr uint32_t cpu_read_protection = 0x01u;
+	const uint64_t     size_bytes          = static_cast<uint64_t>(size_dw) * sizeof(uint32_t);
+	if (address == 0 || address > std::numeric_limits<uint64_t>::max() - size_bytes) {
+		return false;
+	}
+
+	const uint64_t end = address + size_bytes;
+	for (uint64_t cursor = address; cursor < end;) {
+		LibKernel::Memory::VirtualQueryInfo info {};
+		if (LibKernel::Memory::KernelVirtualQuery(reinterpret_cast<const void*>(cursor), 0, &info,
+		                                          sizeof(info)) != OK ||
+		    info.is_committed == 0 ||
+		    (static_cast<uint32_t>(info.protection) & cpu_read_protection) == 0 ||
+		    info.start > cursor || info.end <= cursor) {
+			return false;
+		}
+		cursor = std::min<uint64_t>(end, info.end);
+	}
+
+	const auto* first = reinterpret_cast<const uint32_t*>(address);
+	words->assign(first, first + size_dw);
+	return true;
+}
+
 GuestGpu::GuestGpu(RenderContext& renderer): m_renderer(renderer) {
 	EXIT_NOT_IMPLEMENTED(!Common::Thread::IsMainThread());
 	GraphicsInitJmpTables();
 	m_gfx_cp = std::make_unique<CommandProcessor>(renderer, 0);
+	if (Config::CommandBufferDumpEnabled()) {
+		m_pm4_inspector = std::make_unique<Pm4::SubmissionInspector>(
+		    Config::GetCommandBufferDumpFolder(), ReadGuestWordsForInspector);
+	}
 	m_thread = std::jthread(ThreadRun, this);
 }
 
@@ -153,7 +193,14 @@ void GuestGpu::Submit(std::span<const uint32_t> draw_commands,
 	submission.commands          = draw_commands;
 	submission.constant_commands = constant_commands;
 	submission.reset_processor   = m_graphics_done;
-	m_graphics_done              = false;
+	if (m_pm4_inspector != nullptr &&
+	    !m_pm4_inspector->CaptureGraphics(static_cast<uint32_t>(GetFrameNum()),
+	                                      submission.reset_processor,
+	                                      reinterpret_cast<uint64_t>(draw_commands.data()),
+	                                      draw_commands)) {
+		LOGF_COLOR(Log::Color::BrightRed, "Can't create PM4 submission inspection\n");
+	}
+	m_graphics_done = false;
 	Enqueue(std::move(submission));
 }
 
@@ -168,6 +215,12 @@ void GuestGpu::SubmitCompute(uint32_t queue, std::span<const uint32_t> commands)
 	submission.type     = SubmissionType::Compute;
 	submission.queue_id = 1 + compute_queue;
 	submission.commands = commands;
+	if (m_pm4_inspector != nullptr &&
+	    !m_pm4_inspector->CaptureAsyncCompute(static_cast<uint32_t>(GetFrameNum()), queue,
+	                                          reinterpret_cast<uint64_t>(commands.data()),
+	                                          commands)) {
+		LOGF_COLOR(Log::Color::BrightRed, "Can't create PM4 submission inspection\n");
+	}
 	Enqueue(std::move(submission));
 }
 

--- a/src/graphics/guest_gpu/graphicsRun.h
+++ b/src/graphics/guest_gpu/graphicsRun.h
@@ -19,6 +19,9 @@
 namespace Libs::Graphics {
 
 class RenderContext;
+namespace Pm4 {
+class SubmissionInspector;
+}
 
 class GuestGpu final {
 public:
@@ -91,6 +94,7 @@ private:
 
 	std::unique_ptr<CommandProcessor>                                m_gfx_cp;
 	std::array<std::unique_ptr<CommandProcessor>, ComputeQueueCount> m_compute_cp;
+	std::unique_ptr<Pm4::SubmissionInspector>                        m_pm4_inspector;
 
 	uint64_t        m_submit_id = 0;
 	std::atomic_int m_done_num  = 0;

--- a/src/graphics/guest_gpu/pm4.cpp
+++ b/src/graphics/guest_gpu/pm4.cpp
@@ -100,6 +100,22 @@ constexpr auto g_opcode_names   = MakeOpcodeNames();
 
 } // namespace
 
+const char* GetOpcodeName(uint8_t opcode) noexcept {
+	return g_opcode_names[opcode];
+}
+
+const char* GetCustomOpcodeName(uint32_t opcode) noexcept {
+	return opcode < g_register_names.size() ? g_register_names[opcode] : "<unknown>";
+}
+
+bool IsOpcodeNamed(uint8_t opcode) noexcept {
+	return g_opcode_names[opcode][0] != '<';
+}
+
+bool IsCustomOpcodeNamed(uint32_t opcode) noexcept {
+	return opcode < g_register_names.size() && g_register_names[opcode][0] != '<';
+}
+
 void DumpPm4PacketStream(Common::File* file, const uint32_t* cmd_buffer, uint32_t start_dw,
                          uint32_t num_dw) {
 	// db_dump();
@@ -132,8 +148,8 @@ void DumpPm4PacketStream(Common::File* file, const uint32_t* cmd_buffer, uint32_
 
 				EXIT_NOT_IMPLEMENTED(len >= dw);
 
-				file->Printf("%s %s(OP:0x%02" PRIx8 ") SH:%s CNT:%u\n", g_opcode_names[op],
-				             (op == IT_NOP ? g_register_names[r] : ""), op, sh_gx ? "GX" : "CX",
+				file->Printf("%s %s(OP:0x%02" PRIx8 ") SH:%s CNT:%u\n", GetOpcodeName(op),
+				             (op == IT_NOP ? GetCustomOpcodeName(r) : ""), op, sh_gx ? "GX" : "CX",
 				             len);
 
 				for (uint32_t i = 0; i < len; i++) {

--- a/src/graphics/guest_gpu/pm4.h
+++ b/src/graphics/guest_gpu/pm4.h
@@ -1091,6 +1091,12 @@ constexpr uint32_t UC_NUM = 0x3FFF + 1;
 void DumpPm4PacketStream(Common::File* file, const uint32_t* cmd_buffer, uint32_t start_dw,
                          uint32_t num_dw);
 
+// Shared by text dumps and the structured inspector so opcode naming stays consistent.
+[[nodiscard]] const char* GetOpcodeName(uint8_t opcode) noexcept;
+[[nodiscard]] const char* GetCustomOpcodeName(uint32_t opcode) noexcept;
+[[nodiscard]] bool        IsOpcodeNamed(uint8_t opcode) noexcept;
+[[nodiscard]] bool        IsCustomOpcodeNamed(uint32_t opcode) noexcept;
+
 } // namespace Libs::Graphics::Pm4
 
 #endif /* EMULATOR_INCLUDE_EMULATOR_GRAPHICS_PM4_H_ */

--- a/src/graphics/guest_gpu/pm4Inspector.cpp
+++ b/src/graphics/guest_gpu/pm4Inspector.cpp
@@ -1,0 +1,583 @@
+#include "graphics/guest_gpu/pm4Inspector.h"
+
+#include "common/file.h"
+#include "graphics/guest_gpu/pm4.h"
+
+#include <algorithm>
+#include <fmt/format.h>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <tuple>
+#include <utility>
+
+namespace Libs::Graphics::Pm4 {
+
+namespace {
+
+constexpr uint32_t RegisterSelectorMask = 0x70000000u;
+
+uint32_t NormalizeRegisterOffset(RegisterSpace space, uint32_t offset, uint8_t opcode) {
+	if (space == RegisterSpace::Shader) {
+		return offset;
+	}
+	if (space == RegisterSpace::Uconfig && opcode == IT_SET_UCONFIG_REG_INDEX) {
+		return offset & 0x0fffffffu;
+	}
+	return offset & ~RegisterSelectorMask;
+}
+
+const char* QueueKindName(SubmissionQueueKind kind) {
+	return kind == SubmissionQueueKind::Graphics ? "graphics" : "async_compute";
+}
+
+uint64_t QueueStateKey(SubmissionQueueKind kind, uint32_t queue) {
+	return (static_cast<uint64_t>(kind) << 32u) | queue;
+}
+
+const char* RegisterSpaceName(RegisterSpace space) {
+	switch (space) {
+		case RegisterSpace::Context: return "context";
+		case RegisterSpace::Shader: return "shader";
+		case RegisterSpace::Uconfig: return "uconfig";
+	}
+	return "unknown";
+}
+
+const char* ReferenceKindName(MemoryReferenceKind kind) {
+	switch (kind) {
+		case MemoryReferenceKind::CommandBuffer: return "command_buffer";
+		case MemoryReferenceKind::RegisterPairs: return "register_pairs";
+		case MemoryReferenceKind::CompareValue: return "compare_value";
+	}
+	return "unknown";
+}
+
+std::string AddressText(uint64_t address) {
+	return fmt::format("0x{:016x}", address);
+}
+
+std::string WordText(uint32_t value) {
+	return fmt::format("0x{:08x}", value);
+}
+
+void HashWord(uint64_t* hash, uint32_t value) {
+	constexpr uint64_t FnvPrime = 1099511628211ull;
+	for (uint32_t shift = 0; shift < 32; shift += 8) {
+		*hash ^= (value >> shift) & 0xffu;
+		*hash *= FnvPrime;
+	}
+}
+
+class Parser final {
+public:
+	Parser(SubmissionInspection* result, QueueRegisterState* state, const MemoryReader& reader,
+	       const InspectionLimits& limits)
+	    : m_result(result), m_state(state), m_reader(reader), m_limits(limits) {}
+
+	void AddRoot(const char* role, uint64_t address, std::span<const uint32_t> words) {
+		AddBuffer(role, address, words, 0);
+	}
+
+private:
+	size_t AddBuffer(const char* role, uint64_t address, std::span<const uint32_t> words,
+	                 uint32_t depth) {
+		BufferInspection buffer;
+		buffer.id               = m_result->buffers.size();
+		buffer.role             = role;
+		buffer.address          = address;
+		buffer.declared_size_dw = static_cast<uint32_t>(words.size());
+		buffer.depth            = depth;
+		buffer.words.assign(words.begin(), words.end());
+		const size_t id = buffer.id;
+		m_result->buffers.push_back(std::move(buffer));
+		m_buffer_ids.emplace(std::make_pair(address, static_cast<uint32_t>(words.size())), id);
+		ParseBuffer(id);
+		return id;
+	}
+
+	void Count(InspectionStatus status) { m_result->status_counts[static_cast<size_t>(status)]++; }
+
+	bool ReadMemory(uint64_t address, uint32_t size_dw, std::vector<uint32_t>* words,
+	                std::string* note) {
+		if (size_dw == 0) {
+			words->clear();
+			return true;
+		}
+		if (!m_reader) {
+			*note = "no memory reader was available";
+			return false;
+		}
+		if (size_dw > m_limits.max_single_snapshot_dw ||
+		    size_dw > m_limits.max_total_snapshot_dw - m_snapshot_dw) {
+			*note = "snapshot limit exceeded";
+			return false;
+		}
+		if (!m_reader(address, size_dw, words) || words->size() != size_dw) {
+			words->clear();
+			*note = "memory was not readable at capture time";
+			return false;
+		}
+		m_snapshot_dw += size_dw;
+		return true;
+	}
+
+	MemoryReference SnapshotWords(MemoryReferenceKind kind, uint64_t address, uint32_t size_dw) {
+		MemoryReference reference;
+		reference.kind    = kind;
+		reference.address = address;
+		reference.size_dw = size_dw;
+		if (address == 0 && size_dw != 0) {
+			reference.note = "null address";
+			return reference;
+		}
+		if (ReadMemory(address, size_dw, &reference.snapshot_words, &reference.note)) {
+			reference.snapshot_status = InspectionStatus::Known;
+		}
+		return reference;
+	}
+
+	MemoryReference SnapshotCommandBuffer(uint64_t address, uint32_t size_dw, uint32_t depth) {
+		MemoryReference reference;
+		reference.kind    = MemoryReferenceKind::CommandBuffer;
+		reference.address = address;
+		reference.size_dw = size_dw;
+		if (size_dw == 0) {
+			reference.snapshot_status = InspectionStatus::Known;
+			reference.note            = "empty command buffer";
+			return reference;
+		}
+		if (address == 0) {
+			reference.note = "null address";
+			return reference;
+		}
+		const auto key = std::make_pair(address, size_dw);
+		if (const auto existing = m_buffer_ids.find(key); existing != m_buffer_ids.end()) {
+			reference.snapshot_status  = InspectionStatus::Known;
+			reference.nested_buffer_id = existing->second;
+			reference.note             = "already captured";
+			return reference;
+		}
+		if (depth > m_limits.max_depth) {
+			reference.note = "maximum indirect-buffer depth exceeded";
+			return reference;
+		}
+		std::vector<uint32_t> words;
+		if (!ReadMemory(address, size_dw, &words, &reference.note)) {
+			return reference;
+		}
+		reference.snapshot_status  = InspectionStatus::Known;
+		reference.nested_buffer_id = AddBuffer("indirect_command_buffer", address, words, depth);
+		return reference;
+	}
+
+	void AddRegisterWrite(PacketInspection* packet, RegisterSpace space, uint32_t raw_offset,
+	                      uint32_t value) {
+		if (raw_offset == 0xffffffffu) {
+			return;
+		}
+		const auto offset = NormalizeRegisterOffset(space, raw_offset, packet->opcode);
+		packet->register_writes.push_back({space, offset, value});
+		m_state->Set(space, offset, value);
+	}
+
+	void InspectDirectRegisters(PacketInspection* packet, RegisterSpace space) {
+		if (packet->payload.size() < 2) {
+			packet->status = InspectionStatus::UnreadableAtCaptureTime;
+			return;
+		}
+		const auto first = packet->payload[0];
+		for (size_t index = 1; index < packet->payload.size(); index++) {
+			AddRegisterWrite(packet, space, first + static_cast<uint32_t>(index - 1),
+			                 packet->payload[index]);
+		}
+		packet->status = InspectionStatus::Known;
+	}
+
+	void InspectIndirectRegisters(PacketInspection* packet, RegisterSpace space) {
+		if (packet->payload.size() != 4) {
+			packet->status = InspectionStatus::Partial;
+			return;
+		}
+		const uint64_t address    = (static_cast<uint64_t>(packet->payload[0]) & 0xfffffffcu) |
+		                            (static_cast<uint64_t>(packet->payload[1]) << 32u);
+		const uint32_t pair_count = packet->payload[3] & 0x3fffu;
+		if (pair_count > std::numeric_limits<uint32_t>::max() / 2u) {
+			packet->status = InspectionStatus::UnreadableAtCaptureTime;
+			return;
+		}
+		auto reference =
+		    SnapshotWords(MemoryReferenceKind::RegisterPairs, address, pair_count * 2u);
+		if (reference.snapshot_status == InspectionStatus::Known) {
+			for (uint32_t index = 0; index < pair_count; index++) {
+				AddRegisterWrite(packet, space, reference.snapshot_words[index * 2u],
+				                 reference.snapshot_words[index * 2u + 1u]);
+			}
+			packet->status = InspectionStatus::Known;
+		} else {
+			packet->status = InspectionStatus::Partial;
+		}
+		packet->references.push_back(std::move(reference));
+	}
+
+	void InspectIndirectBuffer(PacketInspection* packet, uint32_t depth) {
+		if (packet->payload.size() == 3) {
+			const uint64_t address   = static_cast<uint64_t>(packet->payload[0]) |
+			                           (static_cast<uint64_t>(packet->payload[1]) << 32u);
+			const uint32_t size_dw   = packet->payload[2] & 0xfffffu;
+			auto           reference = SnapshotCommandBuffer(address, size_dw, depth + 1u);
+			packet->status           = reference.snapshot_status == InspectionStatus::Known
+			                               ? InspectionStatus::Known
+			                               : InspectionStatus::Partial;
+			packet->references.push_back(std::move(reference));
+			return;
+		}
+		if (packet->payload.size() == 13) {
+			const uint64_t compare_address =
+			    (static_cast<uint64_t>(packet->payload[1]) & 0xfffffff8u) |
+			    (static_cast<uint64_t>(packet->payload[2]) << 32u);
+			packet->references.push_back(
+			    SnapshotWords(MemoryReferenceKind::CompareValue, compare_address, 2));
+
+			const uint64_t then_address =
+			    (static_cast<uint64_t>(packet->payload[7]) & 0xfffffffcu) |
+			    (static_cast<uint64_t>(packet->payload[8]) << 32u);
+			const uint32_t then_size = packet->payload[9] & 0xfffffu;
+			packet->references.push_back(
+			    SnapshotCommandBuffer(then_address, then_size, depth + 1u));
+
+			const uint64_t else_address =
+			    (static_cast<uint64_t>(packet->payload[10]) & 0xfffffffcu) |
+			    (static_cast<uint64_t>(packet->payload[11]) << 32u);
+			const uint32_t else_size = packet->payload[12] & 0xfffffu;
+			if (else_size != 0) {
+				packet->references.push_back(
+				    SnapshotCommandBuffer(else_address, else_size, depth + 1u));
+			}
+			packet->status =
+			    std::all_of(packet->references.begin(), packet->references.end(),
+			                [](const auto& reference) {
+				                return reference.snapshot_status == InspectionStatus::Known;
+			                })
+			        ? InspectionStatus::Known
+			        : InspectionStatus::Partial;
+			return;
+		}
+		packet->status = InspectionStatus::Partial;
+	}
+
+	void InspectType3(PacketInspection* packet, uint32_t depth) {
+		packet->name = GetOpcodeName(packet->opcode);
+		if (packet->opcode == IT_NOP) {
+			packet->custom_opcode = KYTY_PM4_R(packet->header);
+			if (IsCustomOpcodeNamed(packet->custom_opcode)) {
+				packet->name += fmt::format(":{}", GetCustomOpcodeName(packet->custom_opcode));
+			}
+			packet->status = packet->custom_opcode == R_ZERO ? InspectionStatus::Known
+			                                                 : InspectionStatus::Inferred;
+			return;
+		}
+		switch (packet->opcode) {
+			case IT_SET_CONTEXT_REG: InspectDirectRegisters(packet, RegisterSpace::Context); return;
+			case IT_SET_SH_REG: InspectDirectRegisters(packet, RegisterSpace::Shader); return;
+			case IT_SET_UCONFIG_REG:
+			case IT_SET_UCONFIG_REG_INDEX:
+				InspectDirectRegisters(packet, RegisterSpace::Uconfig);
+				return;
+			case IT_SET_CONTEXT_REG_INDIRECT:
+				InspectIndirectRegisters(packet, RegisterSpace::Context);
+				return;
+			case IT_SET_SH_REG_INDIRECT:
+				InspectIndirectRegisters(packet, RegisterSpace::Shader);
+				return;
+			case IT_SET_UCONFIG_REG_INDIRECT:
+				InspectIndirectRegisters(packet, RegisterSpace::Uconfig);
+				return;
+			case IT_INDIRECT_BUFFER: InspectIndirectBuffer(packet, depth); return;
+			default:
+				packet->status = IsOpcodeNamed(packet->opcode) ? InspectionStatus::Inferred
+				                                               : InspectionStatus::Unknown;
+				return;
+		}
+	}
+
+	void ParseBuffer(size_t buffer_id) {
+		const auto                    words = m_result->buffers[buffer_id].words;
+		const auto                    depth = m_result->buffers[buffer_id].depth;
+		std::vector<PacketInspection> packets;
+		for (uint32_t offset = 0; offset < words.size();) {
+			PacketInspection packet;
+			packet.offset_dw = offset;
+			packet.header    = words[offset];
+			packet.type      = packet.header >> 30u;
+			packet.predicate = (packet.header & 1u) != 0;
+
+			uint32_t packet_dw = 0;
+			switch (packet.type) {
+				case 0: packet_dw = ((packet.header >> 16u) & 0x3fffu) + 2u; break;
+				case 1: packet_dw = 3; break;
+				case 2: packet_dw = 1; break;
+				case 3: packet_dw = KYTY_PM4_LEN(packet.header); break;
+				default: break;
+			}
+			const auto remaining = static_cast<uint32_t>(words.size()) - offset;
+			if (packet_dw == 0 || packet_dw > remaining) {
+				packet.size_dw = remaining;
+				packet.status  = InspectionStatus::UnreadableAtCaptureTime;
+				packet.name    = "truncated_or_invalid_packet";
+				if (remaining > 1) {
+					packet.payload.assign(words.begin() + offset + 1, words.end());
+				}
+				Count(packet.status);
+				packets.push_back(std::move(packet));
+				break;
+			}
+
+			packet.size_dw = packet_dw;
+			if (packet_dw > 1) {
+				packet.payload.assign(words.begin() + offset + 1,
+				                      words.begin() + offset + packet_dw);
+			}
+			if (packet.type == 3) {
+				packet.opcode = static_cast<uint8_t>((packet.header >> 8u) & 0xffu);
+				InspectType3(&packet, depth);
+			} else if (packet.type == 2) {
+				packet.name   = "TYPE2_PADDING";
+				packet.status = InspectionStatus::Known;
+			} else {
+				packet.name   = fmt::format("TYPE{}_PACKET", packet.type);
+				packet.status = InspectionStatus::Unsupported;
+			}
+			Count(packet.status);
+			packets.push_back(std::move(packet));
+			offset += packet_dw;
+		}
+		m_result->buffers[buffer_id].packets = std::move(packets);
+	}
+
+	SubmissionInspection*                           m_result;
+	QueueRegisterState*                             m_state;
+	const MemoryReader&                             m_reader;
+	InspectionLimits                                m_limits;
+	uint32_t                                        m_snapshot_dw = 0;
+	std::map<std::pair<uint64_t, uint32_t>, size_t> m_buffer_ids;
+};
+
+nlohmann::json StateToJson(const StateView& state) {
+	return {{"context_registers", state.context_registers},
+	        {"shader_registers", state.shader_registers},
+	        {"uconfig_registers", state.uconfig_registers},
+	        {"hash", AddressText(state.hash)}};
+}
+
+} // namespace
+
+const char* InspectionStatusName(InspectionStatus status) noexcept {
+	switch (status) {
+		case InspectionStatus::Known: return "Known";
+		case InspectionStatus::Partial: return "Partial";
+		case InspectionStatus::Inferred: return "Inferred";
+		case InspectionStatus::Unknown: return "Unknown";
+		case InspectionStatus::Unsupported: return "Unsupported";
+		case InspectionStatus::UnreadableAtCaptureTime: return "UnreadableAtCaptureTime";
+		case InspectionStatus::Count: break;
+	}
+	return "Unknown";
+}
+
+void QueueRegisterState::Reset() {
+	m_context.clear();
+	m_shader.clear();
+	m_uconfig.clear();
+}
+
+std::map<uint32_t, uint32_t>& QueueRegisterState::Select(RegisterSpace space) {
+	switch (space) {
+		case RegisterSpace::Context: return m_context;
+		case RegisterSpace::Shader: return m_shader;
+		case RegisterSpace::Uconfig: return m_uconfig;
+	}
+	return m_context;
+}
+
+const std::map<uint32_t, uint32_t>& QueueRegisterState::Select(RegisterSpace space) const {
+	switch (space) {
+		case RegisterSpace::Context: return m_context;
+		case RegisterSpace::Shader: return m_shader;
+		case RegisterSpace::Uconfig: return m_uconfig;
+	}
+	return m_context;
+}
+
+void QueueRegisterState::Set(RegisterSpace space, uint32_t offset, uint32_t value) {
+	Select(space)[offset] = value;
+}
+
+std::optional<uint32_t> QueueRegisterState::Get(RegisterSpace space, uint32_t offset) const {
+	const auto& registers = Select(space);
+	const auto  value     = registers.find(offset);
+	return value == registers.end() ? std::nullopt : std::optional<uint32_t>(value->second);
+}
+
+StateView QueueRegisterState::View() const {
+	StateView view;
+	view.context_registers = static_cast<uint32_t>(m_context.size());
+	view.shader_registers  = static_cast<uint32_t>(m_shader.size());
+	view.uconfig_registers = static_cast<uint32_t>(m_uconfig.size());
+	uint64_t   hash        = 14695981039346656037ull;
+	const auto hash_map    = [&hash](uint32_t tag, const auto& values) {
+		HashWord(&hash, tag);
+		for (const auto& [offset, value]: values) {
+			HashWord(&hash, offset);
+			HashWord(&hash, value);
+		}
+	};
+	hash_map(0, m_context);
+	hash_map(1, m_shader);
+	hash_map(2, m_uconfig);
+	view.hash = hash;
+	return view;
+}
+
+SubmissionInspection InspectSubmission(const SubmissionMetadata& metadata, const char* root_role,
+                                       uint64_t root_address, std::span<const uint32_t> root_words,
+                                       QueueRegisterState* state, const MemoryReader& reader,
+                                       const InspectionLimits& limits) {
+	SubmissionInspection result;
+	result.metadata           = metadata;
+	result.state_before_reset = state->View();
+	if (metadata.reset_state) {
+		state->Reset();
+	}
+	result.state_at_submit = state->View();
+	Parser parser(&result, state, reader, limits);
+	parser.AddRoot(root_role, root_address, root_words);
+	result.state_after = state->View();
+	return result;
+}
+
+std::string SerializeSubmissionInspection(const SubmissionInspection& inspection) {
+	nlohmann::json root;
+	root["schema"]                 = "kyty.pm4.submission.v1";
+	root["capture"]                = {{"id", inspection.metadata.capture_id},
+	                                  {"frame", inspection.metadata.frame},
+	                                  {"queue", inspection.metadata.queue},
+	                                  {"queue_kind", QueueKindName(inspection.metadata.queue_kind)},
+	                                  {"reset_tracked_state", inspection.metadata.reset_state}};
+	root["tracked_register_state"] = {{"before_reset", StateToJson(inspection.state_before_reset)},
+	                                  {"at_submit", StateToJson(inspection.state_at_submit)},
+	                                  {"after", StateToJson(inspection.state_after)}};
+	root["capture_scope"]          = {
+	    {"command_buffers", "root and readable nested indirect buffers"},
+	    {"indirect_registers", "readable register-pair arrays"},
+	    {"resource_registration_map", "not available"},
+	    {"descriptor_memory", "not yet captured unless encoded as an inspected reference"},
+	    {"classification", "packet structure, not a claim of complete runtime support"}};
+
+	nlohmann::json summary = nlohmann::json::object();
+	for (size_t index = 0; index < static_cast<size_t>(InspectionStatus::Count); index++) {
+		summary[InspectionStatusName(static_cast<InspectionStatus>(index))] =
+		    inspection.status_counts[index];
+	}
+	root["summary"] = std::move(summary);
+
+	root["buffers"] = nlohmann::json::array();
+	for (const auto& buffer: inspection.buffers) {
+		nlohmann::json buffer_json = {{"id", buffer.id},
+		                              {"role", buffer.role},
+		                              {"address", AddressText(buffer.address)},
+		                              {"declared_size_dw", buffer.declared_size_dw},
+		                              {"depth", buffer.depth},
+		                              {"words", buffer.words},
+		                              {"packets", nlohmann::json::array()}};
+		for (const auto& packet: buffer.packets) {
+			nlohmann::json packet_json = {{"offset_dw", packet.offset_dw},
+			                              {"size_dw", packet.size_dw},
+			                              {"header", WordText(packet.header)},
+			                              {"type", packet.type},
+			                              {"predicate", packet.predicate},
+			                              {"status", InspectionStatusName(packet.status)},
+			                              {"name", packet.name},
+			                              {"payload", packet.payload},
+			                              {"register_writes", nlohmann::json::array()},
+			                              {"references", nlohmann::json::array()}};
+			if (packet.type == 3) {
+				packet_json["opcode"]     = packet.opcode;
+				packet_json["opcode_hex"] = fmt::format("0x{:02x}", packet.opcode);
+				if (packet.opcode == IT_NOP) {
+					packet_json["custom_opcode"] = packet.custom_opcode;
+				}
+			}
+			for (const auto& write: packet.register_writes) {
+				packet_json["register_writes"].push_back({{"space", RegisterSpaceName(write.space)},
+				                                          {"offset", WordText(write.offset)},
+				                                          {"value", WordText(write.value)}});
+			}
+			for (const auto& reference: packet.references) {
+				nlohmann::json reference_json = {
+				    {"kind", ReferenceKindName(reference.kind)},
+				    {"address", AddressText(reference.address)},
+				    {"size_dw", reference.size_dw},
+				    {"snapshot_status", InspectionStatusName(reference.snapshot_status)},
+				    {"note", reference.note}};
+				if (reference.nested_buffer_id.has_value()) {
+					reference_json["nested_buffer_id"] = *reference.nested_buffer_id;
+				}
+				if (!reference.snapshot_words.empty()) {
+					reference_json["snapshot_words"] = reference.snapshot_words;
+				}
+				packet_json["references"].push_back(std::move(reference_json));
+			}
+			buffer_json["packets"].push_back(std::move(packet_json));
+		}
+		root["buffers"].push_back(std::move(buffer_json));
+	}
+	return root.dump(2);
+}
+
+SubmissionInspector::SubmissionInspector(std::filesystem::path folder, MemoryReader reader,
+                                         InspectionLimits limits)
+    : m_folder(std::move(folder)), m_reader(std::move(reader)), m_limits(limits) {}
+
+bool SubmissionInspector::CaptureGraphics(uint32_t frame, bool reset_state, uint64_t dcb_address,
+                                          std::span<const uint32_t> dcb_words) {
+	return Capture(SubmissionQueueKind::Graphics, frame, 0, reset_state, "dcb", dcb_address,
+	               dcb_words);
+}
+
+bool SubmissionInspector::CaptureAsyncCompute(uint32_t frame, uint32_t queue, uint64_t acb_address,
+                                              std::span<const uint32_t> acb_words) {
+	return Capture(SubmissionQueueKind::AsyncCompute, frame, queue, false, "acb", acb_address,
+	               acb_words);
+}
+
+bool SubmissionInspector::Capture(SubmissionQueueKind queue_kind, uint32_t frame, uint32_t queue,
+                                  bool reset_state, const char* role, uint64_t address,
+                                  std::span<const uint32_t> words) {
+	std::lock_guard    lock(m_mutex);
+	SubmissionMetadata metadata;
+	metadata.capture_id  = m_next_capture_id++;
+	metadata.frame       = frame;
+	metadata.queue       = queue;
+	metadata.queue_kind  = queue_kind;
+	metadata.reset_state = reset_state;
+	auto inspection =
+	    InspectSubmission(metadata, role, address, words,
+	                      &m_queue_states[QueueStateKey(queue_kind, queue)], m_reader, m_limits);
+	auto json            = SerializeSubmissionInspection(inspection);
+	auto path = m_folder / fmt::format("{:06d}_f{:05d}_q{:02x}_{}.json", metadata.capture_id, frame,
+	                                   queue, role);
+	if (!Common::File::CreateDirectories(path.parent_path())) {
+		return false;
+	}
+	Common::File file;
+	file.Create(path);
+	if (file.IsInvalid() || json.size() > std::numeric_limits<uint32_t>::max()) {
+		return false;
+	}
+	uint32_t bytes_written = 0;
+	file.Write(json.data(), static_cast<uint32_t>(json.size()), &bytes_written);
+	file.Close();
+	return bytes_written == json.size();
+}
+
+} // namespace Libs::Graphics::Pm4

--- a/src/graphics/guest_gpu/pm4Inspector.h
+++ b/src/graphics/guest_gpu/pm4Inspector.h
@@ -1,0 +1,157 @@
+#ifndef GRAPHICS_GUEST_GPU_PM4_INSPECTOR_H
+#define GRAPHICS_GUEST_GPU_PM4_INSPECTOR_H
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace Libs::Graphics::Pm4 {
+
+enum class InspectionStatus : uint8_t {
+	Known,
+	Partial,
+	Inferred,
+	Unknown,
+	Unsupported,
+	UnreadableAtCaptureTime,
+	Count
+};
+
+enum class SubmissionQueueKind : uint8_t { Graphics, AsyncCompute };
+enum class RegisterSpace : uint8_t { Context, Shader, Uconfig };
+enum class MemoryReferenceKind : uint8_t { CommandBuffer, RegisterPairs, CompareValue };
+
+struct RegisterWrite {
+	RegisterSpace space  = RegisterSpace::Context;
+	uint32_t      offset = 0;
+	uint32_t      value  = 0;
+};
+
+struct MemoryReference {
+	MemoryReferenceKind   kind            = MemoryReferenceKind::CommandBuffer;
+	uint64_t              address         = 0;
+	uint32_t              size_dw         = 0;
+	InspectionStatus      snapshot_status = InspectionStatus::UnreadableAtCaptureTime;
+	std::optional<size_t> nested_buffer_id;
+	std::vector<uint32_t> snapshot_words;
+	std::string           note;
+};
+
+struct PacketInspection {
+	uint32_t                     offset_dw     = 0;
+	uint32_t                     size_dw       = 0;
+	uint32_t                     header        = 0;
+	uint32_t                     type          = 0;
+	uint8_t                      opcode        = 0;
+	uint32_t                     custom_opcode = 0;
+	bool                         predicate     = false;
+	InspectionStatus             status        = InspectionStatus::Unknown;
+	std::string                  name;
+	std::vector<uint32_t>        payload;
+	std::vector<RegisterWrite>   register_writes;
+	std::vector<MemoryReference> references;
+};
+
+struct BufferInspection {
+	size_t                        id = 0;
+	std::string                   role;
+	uint64_t                      address          = 0;
+	uint32_t                      declared_size_dw = 0;
+	uint32_t                      depth            = 0;
+	std::vector<uint32_t>         words;
+	std::vector<PacketInspection> packets;
+};
+
+struct StateView {
+	uint32_t context_registers = 0;
+	uint32_t shader_registers  = 0;
+	uint32_t uconfig_registers = 0;
+	uint64_t hash              = 0;
+};
+
+class QueueRegisterState {
+public:
+	void                                  Reset();
+	void                                  Set(RegisterSpace space, uint32_t offset, uint32_t value);
+	[[nodiscard]] std::optional<uint32_t> Get(RegisterSpace space, uint32_t offset) const;
+	[[nodiscard]] StateView               View() const;
+
+private:
+	[[nodiscard]] std::map<uint32_t, uint32_t>&       Select(RegisterSpace space);
+	[[nodiscard]] const std::map<uint32_t, uint32_t>& Select(RegisterSpace space) const;
+
+	std::map<uint32_t, uint32_t> m_context;
+	std::map<uint32_t, uint32_t> m_shader;
+	std::map<uint32_t, uint32_t> m_uconfig;
+};
+
+struct SubmissionMetadata {
+	uint64_t            capture_id  = 0;
+	uint32_t            frame       = 0;
+	uint32_t            queue       = 0;
+	SubmissionQueueKind queue_kind  = SubmissionQueueKind::Graphics;
+	bool                reset_state = false;
+};
+
+struct InspectionLimits {
+	uint32_t max_depth              = 8;
+	uint32_t max_single_snapshot_dw = 256 * 1024;
+	uint32_t max_total_snapshot_dw  = 1024 * 1024;
+};
+
+using MemoryReader =
+    std::function<bool(uint64_t address, uint32_t size_dw, std::vector<uint32_t>* words)>;
+
+struct SubmissionInspection {
+	SubmissionMetadata                                                 metadata;
+	StateView                                                          state_before_reset;
+	StateView                                                          state_at_submit;
+	StateView                                                          state_after;
+	std::array<uint32_t, static_cast<size_t>(InspectionStatus::Count)> status_counts {};
+	std::vector<BufferInspection>                                      buffers;
+};
+
+[[nodiscard]] SubmissionInspection
+InspectSubmission(const SubmissionMetadata& metadata, const char* root_role, uint64_t root_address,
+                  std::span<const uint32_t> root_words, QueueRegisterState* state,
+                  const MemoryReader& reader = {}, const InspectionLimits& limits = {});
+
+[[nodiscard]] std::string SerializeSubmissionInspection(const SubmissionInspection& inspection);
+
+class SubmissionInspector final {
+public:
+	explicit SubmissionInspector(std::filesystem::path folder, MemoryReader reader = {},
+	                             InspectionLimits limits = {});
+
+	bool CaptureGraphics(uint32_t frame, bool reset_state, uint64_t dcb_address,
+	                     std::span<const uint32_t> dcb_words);
+	bool CaptureAsyncCompute(uint32_t frame, uint32_t queue, uint64_t acb_address,
+	                         std::span<const uint32_t> acb_words);
+
+private:
+	bool Capture(SubmissionQueueKind queue_kind, uint32_t frame, uint32_t queue, bool reset_state,
+	             const char* role, uint64_t address, std::span<const uint32_t> words);
+
+	std::filesystem::path                            m_folder;
+	MemoryReader                                     m_reader;
+	InspectionLimits                                 m_limits;
+	// Graphics and compute queue numbers live in separate namespaces. Include the queue kind in
+	// the key so diagnostic state cannot leak if both are represented by the same numeric ID.
+	std::unordered_map<uint64_t, QueueRegisterState> m_queue_states;
+	std::mutex                                       m_mutex;
+	uint64_t                                         m_next_capture_id = 0;
+};
+
+[[nodiscard]] const char* InspectionStatusName(InspectionStatus status) noexcept;
+
+} // namespace Libs::Graphics::Pm4
+
+#endif // GRAPHICS_GUEST_GPU_PM4_INSPECTOR_H

--- a/tests/Pm4InspectorTests.cpp
+++ b/tests/Pm4InspectorTests.cpp
@@ -1,0 +1,223 @@
+#include "graphics/guest_gpu/pm4.h"
+#include "graphics/guest_gpu/pm4Inspector.h"
+
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace {
+
+namespace Pm4 = Libs::Graphics::Pm4;
+
+using Libs::Graphics::Pm4::InspectionStatus;
+using Libs::Graphics::Pm4::InspectSubmission;
+using Libs::Graphics::Pm4::MemoryReader;
+using Libs::Graphics::Pm4::QueueRegisterState;
+using Libs::Graphics::Pm4::RegisterSpace;
+using Libs::Graphics::Pm4::SerializeSubmissionInspection;
+using Libs::Graphics::Pm4::SubmissionMetadata;
+
+void Check(bool value, const char *message) {
+  if (!value) {
+    std::fprintf(stderr, "Pm4InspectorTests: failed: %s\n", message);
+    std::abort();
+  }
+}
+
+SubmissionMetadata Metadata(bool reset = false) {
+  SubmissionMetadata metadata;
+  metadata.capture_id = 17;
+  metadata.frame = 3;
+  metadata.queue = 0;
+  metadata.reset_state = reset;
+  return metadata;
+}
+
+void TestDirectRegistersAndStatePersistence() {
+  QueueRegisterState state;
+  const std::vector<uint32_t> first = {
+      KYTY_PM4(4, Libs::Graphics::Pm4::IT_SET_CONTEXT_REG, 0),
+      0x70000020u,
+      0x11223344u,
+      0x55667788u,
+  };
+  auto result = InspectSubmission(Metadata(true), "dcb", 0x1000, first, &state);
+  Check(result.buffers.size() == 1 && result.buffers[0].packets.size() == 1,
+        "direct register packet was not captured");
+  Check(result.buffers[0].packets[0].status == InspectionStatus::Known,
+        "direct register packet was not classified as known");
+  Check(state.Get(RegisterSpace::Context, 0x20).value_or(0) == 0x11223344u &&
+            state.Get(RegisterSpace::Context, 0x21).value_or(0) == 0x55667788u,
+        "direct context writes were not normalized or persisted");
+
+  const std::vector<uint32_t> second = {
+      KYTY_PM4(3, Libs::Graphics::Pm4::IT_SET_SH_REG, 0), 7, 0xaabbccddu};
+  result = InspectSubmission(Metadata(false), "dcb", 0x2000, second, &state);
+  Check(result.state_at_submit.context_registers == 2,
+        "queue state did not persist between submissions");
+  Check(state.Get(RegisterSpace::Shader, 7).value_or(0) == 0xaabbccddu,
+        "shader register write was not tracked");
+
+  const std::vector<uint32_t> empty;
+  result = InspectSubmission(Metadata(true), "dcb", 0x3000, empty, &state);
+  Check(result.state_before_reset.context_registers == 2 &&
+            result.state_before_reset.shader_registers == 1,
+        "state before reset was not reported");
+  Check(result.state_at_submit.context_registers == 0 &&
+            result.state_after.shader_registers == 0,
+        "submission reset did not clear tracked queue state");
+}
+
+void TestIndirectCommandBufferSnapshot() {
+  constexpr uint64_t nested_address = 0x00400000u;
+  const std::vector<uint32_t> nested = {
+      KYTY_PM4(3, Libs::Graphics::Pm4::IT_SET_SH_REG, 0), 4, 0x12345678u};
+  const MemoryReader reader = [&nested](uint64_t address, uint32_t size_dw,
+                                        std::vector<uint32_t> *words) {
+    if (address != nested_address || size_dw != nested.size()) {
+      return false;
+    }
+    *words = nested;
+    return true;
+  };
+  const std::vector<uint32_t> root = {
+      KYTY_PM4(4, Libs::Graphics::Pm4::IT_INDIRECT_BUFFER, 0),
+      static_cast<uint32_t>(nested_address),
+      static_cast<uint32_t>(nested_address >> 32u),
+      static_cast<uint32_t>(nested.size()),
+  };
+  QueueRegisterState state;
+  auto result =
+      InspectSubmission(Metadata(true), "dcb", 0x1000, root, &state, reader);
+  Check(result.buffers.size() == 2,
+        "nested indirect command buffer was not copied");
+  const auto &reference = result.buffers[0].packets[0].references[0];
+  Check(reference.snapshot_status == InspectionStatus::Known &&
+            reference.nested_buffer_id.value_or(0) == 1,
+        "nested buffer reference was not linked to its snapshot");
+  Check(state.Get(RegisterSpace::Shader, 4).value_or(0) == 0x12345678u,
+        "nested command buffer did not update tracked state");
+}
+
+void TestIndirectRegisterSnapshot() {
+  constexpr uint64_t pairs_address = 0x00500000u;
+  const std::vector<uint32_t> pairs = {0x70000010u, 0x10101010u, 0x70000011u,
+                                       0x20202020u};
+  const MemoryReader reader = [&pairs](uint64_t address, uint32_t size_dw,
+                                       std::vector<uint32_t> *words) {
+    if (address != pairs_address || size_dw != pairs.size()) {
+      return false;
+    }
+    *words = pairs;
+    return true;
+  };
+  const std::vector<uint32_t> root = {
+      KYTY_PM4(5, Libs::Graphics::Pm4::IT_SET_CONTEXT_REG_INDIRECT, 0),
+      static_cast<uint32_t>(pairs_address),
+      static_cast<uint32_t>(pairs_address >> 32u),
+      0,
+      2,
+  };
+  QueueRegisterState state;
+  const auto result =
+      InspectSubmission(Metadata(true), "dcb", 0x1000, root, &state, reader);
+  Check(result.buffers[0].packets[0].register_writes.size() == 2,
+        "indirect register pairs were not decoded");
+  Check(state.Get(RegisterSpace::Context, 0x10).value_or(0) == 0x10101010u &&
+            state.Get(RegisterSpace::Context, 0x11).value_or(0) == 0x20202020u,
+        "indirect register state was not normalized");
+}
+
+void TestMalformedAndUnknownPacketsRemainDiagnostic() {
+  QueueRegisterState state;
+  const std::vector<uint32_t> truncated = {
+      KYTY_PM4(4, Libs::Graphics::Pm4::IT_SET_CONTEXT_REG, 0), 0x20};
+  auto result = InspectSubmission(Metadata(), "dcb", 0x1000, truncated, &state);
+  Check(result.buffers[0].packets[0].status ==
+            InspectionStatus::UnreadableAtCaptureTime,
+        "truncated packet was not marked unreadable");
+
+  const std::vector<uint32_t> unknown = {KYTY_PM4(2, 0xfe, 0), 0};
+  result = InspectSubmission(Metadata(), "dcb", 0x2000, unknown, &state);
+  Check(result.buffers[0].packets[0].status == InspectionStatus::Unknown,
+        "unknown Type-3 opcode was misclassified");
+
+  const std::vector<uint32_t> unsupported = {0x00000000u, 0};
+  result = InspectSubmission(Metadata(), "dcb", 0x3000, unsupported, &state);
+  Check(result.buffers[0].packets[0].status == InspectionStatus::Unsupported,
+        "unsupported packet type was misclassified");
+}
+
+void TestJsonSchema() {
+  QueueRegisterState state;
+  const std::vector<uint32_t> commands = {0x80000000u};
+  const auto result =
+      InspectSubmission(Metadata(true), "dcb", 0x1234, commands, &state);
+  const auto json =
+      nlohmann::json::parse(SerializeSubmissionInspection(result));
+  Check(json.at("schema") == "kyty.pm4.submission.v1",
+        "JSON schema identifier is missing");
+  Check(json.at("capture").at("queue_kind") == "graphics",
+        "JSON queue kind is incorrect");
+  Check(json.at("buffers").at(0).at("packets").at(0).at("status") == "Known",
+        "JSON packet classification is incorrect");
+  Check(json.at("capture_scope").at("resource_registration_map") ==
+            "not available",
+        "JSON does not disclose the unavailable registration map");
+}
+
+void TestCaptureFilesAndQueueIsolation() {
+  const auto unique =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+  const auto folder = std::filesystem::current_path() /
+                      ("kyty_pm4_inspector_" + std::to_string(unique));
+
+  Pm4::SubmissionInspector inspector(folder);
+  const std::vector<uint32_t> graphics = {
+      KYTY_PM4(3, Libs::Graphics::Pm4::IT_SET_CONTEXT_REG, 0),
+      0x70000020u,
+      0x11223344u,
+  };
+  const std::vector<uint32_t> compute = {0x80000000u};
+  Check(inspector.CaptureGraphics(4, true, 0x1000, graphics),
+        "graphics capture file was not written");
+  Check(inspector.CaptureAsyncCompute(4, 0, 0x2000, compute),
+        "compute capture file was not written");
+
+  const auto graphics_path = folder / "000000_f00004_q00_dcb.json";
+  const auto compute_path = folder / "000001_f00004_q00_acb.json";
+  Check(std::filesystem::is_regular_file(graphics_path) &&
+            std::filesystem::is_regular_file(compute_path),
+        "capture filenames do not identify queue roles");
+
+  std::ifstream input(compute_path);
+  const auto json = nlohmann::json::parse(input);
+  Check(json.at("tracked_register_state").at("at_submit").at(
+            "context_registers") == 0,
+        "graphics state leaked into a compute queue with the same numeric ID");
+  input.close();
+
+  std::error_code error;
+  std::filesystem::remove_all(folder, error);
+  Check(!error, "temporary capture directory could not be removed");
+}
+
+} // namespace
+
+int main() {
+  TestDirectRegistersAndStatePersistence();
+  TestIndirectCommandBufferSnapshot();
+  TestIndirectRegisterSnapshot();
+  TestMalformedAndUnknownPacketsRemainDiagnostic();
+  TestJsonSchema();
+  TestCaptureFilesAndQueueIsolation();
+  return 0;
+}


### PR DESCRIPTION
## Summary

Add an opt-in structured PM4 submission inspector alongside the existing text command-buffer dump.

When Command Buffer Dump is enabled, Kyty now writes one JSON trace per graphics or async-compute submission. Normal execution is unchanged when dumping is disabled.

## Captured data

- Root packet words and readable nested indirect command buffers.
- Direct and indirect context, shader, and uconfig register writes.
- Persistent register-state counts and hash per queue.
- Queue, frame, source address, packet offsets, payloads, predicates, and opcode names.
- Explicit Known, Partial, Inferred, Unknown, Unsupported, and UnreadableAtCaptureTime classifications.

Known means the packet structure was decoded. It does not claim complete runtime semantics.

## Safety and correctness

- Validate every mapped guest-memory segment before copying indirect data.
- Cap nesting depth, individual snapshots, and total snapshot size.
- Detect already-captured indirect buffers to stop cycles.
- Keep graphics and async-compute state in separate namespaces even when their numeric queue IDs match.
- Verify directory creation and the exact number of JSON bytes written.
- Preserve existing opcode naming through shared read-only helpers.

## Verification

- pm4_inspector_tests build passed with clang-cl.
- pm4_inspector_tests.exe passed.
- CTest pm4_inspector passed (1/1).
- Full kyty_emulator build passed.

Tests cover direct and indirect registers, nested buffers, malformed and unknown packets, state persistence/reset, JSON schema, trace file output, and cross-kind queue isolation.

## Scope

This PR intentionally excludes the later AGC resource-registration layer from the external branch because those ABI additions require separate validation. It also does not overlap the PM4 fuzzer in #302: that PR stress-tests packet walking, while this change produces deterministic semantic traces for real submissions.

The SDK 12 Shader Core ISA corpus confirms command-buffer interaction at a general level but does not document the private packet names used here. Accordingly, unsupported named opcodes are classified as Inferred, not Known.

Original work is retained through the commit co-author trailer.