### PR TITLE
renderer: preserve GPU-authored storage images during GC

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1899,9 +1899,19 @@ void TextureCache::RunGarbageCollector() {
 		size_t         deletions = aggressive ? 40 : pressured ? 20 : 10;
 		std::vector<ImageId> candidates;
 		candidates.reserve(deletions);
+		const auto gpu_authored_storage = [](const Image& image) {
+			return image.IsGpuModified() && image.usage.storage && !image.usage.render_target &&
+			       !image.usage.video_out;
+		};
 		// Deleting depth recursively deletes its stencil association, so finish LRU traversal
 		// first.
 		m_lru_cache.ForEachItemBelow(tick - age, [&](ImageId id) {
+			const auto owner = m_slot_images.try_get(id);
+			// Storage-only images can contain data that has never been materialized in guest
+			// memory. Do not let protected entries consume the finite collection budget.
+			if (owner != nullptr && owner->registered && gpu_authored_storage(*owner)) {
+				return false;
+			}
 			candidates.push_back(id);
 			return candidates.size() == deletions;
 		});
@@ -1912,6 +1922,9 @@ void TextureCache::RunGarbageCollector() {
 			--deletions;
 			auto owner = m_slot_images.try_get(id);
 			if (owner == nullptr || !owner->registered || owner->depth_id) {
+				continue;
+			}
+			if (gpu_authored_storage(*owner)) {
 				continue;
 			}
 			if (owner->IsGpuModified()) {

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -6174,6 +6174,65 @@ public:
               "stale native bytes");
       DestroyBuffer(&alias_readback);
 
+      constexpr uint64_t gpu_authored_storage_offset = 0x338000;
+      auto gpu_authored_storage = MakeLinearDesc(
+          base + gpu_authored_storage_offset, sizeof(uint32_t),
+          vk::Format::eR32Uint, Prospero::BufferFormat::k32UInt,
+          Prospero::ImageType::kColor2D, {1, 1, 1}, 1, 4, 1);
+      gpu_authored_storage.type = BindingType::Storage;
+      gpu_authored_storage.view_info.usage = vk::ImageUsageFlagBits::eStorage;
+      const auto gpu_authored_storage_image =
+          texture_cache.FindImage(gpu_authored_storage);
+      auto &gpu_authored_storage_owner =
+          texture_cache.GetImage(gpu_authored_storage_image);
+      gpu_authored_storage_owner.usage.storage = true;
+      texture_cache.MarkGpuWritten(gpu_authored_storage_image);
+      const std::array gpu_authored_storage_images{
+          gpu_authored_storage_image};
+      TextureCacheTestAccess::ConfigureGarbageCollection(
+          texture_cache, gpu_authored_storage_images, 121, 0);
+      texture_cache.RunGarbageCollector();
+      Require(name, "GPU-authored storage pressure retention",
+              TextureCacheTestAccess::Contains(
+                  texture_cache, gpu_authored_storage_image) &&
+                  texture_cache.GetImage(gpu_authored_storage_image)
+                      .IsGpuModified(),
+              "pressure GC discarded a storage image whose authoritative "
+              "contents exist only in GPU memory");
+
+      constexpr uint64_t gc_starvation_offset = 0x340000;
+      constexpr size_t gc_protected_count = 20;
+      std::array<ImageId, gc_protected_count + 1> gc_starvation_images{};
+      for (size_t index = 0; index < gc_starvation_images.size(); ++index) {
+        auto desc = MakeLinearDesc(
+            base + gc_starvation_offset + index * 0x100, sizeof(uint32_t),
+            vk::Format::eR32Uint, Prospero::BufferFormat::k32UInt,
+            Prospero::ImageType::kColor2D, {1, 1, 1}, 1, 4, 1);
+        const auto image = texture_cache.FindImage(desc);
+        gc_starvation_images[index] = image;
+        if (index < gc_protected_count) {
+          auto &owner = texture_cache.GetImage(image);
+          owner.usage.storage = true;
+          texture_cache.MarkGpuWritten(image);
+        }
+      }
+      TextureCacheTestAccess::ConfigureGarbageCollection(
+          texture_cache, gc_starvation_images, 121, 0);
+      texture_cache.RunGarbageCollector();
+      const bool protected_storage_survived = std::ranges::all_of(
+          std::span{gc_starvation_images}.first(gc_protected_count),
+          [&](ImageId image) {
+            return TextureCacheTestAccess::Contains(texture_cache, image) &&
+                   texture_cache.GetImage(image).IsGpuModified();
+          });
+      Require(
+          name, "GPU-authored storage GC progress",
+          protected_storage_survived &&
+              !TextureCacheTestAccess::Contains(texture_cache,
+                                                gc_starvation_images.back()),
+          "protected GPU storage exhausted the pressure-GC candidate budget "
+          "before an evictable image");
+
       constexpr uint64_t submit_readback_offset = 0x336000;
       constexpr uint32_t submit_readback_value = 0x13579bdfu;
       constexpr uint32_t submit_readback_stale = 0x2468ace0u;


### PR DESCRIPTION
## Summary
- retain GPU-modified storage-only images whose authoritative contents remain in host GPU memory
- exclude protected entries while filling the bounded LRU deletion batch
- verify both data retention and forward GC progress after 20 protected entries

## Why
Pressure GC can otherwise clear and delete a GPU-authored storage image without publishing its only current contents to guest memory. The next use is then reconstructed from stale or empty guest data, producing black or corrupted textures.

This isolates and hardens the GC part of #266. Unlike the original traversal, it keeps the candidate vector bounded and prevents protected images from starving a later evictable image.

## Game / PPSA context
- Scars Above — PPSA08597 (storage-image and black-world investigation)
- Demon's Souls — PPSA01342 (texture/color corruption investigation)

## Validation
- built: kyty_emulator, shader_recompiler_compute_tests
- passed: texture_cache_image_overlap
- passed: shader_recompiler_compute
- git diff --check

Co-authorship preserves credit for the original #266 change and the hardened regression work.