### PR TITLE
audio: accept streaming ATRAC9 RIFF data chunks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,6 +464,12 @@ add_executable(audio_out2_port_tests EXCLUDE_FROM_ALL
 target_link_libraries(audio_out2_port_tests common fmt::fmt)
 target_include_directories(audio_out2_port_tests PRIVATE ${inc_headers})
 
+add_executable(ajm_atrac9_streaming_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/AjmAtrac9StreamingTests.cpp"
+)
+target_link_libraries(ajm_atrac9_streaming_tests common FFmpeg::ffmpeg fmt::fmt LibAtrac9)
+target_include_directories(ajm_atrac9_streaming_tests PRIVATE ${inc_headers})
+
 add_executable(event_queue_lifetime_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/EventQueueLifetimeTests.cpp"
 	"${KYTY_SOURCE_DIR}/kernel/eventQueue.cpp"
@@ -538,6 +544,7 @@ if(BUILD_TESTING)
 	add_test(NAME kernel_file_system COMMAND $<TARGET_FILE:kernel_file_system_tests>)
 	add_test(NAME sync_on_address COMMAND $<TARGET_FILE:sync_on_address_tests>)
 	add_test(NAME audio_out2_port COMMAND $<TARGET_FILE:audio_out2_port_tests>)
+	add_test(NAME ajm_atrac9_streaming COMMAND $<TARGET_FILE:ajm_atrac9_streaming_tests>)
 	add_test(NAME shader_recompiler_compute COMMAND $<TARGET_FILE:shader_recompiler_compute_tests>)
 	add_test(NAME shader_recompiler_alignbyte
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --alignbyte-only)
@@ -594,6 +601,7 @@ if(BUILD_TESTING)
 		shader_recompiler_compute_tests
 		virtual_memory_allocation_tests
 		audio_out2_port_tests
+		ajm_atrac9_streaming_tests
 	)
 endif()
 

--- a/src/libs/ajm/atrac9_decoder.h
+++ b/src/libs/ajm/atrac9_decoder.h
@@ -463,7 +463,20 @@ private:
 			const auto* chunk      = input + offset;
 			const auto  chunk_size = static_cast<size_t>(AjmReadLe32(chunk + 4));
 			const auto  payload    = offset + 8;
-			if (payload > input_size || chunk_size > input_size - payload) {
+
+			// A streaming RIFF buffer can contain the data header and only the currently
+			// available packets, while the chunk size describes the complete stream. The
+			// header is enough to locate audio data; metadata chunks still require their
+			// full payload before they can be parsed safely.
+			if (AjmFourCcEquals(chunk, 'd', 'a', 't', 'a')) {
+				*data_offset                  = payload;
+				result->input_consumed        = payload;
+				result->format                = GetFormat();
+				result->total_decoded_samples = m_total_decoded_samples;
+				return true;
+			}
+
+			if (chunk_size > input_size - payload) {
 				result->result = AJM_RESULT_PARTIAL_INPUT;
 				return false;
 			}
@@ -495,12 +508,6 @@ private:
 					LOGF("AJM ATRAC9 gapless: total=%" PRIu32 ", skip=%" PRIu16 "\n",
 					     gapless_decode.total_samples, gapless_decode.skip_samples);
 				}
-			} else if (AjmFourCcEquals(chunk, 'd', 'a', 't', 'a')) {
-				*data_offset                  = payload;
-				result->input_consumed        = payload;
-				result->format                = GetFormat();
-				result->total_decoded_samples = m_total_decoded_samples;
-				return true;
 			}
 
 			const auto padded_size = chunk_size + (chunk_size & 1u);

