### PR TITLE
loader: validate ELF and SELF file bounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,13 @@ add_executable(resource_tracking_tests EXCLUDE_FROM_ALL
 target_link_libraries(resource_tracking_tests fmt::fmt)
 target_include_directories(resource_tracking_tests PRIVATE ${inc_headers})
 
+add_executable(elf_validator_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/ElfValidatorTests.cpp"
+	"${KYTY_SOURCE_DIR}/loader/elfValidator.cpp"
+)
+target_link_libraries(elf_validator_tests common)
+target_include_directories(elf_validator_tests PRIVATE ${inc_headers})
+
 add_executable(audio_out2_port_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/AudioOut2PortTests.cpp"
 	"${KYTY_SOURCE_DIR}/libs/libAudio2.cpp"
@@ -534,6 +541,7 @@ if(BUILD_TESTING)
 	add_test(NAME shader_vertex_metadata COMMAND $<TARGET_FILE:shader_vertex_metadata_tests>)
 	add_test(NAME shader_stage_runtime COMMAND $<TARGET_FILE:shader_stage_runtime_tests>)
 	add_test(NAME resource_tracking COMMAND $<TARGET_FILE:resource_tracking_tests>)
+	add_test(NAME elf_validator COMMAND $<TARGET_FILE:elf_validator_tests>)
 	add_test(NAME event_queue_lifetime COMMAND $<TARGET_FILE:event_queue_lifetime_tests>)
 	add_test(NAME kernel_file_system COMMAND $<TARGET_FILE:kernel_file_system_tests>)
 	add_test(NAME sync_on_address COMMAND $<TARGET_FILE:sync_on_address_tests>)
@@ -588,6 +596,7 @@ if(BUILD_TESTING)
 		shader_vertex_metadata_tests
 		shader_stage_runtime_tests
 		resource_tracking_tests
+		elf_validator_tests
 		event_queue_lifetime_tests
 		kernel_file_system_tests
 		sync_on_address_tests

--- a/src/loader/elf.cpp
+++ b/src/loader/elf.cpp
@@ -1,4 +1,5 @@
 #include "loader/elf.h"
+#include "loader/elfValidator.h"
 
 #include "common/assert.h"
 #include "common/file.h"
@@ -437,23 +438,10 @@ bool Elf64::IsSelf() const {
 		return false;
 	}
 
-	const bool known_magic = (m_self->ident[0] == 0x4f && m_self->ident[1] == 0x15 &&
-	                          m_self->ident[2] == 0x3d && m_self->ident[3] == 0x1d) ||
-	                         (m_self->ident[0] == 0x54 && m_self->ident[1] == 0x14 &&
-	                          m_self->ident[2] == 0xf5 && m_self->ident[3] == 0xee);
-	if (!known_magic) {
+	if (!HasSupportedSelfMagic(*m_self)) {
 		return false;
 	}
-
-	const bool known_ident_tail =
-	    (m_self->ident[4] == 0x00 && m_self->ident[5] == 0x01 && m_self->ident[6] == 0x01 &&
-	     m_self->ident[7] == 0x12 && m_self->ident[8] == 0x01 && m_self->ident[9] == 0x01 &&
-	     m_self->ident[10] == 0x00 && m_self->ident[11] == 0x00 && m_self->unknown == 0x22) ||
-	    (m_self->ident[4] == 0x10 && m_self->ident[5] == 0x01 && m_self->ident[6] == 0x01 &&
-	     m_self->ident[7] == 0x12 && m_self->ident[8] == 0x01 && m_self->ident[9] == 0x01 &&
-	     m_self->ident[10] == 0x00 && m_self->ident[11] == 0x10 && m_self->unknown == 0x32);
-
-	if (!known_ident_tail) {
+	if (!IsSupportedSelfHeader(*m_self)) {
 		LOGF("Unknown SELF file\n");
 		return false;
 	}
@@ -531,6 +519,12 @@ bool Elf64::IsValid() const {
 
 void Elf64::Open(const std::filesystem::path& file_name) {
 	Clear();
+
+	std::string validation_error;
+	if (!ValidateElfFile(file_name, nullptr, &validation_error)) {
+		EXIT("Invalid ELF/SELF %s: %s\n", Common::PathToString(file_name).c_str(),
+		     validation_error.c_str());
+	}
 
 	m_f = std::make_unique<Common::File>();
 	m_f->Open(file_name, Common::File::Mode::Read);

--- a/src/loader/elf.h
+++ b/src/loader/elf.h
@@ -154,6 +154,29 @@ struct SelfSegment {
 	uint64_t decompressed_size;
 };
 
+// Kyty currently supports the two SELF header variants below. Keep validation and loading on the
+// same classification rule so a container cannot be checked as SELF and then parsed as raw ELF.
+inline bool HasSupportedSelfMagic(const SelfHeader& header) {
+	return (header.ident[0] == 0x4f && header.ident[1] == 0x15 &&
+	        header.ident[2] == 0x3d && header.ident[3] == 0x1d) ||
+	       (header.ident[0] == 0x54 && header.ident[1] == 0x14 &&
+	        header.ident[2] == 0xf5 && header.ident[3] == 0xee);
+}
+
+inline bool IsSupportedSelfHeader(const SelfHeader& header) {
+	if (!HasSupportedSelfMagic(header)) {
+		return false;
+	}
+	return (header.ident[4] == 0x00 && header.ident[5] == 0x01 &&
+	        header.ident[6] == 0x01 && header.ident[7] == 0x12 &&
+	        header.ident[8] == 0x01 && header.ident[9] == 0x01 &&
+	        header.ident[10] == 0x00 && header.ident[11] == 0x00 && header.unknown == 0x22) ||
+	       (header.ident[4] == 0x10 && header.ident[5] == 0x01 &&
+	        header.ident[6] == 0x01 && header.ident[7] == 0x12 &&
+	        header.ident[8] == 0x01 && header.ident[9] == 0x01 &&
+	        header.ident[10] == 0x00 && header.ident[11] == 0x10 && header.unknown == 0x32);
+}
+
 struct Elf64_Ehdr // NOLINT(readability-identifier-naming)
 {
 	uint8_t    e_ident[EI_NIDENT]; /* ELF identification */

--- a/src/loader/elfValidator.cpp
+++ b/src/loader/elfValidator.cpp
@@ -1,0 +1,247 @@
+#include "loader/elfValidator.h"
+
+#include "common/file.h"
+#include "loader/elf.h"
+
+#include <cstring>
+#include <limits>
+
+namespace Loader {
+namespace {
+
+constexpr Elf64_Word SHT_NOBITS = 8;
+
+bool Fail(std::string* error, const char* message) {
+	if (error != nullptr) {
+		*error = message;
+	}
+	return false;
+}
+
+bool CheckedAdd(uint64_t left, uint64_t right, uint64_t* result) {
+	if (result == nullptr || right > std::numeric_limits<uint64_t>::max() - left) {
+		return false;
+	}
+	*result = left + right;
+	return true;
+}
+
+bool RangeFits(uint64_t offset, uint64_t size, uint64_t total) {
+	// ELF permits unused zero-length entries to carry an otherwise irrelevant offset.
+	return size == 0 || (offset <= total && size <= total - offset);
+}
+
+bool TableFits(uint64_t base, uint64_t offset, uint64_t count, uint64_t element_size,
+	           uint64_t total, uint64_t* table_offset = nullptr) {
+	if (count == 0) {
+		if (base > total) {
+			return false;
+		}
+		if (table_offset != nullptr) {
+			*table_offset = base;
+		}
+		return true;
+	}
+	uint64_t absolute = 0;
+	if (!CheckedAdd(base, offset, &absolute) || absolute > total || element_size == 0 ||
+	    count > (total - absolute) / element_size) {
+		return false;
+	}
+	if (table_offset != nullptr) {
+		*table_offset = absolute;
+	}
+	return true;
+}
+
+template <typename T>
+bool ReadStruct(std::span<const uint8_t> image, uint64_t offset, T* value) {
+	if (value == nullptr || offset > image.size() || sizeof(T) > image.size() - offset) {
+		return false;
+	}
+	std::memcpy(value, image.data() + offset, sizeof(T));
+	return true;
+}
+
+bool HasSelfMagic(std::span<const uint8_t> image) {
+	SelfHeader header {};
+	if (image.size() < 4) {
+		return false;
+	}
+	std::memcpy(header.ident, image.data(), 4);
+	return HasSupportedSelfMagic(header);
+}
+
+bool ValidateHeader(const Elf64_Ehdr& header, std::string* error) {
+	if (header.e_ident[EI_MAG0] != 0x7f || header.e_ident[EI_MAG1] != 'E' ||
+	    header.e_ident[EI_MAG2] != 'L' || header.e_ident[EI_MAG3] != 'F') {
+		return Fail(error, "missing ELF magic");
+	}
+	if (header.e_ident[EI_CLASS] != ELFCLASS64 || header.e_ident[EI_DATA] != ELFDATA2LSB ||
+	    header.e_ident[EI_VERSION] != EV_CURRENT) {
+		return Fail(error, "unsupported ELF class, byte order, or identification version");
+	}
+	if (header.e_ident[EI_OSABI] != ELFOSABI_FREEBSD ||
+	    (header.e_ident[EI_ABIVERSION] != 0 && header.e_ident[EI_ABIVERSION] != 2)) {
+		return Fail(error, "unsupported ELF ABI");
+	}
+	if ((header.e_type != ET_DYNEXEC && header.e_type != ET_DYNAMIC) ||
+	    header.e_machine != EM_X86_64 || header.e_version != EV_CURRENT) {
+		return Fail(error, "unsupported ELF type, machine, or version");
+	}
+	if (header.e_ehsize != sizeof(Elf64_Ehdr) || header.e_phentsize != sizeof(Elf64_Phdr) ||
+	    (header.e_shnum != 0 && header.e_shentsize != sizeof(Elf64_Shdr))) {
+		return Fail(error, "invalid ELF header entry sizes");
+	}
+	return true;
+}
+
+} // namespace
+
+bool ValidateElfImage(std::span<const uint8_t> image, ElfValidationReport* report,
+	                  std::string* error) {
+	ElfValidationReport local;
+	if (image.empty()) {
+		return Fail(error, "empty ELF/SELF image");
+	}
+
+	SelfHeader self_header {};
+	if (HasSelfMagic(image)) {
+		local.self = true;
+		if (!ReadStruct(image, 0, &self_header)) {
+			return Fail(error, "truncated SELF header");
+		}
+		if (!IsSupportedSelfHeader(self_header)) {
+			return Fail(error, "unsupported SELF header variant");
+		}
+		if (self_header.file_size > image.size()) {
+			return Fail(error, "SELF declared file size is outside the file");
+		}
+		if (!TableFits(sizeof(SelfHeader), 0, self_header.segments_num, sizeof(SelfSegment),
+		               image.size(), &local.elf_offset)) {
+			return Fail(error, "truncated SELF segment table");
+		}
+		local.elf_offset +=
+		    static_cast<uint64_t>(self_header.segments_num) * sizeof(SelfSegment);
+		for (uint16_t index = 0; index < self_header.segments_num; index++) {
+			SelfSegment segment {};
+			const auto offset = sizeof(SelfHeader) +
+			                    static_cast<uint64_t>(index) * sizeof(SelfSegment);
+			if (!ReadStruct(image, offset, &segment) ||
+			    !RangeFits(segment.offset, segment.compressed_size, image.size())) {
+				return Fail(error, "SELF segment payload is outside the file");
+			}
+		}
+	}
+
+	Elf64_Ehdr header {};
+	if (!ReadStruct(image, local.elf_offset, &header)) {
+		return Fail(error, "truncated ELF header");
+	}
+	if (!ValidateHeader(header, error)) {
+		return false;
+	}
+
+	uint64_t program_table = 0;
+	if (!TableFits(local.elf_offset, header.e_phoff, header.e_phnum, sizeof(Elf64_Phdr),
+	               image.size(), &program_table)) {
+		return Fail(error, "ELF program header table is outside the file");
+	}
+	uint64_t section_table = 0;
+	if (!local.self && header.e_shnum != 0 &&
+	    !TableFits(local.elf_offset, header.e_shoff, header.e_shnum, sizeof(Elf64_Shdr),
+	               image.size(), &section_table)) {
+		return Fail(error, "ELF section header table is outside the file");
+	}
+
+	uint32_t process_param_count = 0;
+	for (Elf64_Half index = 0; index < header.e_phnum; index++) {
+		Elf64_Phdr program {};
+		const auto offset = program_table + static_cast<uint64_t>(index) * sizeof(Elf64_Phdr);
+		if (!ReadStruct(image, offset, &program)) {
+			return Fail(error, "truncated ELF program header");
+		}
+		if (!local.self && !RangeFits(program.p_offset, program.p_filesz, image.size())) {
+			return Fail(error, "ELF segment payload is outside the file");
+		}
+		if (local.self &&
+		    program.p_filesz > std::numeric_limits<uint64_t>::max() - program.p_offset) {
+			return Fail(error, "SELF ELF segment range overflows");
+		}
+		if (program.p_type == PT_OS_PROCPARAM) {
+			process_param_count++;
+			if (process_param_count != 1) {
+				return Fail(error, "ELF contains multiple process-parameter segments");
+			}
+			if (program.p_filesz < 0x18u) {
+				return Fail(error, "ELF process-parameter segment is truncated");
+			}
+		}
+	}
+
+	if (local.self) {
+		for (uint16_t index = 0; index < self_header.segments_num; index++) {
+			SelfSegment segment {};
+			if (!ReadStruct(image,
+			                sizeof(SelfHeader) + static_cast<uint64_t>(index) * sizeof(SelfSegment),
+			                &segment)) {
+				return Fail(error, "truncated SELF segment table");
+			}
+			if ((segment.type & 0x800u) == 0u) {
+				continue;
+			}
+
+			const auto program_index = (segment.type >> 20u) & 0xfffu;
+			if (program_index >= header.e_phnum) {
+				return Fail(error, "SELF segment references an invalid ELF program header");
+			}
+			Elf64_Phdr program {};
+			if (!ReadStruct(image, program_table + program_index * sizeof(Elf64_Phdr), &program)) {
+				return Fail(error, "truncated ELF program header");
+			}
+			if (segment.compressed_size != segment.decompressed_size) {
+				return Fail(error, "compressed SELF segments are not supported");
+			}
+			if (segment.decompressed_size != program.p_filesz) {
+				return Fail(error, "SELF segment size does not match its ELF program header");
+			}
+		}
+	} else if (header.e_shnum != 0) {
+		for (Elf64_Half index = 0; index < header.e_shnum; index++) {
+			Elf64_Shdr section {};
+			const auto offset = section_table + static_cast<uint64_t>(index) * sizeof(Elf64_Shdr);
+			if (!ReadStruct(image, offset, &section)) {
+				return Fail(error, "truncated ELF section header");
+			}
+			if (section.sh_type != SHT_NOBITS &&
+			    !RangeFits(section.sh_offset, section.sh_size, image.size())) {
+				return Fail(error, "ELF section payload is outside the file");
+			}
+		}
+	}
+
+	if (report != nullptr) {
+		*report = local;
+	}
+	if (error != nullptr) {
+		error->clear();
+	}
+	return true;
+}
+
+bool ValidateElfFile(const std::filesystem::path& file_name, ElfValidationReport* report,
+	                 std::string* error) {
+	Common::File file(file_name, Common::File::Mode::Read);
+	if (file.IsInvalid()) {
+		return Fail(error, "cannot open ELF/SELF image");
+	}
+	if (file.Size() > std::numeric_limits<uint32_t>::max()) {
+		file.Close();
+		return Fail(error, "ELF/SELF image exceeds the supported validator size");
+	}
+	auto image = file.ReadWholeBuffer();
+	file.Close();
+	return ValidateElfImage(
+	    {reinterpret_cast<const uint8_t*>(image.GetDataConst()), image.Size()}, report, error);
+}
+
+} // namespace Loader

--- a/src/loader/elfValidator.h
+++ b/src/loader/elfValidator.h
@@ -1,0 +1,28 @@
+#ifndef KYTY_LOADER_ELF_VALIDATOR_H_
+#define KYTY_LOADER_ELF_VALIDATOR_H_
+
+#include <cstdint>
+#include <filesystem>
+#include <span>
+#include <string>
+
+namespace Loader {
+
+struct ElfValidationReport {
+	bool     self       = false;
+	uint64_t elf_offset = 0;
+};
+
+// Validates every file-backed range that Elf64 will read before the loader allocates tables or
+// dereferences SELF program-header references. It does not authenticate or decrypt SELF content.
+[[nodiscard]] bool ValidateElfImage(std::span<const uint8_t> image,
+	                                ElfValidationReport* report,
+	                                std::string* error = nullptr);
+
+[[nodiscard]] bool ValidateElfFile(const std::filesystem::path& file_name,
+	                               ElfValidationReport* report,
+	                               std::string* error = nullptr);
+
+} // namespace Loader
+
+#endif /* KYTY_LOADER_ELF_VALIDATOR_H_ */

--- a/tests/ElfValidatorTests.cpp
+++ b/tests/ElfValidatorTests.cpp
@@ -1,0 +1,252 @@
+#include "common/file.h"
+#include "loader/elf.h"
+#include "loader/elfValidator.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace Loader;
+
+void Check(bool value, const char* text) {
+	if (!value) {
+		std::fprintf(stderr, "ElfValidatorTests: failed: %s\n", text);
+		std::abort();
+	}
+}
+
+template <typename T>
+void Store(std::vector<uint8_t>& image, size_t offset, const T& value) {
+	if (image.size() < offset + sizeof(T)) {
+		image.resize(offset + sizeof(T));
+	}
+	std::memcpy(image.data() + offset, &value, sizeof(T));
+}
+
+Elf64_Ehdr Header(uint16_t program_count = 1) {
+	Elf64_Ehdr header {};
+	header.e_ident[EI_MAG0]       = 0x7f;
+	header.e_ident[EI_MAG1]       = 'E';
+	header.e_ident[EI_MAG2]       = 'L';
+	header.e_ident[EI_MAG3]       = 'F';
+	header.e_ident[EI_CLASS]      = ELFCLASS64;
+	header.e_ident[EI_DATA]       = ELFDATA2LSB;
+	header.e_ident[EI_VERSION]    = EV_CURRENT;
+	header.e_ident[EI_OSABI]      = ELFOSABI_FREEBSD;
+	header.e_ident[EI_ABIVERSION] = 2;
+	header.e_type                 = ET_DYNEXEC;
+	header.e_machine              = EM_X86_64;
+	header.e_version              = EV_CURRENT;
+	header.e_phoff                = sizeof(Elf64_Ehdr);
+	header.e_ehsize               = sizeof(Elf64_Ehdr);
+	header.e_phentsize            = sizeof(Elf64_Phdr);
+	header.e_phnum                = program_count;
+	return header;
+}
+
+SelfHeader Self() {
+	SelfHeader self {};
+	const uint8_t ident[] = {0x4f, 0x15, 0x3d, 0x1d, 0x00, 0x01,
+	                         0x01, 0x12, 0x01, 0x01, 0x00, 0x00};
+	std::memcpy(self.ident, ident, sizeof(ident));
+	self.unknown = 0x22;
+	return self;
+}
+
+std::vector<uint8_t> RawElf() {
+	std::vector<uint8_t> image(0x180);
+	const auto           header = Header();
+	Store(image, 0, header);
+	Elf64_Phdr load {};
+	load.p_type   = PT_LOAD;
+	load.p_offset = 0x100;
+	load.p_filesz = 0x20;
+	load.p_memsz  = 0x20;
+	Store(image, header.e_phoff, load);
+	return image;
+}
+
+std::vector<uint8_t> SelfImage() {
+	std::vector<uint8_t> image(0x180);
+	auto                 self = Self();
+	self.segments_num           = 1;
+	Store(image, 0, self);
+	SelfSegment segment {};
+	segment.type              = 0x800u;
+	segment.offset            = 0x140;
+	segment.compressed_size   = 0x20;
+	segment.decompressed_size = 0x20;
+	Store(image, sizeof(SelfHeader), segment);
+
+	const uint64_t elf_offset = sizeof(SelfHeader) + sizeof(SelfSegment);
+	const auto     header     = Header();
+	Store(image, elf_offset, header);
+	Elf64_Phdr load {};
+	load.p_type   = PT_LOAD;
+	load.p_offset = 0x2000;
+	load.p_filesz = 0x20;
+	load.p_memsz  = 0x20;
+	Store(image, elf_offset + header.e_phoff, load);
+	return image;
+}
+
+void TestRawElfAndFile() {
+	const auto image = RawElf();
+	ElfValidationReport report;
+	std::string         error;
+	Check(ValidateElfImage(image, &report, &error), error.c_str());
+	Check(!report.self && report.elf_offset == 0, "raw ELF report");
+
+	const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+	const auto path = std::filesystem::current_path() /
+	                  ("kyty_elf_validator_" + std::to_string(unique) + ".bin");
+	Common::File output(path);
+	Check(!output.IsInvalid(), "create temporary ELF file");
+	uint32_t written = 0;
+	output.Write(image.data(), static_cast<uint32_t>(image.size()), &written);
+	Check(written == image.size() && output.Flush(), "write temporary ELF file");
+	output.Close();
+	Check(ValidateElfFile(path, &report, &error), error.c_str());
+	Check(Common::File::DeleteFile(path), "remove temporary ELF file");
+}
+
+void TestProgramAndSegmentBounds() {
+	std::string error;
+	auto        truncated = RawElf();
+	truncated.resize(sizeof(Elf64_Ehdr) + sizeof(Elf64_Phdr) - 1u);
+	Check(!ValidateElfImage(truncated, nullptr, &error) &&
+	          error.find("program header table") != std::string::npos,
+	      "truncated program table");
+
+	auto overflow = RawElf();
+	auto header   = Header();
+	header.e_phoff = std::numeric_limits<uint64_t>::max() - 8u;
+	Store(overflow, 0, header);
+	Check(!ValidateElfImage(overflow, nullptr, &error) &&
+	          error.find("program header table") != std::string::npos,
+	      "overflowing program-table offset");
+
+	auto outside = RawElf();
+	Elf64_Phdr load {};
+	load.p_type   = PT_LOAD;
+	load.p_offset = 0x170;
+	load.p_filesz = 0x20;
+	Store(outside, Header().e_phoff, load);
+	Check(!ValidateElfImage(outside, nullptr, &error) &&
+	          error.find("segment payload") != std::string::npos,
+	      "segment outside file");
+
+	load.p_offset = std::numeric_limits<uint64_t>::max();
+	load.p_filesz = 0;
+	Store(outside, Header().e_phoff, load);
+	Check(ValidateElfImage(outside, nullptr, &error),
+	      "zero-length segment with unused offset");
+
+	auto no_programs      = RawElf();
+	auto empty_header     = Header(0);
+	empty_header.e_phoff = std::numeric_limits<uint64_t>::max();
+	Store(no_programs, 0, empty_header);
+	Check(ValidateElfImage(no_programs, nullptr, &error),
+	      "empty program table with unused offset");
+}
+
+void TestSectionBounds() {
+	std::string error;
+	auto        image  = RawElf();
+	auto        header = Header();
+	header.e_shoff     = 0x120;
+	header.e_shentsize = sizeof(Elf64_Shdr);
+	header.e_shnum     = 1;
+	Store(image, 0, header);
+	Elf64_Shdr section {};
+	section.sh_type   = 1;
+	section.sh_offset = 0x170;
+	section.sh_size   = 0x20;
+	Store(image, header.e_shoff, section);
+	Check(!ValidateElfImage(image, nullptr, &error) &&
+	          error.find("section payload") != std::string::npos,
+	      "section outside file");
+
+	section.sh_type   = 8; // SHT_NOBITS has no file payload.
+	section.sh_offset = std::numeric_limits<uint64_t>::max();
+	Store(image, header.e_shoff, section);
+	Check(ValidateElfImage(image, nullptr, &error), "NOBITS section without file payload");
+}
+
+void TestSelfContainer() {
+	auto image = SelfImage();
+	ElfValidationReport report;
+	std::string         error;
+	Check(ValidateElfImage(image, &report, &error), error.c_str());
+	Check(report.self && report.elf_offset == sizeof(SelfHeader) + sizeof(SelfSegment),
+	      "SELF embedded ELF offset");
+
+	auto unsupported = image;
+	unsupported[4]   = 0xff;
+	Check(!ValidateElfImage(unsupported, nullptr, &error) &&
+	          error.find("unsupported SELF") != std::string::npos,
+	      "unsupported SELF variant");
+
+	auto declared_size = image;
+	auto self          = Self();
+	self.segments_num  = 1;
+	self.file_size     = declared_size.size() + 1;
+	Store(declared_size, 0, self);
+	Check(!ValidateElfImage(declared_size, nullptr, &error) &&
+	          error.find("declared file size") != std::string::npos,
+	      "SELF declared file size");
+
+	auto invalid_reference = image;
+	SelfSegment segment {};
+	std::memcpy(&segment, invalid_reference.data() + sizeof(SelfHeader), sizeof(segment));
+	segment.type = 0x800u | (1ull << 20u);
+	Store(invalid_reference, sizeof(SelfHeader), segment);
+	Check(!ValidateElfImage(invalid_reference, nullptr, &error) &&
+	          error.find("invalid ELF program header") != std::string::npos,
+	      "SELF program-header reference");
+
+	auto compressed = image;
+	std::memcpy(&segment, compressed.data() + sizeof(SelfHeader), sizeof(segment));
+	segment.compressed_size = 0x10;
+	Store(compressed, sizeof(SelfHeader), segment);
+	Check(!ValidateElfImage(compressed, nullptr, &error) &&
+	          error.find("compressed SELF") != std::string::npos,
+	      "unsupported SELF compression");
+
+	auto overflowing = image;
+	std::memcpy(&segment, overflowing.data() + sizeof(SelfHeader), sizeof(segment));
+	segment.offset          = std::numeric_limits<uint64_t>::max() - 3u;
+	segment.compressed_size = 8;
+	Store(overflowing, sizeof(SelfHeader), segment);
+	Check(!ValidateElfImage(overflowing, nullptr, &error) &&
+	          error.find("SELF segment payload") != std::string::npos,
+	      "overflowing SELF payload");
+
+	auto program_overflow = image;
+	Elf64_Phdr program {};
+	program.p_type   = PT_LOAD;
+	program.p_offset = std::numeric_limits<uint64_t>::max() - 3u;
+	program.p_filesz = 8;
+	const auto program_offset = sizeof(SelfHeader) + sizeof(SelfSegment) + sizeof(Elf64_Ehdr);
+	Store(program_overflow, program_offset, program);
+	Check(!ValidateElfImage(program_overflow, nullptr, &error) &&
+	          error.find("segment range overflows") != std::string::npos,
+	      "overflowing SELF ELF segment range");
+}
+
+} // namespace
+
+int main() {
+	TestRawElfAndFile();
+	TestProgramAndSegmentBounds();
+	TestSectionBounds();
+	TestSelfContainer();
+	return 0;
+}


### PR DESCRIPTION
## Summary

- validate ELF/SELF file-backed ranges before `Elf64` allocates or reads loader tables
- use overflow-safe arithmetic for program tables, section tables, segment payloads, and SELF payloads
- validate SELF program-header references before `LoadSegment` indexes them
- share the exact SELF header classification between validation and loading
- report unsupported compression and inconsistent SELF sizes explicitly

## Safety and compatibility details

The validator runs before the existing loader reads the image. It checks only invariants that the current `Elf64` implementation already relies on:

- supported ELF/SELF header variants
- exact table entry sizes consumed by the loader
- complete file-backed tables and payloads
- at most one process-parameter segment
- valid SELF-to-program-header indices
- uncompressed SELF payloads whose sizes match the referenced ELF program headers

Zero-length segments and empty tables may retain otherwise unused offsets, avoiding over-validation. The validator does not authenticate, decrypt, or claim general SELF format support.

The local SDK 12 corpus has no ELF/SELF container documentation matching these fields, so this PR deliberately makes no SDK-derived metadata or format claims. The SDK-version extraction present in the experimental KytyTouche implementation was omitted.

## Relationship to #302

PR #302 improves named boot-header failures. This PR covers deeper table, payload, arithmetic-overflow, and SELF-reference bounds that #302 does not validate. Both touch `elf.cpp`, so a small rebase conflict is expected if #302 merges first; the functionality is complementary.

## Validation

- dedicated `elf_validator_tests` Release build: passed
- direct `elf_validator_tests.exe`: passed
- `ctest --test-dir _Build/launcher-usability -C Release -R "^elf_validator$" --output-on-failure`: 1/1 passed
- full `kyty_emulator` Release build with clang-cl: passed

Tests cover raw ELF, real file I/O, truncated and overflowing tables, out-of-range and zero-length segments, section payloads, `SHT_NOBITS`, empty tables, supported and unsupported SELF headers, declared size, invalid program-header references, compression, size mismatches, and overflowing ranges.

## Provenance

This isolates and substantially hardens the ELF validator introduced in KytyTouche commit `9b5f2cd`. Original authorship is retained through the commit co-author trailer.
