### PR TITLE
controller: forward guest vibration to SDL rumble

### DIFF
--- a/src/libs/controller.cpp
+++ b/src/libs/controller.cpp
@@ -1,5 +1,6 @@
 #include "libs/controller.h"
 
+#include "SDL.h"
 #include "common/assert.h"
 #include "common/common.h"
 #include "common/logging/log.h"
@@ -20,6 +21,9 @@ LIB_NAME("Pad", "Pad");
 
 constexpr int PAD_ERROR_INVALID_ARG    = -2137915391; /* 0x80920001 */
 constexpr int PAD_ERROR_INVALID_HANDLE = -2137915389; /* 0x80920003 */
+
+// SDL limits rumble commands to 0xffff ms; zero strengths stop immediately.
+constexpr uint32_t RUMBLE_DURATION_MS = 0xffff;
 
 struct PadControllerInformation {
 	float    touch_pixel_density;
@@ -58,6 +62,7 @@ public:
 	void Axis(int id, Axis axis, int value);
 	void ResetInputState();
 	void GetConnectionInfo(bool* flag, int* count);
+	void SetVibration(uint8_t large_motor, uint8_t small_motor);
 	void ReadState(ControllerState* state, bool* flag, int* count);
 	int  ReadStates(ControllerState* states, int states_num, bool* flag, int* count);
 
@@ -266,6 +271,25 @@ void GameController::ResetInputState() {
 	m_states_num  = 0;
 	m_first_state = 0;
 	AddState(state);
+}
+
+void GameController::SetVibration(uint8_t large_motor, uint8_t small_motor) {
+	Common::LockGuard lock(m_mutex);
+
+	if (m_active_id == HOST_INPUT_CONTROLLER_ID) {
+		return;
+	}
+
+	auto* pad = SDL_GameControllerFromInstanceID(static_cast<SDL_JoystickID>(m_active_id));
+	if (pad == nullptr) {
+		return;
+	}
+
+	const auto large = static_cast<uint16_t>(large_motor * 0x101U);
+	const auto small = static_cast<uint16_t>(small_motor * 0x101U);
+	if (SDL_GameControllerRumble(pad, large, small, RUMBLE_DURATION_MS) != 0) {
+		LOGF("\t rumble failed: %s\n", SDL_GetError());
+	}
 }
 
 void GameController::GetConnectionInfo(bool* flag, int* count) {
@@ -543,6 +567,9 @@ int KYTY_SYSV_ABI PadSetVibration(int handle, const PadVibrationParam* param) {
 	LOGF("\t large_motor = %d\n"
 	     "\t small_motor = %d\n",
 	     static_cast<int>(param->large_motor), static_cast<int>(param->small_motor));
+
+	EXIT_IF(g_controller == nullptr);
+	g_controller->SetVibration(param->large_motor, param->small_motor);
 
 	return OK;
 }


### PR DESCRIPTION
## Summary

- `scePadSetVibration` logged the requested motor levels and then discarded them, so guest rumble never reached the pad. Forward both motors to `SDL_GameControllerRumble`.
- `large_motor` drives SDL's low frequency motor and `small_motor` the high frequency one, scaled from the guest's 8 bit levels to SDL's 16 bit range (`0xff` -> `0xffff`).
- The guest API holds the motors until the guest changes them, while SDL rumble always expires. SDL clamps the duration to `0xffff` ms internally, so that maximum is requested and an explicit zero level stops the motors early instead.
- Keyboard and mouse input is mapped onto a virtual pad that has no motors, so that path returns early.

## Test plan

Windows 11 25H2, clang-cl 20.1.8, RTX 2060, DualShock 4 v2 (CUH-ZCT2) over Bluetooth.

- [x] `ctest`: 31/31, three consecutive runs.
- [x] The guest call resolves a live `SDL_GameController*` rather than the virtual keyboard pad (checked with temporary logging, since removed).
- [x] SDL reports no error for the resulting rumble call.
- [x] The motors physically run when a non-zero level is sent through this path.
**Not verified:** rumble driven by real gameplay. The only title I have (Tetris Forever, PPSA25646) calls `scePadSetVibration(0, 0)` once at startup and never again, so I could not exercise a game-driven effect. I confirmed the motors with a forced non-zero call through the same code path instead.

An automated test did not seem practical here, since the behaviour only shows up as physical motor output on real hardware. Happy to add one if you have a preferred approach.

Only Windows and a DualShock 4 were tested. Adaptive triggers are untouched: that is DualSense-only hardware and `scePadSetTriggerEffect` remains a stub.

## AI use

Developed with AI assistance (Claude). It located the stub, wrote the change, and ran the builds, tests and logging on my machine. I reviewed the diff, checked the motor scaling and that the SDL calls used here lock internally so they are safe from the guest thread, and ran the emulator with my own controller to confirm the rumble fires.
