### PR TITLE
renderer: clamp render area to attachment mip views

### DIFF
--- a/src/graphics/host_gpu/renderer/render.h
+++ b/src/graphics/host_gpu/renderer/render.h
@@ -173,6 +173,8 @@ private:
 	                         const DrawEmitInfo& emit, const DrawIndexBufferSource& index_source,
 	                         bool primitive_restart_enable, bool log_pipeline_phase,
 	                         bool set_bind_debug, bool set_auto_debug);
+	[[nodiscard]] static vk::Extent2D AttachmentViewExtent(const Image&         image,
+	                                                       const ImageViewInfo& view);
 	[[nodiscard]] RenderState AcquireRenderTargets(CommandBuffer& buffer, RenderColorInfo* colors,
 	                                               uint32_t color_count, RenderDepthInfo& depth);
 	[[nodiscard]] bool        ResolveColorTargets(uint64_t submit_id, CommandBuffer& buffer,

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -567,6 +567,12 @@ static bool ResolveDccAttachmentClear(TextureCache& cache, const RenderColorInfo
 	return true;
 }
 
+vk::Extent2D RenderExecutor::AttachmentViewExtent(const Image&         image,
+                                                  const ImageViewInfo& view) {
+	return {std::max(image.backing.extent.width >> view.base_level, 1u),
+	        std::max(image.backing.extent.height >> view.base_level, 1u)};
+}
+
 RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderColorInfo* colors,
                                                  uint32_t color_count, RenderDepthInfo& depth) {
 	EXIT_IF(colors == nullptr || color_count > RENDER_COLOR_ATTACHMENTS_MAX);
@@ -616,8 +622,9 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 		              ImageSubresourceRange {view.base_level, view.level_count, view.base_layer,
 		                                     view.layer_count},
 		              buffer.Handle());
-		state.width             = std::min(state.width, target.extent.width);
-		state.height            = std::min(state.height, target.extent.height);
+		const auto view_extent  = AttachmentViewExtent(image, view);
+		state.width             = std::min({state.width, target.extent.width, view_extent.width});
+		state.height            = std::min({state.height, target.extent.height, view_extent.height});
 		state.num_layers        = std::min(state.num_layers, view.layer_count);
 		auto& attachment        = state.color_attachments[i];
 		attachment.image_view   = target.image_view;
@@ -675,8 +682,9 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 		              ImageSubresourceRange {view.base_level, view.level_count, view.base_layer,
 		                                     view.layer_count},
 		              buffer.Handle());
-		state.width               = std::min(state.width, depth.width);
-		state.height              = std::min(state.height, depth.height);
+		const auto view_extent    = AttachmentViewExtent(image, view);
+		state.width               = std::min({state.width, depth.width, view_extent.width});
+		state.height              = std::min({state.height, depth.height, view_extent.height});
 		state.num_layers          = std::min(state.num_layers, view.layer_count);
 		const auto aspects        = ImageViewOps::DepthAspectMask(depth.format);
 		auto&      attachment     = state.depth_stencil_attachment;

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -484,6 +484,11 @@ struct RenderExecutorTestAccess {
     return executor.AcquireRenderTargets(buffer, colors, color_count, depth);
   }
 
+  static vk::Extent2D AttachmentViewExtent(const Image &image,
+                                           const ImageViewInfo &view) {
+    return RenderExecutor::AttachmentViewExtent(image, view);
+  }
+
   static void ResetBindings(RenderExecutor &executor) {
     executor.ResetBindings();
   }
@@ -2895,6 +2900,8 @@ public:
     auto mip_info = sampled;
     mip_info.base_level = 1;
     const auto mip = color.FindView(mip_info);
+    const auto mip_extent =
+        RenderExecutorTestAccess::AttachmentViewExtent(color, mip_info);
     auto layer_info = sampled;
     layer_info.base_layer = 1;
     const auto layer = color.FindView(layer_info);
@@ -2919,9 +2926,9 @@ public:
                 array != first && reinterpreted != nullptr &&
                 reinterpreted != first && storage != nullptr &&
                 storage != first && attachment == first &&
-                color.views.size() == 7,
+                color.views.size() == 7 && mip_extent == vk::Extent2D{4, 4},
             "dynamic view identity omitted mapping, format, mip, layer, type, "
-            "or storage usage");
+            "storage usage, or the selected mip extent");
 
     ImageInfo depth_info{};
     depth_info.pixel_format = vk::Format::eD32Sfloat;


### PR DESCRIPTION
## Summary
- derive the physical width and height of each attachment from its selected base mip
- intersect guest target dimensions with the concrete color/depth view extent
- share one helper between color and depth attachment handling
- add a regression proving an 8x8 backing at mip 1 exposes a 4x4 attachment area

## Why
Render-target aliases can share pitch/backing while exposing a smaller mip or a target that differs by one texel. Using only guest dimensions can make VkRenderingInfo::renderArea exceed an attachment view.

This isolates the render-area part of #266; it does not include image-copy, storage-format, GC, GE, or sampled-depth changes.

## Game / PPSA context
- Scars Above — PPSA08597
- Demon's Souls — PPSA01342

## Validation
- built: kyty_emulator, shader_recompiler_compute_tests
- passed: texture_cache_image_views
- passed: shader_recompiler_compute
- git diff --check