### PR TITLE
graphics: clamp 3D target views to mip depth

### DIFF
--- a/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
@@ -100,17 +100,6 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 		EXIT("unsupported render-target sample configuration: samples=%u fragments=%u\n",
 		     rt.attrib.num_samples, rt.attrib.num_fragments);
 	}
-	const auto view = ResolveTargetViewInfo(
-	    rt.view.base_array_slice_index, rt.view.last_array_slice_index, render_target_slice_offset);
-	switch (view.type) {
-		case TargetViewType::Image2D:
-		case TargetViewType::Image2DArray: break;
-		case TargetViewType::Unsupported:
-			EXIT("invalid render-target view: base=%u last=%u draw_offset=%u\n",
-			     rt.view.base_array_slice_index, rt.view.last_array_slice_index,
-			     render_target_slice_offset);
-	}
-	r.base_array_layer    = view.base_layer;
 	const uint32_t levels = rt.attrib2.num_mip_levels + 1u;
 	if (levels == 0 || levels > 16 || rt.view.current_mip_level >= levels) {
 		EXIT("unsupported render-target mip range: current=%u levels=%u\n",
@@ -165,11 +154,27 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 	if (volume && samples != 1) {
 		EXIT("multisampled 3D render targets are unsupported\n");
 	}
-	const uint32_t depth        = volume ? rt.attrib3.depth + 1u : 1u;
-	const bool     standard4    = rt.attrib3.tile_mode == Prospero::TileMode::kStandard4KB;
-	const bool     standard64   = rt.attrib3.tile_mode == Prospero::TileMode::kStandard64KB;
-	const bool     depth_tile   = rt.attrib3.tile_mode == Prospero::TileMode::kDepth;
-	const bool     texture_tile = standard4 || standard64 || depth_tile;
+	const uint32_t depth      = volume ? rt.attrib3.depth + 1u : 1u;
+	const uint32_t view_depth = std::max(depth >> rt.view.current_mip_level, 1u);
+	const auto     view =
+	    volume ? ResolveVolumeTargetViewInfo(rt.view.base_array_slice_index,
+	                                         rt.view.last_array_slice_index, view_depth,
+	                                         render_target_slice_offset)
+	           : ResolveTargetViewInfo(rt.view.base_array_slice_index,
+	                                   rt.view.last_array_slice_index, render_target_slice_offset);
+	switch (view.type) {
+		case TargetViewType::Image2D:
+		case TargetViewType::Image2DArray: break;
+		case TargetViewType::Unsupported:
+			EXIT("invalid render-target view: base=%u last=%u depth=%u mip=%u draw_offset=%u\n",
+			     rt.view.base_array_slice_index, rt.view.last_array_slice_index, view_depth,
+			     rt.view.current_mip_level, render_target_slice_offset);
+	}
+	r.base_array_layer      = view.base_layer;
+	const bool standard4    = rt.attrib3.tile_mode == Prospero::TileMode::kStandard4KB;
+	const bool standard64   = rt.attrib3.tile_mode == Prospero::TileMode::kStandard64KB;
+	const bool depth_tile   = rt.attrib3.tile_mode == Prospero::TileMode::kDepth;
+	const bool texture_tile = standard4 || standard64 || depth_tile;
 
 	switch (rt.attrib3.tile_mode) {
 		case Prospero::TileMode::kLinear:
@@ -314,12 +319,6 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 
 	const vk::Extent2D view_extent = {std::max(width >> rt.view.current_mip_level, 1u),
 	                                  std::max(height >> rt.view.current_mip_level, 1u)};
-	const uint32_t     view_depth  = std::max(depth >> rt.view.current_mip_level, 1u);
-	if (volume &&
-	    (view.base_layer >= view_depth || view.layer_count > view_depth - view.base_layer)) {
-		EXIT("3D render-target view exceeds mip depth: base=%u count=%u depth=%u mip=%u\n",
-		     view.base_layer, view.layer_count, view_depth, rt.view.current_mip_level);
-	}
 
 	auto decision_log_id = g_render_color_log_count.fetch_add(1);
 	if (decision_log_id < 128) {

--- a/src/graphics/host_gpu/renderer/renderTarget.h
+++ b/src/graphics/host_gpu/renderer/renderTarget.h
@@ -3,6 +3,7 @@
 
 #include "graphics/host_gpu/vulkanCommon.h"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <type_traits>
@@ -65,6 +66,18 @@ inline constexpr TargetViewInfo ResolveTargetViewInfo(uint32_t base_layer, uint3
 	}
 	return {base_layer == last_layer ? TargetViewType::Image2D : TargetViewType::Image2DArray,
 	        base_layer, last_layer - base_layer + 1u, last_layer + 1u};
+}
+
+[[nodiscard]] inline constexpr TargetViewInfo
+ResolveVolumeTargetViewInfo(uint32_t base_layer, uint32_t last_layer, uint32_t mip_depth,
+                            uint32_t draw_layer_offset = 0) {
+	if (mip_depth == 0 || base_layer >= mip_depth) {
+		return {};
+	}
+	// A 3D target view addresses slices of the selected mip. Clamp its inclusive upper bound to
+	// that mip's physical depth while preserving a valid nonzero base slice.
+	const auto clamped_last_layer = std::min(last_layer, mip_depth - 1u);
+	return ResolveTargetViewInfo(base_layer, clamped_last_layer, draw_layer_offset);
 }
 
 #pragma pack(push, 1)

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -22961,6 +22961,30 @@ void CheckNativeMsaaState() {
   std::printf("[host]    %-32s ok\n", "NativeMsaaState");
 }
 
+void CheckRenderTargetViewRanges() {
+  constexpr auto array_view = ResolveTargetViewInfo(2, 5);
+  constexpr auto volume_view = ResolveVolumeTargetViewInfo(0, 64, 64);
+  constexpr auto volume_subview = ResolveVolumeTargetViewInfo(5, 70, 64);
+  constexpr auto invalid_volume = ResolveVolumeTargetViewInfo(64, 64, 64);
+
+  Require("RenderTargetViewRanges", "2D array inclusive range",
+          array_view.type == TargetViewType::Image2DArray &&
+              array_view.base_layer == 2 && array_view.layer_count == 4 &&
+              array_view.image_layers == 6,
+          "2D array view semantics changed");
+  Require("RenderTargetViewRanges", "3D mip-depth clamp",
+          volume_view.type == TargetViewType::Image2DArray &&
+              volume_view.base_layer == 0 && volume_view.layer_count == 64,
+          "3D slice maximum was not clamped to mip depth");
+  Require("RenderTargetViewRanges", "3D subrange clamp",
+          volume_subview.base_layer == 5 && volume_subview.layer_count == 59,
+          "3D subrange did not preserve its base slice");
+  Require("RenderTargetViewRanges", "3D invalid base",
+          invalid_volume.type == TargetViewType::Unsupported,
+          "3D view admitted a base slice outside the mip depth");
+  std::printf("[host]    %-32s ok\n", "RenderTargetViewRanges");
+}
+
 void CheckDepthHtileStencilCompatibility() {
   Require("DepthHtileStencilCompatibility", "disabled acceleration",
           depth_htile_stencil_acceleration_compatible(false, false, true),
@@ -24470,6 +24494,7 @@ int main(int argc, char **argv) {
   CheckStorageTextureVolumeMipRegions();
   CheckStorageTextureGpuOwnedRebindState();
   CheckNativeMsaaState();
+  CheckRenderTargetViewRanges();
   CheckPs5DepthRegisterDecoding();
   CheckDepthHtileStencilCompatibility();
   CheckStencilAttachmentAccess();


### PR DESCRIPTION
## Summary

- resolve a 3D render-target slice view after computing the selected mip depth
- clamp the inclusive last slice to the physical depth of that mip
- reject a base slice outside the mip while preserving valid nonzero-base subranges
- retain the existing 1D and 2D target paths unchanged

## Why

A volume target becomes shallower at every mip. Treating its register slice range as an unconstrained 2D-array range can either reject a valid broad upper bound or attempt to create a Vulkan view beyond the selected mip depth.

## Scope

This PR only changes 3D color-target view resolution. It does not alter tiling, memory footprints, depth targets, image-cache ownership, or the existing 1D/2D behavior.

## Validation

Focused coverage checks inclusive 2D ranges, full 3D mip clamping, nonzero-base 3D subranges, and invalid bases.

- cmake --build _Build/launcher-usability --target shader_recompiler_compute_tests kyty_emulator --config Release
- ctest --test-dir _Build/launcher-usability -R ^(shader_cfg|shader_recompiler_compute)$ --output-on-failure
- 2/2 relevant suites passed