### PR TITLE
tests: isolate CMPX SDWA shader coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,8 @@ if(BUILD_TESTING)
 	add_test(NAME shader_recompiler_compute COMMAND $<TARGET_FILE:shader_recompiler_compute_tests>)
 	add_test(NAME shader_recompiler_alignbyte
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --alignbyte-only)
+	add_test(NAME shader_recompiler_cmpx_sdwa
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --cmpx-sdwa-only)
 	add_test(NAME virtual_memory_allocation
 		COMMAND $<TARGET_FILE:virtual_memory_allocation_tests>)
 	add_test(NAME guest_red_zone_patcher

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -24426,6 +24426,13 @@ int main(int argc, char **argv) {
     CheckIndirectImageKeySwitch();
     return 0;
   }
+  if (argc == 2 && std::strcmp(argv[1], "--cmpx-sdwa-only") == 0) {
+    VulkanHarness vulkan;
+    RunCase(&vulkan, VectorVopcSdwaCmpxWritesExecMask());
+    RunCase(&vulkan, VectorVopcCmpxGtU16CapturedSdwaExecMask());
+    RunCase(&vulkan, VectorVopcCmpxNgtF16CapturedSdwaExecMask());
+    return 0;
+  }
   if (argc == 2 && std::strcmp(argv[1], "--storage-mip-host-only") == 0) {
     VulkanHarness vulkan;
     vulkan.CheckRenderExecutorStencilBindingDiscovery();


### PR DESCRIPTION
## Summary
- Adds a focused test selector for the existing VOPC SDWA CMPX EXEC-mask case.
- Covers the unsigned 16-bit greater-than and unordered float16 not-greater-than CMPX paths.
- Registers the selector as its own CTest so failures are reported independently.

## Verification
- cmake --build _Build/launcher-usability --target shader_recompiler_compute_tests -j 6
- ctest --test-dir _Build/launcher-usability -R ^shader_recompiler_cmpx_sdwa$ --output-on-failure

The focused test passes. Production code is unchanged.