### PR TITLE
graphics: make Vulkan present mode configurable

### DIFF
--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -37,6 +37,10 @@ bool FullscreenEnabled() {
 	return g_config->fullscreen_enabled;
 }
 
+PresentMode GetPresentMode() {
+	return g_config->present_mode;
+}
+
 uint32_t GetVblankFrequency() {
 	return std::clamp(g_config->vblank_frequency, 30u, 360u);
 }

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -26,6 +26,8 @@ enum class ProfilerDirection { None, Network };
 
 enum class OutputDirection { Silent, Console, File };
 
+enum class PresentMode { Fifo, Mailbox, FifoRelaxed, Immediate };
+
 using Keymap = std::vector<std::string>;
 
 constexpr uint32_t DEFAULT_CONSOLE_LANGUAGE = 1;
@@ -35,6 +37,7 @@ struct ConfigOptions {
 	uint32_t               screen_width                = 1280;
 	uint32_t               screen_height               = 720;
 	bool                   fullscreen_enabled          = false;
+	PresentMode            present_mode                = PresentMode::Fifo;
 	uint32_t               vblank_frequency            = 60;
 	uint32_t               console_language            = DEFAULT_CONSOLE_LANGUAGE;
 	bool                   vulkan_validation_enabled   = false;
@@ -61,12 +64,13 @@ struct ConfigOptions {
 
 void Load(const ConfigOptions& cfg);
 
-uint32_t GetScreenWidth();
-uint32_t GetScreenHeight();
-bool     FullscreenEnabled();
-uint32_t GetVblankFrequency();
-uint32_t GetConsoleLanguage();
-bool     VulkanValidationEnabled();
+uint32_t    GetScreenWidth();
+uint32_t    GetScreenHeight();
+bool        FullscreenEnabled();
+PresentMode GetPresentMode();
+uint32_t    GetVblankFrequency();
+uint32_t    GetConsoleLanguage();
+bool        VulkanValidationEnabled();
 
 bool                   ShaderValidationEnabled();
 ShaderOptimizationType GetShaderOptimizationType();

--- a/src/graphics/presentation/window/swapchain.cpp
+++ b/src/graphics/presentation/window/swapchain.cpp
@@ -57,6 +57,32 @@
 
 namespace Libs::Graphics {
 
+static vk::PresentModeKHR RequestedPresentMode() {
+	switch (Config::GetPresentMode()) {
+		case Config::PresentMode::Fifo: return vk::PresentModeKHR::eFifo;
+		case Config::PresentMode::Mailbox: return vk::PresentModeKHR::eMailbox;
+		case Config::PresentMode::FifoRelaxed: return vk::PresentModeKHR::eFifoRelaxed;
+		case Config::PresentMode::Immediate: return vk::PresentModeKHR::eImmediate;
+	}
+	return vk::PresentModeKHR::eFifo;
+}
+
+static vk::PresentModeKHR SelectPresentMode(const SurfaceCapabilities& surface) {
+	EXIT_IF(surface.present_modes.empty());
+	const auto requested = RequestedPresentMode();
+	if (std::ranges::find(surface.present_modes, requested) != surface.present_modes.end()) {
+		return requested;
+	}
+	// FIFO is required by VK_KHR_surface. Keep the first reported mode as a defensive fallback for
+	// non-conforming drivers so vkCreateSwapchainKHR still receives a supported value.
+	const auto fifo = std::ranges::find(surface.present_modes, vk::PresentModeKHR::eFifo);
+	const auto fallback =
+	    fifo != surface.present_modes.end() ? *fifo : surface.present_modes.front();
+	LOGF("Requested Vulkan present mode %s is unavailable; falling back to %s\n",
+	     vk::to_string(requested).c_str(), vk::to_string(fallback).c_str());
+	return fallback;
+}
+
 struct Presenter::Frame {
 	VulkanImage image;
 	uint64_t    present_tick = 0;
@@ -426,6 +452,7 @@ void Swapchain::Create() {
 	    surface.capabilities.supportedCompositeAlpha & vk::CompositeAlphaFlagBitsKHR::eOpaque
 	        ? vk::CompositeAlphaFlagBitsKHR::eOpaque
 	        : vk::CompositeAlphaFlagBitsKHR::eInherit;
+	const auto present_mode = SelectPresentMode(surface);
 
 	vk::SurfaceFormatKHR format {vk::Format::eR8G8B8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear};
 	if (surface.formats.size() != 1 || surface.formats.front().format != vk::Format::eUndefined) {
@@ -459,8 +486,9 @@ void Swapchain::Create() {
 	create_info.imageSharingMode = vk::SharingMode::eExclusive;
 	create_info.preTransform     = transform;
 	create_info.compositeAlpha   = composite;
-	create_info.presentMode      = vk::PresentModeKHR::eFifo;
+	create_info.presentMode      = present_mode;
 	create_info.clipped          = VK_TRUE;
+	LOGF("Vulkan swapchain present mode: %s\n", vk::to_string(present_mode).c_str());
 	RequireVulkanSuccess(graphics.device.createSwapchainKHR(&create_info, nullptr, &m_handle),
 	                     "vkCreateSwapchainKHR");
 	EXIT_IF(m_handle == nullptr);

--- a/src/launcher/forms/configuration_edit_dialog.ui
+++ b/src/launcher/forms/configuration_edit_dialog.ui
@@ -116,13 +116,27 @@
        </widget>
       </item>
       <item row="2" column="0">
+       <widget class="QLabel" name="label_present_mode">
+        <property name="text">
+         <string>Present mode:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="comboBox_present_mode">
+        <property name="toolTip">
+         <string>FIFO avoids tearing; Mailbox reduces latency; Immediate may tear</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
        <widget class="QLabel" name="label_vblank_frequency">
         <property name="text">
          <string>Vblank frequency:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QSpinBox" name="spinBox_vblank_frequency">
         <property name="toolTip">
          <string>Virtual display refresh rate used for frame pacing</string>
@@ -138,56 +152,56 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_console_language">
         <property name="text">
          <string>Console language:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QComboBox" name="comboBox_console_language">
         <property name="toolTip">
          <string>Language</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="label_20">
         <property name="text">
          <string>Shader optimization type:</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QComboBox" name="comboBox_shader_optimization_type">
         <property name="toolTip">
          <string>Optimize shaders for code size or performance</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="label_21">
         <property name="text">
          <string>Shader log direction:</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <widget class="QComboBox" name="comboBox_shader_log_direction">
         <property name="toolTip">
          <string>Dump shaders to file or console window. If enabled may decrease emulator performance</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_22">
         <property name="text">
          <string>Shader log folder:</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="MandatoryLineEdit" name="lineEdit_shader_log_folder">
         <property name="toolTip">
          <string>Specify directory to dump shaders</string>
@@ -197,14 +211,14 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="label_24">
         <property name="text">
          <string>Command buffer dump folder:</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="8" column="1">
        <widget class="MandatoryLineEdit" name="lineEdit_cmd_dump_folder">
         <property name="toolTip">
          <string>Specify directory to dump command buffers</string>
@@ -214,28 +228,28 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="9" column="0">
        <widget class="QLabel" name="label_25">
         <property name="text">
          <string>Printf direction:</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="1">
+      <item row="9" column="1">
        <widget class="QComboBox" name="comboBox_printf_direction">
         <property name="toolTip">
          <string>Print logs to file or console window. If enabled may decrease emulator performance</string>
         </property>
        </widget>
       </item>
-      <item row="9" column="0">
+      <item row="10" column="0">
        <widget class="QLabel" name="label_26">
         <property name="text">
          <string>Printf output file:</string>
         </property>
        </widget>
       </item>
-      <item row="9" column="1">
+      <item row="10" column="1">
        <widget class="MandatoryLineEdit" name="lineEdit_printf_file">
         <property name="toolTip">
          <string>Specify file to dump logs</string>
@@ -245,14 +259,14 @@
         </property>
        </widget>
       </item>
-      <item row="10" column="0">
+      <item row="11" column="0">
        <widget class="QLabel" name="label_27">
         <property name="text">
          <string>Profiler direction:</string>
         </property>
        </widget>
       </item>
-      <item row="10" column="1">
+      <item row="11" column="1">
        <widget class="QComboBox" name="comboBox_profiler_direction">
         <property name="toolTip">
          <string>Enable or disable profiler. If enabled may decrease emulator performance</string>

--- a/src/launcher/include/configuration.h
+++ b/src/launcher/include/configuration.h
@@ -60,6 +60,9 @@ public:
 	enum class ShaderOptimizationType { None, Size, Performance };
 	Q_ENUM(ShaderOptimizationType)
 
+	enum class PresentMode { Fifo, Mailbox, FifoRelaxed, Immediate };
+	Q_ENUM(PresentMode)
+
 	enum class ShaderLogDirection { Silent, Console, File };
 	Q_ENUM(ShaderLogDirection)
 
@@ -86,6 +89,7 @@ public:
 
 	Resolution             screen_resolution           = Resolution::R1280X720;
 	bool                   fullscreen_enabled          = false;
+	PresentMode            present_mode                = PresentMode::Fifo;
 	int                    vblank_frequency            = 60;
 	int                    console_language            = DEFAULT_CONSOLE_LANGUAGE;
 	bool                   vulkan_validation_enabled   = false;
@@ -109,6 +113,7 @@ public:
 	void CopyEmulatorSettingsFrom(const Configuration& other) {
 		screen_resolution           = other.screen_resolution;
 		fullscreen_enabled          = other.fullscreen_enabled;
+		present_mode                = other.present_mode;
 		vblank_frequency            = other.vblank_frequency;
 		console_language            = other.console_language;
 		vulkan_validation_enabled   = other.vulkan_validation_enabled;
@@ -149,6 +154,7 @@ public:
 		KYTY_CFG_SET(custom_settings);
 		KYTY_CFG_SET(screen_resolution);
 		KYTY_CFG_SET(fullscreen_enabled);
+		KYTY_CFG_SET(present_mode);
 		KYTY_CFG_SET(vblank_frequency);
 		KYTY_CFG_SET(console_language);
 		KYTY_CFG_SET(vulkan_validation_enabled);
@@ -176,6 +182,7 @@ public:
 		KYTY_CFG_GET(custom_settings);
 		KYTY_CFG_GET(screen_resolution);
 		KYTY_CFG_GET(fullscreen_enabled);
+		KYTY_CFG_GET(present_mode);
 		vblank_frequency = s->value("vblank_frequency", vblank_frequency).toInt();
 		console_language = s->value("console_language", console_language).toInt();
 		if (console_language < 0 || console_language > MAX_CONSOLE_LANGUAGE) {

--- a/src/launcher/src/configurationEditDialog.cpp
+++ b/src/launcher/src/configurationEditDialog.cpp
@@ -154,6 +154,7 @@ static void ListInit(QComboBox* combo, T value) {
 void ConfigurationEditDialog::Init(const Configuration& info) {
 	ListInit(m_ui->comboBox_screen_resolution, info.screen_resolution);
 	m_ui->checkBox_fullscreen->setChecked(info.fullscreen_enabled);
+	ListInit(m_ui->comboBox_present_mode, info.present_mode);
 	m_ui->spinBox_vblank_frequency->setValue(info.vblank_frequency);
 	m_ui->comboBox_console_language->clear();
 	m_ui->comboBox_console_language->addItems(CONSOLE_LANGUAGE_NAMES);
@@ -286,6 +287,8 @@ static void UpdateInfo(Configuration& info, Ui::ConfigurationEditDialog& ui) {
 	info.screen_resolution =
 	    TextToEnum<Configuration::Resolution>(ui.comboBox_screen_resolution->currentText());
 	info.fullscreen_enabled        = ui.checkBox_fullscreen->isChecked();
+	info.present_mode =
+	    TextToEnum<Configuration::PresentMode>(ui.comboBox_present_mode->currentText());
 	info.vblank_frequency          = ui.spinBox_vblank_frequency->value();
 	info.console_language          = ui.comboBox_console_language->currentIndex();
 	info.vulkan_validation_enabled = ui.checkBox_vulkan_validation->isChecked();

--- a/src/launcher/src/mainDialog.cpp
+++ b/src/launcher/src/mainDialog.cpp
@@ -207,6 +207,7 @@ static QStringList CreateEmulatorArgs(const Configuration& info) {
 	if (info.fullscreen_enabled) {
 		args << "--fullscreen";
 	}
+	args << "--present-mode" << EnumToText(info.present_mode);
 	args << "--vblank-frequency" << QString::number(info.vblank_frequency);
 	args << "--console-language" << QString::number(info.console_language);
 	args << "--vulkan-validation" << BoolArg(info.vulkan_validation_enabled);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ static void PrintUsage() {
 	::printf("  --screen-width <num>                 Window width. Default: 1280.\n");
 	::printf("  --screen-height <num>                Window height. Default: 720.\n");
 	::printf("  --fullscreen                         Run in borderless desktop fullscreen.\n");
+	::printf("  --present-mode <value>               Fifo, Mailbox, FifoRelaxed, or Immediate.\n");
 	::printf("  --vblank-frequency <num>             Virtual vblank frequency. Default: 60.\n");
 	::printf("  --console-language <0-29>            Console language. Default: 1 (English US).\n");
 	::printf("  --vulkan-validation <true|false>     Enable Vulkan validation.\n");
@@ -201,6 +202,11 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 			options.config.screen_width = static_cast<uint32_t>(Common::ToInt32(value));
 		} else if (arg == "--screen-height") {
 			options.config.screen_height = static_cast<uint32_t>(Common::ToInt32(value));
+		} else if (arg == "--present-mode") {
+			if (!ParseEnum(value, options.config.present_mode)) {
+				::printf("invalid present mode: %s\n", value.c_str());
+				return false;
+			}
 		} else if (arg == "--vblank-frequency") {
 			const int32_t vblank_frequency = Common::ToInt32(value);
 			options.config.vblank_frequency =


### PR DESCRIPTION
## Summary

- Add FIFO, Mailbox, FIFO-relaxed, and Immediate modes to the emulator CLI and launcher settings.
- Persist the launcher choice and pass it to the emulator.
- Select a requested mode only when the active Vulkan surface reports it.

## Fallback and compatibility

Unavailable modes fall back to FIFO. Vulkan requires surfaces to support FIFO: https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_swapchain.html. A defensive fallback to the first reported mode also avoids passing an unsupported value if a driver is non-conforming.

## Validation

- Built kyty_emulator and launcher with clang-cl Release.
- Launcher UIC generation and XML parsing passed.
- CLI accepted Mailbox with exit code 0 under --help.
- CLI rejected an unknown mode with exit code 1.

## Scope

This PR changes only presentation selection. Pipeline caching and unrelated performance instrumentation from the source commit are intentionally excluded because active PRs already cover those areas.

Adapted from KytyTouche commit a9bac98; GodsWill is credited as co-author.