### PR TITLE
shader: ignore unreachable descriptor Phi inputs

### DIFF
--- a/src/graphics/shader/recompiler/ir/passes/ResourceTracking.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceTracking.cpp
@@ -6,7 +6,9 @@
 
 #include <algorithm>
 #include <fmt/format.h>
+#include <optional>
 #include <span>
+#include <unordered_set>
 #include <utility>
 
 namespace Libs::Graphics::ShaderRecompiler::IR {
@@ -61,6 +63,92 @@ Value CanonicalizeSampleAdjustDword3(Value value) {
 			return value;
 		}
 	}
+}
+
+std::optional<bool> BooleanOnIncomingEdge(Value value, const Block* merge,
+                                          const Block* predecessor,
+                                          std::unordered_set<const Inst*>& visiting) {
+	value = value.Resolve();
+	if (value.IsImmediate()) {
+		return value.GetType() == Type::U1 ? std::optional<bool>(value.U1()) : std::nullopt;
+	}
+	const auto* inst = value.TryInstruction();
+	if (inst == nullptr || !visiting.insert(inst).second) {
+		return std::nullopt;
+	}
+	const auto finish = [&](std::optional<bool> result) {
+		visiting.erase(inst);
+		return result;
+	};
+	if (inst->GetOpcode() == ValueOpcode::Phi && inst->Parent() == merge) {
+		for (size_t index = 0; index < inst->NumArgs(); index++) {
+			if (inst->PhiBlock(index) == predecessor) {
+				return finish(BooleanOnIncomingEdge(inst->Arg(index), merge, predecessor, visiting));
+			}
+		}
+		return finish(std::nullopt);
+	}
+	if (inst->GetOpcode() == ValueOpcode::LogicalNot) {
+		auto operand = BooleanOnIncomingEdge(inst->Arg(0), merge, predecessor, visiting);
+		return finish(operand.has_value() ? std::optional<bool>(!*operand) : std::nullopt);
+	}
+	return finish(std::nullopt);
+}
+
+std::optional<bool> BooleanOnIncomingEdge(Value value, const Block* merge,
+                                          const Block* predecessor) {
+	std::unordered_set<const Inst*> visiting;
+	return BooleanOnIncomingEdge(value, merge, predecessor, visiting);
+}
+
+// A descriptor used directly after a conditional merge cannot observe Phi inputs whose incoming
+// edge selects the other successor. Collapse only when every remaining input is equivalent.
+Value CanonicalizeInactivePhi(const Program& program, const Inst& user, Value value) {
+	value            = value.Resolve();
+	const auto* root = value.TryInstruction();
+	if (root == nullptr || root->GetOpcode() != ValueOpcode::Phi) {
+		return value;
+	}
+	const auto* merge      = root->Parent();
+	const auto* user_block = user.Parent();
+	if (merge == nullptr || user_block == nullptr ||
+	    std::ranges::find(merge->ImmSuccessors(), user_block) == merge->ImmSuccessors().end() ||
+	    program.blocks.size() != program.block_info.size()) {
+		return value;
+	}
+	const auto merge_it = std::ranges::find(program.blocks, merge);
+	const auto user_it  = std::ranges::find(program.blocks, user_block);
+	if (merge_it == program.blocks.end() || user_it == program.blocks.end()) {
+		return value;
+	}
+	const auto& info = program.block_info[static_cast<size_t>(merge_it - program.blocks.begin())];
+	if (info.terminator.kind != CFG::TerminatorKind::ConditionalBranch) {
+		return value;
+	}
+	const auto user_id = program.block_info[static_cast<size_t>(user_it - program.blocks.begin())].id;
+	const bool true_target  = info.terminator.true_block == user_id;
+	const bool false_target = info.terminator.false_block == user_id;
+	if (true_target == false_target) {
+		return value;
+	}
+	const std::optional<bool> target = true_target;
+
+	Value candidate;
+	bool  discarded = false;
+	for (size_t index = 0; index < root->NumArgs(); index++) {
+		const auto edge = BooleanOnIncomingEdge(info.condition, merge, root->PhiBlock(index));
+		if (edge.has_value() && edge != target) {
+			discarded = true;
+			continue;
+		}
+		const auto current = root->Arg(index).Resolve();
+		if (candidate.IsEmpty()) {
+			candidate = current;
+		} else if (!EquivalentValue(program, candidate, current)) {
+			return value;
+		}
+	}
+	return discarded && !candidate.IsEmpty() ? candidate : value;
 }
 
 const char* StageName(ShaderType stage) {
@@ -188,7 +276,7 @@ private:
 		}
 		descriptor.dword_count = width;
 		for (uint32_t i = 0; i < width; i++) {
-			descriptor.dwords[i] = handle.Arg(i).Resolve();
+			descriptor.dwords[i] = CanonicalizeInactivePhi(m_program, handle, handle.Arg(i));
 		}
 		if (sample_adjust) {
 			descriptor.dwords[3] = CanonicalizeSampleAdjustDword3(descriptor.dwords[3]);

--- a/tests/ResourceTrackingTests.cpp
+++ b/tests/ResourceTrackingTests.cpp
@@ -21,6 +21,7 @@ namespace {
 using namespace Libs::Graphics::ShaderRecompiler::IR;
 using Libs::Graphics::ShaderComputeInputInfo;
 using Libs::Graphics::ShaderType;
+namespace CFG = Libs::Graphics::ShaderRecompiler::CFG;
 namespace Decoder = Libs::Graphics::ShaderRecompiler::Decoder;
 
 void Check(bool condition, const char *message) {
@@ -977,6 +978,81 @@ void TestPhiValidation() {
         "control-dependent descriptor phi was not rejected transactionally");
 }
 
+void TestInactiveDescriptorPhiEdgeCase(bool negate_condition) {
+  Fixture fixture;
+  auto *inactive = fixture.block;
+  auto *live = fixture.AddBlock();
+  auto *merge = fixture.AddBlock();
+  auto *resource = fixture.AddBlock();
+  auto *exit = fixture.AddBlock();
+  inactive->AddBranch(merge);
+  live->AddBranch(merge);
+  merge->AddBranch(resource);
+  merge->AddBranch(exit);
+
+  const auto inactive_word = fixture.UserData(0);
+  const auto live_word = fixture.Emit(
+      ValueOpcode::GetUserData, {Value(static_cast<ScalarReg>(1))}, 0, live);
+  auto &condition = merge->AppendNewInst(ValueOpcode::Phi, {},
+                                         static_cast<uint64_t>(Type::U1));
+  condition.AddPhiOperand(inactive, Value(false));
+  condition.AddPhiOperand(live, Value(true));
+  const auto branch_condition =
+      negate_condition
+          ? fixture.Emit(ValueOpcode::LogicalNot, {Value(&condition)}, 0, merge)
+          : Value(&condition);
+  auto &descriptor_word = merge->AppendNewInst(
+      ValueOpcode::Phi, {}, static_cast<uint64_t>(Type::U32));
+  descriptor_word.AddPhiOperand(inactive, inactive_word);
+  descriptor_word.AddPhiOperand(live, live_word);
+
+  const auto merge_index = static_cast<size_t>(
+      std::ranges::find(fixture.program.blocks, merge) -
+      fixture.program.blocks.begin());
+  const auto resource_index = static_cast<size_t>(
+      std::ranges::find(fixture.program.blocks, resource) -
+      fixture.program.blocks.begin());
+  auto &merge_info = fixture.program.block_info[merge_index];
+  merge_info.terminator.kind = CFG::TerminatorKind::ConditionalBranch;
+  const auto resource_id = fixture.program.block_info[resource_index].id;
+  const auto exit_id = fixture.program.block_info.back().id;
+  merge_info.terminator.true_block = negate_condition ? exit_id : resource_id;
+  merge_info.terminator.false_block = negate_condition ? resource_id : exit_id;
+  merge_info.condition = branch_condition;
+
+  const auto handle = fixture.Emit(
+      ValueOpcode::GetBufferResource,
+      {Value(&descriptor_word), Value(0u), Value(64u), Value(0u)},
+      MemoryFlags{0, 24}, resource);
+  MemoryInfo memory;
+  memory.kind = ResourceKind::Buffer;
+  fixture.Emit(ValueOpcode::LoadBufferU32,
+               {handle, Value(0u), Value(0u), Value(0u), Value(true)},
+               fixture.AddMemory(memory, 24), resource);
+  fixture.PlanAndTrack();
+
+  Check(fixture.program.info.buffers.size() == 1u,
+        "inactive descriptor Phi produced an unexpected buffer count");
+  const auto source = fixture.program.info.buffers[0].source;
+  Check(source < fixture.program.descriptor_sources.size() &&
+            fixture.program.descriptor_sources[source].dwords[0].Resolve() ==
+                live_word.Resolve(),
+        "inactive descriptor Phi input was not removed");
+  std::array<uint32_t, 2> user_data{0xdeadbeefu, 0x12345678u};
+  SrtRuntime runtime{.user_data = user_data};
+  DescriptorValue descriptor;
+  std::string error;
+  Check(EvaluateDescriptorSource(fixture.program,
+                                 source, 24, runtime, descriptor, &error) &&
+            descriptor.dwords[0] == user_data[1],
+        "descriptor source retained the input from the unreachable edge");
+}
+
+void TestInactiveDescriptorPhiEdge() {
+  TestInactiveDescriptorPhiEdgeCase(false);
+  TestInactiveDescriptorPhiEdgeCase(true);
+}
+
 void TestLoopCycleEnteredThroughRuntimeValue() {
   Fixture fixture;
   auto *entry = fixture.block;
@@ -1378,6 +1454,7 @@ int main() {
     Run("SRT runtime", TestSrtFlatteningAndRuntimeMemoization);
     Run("dynamic SRT", TestDynamicSrtReadRemainsExplicit);
     Run("phi validation", TestPhiValidation);
+    Run("inactive descriptor Phi edge", TestInactiveDescriptorPhiEdge);
     Run("runtime-rooted loop", TestLoopCycleEnteredThroughRuntimeValue);
     Run("invariant loop phi", TestInvariantLoopPhi);
     Run("DMA address materialization", TestDmaAddressMaterialization);


### PR DESCRIPTION
## Summary

- Discard descriptor Phi inputs only when the merge condition proves their incoming edge selects the other successor.
- Preserve the original Phi unless the resource use is in an immediate conditional successor and every remaining reachable input is equivalent.
- Support direct and logically-negated boolean merge conditions.

## Safety boundary

This does not collapse zero-valued or otherwise ambiguous Phi inputs. Missing CFG evidence always falls back to the existing validation path.

## Validation

- Built resource_tracking_tests and kyty_emulator with clang-cl Release.
- CTest resource_tracking: 1/1 passed.
- Added true-branch, false-branch, and LogicalNot regression coverage.

Adapted from the isolated control-flow improvement in KytyTouche commit 640d02e; GodsWill is credited as co-author.