### PR TITLE
shader: make FP16 round-to-even deterministic

### DIFF
--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAlu.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAlu.cpp
@@ -291,7 +291,14 @@ uint32_t EmitF32ToU32(EmitterState& state, uint32_t src, bool signed_value) {
 }
 
 uint32_t EmitPackHalf(EmitterState& state, uint32_t src) {
-	return EmitExt(state, TypeU32(state), GlslPackHalf2x16, {src});
+	const auto low_f32  = state.builder.AllocateId();
+	const auto high_f32 = state.builder.AllocateId();
+	state.builder.AddFunction({OpCompositeExtract, TypeF32(state), low_f32, src, 0});
+	state.builder.AddFunction({OpCompositeExtract, TypeF32(state), high_f32, src, 1});
+	const auto low = EmitF32ToF16RneBits(state, low_f32);
+	const auto high = NewBinary(state, OpShiftLeftLogical, TypeU32(state),
+	                            EmitF32ToF16RneBits(state, high_f32), ConstantU32(state, 16));
+	return NewBinary(state, OpBitwiseOr, TypeU32(state), low, high);
 }
 
 uint32_t EmitUnpackHalf(EmitterState& state, uint32_t bits) {
@@ -334,10 +341,7 @@ bool EmitValueAlu(ValueEmitContext& ctx, const IR::Inst& inst) {
 			         {ctx.Arg(inst, 0), ConstantU32(state, 0xffu)});
 			return true;
 		case IR::ValueOpcode::ConvertF16F32: {
-			const auto pair = state.builder.AllocateId();
-			state.builder.AddFunction({OpCompositeConstruct, TypeF32Vector(state, 2), pair,
-			                           ctx.Arg(inst, 0), ConstantF32(state, 0)});
-			ctx.Define(inst, EmitPackHalf(state, pair));
+			ctx.Define(inst, EmitF32ToF16RneBits(state, ctx.Arg(inst, 0)));
 			return true;
 		}
 		case IR::ValueOpcode::ConvertF32F16:
@@ -383,7 +387,7 @@ bool EmitValueAlu(ValueEmitContext& ctx, const IR::Inst& inst) {
 			         {ctx.Arg(inst, 0), inst.Arg(1).U32()});
 			return true;
 		case IR::ValueOpcode::PackHalf2x16:
-			ctx.Define(inst, EmitExt(state, TypeU32(state), GlslPackHalf2x16, {ctx.Arg(inst, 0)}));
+			ctx.Define(inst, EmitPackHalf(state, ctx.Arg(inst, 0)));
 			return true;
 		case IR::ValueOpcode::PackSnorm2x16:
 			ctx.Define(inst, EmitExt(state, TypeU32(state), GlslPackSnorm2x16, {ctx.Arg(inst, 0)}));

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAluHelpers.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAluHelpers.cpp
@@ -161,6 +161,109 @@ uint32_t EmitF32ToF16RtzBits(EmitterState& state, uint32_t f32) {
 	return EmitAndConstant(state, EmitSelectValueU32(state, exp_eq_255, special, finite2), 0xffffu);
 }
 
+uint32_t EmitF32ToF16RneBits(EmitterState& state, uint32_t f32) {
+	const auto bits = state.builder.AllocateId();
+	state.builder.AddFunction({OpBitcast, TypeU32(state), bits, f32});
+
+	const auto sign = EmitAndConstant(state, EmitShiftRightConstant(state, bits, 16), 0x8000u);
+	const auto exp  = EmitAndConstant(state, EmitShiftRightConstant(state, bits, 23), 0xffu);
+	const auto mant = EmitAndConstant(state, bits, 0x007fffffu);
+
+	// Normal half values. Adding the rounding increment to the combined exponent/mantissa
+	// intentionally carries into the exponent, including the largest finite value rounding to Inf.
+	const auto half_exp       = state.builder.AllocateId();
+	const auto normal_exp     = state.builder.AllocateId();
+	const auto normal_mant    = EmitShiftRightConstant(state, mant, 13);
+	const auto normal_payload = state.builder.AllocateId();
+	state.builder.AddFunction({OpISub, TypeU32(state), half_exp, exp, ConstantU32(state, 112)});
+	state.builder.AddFunction(
+	    {OpShiftLeftLogical, TypeU32(state), normal_exp, half_exp, ConstantU32(state, 10)});
+	state.builder.AddFunction(
+	    {OpBitwiseOr, TypeU32(state), normal_payload, normal_exp, normal_mant});
+
+	const auto normal_remainder = EmitAndConstant(state, mant, 0x1fffu);
+	const auto normal_above =
+	    EmitCompareU32Constant(state, OpUGreaterThan, normal_remainder, 0x1000u);
+	const auto normal_tie =
+	    EmitCompareU32Constant(state, OpIEqual, normal_remainder, 0x1000u);
+	const auto normal_odd = EmitCompareU32Constant(
+	    state, OpINotEqual, EmitAndConstant(state, normal_mant, 1u), 0u);
+	const auto normal_tie_odd = EmitLogicalAndBool(state, normal_tie, normal_odd);
+	const auto normal_round   = EmitLogicalOrBool(state, normal_above, normal_tie_odd);
+	const auto normal_increment =
+	    EmitSelectValueU32(state, normal_round, ConstantU32(state, 1), ConstantU32(state, 0));
+	const auto rounded_normal_payload = state.builder.AllocateId();
+	const auto normal                 = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpIAdd, TypeU32(state), rounded_normal_payload, normal_payload, normal_increment});
+	state.builder.AddFunction(
+	    {OpBitwiseOr, TypeU32(state), normal, sign, rounded_normal_payload});
+
+	// Half subnormals use the hidden F32 bit and a dynamic right shift. Clamp the shift used by
+	// the straight-line SPIR-V so every lane has a valid 1..31 shift count.
+	const auto mant_with_hidden = EmitOrU32(state, mant, ConstantU32(state, 0x00800000u));
+	const auto raw_sub_shift    = EmitSubConstantMinusU32(state, 126, exp);
+	const auto exp_lt_102       = EmitCompareU32Constant(state, OpULessThan, exp, 102);
+	const auto exp_gt_112       = EmitCompareU32Constant(state, OpUGreaterThan, exp, 112);
+	const auto sub_shift_low =
+	    EmitSelectValueU32(state, exp_lt_102, ConstantU32(state, 24), raw_sub_shift);
+	const auto sub_shift =
+	    EmitSelectValueU32(state, exp_gt_112, ConstantU32(state, 14), sub_shift_low);
+	const auto sub_mant = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpShiftRightLogical, TypeU32(state), sub_mant, mant_with_hidden, sub_shift});
+
+	const auto sub_range = state.builder.AllocateId();
+	const auto sub_mask  = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpShiftLeftLogical, TypeU32(state), sub_range, ConstantU32(state, 1), sub_shift});
+	state.builder.AddFunction(
+	    {OpISub, TypeU32(state), sub_mask, sub_range, ConstantU32(state, 1)});
+	const auto sub_remainder = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpBitwiseAnd, TypeU32(state), sub_remainder, mant_with_hidden, sub_mask});
+	const auto sub_half_shift = state.builder.AllocateId();
+	const auto sub_halfway    = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpISub, TypeU32(state), sub_half_shift, sub_shift, ConstantU32(state, 1)});
+	state.builder.AddFunction(
+	    {OpShiftLeftLogical, TypeU32(state), sub_halfway, ConstantU32(state, 1), sub_half_shift});
+	const auto sub_above = state.builder.AllocateId();
+	const auto sub_tie   = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpUGreaterThan, TypeBool(state), sub_above, sub_remainder, sub_halfway});
+	state.builder.AddFunction({OpIEqual, TypeBool(state), sub_tie, sub_remainder, sub_halfway});
+	const auto sub_odd = EmitCompareU32Constant(
+	    state, OpINotEqual, EmitAndConstant(state, sub_mant, 1u), 0u);
+	const auto sub_tie_odd = EmitLogicalAndBool(state, sub_tie, sub_odd);
+	const auto sub_round   = EmitLogicalOrBool(state, sub_above, sub_tie_odd);
+	const auto sub_increment =
+	    EmitSelectValueU32(state, sub_round, ConstantU32(state, 1), ConstantU32(state, 0));
+	const auto rounded_sub_mant = state.builder.AllocateId();
+	const auto subnormal        = state.builder.AllocateId();
+	state.builder.AddFunction(
+	    {OpIAdd, TypeU32(state), rounded_sub_mant, sub_mant, sub_increment});
+	state.builder.AddFunction({OpBitwiseOr, TypeU32(state), subnormal, sign, rounded_sub_mant});
+
+	// Preserve signed zero, map finite overflow to infinity, and retain a quiet NaN payload.
+	const auto nan_payload = EmitAndConstant(
+	    state, EmitOrU32(state, EmitShiftRightConstant(state, mant, 13), ConstantU32(state, 0x0200u)),
+	    0x03ffu);
+	const auto nan =
+	    EmitOrU32(state, sign, EmitOrU32(state, ConstantU32(state, 0x7c00u), nan_payload));
+	const auto inf       = EmitOrU32(state, sign, ConstantU32(state, 0x7c00u));
+	const auto mant_zero = EmitCompareU32Constant(state, OpIEqual, mant, 0);
+	const auto special   = EmitSelectValueU32(state, mant_zero, inf, nan);
+
+	const auto exp_le_112 = EmitCompareU32Constant(state, OpULessThanEqual, exp, 112);
+	const auto exp_ge_143 = EmitCompareU32Constant(state, OpUGreaterThanEqual, exp, 143);
+	const auto exp_eq_255 = EmitCompareU32Constant(state, OpIEqual, exp, 255);
+	const auto finite0    = EmitSelectValueU32(state, exp_le_112, subnormal, normal);
+	const auto finite1    = EmitSelectValueU32(state, exp_lt_102, sign, finite0);
+	const auto finite2    = EmitSelectValueU32(state, exp_ge_143, inf, finite1);
+	return EmitAndConstant(state, EmitSelectValueU32(state, exp_eq_255, special, finite2), 0xffffu);
+}
+
 uint32_t EmitMinMaxU32Value(EmitterState& state, uint32_t lhs, uint32_t rhs, bool max_value) {
 	const auto cond = state.builder.AllocateId();
 	const auto ret  = state.builder.AllocateId();

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
@@ -819,6 +819,8 @@ uint32_t EmitSubConstantMinusU32(EmitterState& state, uint32_t constant, uint32_
 
 uint32_t EmitF32ToF16RtzBits(EmitterState& state, uint32_t f32);
 
+uint32_t EmitF32ToF16RneBits(EmitterState& state, uint32_t f32);
+
 uint32_t EmitMinMaxU32Value(EmitterState& state, uint32_t lhs, uint32_t rhs, bool max_value);
 
 uint32_t EmitMinMaxI32Value(EmitterState& state, uint32_t lhs, uint32_t rhs, bool max_value);

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -14253,6 +14253,38 @@ TestCase PackedMinMaxF16NanAndSignedZeroEdges() {
            O::BUFFER_STORE_DWORD, O::S_ENDPGM}};
 }
 
