### PR TITLE
shader: preserve logical lane IDs for compute wave64

### DIFF
--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterFlow.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterFlow.cpp
@@ -106,6 +106,19 @@ uint32_t EmitBuiltinU32(ValueEmitContext& ctx, IR::StageInputKind kind, uint32_t
 	return EmitInputComponentU32(state, kind, component);
 }
 
+uint32_t EmitGuestLaneId(EmitterState& state) {
+	// A guest wave64 may span two host wave32 subgroups. The subgroup builtin restarts at 0 for
+	// the upper half, while the flattened compute invocation index preserves the logical lane.
+	if (state.stage == ShaderType::Compute && state.wave_size == 64u) {
+		const auto local_index = EmitLocalInvocationIndex(state);
+		const auto lane        = state.builder.AllocateId();
+		state.builder.AddFunction({OpBitwiseAnd, TypeU32(state), lane, local_index,
+		                           ConstantU32(state, 63)});
+		return lane;
+	}
+	return EmitSubgroupLocalInvocationId(state);
+}
+
 uint32_t EmitWqm(ValueEmitContext& ctx, uint32_t active) {
 	auto&      state  = ctx.state;
 	const auto ballot = state.builder.AllocateId();
@@ -554,7 +567,7 @@ bool EmitValueFlow(ValueEmitContext& ctx, const IR::Inst& inst) {
 			ctx.Define(inst, EmitWqm(ctx, ctx.Arg(inst, 0)));
 			return true;
 		case IR::ValueOpcode::LaneId:
-			ctx.Define(inst, EmitSubgroupLocalInvocationId(state));
+			ctx.Define(inst, EmitGuestLaneId(state));
 			return true;
 		case IR::ValueOpcode::Ballot:
 			ctx.Emit(inst, OpGroupNonUniformBallot, IR::Type::U32x4,

--- a/src/graphics/shader/recompiler/ir/passes/ShaderInfoCollection.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ShaderInfoCollection.cpp
@@ -212,14 +212,22 @@ void CollectPixelInputs(const Program& program, const ShaderPixelInputInfo* pixe
 	}
 }
 
-void CollectComputeInputs(const ShaderComputeInputInfo* compute, ShaderInfo& info) {
+void CollectComputeInputs(const Program& program, const ShaderComputeInputInfo* compute,
+                          ShaderInfo& info) {
+	const bool uses_lane_id = std::any_of(
+	    program.blocks.begin(), program.blocks.end(), [](const auto* block) {
+		    return std::any_of(block->begin(), block->end(), [](const auto& inst) {
+			    return inst.GetOpcode() == ValueOpcode::LaneId;
+		    });
+	    });
 	if (compute->group_id[0] || compute->group_id[1] || compute->group_id[2]) {
 		AddInput(info, StageInputKind::WorkgroupId, 0, 3, "gl_WorkGroupID");
 	}
 	if (compute->thread_ids_num > 0) {
 		AddInput(info, StageInputKind::LocalInvocationId, 0, 3, "gl_LocalInvocationID");
 	}
-	if (compute->thread_ids_num > 0 || compute->tg_size_en) {
+	if (compute->thread_ids_num > 0 || compute->tg_size_en ||
+	    (program.wave_size == 64u && uses_lane_id)) {
 		AddInput(info, StageInputKind::LocalInvocationIndex, 0, 1, "gl_LocalInvocationIndex");
 	}
 	if (compute->dispatch_thread_dimensions) {
@@ -379,7 +387,7 @@ bool CollectShaderInfo(Program& program, const ShaderInfoOptions& options, std::
 	switch (program.stage) {
 		case ShaderType::Vertex: CollectVertexInputs(program, options.vertex, next); break;
 		case ShaderType::Pixel: CollectPixelInputs(program, options.pixel, next); break;
-		case ShaderType::Compute: CollectComputeInputs(options.compute, next); break;
+		case ShaderType::Compute: CollectComputeInputs(program, options.compute, next); break;
 		default: return false;
 	}
 	CollectBuiltinInputs(program, next);

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -13826,6 +13826,18 @@ TestCase VectorMbcntUsesThreadMask() {
   return test;
 }
 
+TestCase VectorMbcntWave64UsesLogicalLaneId() {
+  auto test = VectorMbcntUsesThreadMask();
+  test.name = "VectorMbcntWave64UsesLogicalLaneId";
+  test.expected.resize(64);
+  std::iota(test.expected.begin(), test.expected.end(), 0u);
+  test.compute_info.threads_num[0] = 64;
+  test.compute_info.wave_size = 64;
+  test.dispatch_x = 1;
+  test.required_spirv = {"BuiltIn LocalInvocationIndex", "OpBitwiseAnd"};
+  return test;
+}
+
 TestCase VectorAddcUsesPerLaneCarryIn() {
   using O = ShaderOpcode;
 
@@ -20365,6 +20377,7 @@ std::vector<TestCase> MakeCases() {
   AddCase(VectorAlignByteUsesFiveBitByteOffset);
   AddCase(VectorCarryAndBitCountOps);
   AddCase(VectorMbcntUsesThreadMask);
+  AddCase(VectorMbcntWave64UsesLogicalLaneId);
   AddCase(VectorAddcWritesPerLaneCarryOut);
   AddCase(VectorAddcUsesPerLaneCarryIn);
   AddCase(VectorSubrevCoCiU32ExactRawOnGpu);


### PR DESCRIPTION
## Summary

Preserve the PS5 logical lane ID for compute wave64 shaders when the Vulkan host executes the guest wave as two wave32 subgroups.

## Problem

LaneId was emitted from SubgroupLocalInvocationId. In the upper host subgroup that value restarts at zero, so V_MBCNT_LO/HI could assign lanes 32-63 the same indices as lanes 0-31.

## Implementation

- for compute wave64, derive the guest lane as LocalInvocationIndex & 63
- keep the subgroup builtin for other stages and wave sizes
- request LocalInvocationIndex only when a compute wave64 program actually contains LaneId
- document why the compute path differs from the generic subgroup path

## Regression

VectorMbcntWave64UsesLogicalLaneId executes 64 invocations and verifies the ordered lane results 