### PR TITLE
renderer: allow storage aliases for block-compressed images

### DIFF
--- a/src/graphics/host_gpu/renderer/image/image.cpp
+++ b/src/graphics/host_gpu/renderer/image/image.cpp
@@ -46,6 +46,14 @@ namespace {
 	return static_cast<bool>(properties.optimalTilingFeatures & feature);
 }
 
+[[nodiscard]] vk::Format BlockStorageViewFormat(Prospero::BufferFormat guest_format) {
+	switch (Prospero::BlockCompressedBytesPerBlock(guest_format)) {
+		case 8: return vk::Format::eR32G32Uint;
+		case 16: return vk::Format::eR32G32B32A32Uint;
+		default: return vk::Format::eUndefined;
+	}
+}
+
 [[nodiscard]] vk::ImageUsageFlags ImageUsageFlags(GraphicContext& graphics, const ImageInfo& info) {
 	const auto properties = graphics.GetFormatProperties(info.pixel_format);
 	auto       usage = vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eTransferDst;
@@ -63,7 +71,10 @@ namespace {
 	    HasFormatFeature(properties, vk::FormatFeatureFlagBits::eStorageImage)) {
 		usage |= vk::ImageUsageFlagBits::eStorage;
 	} else if (info.samples == 1) {
-		const auto compatible = SrgbStorageViewFormat(info.pixel_format);
+		const auto block_compatible = BlockStorageViewFormat(info.guest_format);
+		const auto compatible       = block_compatible != vk::Format::eUndefined
+		                                  ? block_compatible
+		                                  : SrgbStorageViewFormat(info.pixel_format);
 		if (compatible != vk::Format::eUndefined &&
 		    HasFormatFeature(graphics.GetFormatProperties(compatible),
 		                     vk::FormatFeatureFlagBits::eStorageImage)) {

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -4578,6 +4578,17 @@ public:
           Prospero::ImageType::kColor2D, {4, 4, 1}, 1, 16, 1);
       const auto compressed_block_image =
           texture_cache.FindImage(compressed_block);
+      auto &compressed_block_native =
+          texture_cache.GetImage(compressed_block_image);
+      ImageViewInfo compressed_storage_info{};
+      compressed_storage_info.format = vk::Format::eR32G32B32A32Uint;
+      compressed_storage_info.type = vk::ImageViewType::e2D;
+      compressed_storage_info.aspect = vk::ImageAspectFlagBits::eColor;
+      compressed_storage_info.level_count = 1;
+      compressed_storage_info.layer_count = 1;
+      compressed_storage_info.usage = vk::ImageUsageFlagBits::eStorage;
+      const auto compressed_storage_view =
+          compressed_block_native.FindView(compressed_storage_info);
       const bool compressed_block_download =
           TextureCacheTestAccess::TryDownload(texture_cache,
                                               compressed_block_image);
@@ -4590,12 +4601,15 @@ public:
           name, "compressed view expansion",
           compressed_block_image &&
               compressed_block_image != uncompressed_block_image &&
-              texture_cache.GetImage(compressed_block_image).backing.format ==
+              compressed_block_native.backing.format ==
                   vk::Format::eBc3UnormBlock &&
+              static_cast<bool>(compressed_block_native.backing.usage &
+                                vk::ImageUsageFlagBits::eStorage) &&
+              compressed_storage_view != nullptr &&
               compressed_block_download &&
               block_alias_after == block_alias_data,
           "size-compatible compressed alias did not preserve its native "
-          "contents");
+          "contents or create its uncompressed storage view");
 
       ImageInfo resolve_source_info{};
       resolve_source_info.pixel_format = vk::Format::eR8G8B8A8Unorm;


### PR DESCRIPTION
## Summary
- map 8-byte BC blocks to R32G32_UINT and 16-byte BC blocks to R32G32B32A32_UINT for storage-capability checks
- advertise storage usage only when that size-compatible format exposes storage-image support
- retain the native BC backing/descriptor format; this change enables compatible uncompressed aliases instead of rewriting sampled descriptors
- create a real BC3-to-RGBA32_UINT storage view in the regression test

## Why
Kyty creates block-compressed images with BLOCK_TEXEL_VIEW_COMPATIBLE and EXTENDED_USAGE. Without eStorage on the backing, a later size-compatible uncompressed storage alias cannot create or bind its view even when the device supports that view format.

This isolates and strengthens the BC-storage part of #266.

## Game / PPSA context
- Scars Above — PPSA08597
- Demon's Souls — PPSA01342

## Validation
- real Vulkan BC3 4x4 to R32G32B32A32_UINT 1x1 storage view created successfully
- built: kyty_emulator, shader_recompiler_compute_tests
- passed: texture_cache_image_overlap
- passed: shader_recompiler_compute
- git diff --check