### PR TITLE
shader: accept SDWA for VOP1 bit operations

### DIFF
--- a/src/graphics/shader/recompiler/frontend/decode/VectorAluOps.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/VectorAluOps.cpp
@@ -515,6 +515,8 @@ constexpr Vop1SdwaRule VOP1_SDWA_RULES[] = {
     {Opcode::V_CVT_F32_U32, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
     {Opcode::V_CVT_F32_I32, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
     {Opcode::V_CVT_F32_UBYTE0, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
+    {Opcode::V_NOT_B32, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
+    {Opcode::V_FFBL_B32, SdwaSelBytes() | SdwaSelWords() | SdwaSelFull(), 0, 0, false},
     {Opcode::V_CVT_F32_F16, SdwaSelWords() | SdwaSelFull(), 0, 0, true},
     {Opcode::V_CVT_F16_F32, SdwaSelFull(), SdwaSelWords(), SdwaSelFull(), false},
     {Opcode::V_CVT_F16_U16, SdwaSelWords() | SdwaSelFull(), SdwaSelWords(),

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -13355,6 +13355,52 @@ TestCase VectorIntegerOps() {
            O::S_ENDPGM}};
 }
 
+TestCase Vop1SdwaFfblCapturedHighWordSource() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendBufferLoadDword(&code, 2, 30);
+  code.push_back(0x7e2074f9u);
+  code.push_back(0x00050602u); // v_ffbl_b32 v16, v2.word1
+  AppendStoreVgpr(&code, 16, 0);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "Vop1SdwaFfblCapturedHighWordSource";
+  test.code = std::move(code);
+  test.initial = {0x00400000u};
+  test.expected = {6u};
+  test.opcodes = {O::BUFFER_LOAD_DWORD, O::V_FFBL_B32, O::BUFFER_STORE_DWORD,
+                  O::S_ENDPGM};
+  test.decoded_counts = {{"V_FFBL_B32 v16, v2.sdwa(sel=5,sext=0)", 1}};
+  test.ir_counts = {{" = BitFieldUExtract ", 1}, {" = FindILsb32 ", 1}};
+  test.required_spirv = {"OpBitFieldUExtract"};
+  return test;
+}
+
+TestCase Vop1SdwaNotCapturedByte0Source() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendBufferLoadDword(&code, 2, 30);
+  code.push_back(0x7e046ef9u);
+  code.push_back(0x00000602u); // v_not_b32 v2, v2.byte0
+  AppendStoreVgpr(&code, 2, 0);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "Vop1SdwaNotCapturedByte0Source";
+  test.code = std::move(code);
+  test.initial = {0x12345678u};
+  test.expected = {0xffffff87u};
+  test.opcodes = {O::BUFFER_LOAD_DWORD, O::V_NOT_B32, O::BUFFER_STORE_DWORD,
+                  O::S_ENDPGM};
+  test.decoded_counts = {{"V_NOT_B32 v2, v2.sdwa(sel=0,sext=0)", 1}};
+  test.ir_counts = {{" = BitFieldUExtract ", 1}, {" = BitwiseNot32 ", 1}};
+  test.required_spirv = {"OpBitFieldUExtract", "OpNot"};
+  return test;
+}
+
 TestCase Vop2SdwaSubNcExactByte2Destination() {
   using O = ShaderOpcode;
 
@@ -20350,6 +20396,8 @@ std::vector<TestCase> MakeCases() {
   AddCase(VectorMoves);
   AddCase(VectorVop3MoveAppliesFloatSourceModifiers);
   AddCase(VectorIntegerOps);
+  AddCase(Vop1SdwaFfblCapturedHighWordSource);
+  AddCase(Vop1SdwaNotCapturedByte0Source);
   AddCase(Vop2SdwaSubNcExactByte2Destination);
   AddCase(Vop2SdwaAddNcCapturedHighWordDestination);
   AddCase(Vop2SdwaAshrrevCapturedWord0SignExtends);


### PR DESCRIPTION
## Summary

Accept the documented VOP1 SDWA encoding for V_NOT_B32 and V_FFBL_B32.

Both operations already had decoder, IR, and SPIR-V implementations. They were rejected only because the VOP1 SDWA validation table did not list them.

## Changes

- allow byte, word, and full-dword SDWA source selectors for both operations
- keep source modifiers and partial destinations disabled
- add captured binary regressions for:
  - _ffbl_b32 v16, v2.word1
  - _not_b32 v2, v2.byte0

The tests verify the decoded selector, sub-dword extraction IR, emitted SPIR-V operation, and final GPU result.

## Validation

- ctest -R ^shader_cfg$ --output-on-failure
- ctest -R ^shader_recompiler_compute$ --output-on-failure
- Release builds: shader_recompiler_compute_tests, kyty_emulator

## Scope

Isolated from the compatibility work authored by SueryRD. No unrelated VOP2 rule, ALU lowering, or runtime changes are included.