### PR TITLE
shader: fix VOP2 packed FMAC high-half selectors

### DIFF
--- a/src/graphics/shader/recompiler/frontend/decode/VectorAluOps.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/VectorAluOps.cpp
@@ -443,9 +443,17 @@ bool IsNativeVop3B16BinaryOpcode(Opcode opcode) {
 	}
 }
 
-void ApplyDefaultVop2F16Destination(Instruction& inst) {
+void ApplyDefaultVop2F16Selectors(Instruction& inst) {
 	if (IsVop2LowHalfF16Opcode(inst.opcode)) {
 		inst.dst.sdwa_sel = 4;
+	}
+
+	if (inst.opcode == Opcode::V_PK_FMAC_F16) {
+		// VOP2 has no OP_SEL_HI fields. Its packed high operation implicitly reads the
+		// high halves of both multiplicands and of the destination accumulator.
+		inst.src0.op_sel_hi = true;
+		inst.src1.op_sel_hi = true;
+		inst.dst.op_sel_hi  = true;
 	}
 }
 
@@ -1088,7 +1096,7 @@ bool DecodeVop2Dpp(uint32_t pc, std::span<const uint32_t> code, uint32_t word_in
 	if (!DecodeScalarSource(src0 + 256u, pc, inst.src0, error)) {
 		return false;
 	}
-	ApplyDefaultVop2F16Destination(inst);
+	ApplyDefaultVop2F16Selectors(inst);
 	ApplyDppModifier(inst.src0, modifier);
 	inst.src1.negate   = ((modifier >> 22u) & 0x1u) != 0u;
 	inst.src1.absolute = ((modifier >> 23u) & 0x1u) != 0u;
@@ -1557,7 +1565,7 @@ bool DecodeVop2(uint32_t pc, std::span<const uint32_t> code, uint32_t word_index
 	if (!DecodeScalarSource(src0, pc, inst.src0, error)) {
 		return false;
 	}
-	ApplyDefaultVop2F16Destination(inst);
+	ApplyDefaultVop2F16Selectors(inst);
 	return FinalizeVop2Instruction(pc, code, word_index, inst, error);
 }
 

--- a/tests/shaderCfgTests.cpp
+++ b/tests/shaderCfgTests.cpp
@@ -4079,6 +4079,19 @@ void TestNewShaderDecoderArchitecture() {
               packed_inst.src2.op_sel_hi == (source == 2u),
           "VOP3P OPSEL_HI source bit mapping is incorrect");
   }
+
+  const uint32_t vop2_packed_fmac[] = {
+      EncodeVop2(0x3cu, 2u, 0u + 256u, 1u),
+  };
+  Instruction packed_fmac;
+  Check(DecodeInstruction(vop2_packed_fmac, 0u, packed_fmac, &error),
+        error.c_str());
+  Check(packed_fmac.family == Family::VOP2 &&
+            packed_fmac.opcode == Opcode::V_PK_FMAC_F16 &&
+            !packed_fmac.src0.op_sel && packed_fmac.src0.op_sel_hi &&
+            !packed_fmac.src1.op_sel && packed_fmac.src1.op_sel_hi &&
+            !packed_fmac.dst.op_sel && packed_fmac.dst.op_sel_hi,
+        "VOP2 V_PK_FMAC_F16 did not select both packed halves");
 }
 
 void TestNewShaderRecompilerRejectsDppOn64BitCompares() {


### PR DESCRIPTION
## Summary
- initializes the implicit high-half selectors for VOP2 V_PK_FMAC_F16
- keeps low-half selectors unchanged
- renames the helper to reflect that it configures operand selectors, not only the destination
- adds a direct decoder regression for both source halves and the destination accumulator

## Problem
V_PK_FMAC_F16 is the VOP2 exception among packed 16-bit math operations and has no encoded OP_SEL_HI fields. The decoder left src0, src1, and vdst high selectors false, so the high packed operation reused low halves instead of consuming the high halves.

## Expected behavior
The low result uses the low halves. The high result implicitly uses the high halves of both multiplicands and the destination accumulator, matching the SDK 12.000 GPU Shader Core ISA packed-math contract.

## Tests
- shader_cfg CTest passed
- full kyty_emulator Release build passed with clang-cl

## Scope
Two files only: VOP2 decoder behavior and its regression test. No VOP3P, translation, IR, or SPIR-V behavior changes.