### PR TITLE
loader: add opt-in strict unresolved import mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,13 @@ add_executable(bit_array_tests EXCLUDE_FROM_ALL
 )
 target_include_directories(bit_array_tests PRIVATE ${inc_headers})
 
+add_executable(strict_unresolved_import_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/StrictUnresolvedImportTests.cpp"
+	"${KYTY_SOURCE_DIR}/loader/unresolvedImportPolicy.cpp"
+)
+target_link_libraries(strict_unresolved_import_tests common fmt::fmt)
+target_include_directories(strict_unresolved_import_tests PRIVATE ${inc_headers})
+
 add_executable(ime_dialog_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/ImeDialogTests.cpp"
 	"${KYTY_SOURCE_DIR}/libs/imeCommon.cpp"
@@ -531,6 +538,7 @@ if(BUILD_TESTING)
 	add_test(NAME memory_tracker COMMAND $<TARGET_FILE:memory_tracker_tests>)
 	add_test(NAME page_manager COMMAND $<TARGET_FILE:page_manager_tests>)
 	add_test(NAME bit_array COMMAND $<TARGET_FILE:bit_array_tests>)
+	add_test(NAME strict_unresolved_import COMMAND $<TARGET_FILE:strict_unresolved_import_tests>)
 	add_test(NAME shader_vertex_metadata COMMAND $<TARGET_FILE:shader_vertex_metadata_tests>)
 	add_test(NAME shader_stage_runtime COMMAND $<TARGET_FILE:shader_stage_runtime_tests>)
 	add_test(NAME resource_tracking COMMAND $<TARGET_FILE:resource_tracking_tests>)
@@ -585,6 +593,7 @@ if(BUILD_TESTING)
 		memory_tracker_tests
 		page_manager_tests
 		bit_array_tests
+		strict_unresolved_import_tests
 		shader_vertex_metadata_tests
 		shader_stage_runtime_tests
 		resource_tracking_tests

--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -109,6 +109,10 @@ bool PlayGoHackEnabled() {
 	return g_config->playgo_hack_enabled;
 }
 
+bool StrictUnresolvedImportsEnabled() {
+	return g_config->strict_unresolved_imports;
+}
+
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 bool RedZoneProtectionEnabled() {
 	return g_config->red_zone_protection_enabled;

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -53,6 +53,8 @@ struct ConfigOptions {
 	bool                   renderdoc_enabled           = false;
 	bool                   readback_linear_images      = false;
 	bool                   playgo_hack_enabled         = false;
+	// Debugging safeguard: abort only when an unresolved import thunk is executed.
+	bool                   strict_unresolved_imports   = false;
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	bool red_zone_protection_enabled = false;
 #endif
@@ -90,6 +92,7 @@ bool GpuAssistedValidationEnabled();
 bool RenderDocEnabled();
 bool ReadbackLinearImagesEnabled();
 bool PlayGoHackEnabled();
+bool StrictUnresolvedImportsEnabled();
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 bool RedZoneProtectionEnabled();
 #endif

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -21,6 +21,7 @@
 #include "loader/jit.h"
 #include "loader/redZonePatcher.h"
 #include "loader/symbolDatabase.h"
+#include "loader/unresolvedImportPolicy.h"
 #include "loader/x64InstructionEmulator.h"
 
 #include <algorithm>
@@ -337,6 +338,24 @@ static KYTY_SYSV_ABI uint64_t ResolveImportStubWithId(uint64_t record_id) {
 			LOGF("Unresolved import stub called [%u]: record_id=%" PRIu64 " symbol=<bad-record>\n",
 			     log_index, record_id);
 		}
+	}
+
+	if (Config::StrictUnresolvedImportsEnabled()) {
+		StrictUnresolvedImportDetails        details {};
+		const StrictUnresolvedImportDetails* details_ptr = nullptr;
+		if (record_id < g_stubbed_imports.size()) {
+			const auto& record       = g_stubbed_imports[record_id];
+			details.symbol           = record.name;
+			details.type             = Common::EnumName(record.type);
+			details.bind             = Common::EnumName(record.bind);
+			details.program          = record.program;
+			details.patch_vaddr      = record.patch_vaddr;
+			details.relocation_index = record.index;
+			details_ptr              = &details;
+		}
+
+		const auto error = FormatStrictUnresolvedImportError(record_id, details_ptr);
+		EXIT("%s\n", error.c_str());
 	}
 	return 0;
 }

--- a/src/loader/unresolvedImportPolicy.cpp
+++ b/src/loader/unresolvedImportPolicy.cpp
@@ -1,0 +1,20 @@
+#include "loader/unresolvedImportPolicy.h"
+
+#include <fmt/format.h>
+
+namespace Loader {
+
+std::string FormatStrictUnresolvedImportError(uint64_t                             record_id,
+                                              const StrictUnresolvedImportDetails* details) {
+	if (details == nullptr) {
+		return fmt::format("strict unresolved import: invalid record_id={}", record_id);
+	}
+
+	return fmt::format(
+	    "strict unresolved import: symbol={} type={} bind={} program={} patch_vaddr=0x{:016x} "
+	    "jmprela_index={} record_id={}",
+	    details->symbol, details->type, details->bind, details->program, details->patch_vaddr,
+	    details->relocation_index, record_id);
+}
+
+} // namespace Loader

--- a/src/loader/unresolvedImportPolicy.h
+++ b/src/loader/unresolvedImportPolicy.h
@@ -1,0 +1,29 @@
+#ifndef LOADER_INCLUDE_LOADER_UNRESOLVED_IMPORT_POLICY_H_
+#define LOADER_INCLUDE_LOADER_UNRESOLVED_IMPORT_POLICY_H_
+
+#include "common/common.h"
+
+#include <cstdint>
+#include <string>
+
+namespace Loader {
+
+// Host-side context captured for a guest import that could not be resolved.
+// Keeping this independent of RuntimeLinker makes strict-mode diagnostics testable.
+struct StrictUnresolvedImportDetails {
+	std::string symbol;
+	std::string type;
+	std::string bind;
+	std::string program;
+	uint64_t    patch_vaddr      = 0;
+	uint32_t    relocation_index = 0;
+};
+
+// Returns a stable, single-line diagnostic. A null details pointer represents a
+// corrupt or stale thunk whose record id no longer exists.
+[[nodiscard]] std::string
+FormatStrictUnresolvedImportError(uint64_t record_id, const StrictUnresolvedImportDetails* details);
+
+} // namespace Loader
+
+#endif /* LOADER_INCLUDE_LOADER_UNRESOLVED_IMPORT_POLICY_H_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,7 @@ static void PrintUsage() {
 	::printf(
 	    "  --readback-linear-images <true|false> Read back writable linear images on submit.\n");
 	::printf("  --playgo-hack                       Use the supplied PlayGo stub fallback.\n");
+	::printf("  --strict-unresolved-imports         Abort when an unresolved import is called.\n");
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	::printf("  --redzone                            Protect the guest SysV red zone.\n");
 #endif
@@ -146,6 +147,11 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 
 		if (arg == "--playgo-hack") {
 			options.config.playgo_hack_enabled = true;
+			continue;
+		}
+
+		if (arg == "--strict-unresolved-imports") {
+			options.config.strict_unresolved_imports = true;
 			continue;
 		}
 

--- a/tests/StrictUnresolvedImportTests.cpp
+++ b/tests/StrictUnresolvedImportTests.cpp
@@ -1,0 +1,57 @@
+#include "common/emulatorConfig.h"
+#include "loader/unresolvedImportPolicy.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+void Check(bool value, const char* message) {
+	if (!value) {
+		std::fprintf(stderr, "StrictUnresolvedImportTests: failed: %s\n", message);
+		std::abort();
+	}
+}
+
+void TestConfigurationIsOptIn() {
+	Config::Initialize();
+	Check(!Config::StrictUnresolvedImportsEnabled(), "strict mode was enabled by default");
+
+	Config::ConfigOptions options;
+	options.strict_unresolved_imports = true;
+	Config::Load(options);
+	Check(Config::StrictUnresolvedImportsEnabled(), "strict mode was not loaded");
+	Config::Shutdown();
+}
+
+void TestDiagnosticIncludesRelocationContext() {
+	Loader::StrictUnresolvedImportDetails details;
+	details.symbol           = "EwB7Qa7y2Rk[libSceExample]";
+	details.type             = "Func";
+	details.bind             = "Global";
+	details.program          = "/app0/eboot.bin";
+	details.patch_vaddr      = 0x1234abcd;
+	details.relocation_index = 17;
+
+	const auto message = Loader::FormatStrictUnresolvedImportError(3, &details);
+	Check(message == "strict unresolved import: symbol=EwB7Qa7y2Rk[libSceExample] "
+	                 "type=Func "
+	                 "bind=Global program=/app0/eboot.bin patch_vaddr=0x000000001234abcd "
+	                 "jmprela_index=17 record_id=3",
+	      "valid record diagnostic lost context");
+}
+
+void TestInvalidRecordDiagnostic() {
+	const auto message = Loader::FormatStrictUnresolvedImportError(99, nullptr);
+	Check(message == "strict unresolved import: invalid record_id=99",
+	      "invalid record diagnostic was ambiguous");
+}
+
+} // namespace
+
+int main() {
+	TestConfigurationIsOptIn();
+	TestDiagnosticIncludesRelocationContext();
+	TestInvalidRecordDiagnostic();
+	return 0;
+}


### PR DESCRIPTION
## Summary
- adds --strict-unresolved-imports as an opt-in debugging safeguard
- aborts only when a still-unresolved import thunk is actually invoked
- reports symbol, type, binding, program, patch address, relocation index, and record id
- isolates stable diagnostic formatting in unresolvedImportPolicy

## Behavior
Default behavior is unchanged: unresolved imports keep logging and return zero. With strict mode enabled, late resolution is still attempted first; only a failed invocation terminates the emulator with actionable context. Invalid or stale record ids receive a separate deterministic diagnostic.

## Tests
- strict_unresolved_import_tests: default/loaded configuration and valid/invalid diagnostics
- ctest --output-on-failure -R strict_unresolved_import
- full kyty_emulator Release build with clang-cl
- kyty_emulator --help --strict-unresolved-imports CLI smoke test

## Attribution
Adapted from the strict unresolved-import behavior developed in the external KytyTouche branch, with expanded diagnostics, documentation, and isolated tests.