### PR TITLE
shader: honor FP16 overflow mode across shader stages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,8 @@ if(BUILD_TESTING)
 	add_test(NAME shader_recompiler_compute COMMAND $<TARGET_FILE:shader_recompiler_compute_tests>)
 	add_test(NAME shader_recompiler_alignbyte
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --alignbyte-only)
+	add_test(NAME shader_recompiler_fp16_overflow
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --fp16-overflow-only)
 	add_test(NAME virtual_memory_allocation
 		COMMAND $<TARGET_FILE:virtual_memory_allocation_tests>)
 	add_test(NAME guest_red_zone_patcher

--- a/src/graphics/shader/recompiler/frontend/translate/Convert.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Convert.cpp
@@ -70,7 +70,15 @@ void Translator::V_CVT_I32_F32(const Decoder::Instruction& inst) {
 }
 
 void Translator::V_CVT_F16_F32(const Decoder::Instruction& inst) {
-	WriteF16(DestinationOperand(inst), IR::F32(ReadOperand(SourceAt(inst, 0), IR::Type::F32)));
+	const auto source = IR::F32(ReadOperand(SourceAt(inst, 0), IR::Type::F32));
+	auto       result = ApplyF32ResultModifiers(inst.dst, source);
+	const std::array<IR::F32, 3> args {source, IR::F32(IR::Value::F32(0.0f)),
+	                                      IR::F32(IR::Value::F32(0.0f))};
+	result = ApplyF16Overflow(inst.opcode, result, args, 1u);
+	auto raw  = DestinationOperand(inst);
+	raw.omod  = 0u;
+	raw.clamp = false;
+	WriteF16(raw, result);
 }
 
 void Translator::V_CVT_F32_F16(const Decoder::Instruction& inst) {

--- a/src/graphics/shader/recompiler/frontend/translate/Float.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Float.cpp
@@ -8,17 +8,24 @@ namespace Libs::Graphics::ShaderRecompiler::Frontend {
 bool Translator::PackedFloat16(const Decoder::Instruction& inst, IR::ValueOpcode opcode,
                                bool accumulator, bool quiet_snan) {
 	const auto translate_lane = [&](bool high) {
-		const auto lhs = ReadF16LaneAsF32(inst.src0, high, true);
-		const auto rhs = ReadF16LaneAsF32(inst.src1, high, true);
-		IR::F32    result;
+		std::array<IR::F32, 3> args;
+		args[0] = ReadF16LaneAsF32(inst.src0, high, true);
+		args[1] = ReadF16LaneAsF32(inst.src1, high, true);
+		uint32_t arg_count = 2u;
+		IR::F32 result;
 		if (accumulator) {
-			result = IR::F32(ir.Emit(opcode, {lhs, rhs, ReadF16LaneAsF32(inst.dst, high, true)}));
+			args[2] = ReadF16LaneAsF32(inst.dst, high, true);
+			arg_count = 3u;
+			result = IR::F32(ir.Emit(opcode, {args[0], args[1], args[2]}));
 		} else if (inst.src_count == 3u) {
-			result = IR::F32(ir.Emit(opcode, {lhs, rhs, ReadF16LaneAsF32(inst.src2, high, true)}));
+			args[2] = ReadF16LaneAsF32(inst.src2, high, true);
+			arg_count = 3u;
+			result = IR::F32(ir.Emit(opcode, {args[0], args[1], args[2]}));
 		} else {
-			result = IR::F32(ir.Emit(opcode, {lhs, rhs}));
+			result = IR::F32(ir.Emit(opcode, {args[0], args[1]}));
 		}
-		return ApplyF32ResultModifiers(inst.dst, result);
+		result = ApplyF32ResultModifiers(inst.dst, result);
+		return ApplyF16Overflow(inst.opcode, result, args, arg_count);
 	};
 	auto raw    = DestinationOperand(inst);
 	raw.omod    = 0u;
@@ -50,13 +57,19 @@ bool Translator::Float16Unary(const Decoder::Instruction& inst, IR::ValueOpcode 
                               bool invalid_negative) {
 	const auto argument = ReadF16AsF32(inst.src0);
 	auto       result   = IR::F32(ir.Emit(opcode, {argument}));
+	result = ApplyF32ResultModifiers(inst.dst, result);
+	const std::array<IR::F32, 3> args {argument, IR::F32(IR::Value::F32(0.0f)),
+	                                      IR::F32(IR::Value::F32(0.0f))};
+	result = ApplyF16Overflow(inst.opcode, result, args, 1u);
 	if (!invalid_negative) {
-		WriteF16(DestinationOperand(inst), result);
+		auto raw  = DestinationOperand(inst);
+		raw.omod  = 0u;
+		raw.clamp = false;
+		WriteF16(raw, result);
 		return true;
 	}
 	const auto negative =
 	    IR::U1(ir.Emit(IR::ValueOpcode::FPOrdLessThan32, {argument, IR::Value::F32(0.0f)}));
-	result             = ApplyF32ResultModifiers(inst.dst, result);
 	const auto bits    = PackHalf2x16(result, IR::F32(IR::Value::F32(0.0f)));
 	const auto invalid = IR::U32(IR::Value(inst.dst.clamp ? 0u : 0xfe00u));
 	WriteU16(DestinationOperand(inst), ir.Select(negative, invalid, bits));
@@ -67,18 +80,31 @@ bool Translator::Float16Binary(const Decoder::Instruction& inst, IR::ValueOpcode
                                bool reverse) {
 	const auto lhs = ReadF16AsF32(reverse ? inst.src1 : inst.src0);
 	const auto rhs = ReadF16AsF32(reverse ? inst.src0 : inst.src1);
-	WriteF16(DestinationOperand(inst), IR::F32(ir.Emit(opcode, {lhs, rhs})));
+	const std::array<IR::F32, 3> args {lhs, rhs, IR::F32(IR::Value::F32(0.0f))};
+	auto result = IR::F32(ir.Emit(opcode, {lhs, rhs}));
+	result = ApplyF32ResultModifiers(inst.dst, result);
+	result = ApplyF16Overflow(inst.opcode, result, args, 2u);
+	auto raw  = DestinationOperand(inst);
+	raw.omod  = 0u;
+	raw.clamp = false;
+	WriteF16(raw, result);
 	return true;
 }
 
 bool Translator::Float16Ternary(const Decoder::Instruction& inst, IR::ValueOpcode opcode,
                                 bool accumulator, bool mix) {
-	std::array<IR::Value, 3> args;
+	std::array<IR::F32, 3> args;
 	for (uint32_t index = 0; index < args.size(); index++) {
 		const auto operand = accumulator && index == 2u ? inst.dst : SourceAt(inst, index);
-		args[index] = mix ? IR::Value(ReadMixF32(operand)) : IR::Value(ReadF16AsF32(operand));
+		args[index] = mix ? ReadMixF32(operand) : ReadF16AsF32(operand);
 	}
-	WriteF16(DestinationOperand(inst), IR::F32(ir.Emit(opcode, {args[0], args[1], args[2]})));
+	auto result = IR::F32(ir.Emit(opcode, {args[0], args[1], args[2]}));
+	result = ApplyF32ResultModifiers(inst.dst, result);
+	result = ApplyF16Overflow(inst.opcode, result, args, 3u);
+	auto raw  = DestinationOperand(inst);
+	raw.omod  = 0u;
+	raw.clamp = false;
+	WriteF16(raw, result);
 	return true;
 }
 

--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -1155,8 +1155,11 @@ bool TranslateProgram(const Decoder::Program& decoded, const CFG::Graph& cfg,
 	}
 	for (const auto& cfg_block: cfg.blocks) {
 		const auto         typed_index = block_indices.at(cfg_block.id);
-		const bool fp16_overflow =
-		    options.compute != nullptr && options.compute->fp16_overflow;
+		const bool fp16_overflow = options.compute != nullptr
+		                                 ? options.compute->fp16_overflow
+		                             : options.pixel != nullptr ? options.pixel->fp16_overflow
+		                             : options.vertex != nullptr ? options.vertex->fp16_overflow
+		                                                          : false;
 		Translator translator(result, result.blocks[typed_index], vector_limit, options.wave_size,
 		                      fp16_overflow);
 		for (uint32_t index = cfg_block.inst_begin; index < cfg_block.inst_end; index++) {

--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -353,6 +353,45 @@ IR::F32 Translator::ApplyF32ResultModifiers(const Decoder::Operand& operand, IR:
 	return value;
 }
 
+IR::F32 Translator::ApplyF16Overflow(Decoder::Opcode opcode, IR::F32 value,
+                                     const std::array<IR::F32, 3>& args,
+                                     uint32_t arg_count) {
+	if (!current_fp16_overflow) {
+		return value;
+	}
+
+	const auto magnitude_bits = [&](IR::F32 input) {
+		return ir.BitwiseAnd(ir.BitCastU32(input), IR::U32(IR::Value(0x7fffffffu)));
+	};
+	const auto is_infinity = [&](IR::F32 input) {
+		return ir.IEqual(magnitude_bits(input), IR::U32(IR::Value(0x7f800000u)));
+	};
+
+	// FP16_OVFL saturates arithmetic overflow, while infinities inherited from an operand and
+	// architectural reciprocal/logarithm poles remain infinite. Ordered comparison leaves NaNs
+	// unchanged and payload-preserving conversion stays in the existing half packing path.
+	IR::U1 genuine_infinity(IR::Value(false));
+	for (uint32_t index = 0; index < arg_count; index++) {
+		genuine_infinity = ir.LogicalOr(genuine_infinity, is_infinity(args[index]));
+	}
+	if (arg_count != 0u &&
+	    (opcode == Decoder::Opcode::V_RCP_F16 || opcode == Decoder::Opcode::V_RSQ_F16 ||
+	     opcode == Decoder::Opcode::V_LOG_F16)) {
+		const auto zero = ir.IEqual(magnitude_bits(args[0]), IR::U32(IR::Value(0u)));
+		genuine_infinity = ir.LogicalOr(genuine_infinity, zero);
+	}
+
+	const auto magnitude = IR::F32(ir.Emit(IR::ValueOpcode::FPAbs32, {value}));
+	const auto overflow = IR::U1(ir.Emit(
+	    IR::ValueOpcode::FPOrdGreaterThan32, {magnitude, IR::Value::F32(65504.0f)}));
+	const auto should_clamp = ir.LogicalAnd(overflow, ir.LogicalNot(genuine_infinity));
+	const auto negative = IR::U1(
+	    ir.Emit(IR::ValueOpcode::FPOrdLessThan32, {value, IR::Value::F32(0.0f)}));
+	const auto maximum = SelectF32(negative, IR::F32(IR::Value::F32(-65504.0f)),
+	                              IR::F32(IR::Value::F32(65504.0f)));
+	return SelectF32(should_clamp, maximum, value);
+}
+
 void Translator::WriteOperand(const Decoder::Operand& operand, IR::Value value) {
 	if (operand.kind == Decoder::OperandKind::Null) {
 		return;
@@ -1116,7 +1155,10 @@ bool TranslateProgram(const Decoder::Program& decoded, const CFG::Graph& cfg,
 	}
 	for (const auto& cfg_block: cfg.blocks) {
 		const auto         typed_index = block_indices.at(cfg_block.id);
-		Translator translator(result, result.blocks[typed_index], vector_limit, options.wave_size);
+		const bool fp16_overflow =
+		    options.compute != nullptr && options.compute->fp16_overflow;
+		Translator translator(result, result.blocks[typed_index], vector_limit, options.wave_size,
+		                      fp16_overflow);
 		for (uint32_t index = cfg_block.inst_begin; index < cfg_block.inst_end; index++) {
 			const auto& instruction = decoded.instructions[index];
 			if (IsCodeTableLoad(cfg, instruction.pc)) {

--- a/src/graphics/shader/recompiler/frontend/translate/Translator.h
+++ b/src/graphics/shader/recompiler/frontend/translate/Translator.h
@@ -9,9 +9,10 @@ namespace Libs::Graphics::ShaderRecompiler::Frontend {
 
 class Translator {
 public:
-	Translator(IR::Program& program, IR::Block* block, uint32_t vector_limit, uint32_t wave_size)
+	Translator(IR::Program& program, IR::Block* block, uint32_t vector_limit, uint32_t wave_size,
+	           bool fp16_overflow)
 	    : program(program), ir(block), current_vector_limit(vector_limit),
-	      current_wave_size(wave_size) {}
+	      current_wave_size(wave_size), current_fp16_overflow(fp16_overflow) {}
 
 	bool TranslateInstruction(const Decoder::Instruction& inst, std::string* error);
 	bool TranslateEmbeddedFetch(const Decoder::Instruction& inst, uint32_t attribute,
@@ -32,6 +33,9 @@ private:
 	IR::U1                 ThreadBit(IR::U32 low);
 	void                   WriteRawU32(const Decoder::Operand& operand, IR::U32 value);
 	IR::F32                ApplyF32ResultModifiers(const Decoder::Operand& operand, IR::F32 value);
+	IR::F32                ApplyF16Overflow(Decoder::Opcode opcode, IR::F32 value,
+	                                       const std::array<IR::F32, 3>& args,
+	                                       uint32_t arg_count);
 	void                   WriteOperand(const Decoder::Operand& operand, IR::Value value);
 	IR::U32                PackHalf2x16(IR::F32 low, IR::F32 high);
 	void                   WriteF16(const Decoder::Operand& operand, IR::F32 value);
@@ -254,6 +258,7 @@ private:
 	uint32_t        current_pc           = 0;
 	uint32_t        current_vector_limit = 1;
 	uint32_t        current_wave_size    = 64;
+	bool            current_fp16_overflow = false;
 };
 
 } // namespace Libs::Graphics::ShaderRecompiler::Frontend

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -809,6 +809,7 @@ static void ShaderGetStaticInputInfoCS(const HW::ComputeShaderInfo& regs,
 	info.threads_num[2]      = regs.cs_regs.num_thread_z;
 	info.lds_size_dwords     = static_cast<uint32_t>(regs.cs_regs.lds_size) * 128u;
 	info.scratch_size_dwords = data.scratch_size_dwords;
+	info.fp16_overflow       = regs.cs_regs.fp16_overflow;
 	info.group_id[0]         = regs.cs_regs.tgid_x_en != 0;
 	info.group_id[1]         = regs.cs_regs.tgid_y_en != 0;
 	info.group_id[2]         = regs.cs_regs.tgid_z_en != 0;
@@ -966,6 +967,7 @@ void BuildStageStaticKey(const ShaderComputeInputInfo& info, std::vector<uint32_
 	key.push_back(info.thread_ids_num);
 	key.push_back(info.lds_size_dwords);
 	key.push_back(info.scratch_size_dwords);
+	key.push_back(static_cast<uint32_t>(info.fp16_overflow));
 	key.push_back(static_cast<uint32_t>(info.needs_lds_barriers));
 	key.push_back(static_cast<uint32_t>(info.dispatch_thread_dimensions));
 	for (int i = 0; i < 3; i++) {
@@ -1108,10 +1110,12 @@ void ShaderDbgDumpInputInfo(const ShaderComputeInputInfo& info) {
 	     "\t thread_ids_num     = %d\n"
 	     "\t wave_size          = %u\n"
 	     "\t lds_size_dwords    = %u\n"
+	     "\t fp16_overflow      = %s\n"
 	     "\t needs_lds_barriers = %s\n"
 	     "\t threads_num        = {%u, %u, %u}\n"
 	     "\t tg_size_en         = %s\n",
 	     info.workgroup_register, info.thread_ids_num, info.wave_size, info.lds_size_dwords,
+	     info.fp16_overflow ? "true" : "false",
 	     info.needs_lds_barriers ? "true" : "false",
 	     info.threads_num[0], info.threads_num[1], info.threads_num[2],
 	     info.tg_size_en ? "true" : "false");

--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -695,6 +695,7 @@ static bool ShaderGetStaticInputInfoVS(const HW::VertexShaderInfo& regs,
 	const HW::UserSgprInfo& user_sgpr     = regs.gs_user_sgpr;
 	auto                    user_sgpr_num = regs.gs_regs.rsrc2.user_sgpr;
 	info.scratch_size_dwords = data.scratch_size_dwords;
+	info.fp16_overflow       = regs.gs_regs.rsrc1.fp16_overflow;
 
 	if (data.user_data == nullptr) {
 		LOGF("ShaderGetInputInfoVS(): no AGC user data for shader=0x%016" PRIx64 " es=0x%016" PRIx64
@@ -744,6 +745,7 @@ static void ShaderGetStaticInputInfoPS(
 
 	ps_info = {};
 	ps_info.scratch_size_dwords = data.scratch_size_dwords;
+	ps_info.fp16_overflow       = regs.ps_regs.rsrc1.fp16_overflow;
 	ps_info.push_constant_offset =
 	    vs_info.stage.program != nullptr
 	        ? vs_info.stage.program->bindings.push_constant_offset +
@@ -892,6 +894,7 @@ void BuildStageStaticKey(const ShaderVertexInputInfo& info, std::vector<uint32_t
 	key.push_back(static_cast<uint32_t>(info.fetch_embedded));
 	key.push_back(info.resources_num);
 	key.push_back(info.scratch_size_dwords);
+	key.push_back(static_cast<uint32_t>(info.fp16_overflow));
 	key.push_back(info.pa_cl_vs_out_cntl);
 
 	for (int i = 0; i < info.resources_num; i++) {
@@ -933,6 +936,7 @@ void BuildStageStaticKey(const ShaderPixelInputInfo& info, std::vector<uint32_t>
 	key.clear();
 	key.push_back(info.push_constant_offset);
 	key.push_back(info.scratch_size_dwords);
+	key.push_back(static_cast<uint32_t>(info.fp16_overflow));
 	key.push_back(info.input_num);
 	key.push_back(info.ps_system_input_base);
 	key.push_back(info.custom_interpolation_mask);

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -93,6 +93,7 @@ struct ShaderComputeInputInfo {
 	uint32_t           dispatch_threads_num[3]    = {0, 0, 0};
 	uint32_t           lds_size_dwords            = 0;
 	uint32_t           scratch_size_dwords        = 0;
+	bool               fp16_overflow              = false;
 	bool               group_id[3]                = {false, false, false};
 	bool               dispatch_thread_dimensions = false;
 	bool               needs_lds_barriers          = false;

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -82,6 +82,7 @@ struct ShaderVertexInputInfo {
 	int                     buffers_num         = 0;
 	int                     export_count        = 0;
 	uint32_t                scratch_size_dwords = 0;
+	bool                    fp16_overflow       = false;
 	uint32_t                param_export_mask   = 0;
 	uint32_t                pa_cl_vs_out_cntl    = 0;
 	bool                    fetch_external      = false;
@@ -115,6 +116,7 @@ struct ShaderPixelInputInfo {
 	uint32_t                                       mrt_output_mask              = 0;
 	uint32_t                                       push_constant_offset         = 0;
 	uint32_t                                       scratch_size_dwords          = 0;
+	bool                                           fp16_overflow                = false;
 	bool                                           ps_pos_x                     = false;
 	bool                                           ps_pos_y                     = false;
 	bool                                           ps_pos_xy                    = false;

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -987,6 +987,7 @@ struct GraphicsCase {
   std::vector<u32> pixel_interpolator_settings;
   bool pixel_no_perspective = false;
   std::vector<u32> vertices;
+  bool fp16_overflow = false;
 };
 
 struct CompiledShader {
@@ -1317,6 +1318,7 @@ CompiledShader CompileFragmentCase(const GraphicsCase &test) {
           ? 1u
           : static_cast<u32>(test.pixel_interpolator_settings.size());
   pixel_info.ps_no_perspective = test.pixel_no_perspective;
+  pixel_info.fp16_overflow = test.fp16_overflow;
   for (u32 i = 0; i < std::size(pixel_info.interpolator_settings); i++) {
     pixel_info.interpolator_settings[i] = i;
   }
@@ -20074,6 +20076,38 @@ TestCase ImageAtomicGlc0DoesNotReturnOldValue() {
   return test;
 }
 
+GraphicsCase GraphicsFp16OverflowMode(bool enabled) {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0x7bff7bffu); // packed +MAX_FP16
+  AppendVMovLiteral(&code, 1, 0x40004000u); // packed +2.0h
+  AppendVMovLiteral(&code, 2, 0x7c007c00u); // packed +Inf
+  AppendVMovLiteral(&code, 3, 0x12347bffu); // scalar +MAX_FP16
+  AppendVMovLiteral(&code, 4, 0x00004000u); // scalar +2.0h
+  AppendVMovLiteral(&code, 5, 0x3f800000u); // +1.0f
+  AppendVop3p(&code, 0x10, 10, Vgpr(0), Vgpr(1), 0, 0x3);
+  AppendVop3p(&code, 0x10, 11, Vgpr(2), Vgpr(1), 0, 0x3);
+  code.push_back(EncodeVop2(0x35, 3, Vgpr(3), 4));
+  code.push_back(EncodeExp0(0x00, 0xf));
+  code.push_back(EncodeExp1(10, 11, 3, 5));
+  AppendEnd(&code);
+
+  GraphicsCase test;
+  test.name = enabled ? "GraphicsFp16OverflowEnabled"
+                      : "GraphicsFp16OverflowDisabled";
+  test.fragment_code = std::move(code);
+  test.expected_pixel = enabled
+                            ? std::vector<u32>{0x7bff7bffu, 0x7c007c00u,
+                                               0x12347bffu, 0x3f800000u}
+                            : std::vector<u32>{0x7c007c00u, 0x7c007c00u,
+                                               0x12347c00u, 0x3f800000u};
+  test.opcodes = {O::V_MOV_B32, O::V_PK_MUL_F16, O::V_MUL_F16, O::EXP,
+                  O::S_ENDPGM};
+  test.fp16_overflow = enabled;
+  return test;
+}
+
 GraphicsCase GraphicsInterpolationExport() {
   using O = ShaderOpcode;
 
@@ -20622,6 +20656,8 @@ std::vector<TestCase> MakeCases() {
 
 std::vector<GraphicsCase> MakeGraphicsCases() {
   return {
+      GraphicsFp16OverflowMode(false),
+      GraphicsFp16OverflowMode(true),
       GraphicsInterpolationExport(),
       GraphicsFlatInterpolatorExport(),
       GraphicsDsAddtidScratchExport(),
@@ -23023,6 +23059,32 @@ void CheckComputeFp16OverflowStaticKey() {
   std::printf("[host]    %-32s ok\n", "ComputeFp16OverflowStaticKey");
 }
 
+void CheckGraphicsFp16OverflowStaticKeys() {
+  ShaderVertexInputInfo vertex_disabled{};
+  ShaderVertexInputInfo vertex_enabled{};
+  ShaderPixelInputInfo pixel_disabled{};
+  ShaderPixelInputInfo pixel_enabled{};
+  vertex_enabled.fp16_overflow = true;
+  pixel_enabled.fp16_overflow = true;
+
+  std::vector<u32> vertex_disabled_key;
+  std::vector<u32> vertex_enabled_key;
+  std::vector<u32> pixel_disabled_key;
+  std::vector<u32> pixel_enabled_key;
+  BuildStageStaticKey(vertex_disabled, vertex_disabled_key);
+  BuildStageStaticKey(vertex_enabled, vertex_enabled_key);
+  BuildStageStaticKey(pixel_disabled, pixel_disabled_key);
+  BuildStageStaticKey(pixel_enabled, pixel_enabled_key);
+
+  Require("GraphicsFp16OverflowStaticKeys", "program cache separation",
+          vertex_disabled_key.size() == vertex_enabled_key.size() &&
+              vertex_disabled_key != vertex_enabled_key &&
+              pixel_disabled_key.size() == pixel_enabled_key.size() &&
+              pixel_disabled_key != pixel_enabled_key,
+          "FP16_OVERFLOW did not specialize the vertex and pixel program keys");
+  std::printf("[host]    %-32s ok\n", "GraphicsFp16OverflowStaticKeys");
+}
+
 void CheckDepthHtileStencilCompatibility() {
   Require("DepthHtileStencilCompatibility", "disabled acceleration",
           depth_htile_stencil_acceleration_compatible(false, false, true),
@@ -24488,6 +24550,16 @@ int main(int argc, char **argv) {
     CheckIndirectImageKeySwitch();
     return 0;
   }
+  if (argc == 2 && std::strcmp(argv[1], "--fp16-overflow-only") == 0) {
+    VulkanHarness vulkan;
+    CheckComputeFp16OverflowStaticKey();
+    CheckGraphicsFp16OverflowStaticKeys();
+    RunCase(&vulkan, ComputeFp16OverflowMode(false));
+    RunCase(&vulkan, ComputeFp16OverflowMode(true));
+    RunGraphicsCase(&vulkan, GraphicsFp16OverflowMode(false));
+    RunGraphicsCase(&vulkan, GraphicsFp16OverflowMode(true));
+    return 0;
+  }
   if (argc == 2 && std::strcmp(argv[1], "--storage-mip-host-only") == 0) {
     VulkanHarness vulkan;
     vulkan.CheckRenderExecutorStencilBindingDiscovery();
@@ -24533,6 +24605,7 @@ int main(int argc, char **argv) {
   CheckStorageTextureGpuOwnedRebindState();
   CheckNativeMsaaState();
   CheckComputeFp16OverflowStaticKey();
+  CheckGraphicsFp16OverflowStaticKeys();
   CheckPs5DepthRegisterDecoding();
   CheckDepthHtileStencilCompatibility();
   CheckStencilAttachmentAccess();

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -14253,6 +14253,52 @@ TestCase PackedMinMaxF16NanAndSignedZeroEdges() {
            O::BUFFER_STORE_DWORD, O::S_ENDPGM}};
 }
 
+TestCase ComputeFp16OverflowMode(bool enabled) {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0x7bff7bffu); // packed +MAX_FP16
+  AppendVMovLiteral(&code, 1, 0x40004000u); // packed +2.0h
+  AppendVMovLiteral(&code, 2, 0x7c007c00u); // packed +Inf
+  AppendVMovLiteral(&code, 3, 0x12347bffu); // scalar +MAX_FP16
+  AppendVMovLiteral(&code, 4, 0x00004000u); // scalar +2.0h
+  AppendVMovLiteral(&code, 5, 0x4788b800u); // +70000.0f
+  AppendVMovLiteral(&code, 6, 0xc788b800u); // -70000.0f
+  AppendVMovLiteral(&code, 7, 0x7f800000u); // +Inf
+
+  AppendVop3p(&code, 0x10, 10, Vgpr(0), Vgpr(1), 0, 0x3);
+  AppendVop3p(&code, 0x10, 11, Vgpr(2), Vgpr(1), 0, 0x3);
+  code.push_back(EncodeVop2(0x35, 3, Vgpr(3), 4));
+  code.push_back(EncodeVop1(0x0a, 12, Vgpr(5)));
+  code.push_back(EncodeVop1(0x0a, 13, Vgpr(6)));
+  code.push_back(EncodeVop1(0x0a, 14, Vgpr(7)));
+  AppendStoreVgpr(&code, 10, 0);
+  AppendStoreVgpr(&code, 11, 1);
+  AppendStoreVgpr(&code, 3, 2);
+  AppendStoreVgpr(&code, 12, 3);
+  AppendStoreVgpr(&code, 13, 4);
+  AppendStoreVgpr(&code, 14, 5);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = enabled ? "ComputeFp16OverflowEnabled"
+                      : "ComputeFp16OverflowDisabled";
+  test.code = std::move(code);
+  test.expected = enabled
+                      ? std::vector<u32>{0x7bff7bffu, 0x7c007c00u,
+                                         0x12347bffu, 0x00007bffu,
+                                         0x0000fbffu, 0x00007c00u}
+                      : std::vector<u32>{0x7c007c00u, 0x7c007c00u,
+                                         0x12347c00u, 0x00007c00u,
+                                         0x0000fc00u, 0x00007c00u};
+  test.opcodes = {O::V_MOV_B32, O::V_PK_MUL_F16, O::V_MUL_F16,
+                  O::V_CVT_F16_F32, O::BUFFER_STORE_DWORD,
+                  O::S_ENDPGM};
+  test.compute_info.fp16_overflow = enabled;
+  test.has_compute_info = true;
+  return test;
+}
+
 TestCase VectorMinMaxF16Ops() {
   using O = ShaderOpcode;
 
@@ -20378,6 +20424,8 @@ std::vector<TestCase> MakeCases() {
   AddCase(CvtPkU8F32PacksSelectedByte);
   AddCase(CvtPkrtzF16F32SubnormalRoundsTowardZero);
   AddCase(PackedMinMaxF16NanAndSignedZeroEdges);
+  cases.push_back(ComputeFp16OverflowMode(false));
+  cases.push_back(ComputeFp16OverflowMode(true));
   AddCase(VectorMinMaxF16Ops);
   AddCase(VectorCvtU16F16Sdwa);
   AddCase(VectorMinMaxMed3F16Ops);
@@ -22961,6 +23009,20 @@ void CheckNativeMsaaState() {
   std::printf("[host]    %-32s ok\n", "NativeMsaaState");
 }
 
+void CheckComputeFp16OverflowStaticKey() {
+  ShaderComputeInputInfo disabled{};
+  ShaderComputeInputInfo enabled{};
+  enabled.fp16_overflow = true;
+  std::vector<u32> disabled_key;
+  std::vector<u32> enabled_key;
+  BuildStageStaticKey(disabled, disabled_key);
+  BuildStageStaticKey(enabled, enabled_key);
+  Require("ComputeFp16OverflowStaticKey", "pipeline cache separation",
+          disabled_key.size() == enabled_key.size() && disabled_key != enabled_key,
+          "FP16_OVFL did not specialize the compute program cache key");
+  std::printf("[host]    %-32s ok\n", "ComputeFp16OverflowStaticKey");
+}
+
 void CheckDepthHtileStencilCompatibility() {
   Require("DepthHtileStencilCompatibility", "disabled acceleration",
           depth_htile_stencil_acceleration_compatible(false, false, true),
@@ -24470,6 +24532,7 @@ int main(int argc, char **argv) {
   CheckStorageTextureVolumeMipRegions();
   CheckStorageTextureGpuOwnedRebindState();
   CheckNativeMsaaState();
+  CheckComputeFp16OverflowStaticKey();
   CheckPs5DepthRegisterDecoding();
   CheckDepthHtileStencilCompatibility();
   CheckStencilAttachmentAccess();


### PR DESCRIPTION
## Summary
- Propagates COMPUTE/GS/PS PGM_RSRC1.FP16_OVFL into compute, vertex, and pixel translation.
- Includes the mode in every affected static shader key to prevent incompatible cached modules from being reused.
- Saturates finite packed and scalar FP16 arithmetic overflow to signed 65504 when enabled.
- Applies the same mode to V_CVT_F16_F32 while preserving NaNs, inherited infinities, and reciprocal/logarithm poles.

## Why
FP16_OVFL selects whether finite values outside the half-float range become infinities or the largest finite half value. Ignoring it changes guest results and leaves shader cache keys incomplete. Overflow detection uses an ordered magnitude comparison so NaNs remain untouched.

## Scope
This PR changes only FP16_OVFL. DX10_CLAMP, FP_ROUND, denormal, and IEEE-mode work remain isolated.

## Validation
- Release build: shader_recompiler_compute_tests
- shader_recompiler_fp16_overflow: passed
- shader_recompiler_compute: passed
- Enabled/disabled compute packed, scalar, and F32-to-F16 cases
- Enabled/disabled Vulkan pixel runtime cases
- Compute, vertex, and pixel static-key separation checks