### PR TITLE
shader: clamp scalar-buffer reads to the final dword

### DIFF
--- a/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
@@ -550,11 +550,15 @@ private:
 			const auto size = stride == 0u
 			                      ? static_cast<uint64_t>(static_cast<uint32_t>(records))
 			                      : static_cast<uint64_t>(stride) * static_cast<uint32_t>(records);
-			if (aligned > size || size - aligned < sizeof(uint32_t)) {
-				return Fail(
-				    error, fmt::format("constant-buffer offset {} exceeds size {}", aligned, size));
+			if (size < sizeof(uint32_t)) {
+				return Fail(error, fmt::format(
+				                       "constant-buffer size {} has no complete dword", size));
 			}
-			address = ((base & ~uint64_t {3}) + byte_offset) & ~uint64_t {3};
+			// Scalar buffer reads beyond the descriptor are clamped per dword to the
+			// final complete element rather than returning zero or rejecting the walk.
+			const auto last_valid_offset = (size - sizeof(uint32_t)) & ~uint64_t {3};
+			const auto clamped_offset    = std::min(aligned, last_valid_offset);
+			address = (base & ~uint64_t {3}) + clamped_offset;
 		} else {
 			const auto relative = (immediate & ~int64_t {3}) +
 			                      static_cast<int64_t>(static_cast<uint32_t>(offset) & ~3u);

--- a/tests/ScalarProvenanceTests.cpp
+++ b/tests/ScalarProvenanceTests.cpp
@@ -356,10 +356,9 @@ void TestConstantBufferBounds() {
                 {overflow_read, Value(0u), Value(16u), Value(0u)});
   overflow.Plan();
   flat = {0x55u};
-  Check(!WalkSrt(overflow.program, runtime, flat, &error) &&
-            flat == std::vector<uint32_t>{0x55u} &&
-            error.find("exceeds size") != std::string::npos,
-        "out-of-bounds constant-buffer walk was not transactional");
+  Check(WalkSrt(overflow.program, runtime, flat, &error) &&
+            flat == std::vector<uint32_t>{0xa5a5a5a5u},
+        "out-of-bounds constant-buffer read did not clamp to the final dword");
 }
 
 void TestReadLaneElimination() {


### PR DESCRIPTION
## Summary
- clamp out-of-range scalar constant-buffer reads to the final complete dword
- retain an explicit diagnostic for descriptors smaller than one dword
- add a runtime SRT regression test that resolves offset 16 of a 16-byte buffer from offset 12

## Rationale
PS5 scalar-buffer addressing clamps accesses beyond the descriptor to the final valid element on a dword-by-dword basis. Aborting SRT evaluation rejects valid hardware behavior; returning zero also produces the wrong descriptor data.

## Validation
- built: kyty_emulator, scalar_provenance_tests, shader_recompiler_compute_tests
- passed: scalar_provenance
- passed: shader_cfg
- passed: shader_recompiler_compute
- git diff --check

Reference used for semantic verification: GPU Shader Core ISA Specification, SDK 12.000, scalar buffer addressing, page 3. No SDK material is included in this change.