+TestCase Fp16RoundNearestEvenConversion() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0x3f803000u); // tie: 0x3c01/0x3c02
+  AppendVMovLiteral(&code, 1, 0x33c00000u); // tie: 0x0001/0x0002
+  AppendVMovLiteral(&code, 2, 0x33000000u); // tie: 0x0000/0x0001
+  AppendVMovLiteral(&code, 3, 0xb3c00000u); // negative subnormal tie
+  code.push_back(EncodeVop1(0x0a, 10, Vgpr(0)));
+  code.push_back(EncodeVop1(0x0a, 11, Vgpr(1)));
+  code.push_back(EncodeVop1(0x0a, 12, Vgpr(2)));
+  code.push_back(EncodeVop1(0x0a, 13, Vgpr(3)));
+
+  AppendVMovLiteral(&code, 4, 0x3c013c01u);
+  AppendVMovLiteral(&code, 5, 0x10001000u);
+  AppendVop3p(&code, 0x0f, 14, Vgpr(4), Vgpr(5), 0, 0x3);
+  for (u32 i = 0; i < 5; i++) {
+    AppendStoreVgpr(&code, 10 + i, i);
+  }
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "Fp16RoundNearestEvenConversion";
+  test.code = std::move(code);
+  test.expected = {0x00003c02u, 0x00000002u, 0x00000000u,
+                   0x00008002u, 0x3c023c02u};
+  test.opcodes = {O::V_MOV_B32, O::V_CVT_F16_F32, O::V_PK_ADD_F16,
+                  O::BUFFER_STORE_DWORD, O::S_ENDPGM};
+  test.forbidden_spirv = {"PackHalf2x16"};
+  return test;
+}
+
 TestCase VectorMinMaxF16Ops() {
   using O = ShaderOpcode;
 
@@ -20378,6 +20410,7 @@ std::vector<TestCase> MakeCases() {
   AddCase(CvtPkU8F32PacksSelectedByte);
   AddCase(CvtPkrtzF16F32SubnormalRoundsTowardZero);
   AddCase(PackedMinMaxF16NanAndSignedZeroEdges);
+  AddCase(Fp16RoundNearestEvenConversion);
   AddCase(VectorMinMaxF16Ops);
   AddCase(VectorCvtU16F16Sdwa);
   AddCase(VectorMinMaxMed3F16Ops);


### PR DESCRIPTION
## Summary

- replace GLSL PackHalf2x16 lowering with an explicit FP32-to-FP16 nearest-even conversion
- handle normal and subnormal ties, signed zero, finite overflow, infinity, and quiet NaN payloads
- route scalar conversion and packed FP16 operations through the same documented helper
- add captured compute-shader coverage for normal and subnormal tie cases

## Why

The guest FP16 conversion path requires deterministic round-to-nearest-even behavior. Delegating it to the backend packing instruction can make the result depend on backend conversion behavior, especially at halfway values. Emitting the bit conversion explicitly keeps shader results stable across drivers.

## Scope

This PR only changes FP32-to-FP16 nearest-even lowering and its focused compute test. Other compute floating-point state modes remain separate work.

## Validation

- cmake --build _Build/launcher-usability --target shader_recompiler_compute_tests kyty_emulator --config Release
- ctest --test-dir _Build/launcher-usability -R ^(shader_cfg|shader_recompiler_compute)$ --output-on-failure
- 2/2 relevant suites passed