--- a/tests/AjmAtrac9StreamingTests.cpp
+++ b/tests/AjmAtrac9StreamingTests.cpp
@@ -1,0 +1,93 @@
+// AjmAt9Decoder is intentionally internal to ajm.cpp. This focused target
+// amalgamates that implementation so it can exercise the real decoder path.
+#include "libs/ajm.cpp"
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+using namespace Libs::Audio::Ajm;
+
+void Check(bool value, const char* message) {
+	if (!value) {
+		std::fprintf(stderr, "AjmAtrac9StreamingTests: failed: %s\n", message);
+		std::abort();
+	}
+}
+
+template <size_t Size>
+void WriteFourCc(std::array<uint8_t, Size>& buffer, size_t offset, const char* value) {
+	std::memcpy(buffer.data() + offset, value, 4);
+}
+
+template <size_t Size>
+void WriteLe16(std::array<uint8_t, Size>& buffer, size_t offset, uint16_t value) {
+	buffer[offset]     = static_cast<uint8_t>(value);
+	buffer[offset + 1] = static_cast<uint8_t>(value >> 8u);
+}
+
+template <size_t Size>
+void WriteLe32(std::array<uint8_t, Size>& buffer, size_t offset, uint32_t value) {
+	for (uint32_t index = 0; index < 4; index++) {
+		buffer[offset + index] = static_cast<uint8_t>(value >> (index * 8u));
+	}
+}
+
+std::array<uint8_t, 76> MakeStreamingHeader() {
+	std::array<uint8_t, 76> header {};
+	WriteFourCc(header, 0, "RIFF");
+	WriteLe32(header, 4, 0x00010044u);
+	WriteFourCc(header, 8, "WAVE");
+
+	WriteFourCc(header, 12, "fmt ");
+	WriteLe32(header, 16, 48);
+	WriteLe16(header, 20, 0xfffe);
+	WriteLe16(header, 22, 2);
+	WriteLe32(header, 24, 48000);
+	constexpr std::array<uint8_t, 16> atrac9_guid = {
+	    0xd2, 0x42, 0xe1, 0x47, 0xba, 0x36, 0x8d, 0x4d,
+	    0x88, 0xfc, 0x61, 0x65, 0x4f, 0x8c, 0x83, 0x6c,
+	};
+	std::memcpy(header.data() + 44, atrac9_guid.data(), atrac9_guid.size());
+	constexpr std::array<uint8_t, 4> atrac9_config = {0xfe, 0x74, 0x0b, 0xe0};
+	std::memcpy(header.data() + 64, atrac9_config.data(), atrac9_config.size());
+
+	WriteFourCc(header, 68, "data");
+	WriteLe32(header, 72, 0x00010000u);
+	return header;
+}
+
+void TestStreamingDataChunkDoesNotRequireDeclaredPayload() {
+	const auto    header = MakeStreamingHeader();
+	AjmAt9Decoder decoder(2, 48000, AjmSampleEncoding::S16,
+	                      AJM_INSTANCE_FLAG_DEC_AT9_PARSE_RIFF_HEADER);
+	const auto    result = decoder.Decode(header.data(), header.size(), nullptr, 0, false, nullptr);
+
+	Check(result.result == AJM_RESULT_PARTIAL_INPUT,
+	      "header-only input did not request the first audio packet");
+	Check(result.input_consumed == header.size(), "valid streaming RIFF header was not consumed");
+	Check(result.format.channel_num == 2 && result.format.sampling_frequency == 48000,
+	      "streaming header did not initialize the ATRAC9 format");
+}
+
+void TestTruncatedMetadataStillRequiresItsPayload() {
+	auto header = MakeStreamingHeader();
+	WriteLe32(header, 16, 0x00010000u);
+
+	AjmAt9Decoder decoder(2, 48000, AjmSampleEncoding::S16,
+	                      AJM_INSTANCE_FLAG_DEC_AT9_PARSE_RIFF_HEADER);
+	const auto    result = decoder.Decode(header.data(), header.size(), nullptr, 0, false, nullptr);
+	Check(result.result == AJM_RESULT_PARTIAL_INPUT && result.input_consumed == 0,
+	      "truncated metadata chunk was accepted as streaming audio");
+}
+
+} // namespace
+
+int main() {
+	TestStreamingDataChunkDoesNotRequireDeclaredPayload();
+	TestTruncatedMetadataStillRequiresItsPayload();
+	return 0;
+}


### PR DESCRIPTION
## Summary
- accepts an ATRAC9 RIFF data chunk when its header is present but its declared full payload has not arrived yet
- consumes and initializes the complete RIFF header, then reports partial input until an audio packet is available
- continues requiring complete payloads for fmt, fact, and other metadata chunks
- adds a focused test using a 76-byte header whose data chunk declares 64 KiB

## Problem
RIFF data chunk sizes describe the complete audio payload. Streaming callers may submit the header and current packets only. The parser applied the metadata completeness check before identifying data, so it rejected a valid streaming header whenever the declared stream was larger than the current AJM input buffer.

## Safety
Only the data header is exempted from the full-payload check. The parser does not read beyond the current buffer, and the decoder's existing minimum-frame logic returns AJM_RESULT_PARTIAL_INPUT when no complete packet follows.

## Tests
- ajm_atrac9_streaming CTest passed
- control case confirms a truncated fmt chunk remains unconsumed and rejected as partial input
- full kyty_emulator Release build passed with clang-cl

## Scope
Three files: parser behavior, focused test target, and CTest registration. No codec, PCM, AudioOut, or ABI changes.