### PR TITLE
shader: honor DX10_CLAMP NaN mode across shader stages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,8 @@ if(BUILD_TESTING)
 	add_test(NAME shader_recompiler_compute COMMAND $<TARGET_FILE:shader_recompiler_compute_tests>)
 	add_test(NAME shader_recompiler_alignbyte
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --alignbyte-only)
+	add_test(NAME shader_recompiler_dx10_clamp
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --dx10-clamp-only)
 	add_test(NAME virtual_memory_allocation
 		COMMAND $<TARGET_FILE:virtual_memory_allocation_tests>)
 	add_test(NAME guest_red_zone_patcher

--- a/src/graphics/shader/recompiler/frontend/translate/Float.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Float.cpp
@@ -8,8 +8,12 @@ namespace Libs::Graphics::ShaderRecompiler::Frontend {
 bool Translator::PackedFloat16(const Decoder::Instruction& inst, IR::ValueOpcode opcode,
                                bool accumulator, bool quiet_snan) {
 	const auto translate_lane = [&](bool high) {
-		const auto lhs = ReadF16LaneAsF32(inst.src0, high, true);
-		const auto rhs = ReadF16LaneAsF32(inst.src1, high, true);
+		auto lhs = ReadF16LaneAsF32(inst.src0, high, true);
+		auto rhs = ReadF16LaneAsF32(inst.src1, high, true);
+		if (quiet_snan) {
+			lhs = ApplyDx10Nan(lhs);
+			rhs = ApplyDx10Nan(rhs);
+		}
 		IR::F32    result;
 		if (accumulator) {
 			result = IR::F32(ir.Emit(opcode, {lhs, rhs, ReadF16LaneAsF32(inst.dst, high, true)}));
@@ -24,7 +28,7 @@ bool Translator::PackedFloat16(const Decoder::Instruction& inst, IR::ValueOpcode
 	raw.omod    = 0u;
 	raw.clamp   = false;
 	auto result = PackHalf2x16(translate_lane(false), translate_lane(true));
-	if (quiet_snan) {
+	if (quiet_snan && !current_dx10_clamp) {
 		const auto quiet_snan_lane = [&](const Decoder::Operand& operand, bool high) {
 			const auto bits     = ReadU16LaneAsU32(operand, high, false);
 			const auto exponent = ir.BitwiseAnd(bits, IR::U32(IR::Value(0x7c00u)));
@@ -65,8 +69,12 @@ bool Translator::Float16Unary(const Decoder::Instruction& inst, IR::ValueOpcode 
 
 bool Translator::Float16Binary(const Decoder::Instruction& inst, IR::ValueOpcode opcode,
                                bool reverse) {
-	const auto lhs = ReadF16AsF32(reverse ? inst.src1 : inst.src0);
-	const auto rhs = ReadF16AsF32(reverse ? inst.src0 : inst.src1);
+	auto lhs = ReadF16AsF32(reverse ? inst.src1 : inst.src0);
+	auto rhs = ReadF16AsF32(reverse ? inst.src0 : inst.src1);
+	if (opcode == IR::ValueOpcode::FPMin32 || opcode == IR::ValueOpcode::FPMax32) {
+		lhs = ApplyDx10Nan(lhs);
+		rhs = ApplyDx10Nan(rhs);
+	}
 	WriteF16(DestinationOperand(inst), IR::F32(ir.Emit(opcode, {lhs, rhs})));
 	return true;
 }
@@ -74,9 +82,15 @@ bool Translator::Float16Binary(const Decoder::Instruction& inst, IR::ValueOpcode
 bool Translator::Float16Ternary(const Decoder::Instruction& inst, IR::ValueOpcode opcode,
                                 bool accumulator, bool mix) {
 	std::array<IR::Value, 3> args;
+	const bool dx10_min_max = opcode == IR::ValueOpcode::FPMinTri32 ||
+	                          opcode == IR::ValueOpcode::FPMaxTri32 ||
+	                          opcode == IR::ValueOpcode::FPMedTri32;
 	for (uint32_t index = 0; index < args.size(); index++) {
 		const auto operand = accumulator && index == 2u ? inst.dst : SourceAt(inst, index);
 		args[index] = mix ? IR::Value(ReadMixF32(operand)) : IR::Value(ReadF16AsF32(operand));
+		if (dx10_min_max) {
+			args[index] = ApplyDx10Nan(IR::F32(args[index]));
+		}
 	}
 	WriteF16(DestinationOperand(inst), IR::F32(ir.Emit(opcode, {args[0], args[1], args[2]})));
 	return true;
@@ -91,9 +105,14 @@ bool Translator::FloatUnary(const Decoder::Instruction& inst, IR::ValueOpcode op
 bool Translator::FloatBinary(const Decoder::Instruction& inst, IR::ValueOpcode opcode,
                              bool reverse) {
 	std::array<IR::Value, 2> args;
+	const bool dx10_min_max =
+	    opcode == IR::ValueOpcode::FPMin32 || opcode == IR::ValueOpcode::FPMax32;
 	for (uint32_t index = 0; index < args.size(); index++) {
 		const auto operand = SourceAt(inst, reverse ? 1u - index : index);
 		args[index]        = ReadOperand(operand, IR::ArgTypeOf(opcode, index));
+		if (dx10_min_max) {
+			args[index] = ApplyDx10Nan(IR::F32(args[index]));
+		}
 	}
 	WriteOperand(DestinationOperand(inst), ir.Emit(opcode, {args[0], args[1]}));
 	return true;
@@ -102,11 +121,17 @@ bool Translator::FloatBinary(const Decoder::Instruction& inst, IR::ValueOpcode o
 bool Translator::FloatTernary(const Decoder::Instruction& inst, IR::ValueOpcode opcode,
                               bool accumulator, bool mix) {
 	std::array<IR::Value, 3> args;
+	const bool dx10_min_max = opcode == IR::ValueOpcode::FPMinTri32 ||
+	                          opcode == IR::ValueOpcode::FPMaxTri32 ||
+	                          opcode == IR::ValueOpcode::FPMedTri32;
 	for (uint32_t index = 0; index < args.size(); index++) {
 		const auto operand = accumulator && index == 2u ? inst.dst : SourceAt(inst, index);
 		const auto type    = IR::ArgTypeOf(opcode, index);
 		args[index]        = type == IR::Type::F32 && mix ? IR::Value(ReadMixF32(operand))
 		                                                  : ReadOperand(operand, type);
+		if (dx10_min_max && type == IR::Type::F32) {
+			args[index] = ApplyDx10Nan(IR::F32(args[index]));
+		}
 	}
 	WriteOperand(DestinationOperand(inst), ir.Emit(opcode, {args[0], args[1], args[2]}));
 	return true;

--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -1129,7 +1129,11 @@ bool TranslateProgram(const Decoder::Program& decoded, const CFG::Graph& cfg,
 	}
 	for (const auto& cfg_block: cfg.blocks) {
 		const auto         typed_index = block_indices.at(cfg_block.id);
-		const bool dx10_clamp = options.compute != nullptr && options.compute->dx10_clamp;
+		const bool dx10_clamp = options.compute != nullptr
+		                              ? options.compute->dx10_clamp
+		                          : options.pixel != nullptr ? options.pixel->dx10_clamp
+		                          : options.vertex != nullptr ? options.vertex->dx10_clamp
+		                                                       : false;
 		Translator translator(result, result.blocks[typed_index], vector_limit, options.wave_size,
 		                      dx10_clamp);
 		for (uint32_t index = cfg_block.inst_begin; index < cfg_block.inst_end; index++) {

--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -337,6 +337,18 @@ void Translator::WriteRawU32(const Decoder::Operand& operand, IR::U32 value) {
 	}
 }
 
+IR::F32 Translator::ApplyDx10Nan(IR::F32 value) {
+	if (!current_dx10_clamp) {
+		return value;
+	}
+	// Inspect the payload instead of relying on an unordered floating-point comparison, which a
+	// host compiler may contract under relaxed rules. DX10 mode maps every NaN sign/payload to +0.
+	const auto magnitude =
+	    ir.BitwiseAnd(ir.BitCastU32(value), IR::U32(IR::Value(0x7fffffffu)));
+	const auto nan = ir.UGreaterThan(magnitude, IR::U32(IR::Value(0x7f800000u)));
+	return SelectF32(nan, IR::F32(IR::Value::F32(0.0f)), value);
+}
+
 IR::F32 Translator::ApplyF32ResultModifiers(const Decoder::Operand& operand, IR::F32 value) {
 	if (operand.omod != 0u) {
 		float multiplier = 0.5f;
@@ -348,6 +360,7 @@ IR::F32 Translator::ApplyF32ResultModifiers(const Decoder::Operand& operand, IR:
 		value = IR::F32(ir.Emit(IR::ValueOpcode::FPMul32, {value, IR::Value::F32(multiplier)}));
 	}
 	if (operand.clamp) {
+		value = ApplyDx10Nan(value);
 		value = IR::F32(ir.Emit(IR::ValueOpcode::FPSaturate32, {value}));
 	}
 	return value;
@@ -1116,7 +1129,9 @@ bool TranslateProgram(const Decoder::Program& decoded, const CFG::Graph& cfg,
 	}
 	for (const auto& cfg_block: cfg.blocks) {
 		const auto         typed_index = block_indices.at(cfg_block.id);
-		Translator translator(result, result.blocks[typed_index], vector_limit, options.wave_size);
+		const bool dx10_clamp = options.compute != nullptr && options.compute->dx10_clamp;
+		Translator translator(result, result.blocks[typed_index], vector_limit, options.wave_size,
+		                      dx10_clamp);
 		for (uint32_t index = cfg_block.inst_begin; index < cfg_block.inst_end; index++) {
 			const auto& instruction = decoded.instructions[index];
 			if (IsCodeTableLoad(cfg, instruction.pc)) {

--- a/src/graphics/shader/recompiler/frontend/translate/Translator.h
+++ b/src/graphics/shader/recompiler/frontend/translate/Translator.h
@@ -9,9 +9,10 @@ namespace Libs::Graphics::ShaderRecompiler::Frontend {
 
 class Translator {
 public:
-	Translator(IR::Program& program, IR::Block* block, uint32_t vector_limit, uint32_t wave_size)
+	Translator(IR::Program& program, IR::Block* block, uint32_t vector_limit, uint32_t wave_size,
+	           bool dx10_clamp)
 	    : program(program), ir(block), current_vector_limit(vector_limit),
-	      current_wave_size(wave_size) {}
+	      current_wave_size(wave_size), current_dx10_clamp(dx10_clamp) {}
 
 	bool TranslateInstruction(const Decoder::Instruction& inst, std::string* error);
 	bool TranslateEmbeddedFetch(const Decoder::Instruction& inst, uint32_t attribute,
@@ -31,6 +32,7 @@ private:
 	IR::Value              ReadOperand(const Decoder::Operand& operand, IR::Type type);
 	IR::U1                 ThreadBit(IR::U32 low);
 	void                   WriteRawU32(const Decoder::Operand& operand, IR::U32 value);
+	IR::F32                ApplyDx10Nan(IR::F32 value);
 	IR::F32                ApplyF32ResultModifiers(const Decoder::Operand& operand, IR::F32 value);
 	void                   WriteOperand(const Decoder::Operand& operand, IR::Value value);
 	IR::U32                PackHalf2x16(IR::F32 low, IR::F32 high);
@@ -254,6 +256,7 @@ private:
 	uint32_t        current_pc           = 0;
 	uint32_t        current_vector_limit = 1;
 	uint32_t        current_wave_size    = 64;
+	bool            current_dx10_clamp   = false;
 };
 
 } // namespace Libs::Graphics::ShaderRecompiler::Frontend

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -695,6 +695,7 @@ static bool ShaderGetStaticInputInfoVS(const HW::VertexShaderInfo& regs,
 	const HW::UserSgprInfo& user_sgpr     = regs.gs_user_sgpr;
 	auto                    user_sgpr_num = regs.gs_regs.rsrc2.user_sgpr;
 	info.scratch_size_dwords = data.scratch_size_dwords;
+	info.dx10_clamp          = regs.gs_regs.rsrc1.dx10_clamp;
 
 	if (data.user_data == nullptr) {
 		LOGF("ShaderGetInputInfoVS(): no AGC user data for shader=0x%016" PRIx64 " es=0x%016" PRIx64
@@ -744,6 +745,7 @@ static void ShaderGetStaticInputInfoPS(
 
 	ps_info = {};
 	ps_info.scratch_size_dwords = data.scratch_size_dwords;
+	ps_info.dx10_clamp          = regs.ps_regs.rsrc1.dx10_clamp;
 	ps_info.push_constant_offset =
 	    vs_info.stage.program != nullptr
 	        ? vs_info.stage.program->bindings.push_constant_offset +
@@ -892,6 +894,7 @@ void BuildStageStaticKey(const ShaderVertexInputInfo& info, std::vector<uint32_t
 	key.push_back(static_cast<uint32_t>(info.fetch_embedded));
 	key.push_back(info.resources_num);
 	key.push_back(info.scratch_size_dwords);
+	key.push_back(static_cast<uint32_t>(info.dx10_clamp));
 	key.push_back(info.pa_cl_vs_out_cntl);
 
 	for (int i = 0; i < info.resources_num; i++) {
@@ -933,6 +936,7 @@ void BuildStageStaticKey(const ShaderPixelInputInfo& info, std::vector<uint32_t>
 	key.clear();
 	key.push_back(info.push_constant_offset);
 	key.push_back(info.scratch_size_dwords);
+	key.push_back(static_cast<uint32_t>(info.dx10_clamp));
 	key.push_back(info.input_num);
 	key.push_back(info.ps_system_input_base);
 	key.push_back(info.custom_interpolation_mask);

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -809,6 +809,7 @@ static void ShaderGetStaticInputInfoCS(const HW::ComputeShaderInfo& regs,
 	info.threads_num[2]      = regs.cs_regs.num_thread_z;
 	info.lds_size_dwords     = static_cast<uint32_t>(regs.cs_regs.lds_size) * 128u;
 	info.scratch_size_dwords = data.scratch_size_dwords;
+	info.dx10_clamp          = regs.cs_regs.dx10_clamp;
 	info.group_id[0]         = regs.cs_regs.tgid_x_en != 0;
 	info.group_id[1]         = regs.cs_regs.tgid_y_en != 0;
 	info.group_id[2]         = regs.cs_regs.tgid_z_en != 0;
@@ -966,6 +967,7 @@ void BuildStageStaticKey(const ShaderComputeInputInfo& info, std::vector<uint32_
 	key.push_back(info.thread_ids_num);
 	key.push_back(info.lds_size_dwords);
 	key.push_back(info.scratch_size_dwords);
+	key.push_back(static_cast<uint32_t>(info.dx10_clamp));
 	key.push_back(static_cast<uint32_t>(info.needs_lds_barriers));
 	key.push_back(static_cast<uint32_t>(info.dispatch_thread_dimensions));
 	for (int i = 0; i < 3; i++) {
@@ -1108,10 +1110,12 @@ void ShaderDbgDumpInputInfo(const ShaderComputeInputInfo& info) {
 	     "\t thread_ids_num     = %d\n"
 	     "\t wave_size          = %u\n"
 	     "\t lds_size_dwords    = %u\n"
+	     "\t dx10_clamp         = %s\n"
 	     "\t needs_lds_barriers = %s\n"
 	     "\t threads_num        = {%u, %u, %u}\n"
 	     "\t tg_size_en         = %s\n",
 	     info.workgroup_register, info.thread_ids_num, info.wave_size, info.lds_size_dwords,
+	     info.dx10_clamp ? "true" : "false",
 	     info.needs_lds_barriers ? "true" : "false",
 	     info.threads_num[0], info.threads_num[1], info.threads_num[2],
 	     info.tg_size_en ? "true" : "false");

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -82,6 +82,7 @@ struct ShaderVertexInputInfo {
 	int                     buffers_num         = 0;
 	int                     export_count        = 0;
 	uint32_t                scratch_size_dwords = 0;
+	bool                    dx10_clamp          = false;
 	uint32_t                param_export_mask   = 0;
 	uint32_t                pa_cl_vs_out_cntl    = 0;
 	bool                    fetch_external      = false;
@@ -115,6 +116,7 @@ struct ShaderPixelInputInfo {
 	uint32_t                                       mrt_output_mask              = 0;
 	uint32_t                                       push_constant_offset         = 0;
 	uint32_t                                       scratch_size_dwords          = 0;
+	bool                                           dx10_clamp                   = false;
 	bool                                           ps_pos_x                     = false;
 	bool                                           ps_pos_y                     = false;
 	bool                                           ps_pos_xy                    = false;

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -93,6 +93,7 @@ struct ShaderComputeInputInfo {
 	uint32_t           dispatch_threads_num[3]    = {0, 0, 0};
 	uint32_t           lds_size_dwords            = 0;
 	uint32_t           scratch_size_dwords        = 0;
+	bool               dx10_clamp                 = false;
 	bool               group_id[3]                = {false, false, false};
 	bool               dispatch_thread_dimensions = false;
 	bool               needs_lds_barriers          = false;

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -14253,6 +14253,64 @@ TestCase PackedMinMaxF16NanAndSignedZeroEdges() {
            O::BUFFER_STORE_DWORD, O::S_ENDPGM}};
 }
 
+TestCase ComputeDx10ClampF16Nan(bool enabled) {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0x7e007e00u); // packed qNaN
+  AppendVMovLiteral(&code, 1, 0x40004000u); // packed +2.0h
+  AppendVMovLiteral(&code, 2, 0x12347e00u); // scalar qNaN
+  AppendVMovLiteral(&code, 3, 0x00004000u); // scalar +2.0h
+
+  AppendVop3p(&code, 0x11, 10, Vgpr(0), Vgpr(1), 0, 0x3);
+  AppendVop3p(&code, 0x12, 11, Vgpr(0), Vgpr(1), 0, 0x3);
+  code.push_back(EncodeVop2(0x3a, 2, Vgpr(2), 3));
+  AppendStoreVgpr(&code, 10, 0);
+  AppendStoreVgpr(&code, 11, 1);
+  AppendStoreVgpr(&code, 2, 2);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = enabled ? "ComputeDx10ClampF16NanEnabled"
+                      : "ComputeDx10ClampF16NanDisabled";
+  test.code = std::move(code);
+  test.expected = enabled
+                      ? std::vector<u32>{0x00000000u, 0x40004000u,
+                                         0x12340000u}
+                      : std::vector<u32>{0x40004000u, 0x40004000u,
+                                         0x12344000u};
+  test.opcodes = {O::V_MOV_B32, O::V_PK_MIN_F16, O::V_PK_MAX_F16,
+                  O::V_MIN_F16, O::BUFFER_STORE_DWORD, O::S_ENDPGM};
+  test.compute_info.dx10_clamp = enabled;
+  test.has_compute_info = true;
+  return test;
+}
+
+TestCase ComputeDx10ClampF32Nan(bool enabled) {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0x7fc00000u); // qNaN
+  AppendVMovLiteral(&code, 1, 0x40000000u); // +2.0f
+  code.push_back(EncodeVop2(0x0f, 10, Vgpr(0), 1));
+  code.push_back(EncodeVop2(0x10, 11, Vgpr(0), 1));
+  AppendStoreVgpr(&code, 10, 0);
+  AppendStoreVgpr(&code, 11, 1);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = enabled ? "ComputeDx10ClampF32NanEnabled"
+                      : "ComputeDx10ClampF32NanDisabled";
+  test.code = std::move(code);
+  test.expected = enabled ? std::vector<u32>{0x00000000u, 0x40000000u}
+                          : std::vector<u32>{0x40000000u, 0x40000000u};
+  test.opcodes = {O::V_MOV_B32, O::V_MIN_F32, O::V_MAX_F32,
+                  O::BUFFER_STORE_DWORD, O::S_ENDPGM};
+  test.compute_info.dx10_clamp = enabled;
+  test.has_compute_info = true;
+  return test;
+}
+
 TestCase VectorMinMaxF16Ops() {
   using O = ShaderOpcode;
 
@@ -20378,6 +20436,10 @@ std::vector<TestCase> MakeCases() {
   AddCase(CvtPkU8F32PacksSelectedByte);
   AddCase(CvtPkrtzF16F32SubnormalRoundsTowardZero);
   AddCase(PackedMinMaxF16NanAndSignedZeroEdges);
+  cases.push_back(ComputeDx10ClampF16Nan(false));
+  cases.push_back(ComputeDx10ClampF16Nan(true));
+  cases.push_back(ComputeDx10ClampF32Nan(false));
+  cases.push_back(ComputeDx10ClampF32Nan(true));
   AddCase(VectorMinMaxF16Ops);
   AddCase(VectorCvtU16F16Sdwa);
   AddCase(VectorMinMaxMed3F16Ops);
@@ -22961,6 +23023,20 @@ void CheckNativeMsaaState() {
   std::printf("[host]    %-32s ok\n", "NativeMsaaState");
 }
 
+void CheckComputeDx10ClampStaticKey() {
+  ShaderComputeInputInfo disabled{};
+  ShaderComputeInputInfo enabled{};
+  enabled.dx10_clamp = true;
+  std::vector<u32> disabled_key;
+  std::vector<u32> enabled_key;
+  BuildStageStaticKey(disabled, disabled_key);
+  BuildStageStaticKey(enabled, enabled_key);
+  Require("ComputeDx10ClampStaticKey", "pipeline cache separation",
+          disabled_key.size() == enabled_key.size() && disabled_key != enabled_key,
+          "DX10_CLAMP did not specialize the compute program cache key");
+  std::printf("[host]    %-32s ok\n", "ComputeDx10ClampStaticKey");
+}
+
 void CheckDepthHtileStencilCompatibility() {
   Require("DepthHtileStencilCompatibility", "disabled acceleration",
           depth_htile_stencil_acceleration_compatible(false, false, true),
@@ -24470,6 +24546,7 @@ int main(int argc, char **argv) {
   CheckStorageTextureVolumeMipRegions();
   CheckStorageTextureGpuOwnedRebindState();
   CheckNativeMsaaState();
+  CheckComputeDx10ClampStaticKey();
   CheckPs5DepthRegisterDecoding();
   CheckDepthHtileStencilCompatibility();
   CheckStencilAttachmentAccess();

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -987,6 +987,7 @@ struct GraphicsCase {
   std::vector<u32> pixel_interpolator_settings;
   bool pixel_no_perspective = false;
   std::vector<u32> vertices;
+  bool dx10_clamp = false;
 };
 
 struct CompiledShader {
@@ -1317,6 +1318,7 @@ CompiledShader CompileFragmentCase(const GraphicsCase &test) {
           ? 1u
           : static_cast<u32>(test.pixel_interpolator_settings.size());
   pixel_info.ps_no_perspective = test.pixel_no_perspective;
+  pixel_info.dx10_clamp = test.dx10_clamp;
   for (u32 i = 0; i < std::size(pixel_info.interpolator_settings); i++) {
     pixel_info.interpolator_settings[i] = i;
   }
@@ -20086,6 +20088,35 @@ TestCase ImageAtomicGlc0DoesNotReturnOldValue() {
   return test;
 }
 
+GraphicsCase GraphicsDx10ClampF32Nan(bool enabled) {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0x7fc00000u); // qNaN
+  AppendVMovLiteral(&code, 1, 0x40000000u); // +2.0f
+  AppendVMovLiteral(&code, 2, 0x3f400000u); // +0.75f
+  AppendVMovLiteral(&code, 3, 0x3f800000u); // +1.0f
+  code.push_back(EncodeVop2(0x0f, 10, Vgpr(0), 1));
+  code.push_back(EncodeVop2(0x10, 11, Vgpr(0), 1));
+  code.push_back(EncodeExp0(0x00, 0xf));
+  code.push_back(EncodeExp1(10, 11, 2, 3));
+  AppendEnd(&code);
+
+  GraphicsCase test;
+  test.name = enabled ? "GraphicsDx10ClampF32NanEnabled"
+                      : "GraphicsDx10ClampF32NanDisabled";
+  test.fragment_code = std::move(code);
+  test.expected_pixel = enabled
+                            ? std::vector<u32>{0x00000000u, 0x40000000u,
+                                               0x3f400000u, 0x3f800000u}
+                            : std::vector<u32>{0x40000000u, 0x40000000u,
+                                               0x3f400000u, 0x3f800000u};
+  test.opcodes = {O::V_MOV_B32, O::V_MIN_F32, O::V_MAX_F32, O::EXP,
+                  O::S_ENDPGM};
+  test.dx10_clamp = enabled;
+  return test;
+}
+
 GraphicsCase GraphicsInterpolationExport() {
   using O = ShaderOpcode;
 
@@ -20636,6 +20667,8 @@ std::vector<TestCase> MakeCases() {
 
 std::vector<GraphicsCase> MakeGraphicsCases() {
   return {
+      GraphicsDx10ClampF32Nan(false),
+      GraphicsDx10ClampF32Nan(true),
       GraphicsInterpolationExport(),
       GraphicsFlatInterpolatorExport(),
       GraphicsDsAddtidScratchExport(),
@@ -23037,6 +23070,32 @@ void CheckComputeDx10ClampStaticKey() {
   std::printf("[host]    %-32s ok\n", "ComputeDx10ClampStaticKey");
 }
 
+void CheckGraphicsDx10ClampStaticKeys() {
+  ShaderVertexInputInfo vertex_disabled{};
+  ShaderVertexInputInfo vertex_enabled{};
+  ShaderPixelInputInfo pixel_disabled{};
+  ShaderPixelInputInfo pixel_enabled{};
+  vertex_enabled.dx10_clamp = true;
+  pixel_enabled.dx10_clamp = true;
+
+  std::vector<u32> vertex_disabled_key;
+  std::vector<u32> vertex_enabled_key;
+  std::vector<u32> pixel_disabled_key;
+  std::vector<u32> pixel_enabled_key;
+  BuildStageStaticKey(vertex_disabled, vertex_disabled_key);
+  BuildStageStaticKey(vertex_enabled, vertex_enabled_key);
+  BuildStageStaticKey(pixel_disabled, pixel_disabled_key);
+  BuildStageStaticKey(pixel_enabled, pixel_enabled_key);
+
+  Require("GraphicsDx10ClampStaticKeys", "program cache separation",
+          vertex_disabled_key.size() == vertex_enabled_key.size() &&
+              vertex_disabled_key != vertex_enabled_key &&
+              pixel_disabled_key.size() == pixel_enabled_key.size() &&
+              pixel_disabled_key != pixel_enabled_key,
+          "DX10_CLAMP did not specialize the vertex and pixel program keys");
+  std::printf("[host]    %-32s ok\n", "GraphicsDx10ClampStaticKeys");
+}
+
 void CheckDepthHtileStencilCompatibility() {
   Require("DepthHtileStencilCompatibility", "disabled acceleration",
           depth_htile_stencil_acceleration_compatible(false, false, true),
@@ -24502,6 +24561,18 @@ int main(int argc, char **argv) {
     CheckIndirectImageKeySwitch();
     return 0;
   }
+  if (argc == 2 && std::strcmp(argv[1], "--dx10-clamp-only") == 0) {
+    VulkanHarness vulkan;
+    CheckComputeDx10ClampStaticKey();
+    CheckGraphicsDx10ClampStaticKeys();
+    RunCase(&vulkan, ComputeDx10ClampF16Nan(false));
+    RunCase(&vulkan, ComputeDx10ClampF16Nan(true));
+    RunCase(&vulkan, ComputeDx10ClampF32Nan(false));
+    RunCase(&vulkan, ComputeDx10ClampF32Nan(true));
+    RunGraphicsCase(&vulkan, GraphicsDx10ClampF32Nan(false));
+    RunGraphicsCase(&vulkan, GraphicsDx10ClampF32Nan(true));
+    return 0;
+  }
   if (argc == 2 && std::strcmp(argv[1], "--storage-mip-host-only") == 0) {
     VulkanHarness vulkan;
     vulkan.CheckRenderExecutorStencilBindingDiscovery();
@@ -24547,6 +24618,7 @@ int main(int argc, char **argv) {
   CheckStorageTextureGpuOwnedRebindState();
   CheckNativeMsaaState();
   CheckComputeDx10ClampStaticKey();
+  CheckGraphicsDx10ClampStaticKeys();
   CheckPs5DepthRegisterDecoding();
   CheckDepthHtileStencilCompatibility();
   CheckStencilAttachmentAccess();


### PR DESCRIPTION
## Summary
- Propagates COMPUTE/GS/PS PGM_RSRC1.DX10_CLAMP into compute, vertex, and pixel translation.
- Includes the mode in every affected static shader key so cached modules cannot cross incompatible NaN modes.
- Maps NaN operands to positive zero for affected FP16/FP32 min, max, median, and destination-clamp paths.
- Preserves signaling-NaN behavior when DX10_CLAMP is disabled.

## Why
DX10_CLAMP changes vector floating-point NaN treatment. Ignoring it produces mode-dependent guest results and can reuse an incompatible cached shader. NaNs are classified from IEEE-754 payload bits so relaxed host floating-point optimization cannot change the decision.

## Scope
This PR changes only DX10_CLAMP. FP_ROUND, denormal, IEEE-mode, and FP16_OVFL behavior remain isolated.

## Validation
- Release build: shader_recompiler_compute_tests
- shader_recompiler_dx10_clamp: passed
- shader_recompiler_compute: passed
- Enabled/disabled compute FP16 and FP32 runtime cases
- Enabled/disabled Vulkan pixel runtime cases
- Compute, vertex, and pixel static-key separation checks