### PR TITLE
shader: support sampled 16-bit SINT textures

### DIFF
--- a/src/graphics/guest_gpu/gpu_format.cpp
+++ b/src/graphics/guest_gpu/gpu_format.cpp
@@ -24,12 +24,12 @@ constexpr FormatInfo kFormatInfo[] = {
 	{BufferFormat::k16UNorm, 2, 0, 2, true, false},
 	{BufferFormat::k16SNorm, 2, 0, 2, true, false},
 	{BufferFormat::k16UInt, 2, 0, 2, true, true},
-	{BufferFormat::k16SInt, 2, 0, 2, false, false},
+	{BufferFormat::k16SInt, 2, 0, 2, true, false},
 	{BufferFormat::k16Float, 2, 0, 2, true, false},
 	{BufferFormat::k8_8UNorm, 2, 0, 2, true, false},
 	{BufferFormat::k8_8SNorm, 2, 0, 2, true, false},
 	{BufferFormat::k8_8UInt, 2, 0, 2, true, true},
-	{BufferFormat::k8_8SInt, 2, 0, 2, false, false},
+	{BufferFormat::k8_8SInt, 2, 0, 2, true, false},
 	{BufferFormat::k32UInt, 4, 0, 4, true, true},
 	{BufferFormat::k32SInt, 4, 0, 4, false, false},
 	{BufferFormat::k32Float, 4, 0, 4, true, false},
@@ -211,6 +211,10 @@ bool IsSampledTextureFormat(BufferFormat format) {
 	return info != nullptr && info->sampled_texture;
 }
 
+bool IsSampledSintTextureFormat(BufferFormat format) {
+	return format == BufferFormat::k16SInt || format == BufferFormat::k8_8SInt;
+}
+
 bool IsUintTextureFormat(BufferFormat format) {
 	const auto* info = FindFormatInfo(format);
 	return info != nullptr && info->uint_texture;
@@ -218,6 +222,15 @@ bool IsUintTextureFormat(BufferFormat format) {
 
 BufferFormat RemapTextureFormat(BufferFormat format) {
 	return format == BufferFormat::k11_11_10UInt ? BufferFormat::k32UInt : format;
+}
+
+BufferFormat RemapSampledTextureFormat(BufferFormat format) {
+	// Vulkan image types cannot change their numeric class after creation. Read the two supported
+	// 16-bit SINT layouts through one UINT word and restore each signed component in the shader.
+	if (IsSampledSintTextureFormat(format)) {
+		return BufferFormat::k16UInt;
+	}
+	return RemapTextureFormat(format);
 }
 
 } // namespace Libs::Graphics::Prospero

--- a/src/graphics/guest_gpu/gpu_format.h
+++ b/src/graphics/guest_gpu/gpu_format.h
@@ -43,8 +43,10 @@ uint32_t                   BlockCompressedBytesPerBlock(BufferFormat format);
 uint32_t                   RenderTargetBytesPerElement(BufferFormat format);
 bool                       IsFmaskTextureFormat(BufferFormat format);
 bool                       IsSampledTextureFormat(BufferFormat format);
+bool                       IsSampledSintTextureFormat(BufferFormat format);
 bool                       IsUintTextureFormat(BufferFormat format);
 BufferFormat               RemapTextureFormat(BufferFormat format);
+BufferFormat               RemapSampledTextureFormat(BufferFormat format);
 
 } // namespace Libs::Graphics::Prospero
 

--- a/src/graphics/host_gpu/renderer/image/textureCommon.cpp
+++ b/src/graphics/host_gpu/renderer/image/textureCommon.cpp
@@ -119,8 +119,9 @@ vk::ComponentMapping TextureGetComponentMapping(uint32_t swizzle) {
 	return components;
 }
 
-SurfaceFormatInfo TextureGetSurfaceFormatInfo(Prospero::BufferFormat format) {
-	const auto backing_format    = Prospero::RemapTextureFormat(format);
+SurfaceFormatInfo TextureGetSurfaceFormatInfo(Prospero::BufferFormat format, bool sampled) {
+	const auto backing_format = sampled ? Prospero::RemapSampledTextureFormat(format)
+	                                    : Prospero::RemapTextureFormat(format);
 	const auto vk_format         = VulkanFormat(backing_format);
 	const auto conversion_format =
 	    backing_format != format ? format : Prospero::BufferFormat::kInvalid;

--- a/src/graphics/host_gpu/renderer/image/textureCommon.h
+++ b/src/graphics/host_gpu/renderer/image/textureCommon.h
@@ -43,8 +43,9 @@ struct TextureUploadLayout {
 	TextureUploadMipLayout mips[16] = {};
 };
 
-vk::ComponentMapping   TextureGetComponentMapping(uint32_t swizzle);
-SurfaceFormatInfo      TextureGetSurfaceFormatInfo(Prospero::BufferFormat format);
+vk::ComponentMapping TextureGetComponentMapping(uint32_t swizzle);
+SurfaceFormatInfo    TextureGetSurfaceFormatInfo(Prospero::BufferFormat format,
+                                                 bool sampled = false);
 RenderTargetFormatInfo TextureGetRenderTargetFormat(Prospero::ChannelLayout layout,
                                                     Prospero::ChannelType   type,
                                                     Prospero::ChannelOrder  order);

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -513,7 +513,8 @@ void ValidateStorageTexture(const ShaderRecompiler::IR::ImageResource& resource,
 	const bool raw_sint_storage = format == Prospero::BufferFormat::k32SInt && uint_resource &&
 	                              resource.written && !resource.read && !resource.atomic;
 	const bool format_ok =
-	    raw_sint_storage || (Prospero::IsSampledTextureFormat(format) &&
+	    raw_sint_storage || (!Prospero::IsSampledSintTextureFormat(format) &&
+	                         Prospero::IsSampledTextureFormat(format) &&
 	                         uint_resource == Prospero::IsUintTextureFormat(format) &&
 	                         (!resource.atomic || format == Prospero::BufferFormat::k32UInt));
 	if (resource_ok && descriptor_ok && encoding_ok && format_ok && size != 0) {
@@ -733,13 +734,15 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	    multisampled ? 1u : static_cast<uint32_t>(view_last_level - base_level) + 1u;
 	const auto depth          = static_cast<uint32_t>(descriptor.Depth()) + 1u;
 	const auto format         = descriptor.Format();
-	const auto surface_format = TextureGetSurfaceFormatInfo(format);
+	const auto surface_format = TextureGetSurfaceFormatInfo(format, !storage);
 	const bool shader_conversion =
 	    surface_format.conversion_format != Prospero::BufferFormat::kInvalid;
+	const bool sampled_uint_class =
+	    Prospero::IsUintTextureFormat(format) || Prospero::IsSampledSintTextureFormat(format);
 	const bool sampled_numeric_class =
 	    storage || (Prospero::IsSampledTextureFormat(format) &&
 	                (resource.kind == ShaderRecompiler::IR::ResourceKind::ImageUint) ==
-	                    Prospero::IsUintTextureFormat(format));
+	                    sampled_uint_class);
 	if (!storage &&
 	    (resource.kind == ShaderRecompiler::IR::ResourceKind::Image ||
 	     resource.kind == ShaderRecompiler::IR::ResourceKind::ImageUint) &&

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
@@ -363,12 +363,18 @@ Format::BufferFormatInfo ImageConversionFormat(const EmitterState&   state,
 	const auto format = state.program.info.images[mem.resource].conversion_format;
 	if (format == Prospero::BufferFormat::kInvalid) return {};
 	const auto info = Format::GetFormatInfo(format);
+	const bool packed_uint = Prospero::IsUintTextureFormat(format) &&
+	                         info.type == Format::ComponentType::Uint && info.packed_bitfield &&
+	                         info.byte_size == sizeof(uint32_t) && info.component_count != 0u &&
+	                         info.component_count <= 4u;
+	// Sampled R16_SINT and RG8_SINT share an R16_UINT backing. Signed extraction restores the
+	// guest-visible 32-bit component values without introducing signed Vulkan image descriptors.
+	const bool sint16_word = info.type == Format::ComponentType::Sint &&
+	                         !info.packed_bitfield && info.byte_size == sizeof(uint16_t) &&
+	                         info.component_count != 0u && info.component_count <= 2u;
 	EXIT_IF(!Prospero::IsSampledTextureFormat(format) ||
-	        !Prospero::IsUintTextureFormat(format) ||
-	        Prospero::RemapTextureFormat(format) == format ||
-	        info.type != Format::ComponentType::Uint || !info.packed_bitfield ||
-	        info.byte_size != sizeof(uint32_t) || info.component_count == 0u ||
-	        info.component_count > 4u);
+	        Prospero::RemapSampledTextureFormat(format) == format ||
+	        (!packed_uint && !sint16_word));
 	return info;
 }
 
@@ -382,10 +388,11 @@ uint32_t UnpackImageTexel(ValueEmitContext& ctx, const IR::MemoryInfo& mem, uint
 	                          ConstantU32(ctx.state, 0), ConstantU32(ctx.state, 0)};
 	for (uint32_t component = 0; component < info.component_count; component++) {
 		components[component] = ctx.state.builder.AllocateId();
-		ctx.state.builder.AddFunction({OpBitFieldUExtract, TypeU32(ctx.state),
-		                               components[component], packed,
-		                               ConstantU32(ctx.state, info.component_bit_offset[component]),
-		                               ConstantU32(ctx.state, info.component_bits[component])});
+		ctx.state.builder.AddFunction(
+		    {info.type == Format::ComponentType::Sint ? OpBitFieldSExtract : OpBitFieldUExtract,
+		     TypeU32(ctx.state), components[component], packed,
+		     ConstantU32(ctx.state, info.component_bit_offset[component]),
+		     ConstantU32(ctx.state, info.component_bits[component])});
 	}
 	for (uint32_t component = info.component_count; component < 4u; component++) {
 		components[component] = components[component % info.component_count];
@@ -429,9 +436,11 @@ uint32_t UnpackImageGather(ValueEmitContext& ctx, const IR::MemoryInfo& mem, uin
 		    {OpCompositeExtract, TypeU32(ctx.state), packed, gathered, lane});
 		values[lane]        = ctx.state.builder.AllocateId();
 		const auto physical = (selector - 4u) % info.component_count;
-		ctx.state.builder.AddFunction({OpBitFieldUExtract, TypeU32(ctx.state), values[lane], packed,
-		                               ConstantU32(ctx.state, info.component_bit_offset[physical]),
-		                               ConstantU32(ctx.state, info.component_bits[physical])});
+		ctx.state.builder.AddFunction(
+		    {info.type == Format::ComponentType::Sint ? OpBitFieldSExtract : OpBitFieldUExtract,
+		     TypeU32(ctx.state), values[lane], packed,
+		     ConstantU32(ctx.state, info.component_bit_offset[physical]),
+		     ConstantU32(ctx.state, info.component_bits[physical])});
 	}
 	const auto result = ctx.state.builder.AllocateId();
 	ctx.state.builder.AddFunction({OpCompositeConstruct, TypeU32Vector(ctx.state, 4), result,

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -77,9 +77,10 @@ uint32_t DescriptorImageSwizzle(const DescriptorValue& descriptor) {
 	return descriptor.dwords[3] & 0xfffu;
 }
 
-Prospero::BufferFormat ImageConversionFormat(Prospero::BufferFormat format) {
-	return Prospero::RemapTextureFormat(format) != format ? format
-	                                                     : Prospero::BufferFormat::kInvalid;
+Prospero::BufferFormat ImageConversionFormat(Prospero::BufferFormat format, bool storage) {
+	const auto backing_format = storage ? Prospero::RemapTextureFormat(format)
+	                                    : Prospero::RemapSampledTextureFormat(format);
+	return backing_format != format ? format : Prospero::BufferFormat::kInvalid;
 }
 
 bool DescriptorIsCube(const DescriptorValue& descriptor) {
@@ -470,7 +471,7 @@ bool ValidateResourceSpecialization(const Program& program, const ResourceSnapsh
 				}
 				return false;
 			}
-			const auto conversion_format = ImageConversionFormat(format);
+			const auto conversion_format = ImageConversionFormat(format, storage);
 			if (image.conversion_format != conversion_format) {
 				if (error != nullptr) {
 					*error = fmt::format("image descriptor {} changed format conversion", i);
@@ -487,8 +488,9 @@ bool ValidateResourceSpecialization(const Program& program, const ResourceSnapsh
 			const bool raw_sint_storage =
 			    storage && format == Prospero::BufferFormat::k32SInt && image.written &&
 			    !image.read && !image.atomic;
+			const bool sampled_sint = !storage && Prospero::IsSampledSintTextureFormat(format);
 			const bool uint_descriptor =
-			    Prospero::IsUintTextureFormat(format) || raw_sint_storage;
+			    Prospero::IsUintTextureFormat(format) || sampled_sint || raw_sint_storage;
 			const auto uint_program = image.kind == ResourceKind::ImageUint ||
 			                          image.kind == ResourceKind::StorageImageUint;
 			if (uint_descriptor != uint_program && !(image.atomic && uint_program)) {
@@ -779,13 +781,15 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 		}
 		const bool storage = image.kind == ResourceKind::StorageImage ||
 		                     image.kind == ResourceKind::StorageImageUint;
-		image.conversion_format = ImageConversionFormat(format);
+		image.conversion_format = ImageConversionFormat(format, storage);
 		if (storage || image.conversion_format != Prospero::BufferFormat::kInvalid) {
 			image.shader_swizzle = DescriptorImageSwizzle(descriptor);
 		}
 		const bool raw_sint_storage = storage && format == Prospero::BufferFormat::k32SInt &&
 		                              image.written && !image.read && !image.atomic;
-		const bool uint_image = Prospero::IsUintTextureFormat(format) || raw_sint_storage;
+		const bool sampled_sint = !storage && Prospero::IsSampledSintTextureFormat(format);
+		const bool uint_image =
+		    Prospero::IsUintTextureFormat(format) || sampled_sint || raw_sint_storage;
 		if (uint_image) {
 			switch (image.kind) {
 				case ResourceKind::Image: image.kind = ResourceKind::ImageUint; break;

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -10620,6 +10620,49 @@ public:
                   storage_only_surface.conversion_format ==
                       Prospero::BufferFormat::kInvalid,
               "storage-only native backing was conflated with sampled support");
+
+      constexpr auto sampled_sint_format = Prospero::BufferFormat::k16SInt;
+      const auto sampled_sint_surface =
+          TextureGetSurfaceFormatInfo(sampled_sint_format, true);
+      const auto storage_sint_surface =
+          TextureGetSurfaceFormatInfo(sampled_sint_format);
+      Require(name, "R16 SINT sampled conversion",
+              Prospero::IsSampledTextureFormat(sampled_sint_format) &&
+                  Prospero::IsSampledSintTextureFormat(sampled_sint_format) &&
+                  !Prospero::IsUintTextureFormat(sampled_sint_format) &&
+                  Prospero::RemapTextureFormat(sampled_sint_format) ==
+                      sampled_sint_format &&
+                  Prospero::RemapSampledTextureFormat(sampled_sint_format) ==
+                      Prospero::BufferFormat::k16UInt &&
+                  sampled_sint_surface.vk_format == vk::Format::eR16Uint &&
+                  sampled_sint_surface.conversion_format ==
+                      sampled_sint_format &&
+                  storage_sint_surface.vk_format == vk::Format::eR16Sint &&
+                  storage_sint_surface.conversion_format ==
+                      Prospero::BufferFormat::kInvalid,
+              "R16 SINT sampled conversion changed storage semantics");
+
+      constexpr auto sampled_rg8_sint_format = Prospero::BufferFormat::k8_8SInt;
+      const auto sampled_rg8_sint_surface =
+          TextureGetSurfaceFormatInfo(sampled_rg8_sint_format, true);
+      const auto storage_rg8_sint_surface =
+          TextureGetSurfaceFormatInfo(sampled_rg8_sint_format);
+      Require(
+          name, "RG8 SINT sampled conversion",
+          Prospero::IsSampledTextureFormat(sampled_rg8_sint_format) &&
+              Prospero::IsSampledSintTextureFormat(sampled_rg8_sint_format) &&
+              !Prospero::IsUintTextureFormat(sampled_rg8_sint_format) &&
+              Prospero::RemapTextureFormat(sampled_rg8_sint_format) ==
+                  sampled_rg8_sint_format &&
+              Prospero::RemapSampledTextureFormat(sampled_rg8_sint_format) ==
+                  Prospero::BufferFormat::k16UInt &&
+              sampled_rg8_sint_surface.vk_format == vk::Format::eR16Uint &&
+              sampled_rg8_sint_surface.conversion_format ==
+                  sampled_rg8_sint_format &&
+              storage_rg8_sint_surface.vk_format == vk::Format::eR8G8Sint &&
+              storage_rg8_sint_surface.conversion_format ==
+                  Prospero::BufferFormat::kInvalid,
+          "RG8 SINT sampled conversion changed storage semantics");
     }
 
     {
@@ -18811,6 +18854,63 @@ TestCase ImageLoadR32UintUsesIntegerSampledImage() {
   return test;
 }
 
+TestCase ImageLoadR16SintSignExtends() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovU32(&code, 20, 2);
+  AppendVMovU32(&code, 21, 1);
+  code.push_back(EncodeMimg0(0x00, 0x1));
+  code.push_back(EncodeMimg1(0, 20));
+  AppendStoreVgpr(&code, 0, 0);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "ImageLoadR16SintSignExtends";
+  test.code = std::move(code);
+  test.expected = {0xffff8001u};
+  test.opcodes = {O::V_MOV_B32, O::IMAGE_LOAD, O::BUFFER_STORE_DWORD,
+                  O::S_ENDPGM};
+  test.sampled_image_rgba.resize(16);
+  test.sampled_image_rgba[3] = 0x00008001u;
+  test.sampled_image_format = vk::Format::eR16Uint;
+  test.sampled_image_dwords_per_pixel = 1;
+  test.user_data = MakeSampledTextureData(Prospero::BufferFormat::k16SInt);
+  test.has_user_data = true;
+  test.required_spirv = {"sampled_uint_2d", "OpTypeImage %uint",
+                         "OpImageFetch %v4uint", "OpBitFieldSExtract"};
+  return test;
+}
+
+TestCase ImageLoadRg8SintSignExtends() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovU32(&code, 20, 2);
+  AppendVMovU32(&code, 21, 1);
+  code.push_back(EncodeMimg0(0x00, 0x3));
+  code.push_back(EncodeMimg1(0, 20));
+  AppendStoreVgpr(&code, 0, 0);
+  AppendStoreVgpr(&code, 1, 1);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "ImageLoadRg8SintSignExtends";
+  test.code = std::move(code);
+  test.expected = {0xffffffffu, 0xffffff80u};
+  test.opcodes = {O::V_MOV_B32, O::IMAGE_LOAD, O::BUFFER_STORE_DWORD,
+                  O::S_ENDPGM};
+  test.sampled_image_rgba.resize(16);
+  test.sampled_image_rgba[3] = 0x000080ffu;
+  test.sampled_image_format = vk::Format::eR16Uint;
+  test.sampled_image_dwords_per_pixel = 1;
+  test.user_data = MakeSampledTextureData(Prospero::BufferFormat::k8_8SInt);
+  test.has_user_data = true;
+  test.required_spirv = {"sampled_uint_2d", "OpTypeImage %uint",
+                         "OpImageFetch %v4uint", "OpBitFieldSExtract"};
+  return test;
+}
+
 TestCase ImageLoadPackedUintUnpacksAndSwizzles() {
   using O = ShaderOpcode;
 
@@ -20531,6 +20631,8 @@ std::vector<TestCase> MakeCases() {
   AddCase(BufferAtomicFMaxContendedWorkgroup);
   AddCase(ImageLoadVariants);
   AddCase(ImageLoadR32UintUsesIntegerSampledImage);
+  AddCase(ImageLoadR16SintSignExtends);
+  AddCase(ImageLoadRg8SintSignExtends);
   AddCase(ImageLoadPackedUintUnpacksAndSwizzles);
   AddCase(ImageSamplePackedUintConvertsSampleAndGather);
   AddCase(ImageLoadR128IgnoresAdjacentMaskSgprs);


### PR DESCRIPTION
## Summary

Add sampled-image support for the guest R16_SINT and RG8_SINT layouts without introducing signed Vulkan image descriptors into the existing unsigned image pipeline.

## Implementation

- classify k16SInt and k8_8SInt as supported sampled formats
- use R16_UINT as the Vulkan backing only for sampled views
- retain the original guest format as shader-conversion metadata
- specialize these descriptors as unsigned images so the generated SPIR-V type matches the Vulkan view
- restore each signed component with OpBitFieldSExtract
- preserve native R16_SINT / R8G8_SINT surface mapping and the previous validation policy for storage images

RG8_SINT is deliberately packed into one 16-bit unsigned word. The shader extracts and sign-extends its two 8-bit lanes after the image read, so byte layout and guest-visible 32-bit results are preserved.

## Tests

- ImageLoadR16SintSignExtends: verifies 