### PR TITLE
renderer: clamp image copies to shared extents

### DIFF
--- a/src/graphics/host_gpu/renderer/image/image.cpp
+++ b/src/graphics/host_gpu/renderer/image/image.cpp
@@ -313,9 +313,9 @@ std::pair<uint32_t, uint32_t> Image::SanitizeCopyLayers(const Image& source,
 	if (source_type == destination_type) {
 		source_layers = destination_layers = std::min(source_layers, destination_layers);
 	} else if (source_type == vk::ImageType::e2D && destination_type == vk::ImageType::e3D) {
-		source_layers = depth;
+		source_layers = std::min(source_layers, depth);
 	} else if (source_type == vk::ImageType::e3D && destination_type == vk::ImageType::e2D) {
-		destination_layers = depth;
+		destination_layers = std::min(destination_layers, depth);
 	}
 	return {source_layers, destination_layers};
 }
@@ -334,9 +334,15 @@ void Image::CopyImage(Image& source) {
 	std::vector<vk::ImageCopy> copies;
 	copies.reserve(levels);
 	for (uint32_t level = 0; level < levels; level++) {
-		const auto width  = std::max(source.backing.extent.width >> level, 1u);
-		const auto height = std::max(source.backing.extent.height >> level, 1u);
-		const auto depth  = std::max(base_depth >> level, 1u);
+		const auto width  = std::min(std::max(source.backing.extent.width >> level, 1u),
+		                             std::max(backing.extent.width >> level, 1u));
+		const auto height = std::min(std::max(source.backing.extent.height >> level, 1u),
+		                             std::max(backing.extent.height >> level, 1u));
+		auto       depth  = std::max(base_depth >> level, 1u);
+		if (source.backing.image_type == vk::ImageType::e3D &&
+		    backing.image_type == vk::ImageType::e3D) {
+			depth = std::min(depth, std::max(source.backing.extent.depth >> level, 1u));
+		}
 		const auto [source_layers, destination_layers] = SanitizeCopyLayers(source, *this, depth);
 		vk::ImageCopy copy {};
 		copy.srcSubresource = {source_aspect, level, 0, 1};
@@ -477,8 +483,10 @@ void Image::CopyImageWithBuffer(Image& source, Buffer& buffer) {
 	               command);
 	Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite, {}, command);
 	for (uint32_t level = 0; level < levels; level++) {
-		const auto width             = std::max(source.backing.extent.width >> level, 1u);
-		const auto height            = std::max(source.backing.extent.height >> level, 1u);
+		const auto width             = std::min(std::max(source.backing.extent.width >> level, 1u),
+		                                        std::max(backing.extent.width >> level, 1u));
+		const auto height            = std::min(std::max(source.backing.extent.height >> level, 1u),
+		                                        std::max(backing.extent.height >> level, 1u));
 		const auto source_depth      = source.backing.image_type == vk::ImageType::e3D
 		                                   ? std::max(source.backing.extent.depth >> level, 1u)
 		                                   : source.backing.layers;

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -182,6 +182,12 @@ struct ImageTestAccess {
                            uint64_t capacity) {
     return Image::CopyRows(row_size, rows, capacity);
   }
+
+  static std::pair<uint32_t, uint32_t>
+  SanitizeCopyLayers(const Image &source, const Image &destination,
+                     uint32_t depth) {
+    return Image::SanitizeCopyLayers(source, destination, depth);
+  }
 };
 
 struct TileManagerTestAccess {
@@ -4538,14 +4544,22 @@ public:
       native_array_info.data = {};
       auto native_volume_info = volume_desc.info;
       native_volume_info.data = {};
+      native_volume_info.extent.depth = 4;
       Libs::Graphics::Image native_array(m_runtime_context, scheduler,
                                          native_array_info);
       Libs::Graphics::Image native_volume(m_runtime_context, scheduler,
                                           native_volume_info);
+      const auto array_to_volume_layers = ImageTestAccess::SanitizeCopyLayers(
+          native_array, native_volume, native_volume_info.extent.depth);
+      const auto volume_to_array_layers = ImageTestAccess::SanitizeCopyLayers(
+          native_volume, native_array, native_volume_info.extent.depth);
       native_volume.CopyImage(native_array);
       native_array.CopyImage(native_volume);
       Require(name, "Image-owned 2D-array/3D copy state",
-              native_volume.backing.state.layout ==
+              array_to_volume_layers == std::pair<uint32_t, uint32_t>{2, 1} &&
+                  volume_to_array_layers ==
+                      std::pair<uint32_t, uint32_t>{1, 2} &&
+                  native_volume.backing.state.layout ==
                       vk::ImageLayout::eTransferSrcOptimal &&
                   native_volume.backing.state.access_mask ==
                       vk::AccessFlagBits2::eTransferRead &&
@@ -4555,7 +4569,8 @@ public:
                       (vk::AccessFlagBits2::eShaderRead |
                        vk::AccessFlagBits2::eTransferRead),
               "Image::CopyImage did not retain pinned "
-              "source/destination states");
+              "source/destination states or clamp unequal array/volume "
+              "slices");
 
       constexpr uint64_t block_alias_offset = 0x23000;
       constexpr std::array<uint32_t, 4> block_alias_data{


### PR DESCRIPTION
## Summary
- clamp width and height at every mip to the extent shared by source and destination
- clamp 3D depth when both images are volumes
- clamp 2D-array layers against 3D mip depth in both conversion directions
- apply the same width/height rule to the buffer-mediated fallback path

## Why
Cached aliases may share pitch and memory while differing by a texel, layer, or volume depth. Building the copy exclusively from the source extent can exceed the destination subresource and trigger Vulkan validation/device errors.

This isolates and hardens the image-copy part of #266.

## Game / PPSA context
- Scars Above — PPSA08597
- Demon's Souls — PPSA01342

## Validation
- runtime regression covers unequal 2D-array/3D slice counts in both directions
- built: kyty_emulator, shader_recompiler_compute_tests
- passed: texture_cache_image_overlap
- passed: shader_recompiler_compute
- git diff --check