### PR TITLE
loader: add unresolved import JSON report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,6 +488,13 @@ add_executable(image_page_table_tests EXCLUDE_FROM_ALL
 target_link_libraries(image_page_table_tests common fmt::fmt)
 target_include_directories(image_page_table_tests PRIVATE ${inc_headers})
 
+add_executable(unresolved_import_report_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/UnresolvedImportReportTests.cpp"
+	"${KYTY_SOURCE_DIR}/loader/unresolvedImportReport.cpp"
+)
+target_link_libraries(unresolved_import_report_tests common nlohmann_json::nlohmann_json)
+target_include_directories(unresolved_import_report_tests PRIVATE ${inc_headers})
+
 add_kyty_full_emulator_test(shader_recompiler_compute_tests "${KYTY_TESTS_DIR}/ShaderRecompilerComputeTests.cpp")
 
 set(gpu_test_generated_dir "${PROJECT_BINARY_DIR}/gpu_test_shaders")
@@ -528,6 +535,7 @@ if(BUILD_TESTING)
 	add_test(NAME shader_cfg COMMAND $<TARGET_FILE:shader_cfg_tests>)
 	add_test(NAME scalar_provenance COMMAND $<TARGET_FILE:scalar_provenance_tests>)
 	add_test(NAME image_page_table COMMAND $<TARGET_FILE:image_page_table_tests>)
+	add_test(NAME unresolved_import_report COMMAND $<TARGET_FILE:unresolved_import_report_tests>)
 	add_test(NAME memory_tracker COMMAND $<TARGET_FILE:memory_tracker_tests>)
 	add_test(NAME page_manager COMMAND $<TARGET_FILE:page_manager_tests>)
 	add_test(NAME bit_array COMMAND $<TARGET_FILE:bit_array_tests>)
@@ -582,6 +590,7 @@ if(BUILD_TESTING)
 		shader_cfg_tests
 		scalar_provenance_tests
 		image_page_table_tests
+		unresolved_import_report_tests
 		memory_tracker_tests
 		page_manager_tests
 		bit_array_tests

--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -109,6 +109,10 @@ bool PlayGoHackEnabled() {
 	return g_config->playgo_hack_enabled;
 }
 
+std::filesystem::path GetUnresolvedImportReportPath() {
+	return g_config->unresolved_import_report;
+}
+
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 bool RedZoneProtectionEnabled() {
 	return g_config->red_zone_protection_enabled;

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -53,6 +53,7 @@ struct ConfigOptions {
 	bool                   renderdoc_enabled           = false;
 	bool                   readback_linear_images      = false;
 	bool                   playgo_hack_enabled         = false;
+	std::filesystem::path  unresolved_import_report;
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	bool red_zone_protection_enabled = false;
 #endif
@@ -90,6 +91,7 @@ bool GpuAssistedValidationEnabled();
 bool RenderDocEnabled();
 bool ReadbackLinearImagesEnabled();
 bool PlayGoHackEnabled();
+std::filesystem::path GetUnresolvedImportReportPath();
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 bool RedZoneProtectionEnabled();
 #endif

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -21,6 +21,7 @@
 #include "loader/jit.h"
 #include "loader/redZonePatcher.h"
 #include "loader/symbolDatabase.h"
+#include "loader/unresolvedImportReport.h"
 #include "loader/x64InstructionEmulator.h"
 
 #include <algorithm>
@@ -137,6 +138,46 @@ static std::atomic_uint32_t             g_unresolved_stub_call_log_count {0};
 static std::vector<uint64_t>            g_unresolved_stub_thunk_pages;
 static uint64_t                         g_unresolved_stub_thunk_offset = 0;
 static constexpr uint64_t               UNRESOLVED_STUB_PAGE_SIZE      = 4096;
+
+static std::string ImportNid(const std::string& qualified_symbol) {
+	const auto separator = qualified_symbol.find('[');
+	return separator == std::string::npos ? qualified_symbol
+	                                      : qualified_symbol.substr(0, separator);
+}
+
+static void WriteConfiguredUnresolvedImportReport() {
+	const auto report_path = Config::GetUnresolvedImportReportPath();
+	if (report_path.empty()) {
+		return;
+	}
+
+	std::vector<UnresolvedImportReportEntry> entries;
+	entries.reserve(g_stubbed_imports.size());
+	for (const auto& record: g_stubbed_imports) {
+		// A record remains allocated after late resolution so its thunk ID stays stable. Only report
+		// records whose live relocation slot still points at that unresolved thunk.
+		if (record.patch_vaddr == 0 || record.thunk_vaddr == 0) {
+			continue;
+		}
+		uint64_t current_target = 0;
+		std::memcpy(&current_target, reinterpret_cast<const void*>(record.patch_vaddr),
+		            sizeof(current_target));
+		if (current_target != record.thunk_vaddr) {
+			continue;
+		}
+
+		entries.push_back({record.program, ImportNid(record.name), record.name,
+		                   Common::EnumName(record.type), Common::EnumName(record.bind), 1});
+	}
+
+	if (WriteUnresolvedImportReportFile(report_path, entries)) {
+		LOGF("Unresolved import report: %s (%zu active relocation sites)\n",
+		     Common::PathToString(report_path).c_str(), entries.size());
+	} else {
+		LOGF("Failed to write unresolved import report: %s\n",
+		     Common::PathToString(report_path).c_str());
+	}
+}
 
 static KYTY_SYSV_ABI uint64_t ResolveImportStubWithId(uint64_t record_id);
 
@@ -1277,6 +1318,7 @@ void RuntimeLinker::RelocateAll() {
 	}
 
 	m_relocated = true;
+	WriteConfiguredUnresolvedImportReport();
 }
 
 void RuntimeLinker::RelocateProgram(Program* program) {
@@ -1286,6 +1328,7 @@ void RuntimeLinker::RelocateProgram(Program* program) {
 	EXIT_IF(std::find(m_programs.begin(), m_programs.end(), program) == m_programs.end());
 
 	Relocate(program);
+	WriteConfiguredUnresolvedImportReport();
 }
 
 void RuntimeLinker::UnloadProgram(Program* program) {

--- a/src/loader/unresolvedImportReport.cpp
+++ b/src/loader/unresolvedImportReport.cpp
@@ -1,0 +1,91 @@
+#include "loader/unresolvedImportReport.h"
+
+#include "common/file.h"
+
+#include <algorithm>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <tuple>
+
+namespace Loader {
+namespace {
+
+auto ImportIdentity(const UnresolvedImportReportEntry& entry) {
+	return std::tie(entry.program, entry.nid, entry.symbol, entry.type, entry.bind);
+}
+
+} // namespace
+
+std::string SerializeUnresolvedImportReport(
+	const std::vector<UnresolvedImportReportEntry>& unresolved_imports) {
+	auto sorted = unresolved_imports;
+	std::sort(sorted.begin(), sorted.end(), [](const auto& left, const auto& right) {
+		return ImportIdentity(left) < ImportIdentity(right);
+	});
+
+	std::vector<UnresolvedImportReportEntry> grouped;
+	grouped.reserve(sorted.size());
+	for (const auto& entry: sorted) {
+		if (!grouped.empty() && ImportIdentity(grouped.back()) == ImportIdentity(entry)) {
+			if (entry.relocation_sites >
+			    std::numeric_limits<uint64_t>::max() - grouped.back().relocation_sites) {
+				return {};
+			}
+			grouped.back().relocation_sites += entry.relocation_sites;
+		} else {
+			grouped.push_back(entry);
+		}
+	}
+
+	nlohmann::ordered_json imports          = nlohmann::ordered_json::array();
+	uint64_t               relocation_sites = 0;
+	for (const auto& entry: grouped) {
+		if (entry.relocation_sites > std::numeric_limits<uint64_t>::max() - relocation_sites) {
+			return {};
+		}
+		relocation_sites += entry.relocation_sites;
+		imports.push_back({{"program", entry.program},
+		                   {"nid", entry.nid},
+		                   {"symbol", entry.symbol},
+		                   {"type", entry.type},
+		                   {"bind", entry.bind},
+		                   {"relocation_sites", entry.relocation_sites}});
+	}
+
+	const nlohmann::ordered_json root = {{"schema_version", 1},
+	                                     {"unique_imports", grouped.size()},
+	                                     {"relocation_sites", relocation_sites},
+	                                     {"imports", std::move(imports)}};
+	return root.dump(2) + "\n";
+}
+
+bool WriteUnresolvedImportReportFile(
+	const std::filesystem::path&                    path,
+	const std::vector<UnresolvedImportReportEntry>& unresolved_imports) {
+	if (path.empty()) {
+		return false;
+	}
+
+	const auto output = SerializeUnresolvedImportReport(unresolved_imports);
+	if (output.empty() || output.size() > std::numeric_limits<uint32_t>::max()) {
+		return false;
+	}
+
+	const auto parent = path.parent_path();
+	if (!parent.empty() && !Common::File::CreateDirectories(parent)) {
+		return false;
+	}
+
+	Common::File file;
+	if (!file.Create(path)) {
+		return false;
+	}
+
+	uint32_t written = 0;
+	file.Write(output.data(), static_cast<uint32_t>(output.size()), &written);
+	const bool flushed = file.Flush();
+	file.Close();
+	return written == output.size() && flushed;
+}
+
+} // namespace Loader

--- a/src/loader/unresolvedImportReport.h
+++ b/src/loader/unresolvedImportReport.h
@@ -1,0 +1,36 @@
+#ifndef KYTY_LOADER_UNRESOLVED_IMPORT_REPORT_H_
+#define KYTY_LOADER_UNRESOLVED_IMPORT_REPORT_H_
+
+#include "common/common.h"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace Loader {
+
+// One currently stubbed import. Entries with the same identity are combined when the report is
+// serialized, so relocation_sites may describe more than one patch location.
+struct UnresolvedImportReportEntry {
+	std::string program;
+	std::string nid;
+	std::string symbol;
+	std::string type;
+	std::string bind;
+	uint64_t    relocation_sites = 1;
+};
+
+// Returns a deterministic, human-readable JSON document. An empty result indicates that a
+// relocation-site counter overflowed; a valid report is never empty, even when it has no imports.
+[[nodiscard]] std::string SerializeUnresolvedImportReport(
+	const std::vector<UnresolvedImportReportEntry>& unresolved_imports);
+
+// Writes schema version 1 of the unresolved-import report. Parent directories are created when
+// necessary. The function returns false for an empty path, serialization failure, or I/O failure.
+[[nodiscard]] bool WriteUnresolvedImportReportFile(
+	const std::filesystem::path&                    path,
+	const std::vector<UnresolvedImportReportEntry>& unresolved_imports);
+
+} // namespace Loader
+
+#endif /* KYTY_LOADER_UNRESOLVED_IMPORT_REPORT_H_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,7 @@ static void PrintUsage() {
 	::printf(
 	    "  --readback-linear-images <true|false> Read back writable linear images on submit.\n");
 	::printf("  --playgo-hack                       Use the supplied PlayGo stub fallback.\n");
+	::printf("  --unresolved-import-report <path>   Write active unresolved imports as JSON.\n");
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	::printf("  --redzone                            Protect the guest SysV red zone.\n");
 #endif
@@ -271,6 +272,12 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 				::printf("invalid boolean for %s: %s\n", arg.c_str(), value.c_str());
 				return false;
 			}
+		} else if (arg == "--unresolved-import-report") {
+			if (value.empty()) {
+				::printf("unresolved import report path cannot be empty\n");
+				return false;
+			}
+			options.config.unresolved_import_report = Common::FixFilenameSlash(value);
 		} else if (arg == "--keymap") {
 			const auto split = value.find('=');
 			if (split == std::string::npos || split == 0 || split + 1 == value.size()) {

--- a/tests/UnresolvedImportReportTests.cpp
+++ b/tests/UnresolvedImportReportTests.cpp
@@ -1,0 +1,85 @@
+#include "loader/unresolvedImportReport.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace {
+
+void Check(bool value, const char* text) {
+	if (!value) {
+		std::fprintf(stderr, "UnresolvedImportReportTests: failed: %s\n", text);
+		std::abort();
+	}
+}
+
+void TestDeterministicGrouping() {
+	const std::vector<Loader::UnresolvedImportReportEntry> entries = {
+	    {"z.prx", "NID-B", "NID-B[lib]", "Function", "Weak", 1},
+	    {"a.prx", "NID-A", "NID-A[lib]", "Function", "Global", 2},
+	    {"a.prx", "NID-A", "NID-A[lib]", "Function", "Global", 3},
+	};
+
+	const auto output = Loader::SerializeUnresolvedImportReport(entries);
+	const auto json   = nlohmann::ordered_json::parse(output);
+	Check(json["schema_version"] == 1, "schema version");
+	Check(json["unique_imports"] == 2, "unique import count");
+	Check(json["relocation_sites"] == 6, "total relocation-site count");
+	Check(json["imports"][0]["program"] == "a.prx", "deterministic ordering");
+	Check(json["imports"][0]["relocation_sites"] == 5, "duplicate grouping");
+	Check(output == Loader::SerializeUnresolvedImportReport(entries),
+	      "serialization must be deterministic");
+}
+
+void TestEmptyAndOverflowReports() {
+	const auto empty = nlohmann::ordered_json::parse(Loader::SerializeUnresolvedImportReport({}));
+	Check(empty["unique_imports"] == 0, "empty report unique count");
+	Check(empty["relocation_sites"] == 0, "empty report relocation count");
+	Check(empty["imports"].empty(), "empty report import list");
+
+	const std::vector<Loader::UnresolvedImportReportEntry> overflow = {
+	    {"a.prx", "NID", "NID[lib]", "Function", "Global",
+	     std::numeric_limits<uint64_t>::max()},
+	    {"a.prx", "NID", "NID[lib]", "Function", "Global", 1},
+	};
+	Check(Loader::SerializeUnresolvedImportReport(overflow).empty(),
+	      "counter overflow must fail serialization");
+}
+
+void TestFileOutput() {
+	const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+	const auto root = std::filesystem::current_path() /
+	                  ("kyty_unresolved_import_report_" + std::to_string(unique));
+	const auto report = root / "nested" / "imports.json";
+
+	Check(Loader::WriteUnresolvedImportReportFile(
+	          report, {{"eboot.bin", "NID", "NID[lib]", "Function", "Global", 1}}),
+	      "write report and create parent directories");
+	std::ifstream input(report, std::ios::binary);
+	Check(input.good(), "open written report");
+	const std::string contents((std::istreambuf_iterator<char>(input)),
+	                           std::istreambuf_iterator<char>());
+	input.close();
+	Check(contents == Loader::SerializeUnresolvedImportReport(
+	                      {{"eboot.bin", "NID", "NID[lib]", "Function", "Global", 1}}),
+	      "written report contents");
+	Check(!Loader::WriteUnresolvedImportReportFile({}, {}), "empty output path must fail");
+
+	std::error_code error;
+	std::filesystem::remove_all(root, error);
+	Check(!error, "remove test directory");
+}
+
+} // namespace
+
+int main() {
+	TestDeterministicGrouping();
+	TestEmptyAndOverflowReports();
+	TestFileOutput();
+	return 0;
+}


### PR DESCRIPTION
## Summary

- add `--unresolved-import-report <path>` as an opt-in diagnostic
- write a deterministic, versioned JSON inventory of active unresolved function-import thunks
- group duplicate import identities while retaining their relocation-site count
- exclude thunk records that were late-resolved or invalidated when a program was unloaded

## Implementation notes

The serializer and file writer live in `loader/unresolvedImportReport.*`, independently from the runtime linker. The public entry type and schema behavior are documented in the header. Serialization rejects counter overflow, checks the exact number of bytes written, flushes the file, and creates missing parent directories.

The runtime linker only takes a snapshot after relocation. Normal startup behavior is unchanged when the CLI option is omitted. This PR adds no PS5 ABI assumptions and has no dependency on the other Techx3 PRs.

## JSON schema

Schema version 1 contains:

- `unique_imports`: number of grouped identities
- `relocation_sites`: total active patch locations
- `imports`: entries sorted by program, NID, symbol, type, and binding

## Validation

- `cmake --build _Build/launcher-usability --config Release --target unresolved_import_report_tests --parallel 2`
- direct `unresolved_import_report_tests.exe`: passed
- `ctest --test-dir _Build/launcher-usability -C Release -R "^unresolved_import_report$" --output-on-failure`: 1/1 passed
- full `kyty_emulator` Release build with clang-cl: passed

The dedicated tests cover deterministic ordering, duplicate grouping, empty reports, overflow rejection, parent-directory creation, and exact file contents.

## Provenance

This isolates and refines the unresolved-import reporting work from the KytyTouche runtime-compatibility branch. Original authorship is retained through the commit co-author trailer.
