### PR TITLE
shader: support heterogeneous indirect image tables

### DIFF
--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
@@ -610,9 +610,9 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			ctx.Fail(inst, "uses depth comparison with a packed integer image");
 			return true;
 		}
-		const auto coord =
-		    CoordF32(ctx, mem, *address, layout.coord, ImageViewCoordinateComponents(view));
 		if (op == IR::ValueOpcode::ImageGatherRaw) {
+			const auto coord =
+			    CoordF32(ctx, mem, *address, layout.coord, ImageViewCoordinateComponents(view));
 			const auto            sampled = MakeSampledImage(state, mem, pc, view);
 			const auto            sample  = state.builder.AllocateId();
 			std::vector<uint32_t> words =
@@ -653,49 +653,75 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		const auto opcode = explicit_lod
 		                        ? (dref ? OpImageSampleDrefExplicitLod : OpImageSampleExplicitLod)
 		                        : (dref ? OpImageSampleDrefImplicitLod : OpImageSampleImplicitLod);
-		const auto result_type =
-		    dref ? TypeF32(state) : (integer ? TypeU32Vector(state, 4) : TypeF32Vector(state, 4));
-		const auto dref_value =
-		    dref ? (layout.dref != NoImageComponent ? AddressF32(ctx, mem, *address, layout.dref)
-		                                            : ZeroF32(state))
-		         : 0u;
-		uint32_t              operand_mask = 0;
-		std::vector<uint32_t> operands;
-		if (HasFlag(mem, Decoder::ImageSampleFlagDerivative)) {
-			operand_mask |= ImageOperandsGradMask;
-			operands.push_back(
-			    CoordF32(ctx, mem, *address, layout.grad_x, ImageViewSpatialComponents(view)));
-			operands.push_back(
-			    CoordF32(ctx, mem, *address, layout.grad_y, ImageViewSpatialComponents(view)));
-		} else if (explicit_lod) {
-			operand_mask |= ImageOperandsLodMask;
-			operands.push_back(HasFlag(mem, Decoder::ImageSampleFlagLod) &&
-			                           layout.lod != NoImageComponent
-			                       ? AddressF32(ctx, mem, *address, layout.lod)
-			                       : ZeroF32(state));
-		} else if (layout.bias != NoImageComponent) {
-			operand_mask |= ImageOperandsBiasMask;
-			operands.push_back(AddressF32(ctx, mem, *address, layout.bias));
-		}
 		const auto EmitSample = [&](uint32_t resource) {
-			const auto            sampled = MakeSampledImage(state, mem, pc, view, resource);
-			const auto            sample  = state.builder.AllocateId();
-			std::vector<uint32_t> words {opcode, result_type, sample, sampled, coord};
-			if (dref) {
-				words.push_back(dref_value);
+			auto selected             = mem;
+			selected.resource         = resource;
+			const auto& image         = state.program.info.images[resource];
+			if (image.conversion_format != Prospero::BufferFormat::kInvalid &&
+			    mem.point_sampler != UINT32_MAX) {
+				selected.sampler = mem.point_sampler;
 			}
-			if (operand_mask != 0u) {
-				words.push_back(operand_mask);
-				words.insert(words.end(), operands.begin(), operands.end());
+			selected.kind            = image.kind;
+			selected.image_dimension = image.dimension;
+			selected.image_cube      = image.cube;
+			const bool selected_integer = selected.kind == IR::ResourceKind::ImageUint;
+
+			const auto selected_view   = SampledImageViewKind(state, selected, pc);
+			const auto selected_layout = Layout(selected, selected_view);
+			const auto selected_coord  =
+			    CoordF32(ctx, selected, *address, selected_layout.coord,
+			             ImageViewCoordinateComponents(selected_view));
+			const auto selected_dref =
+			    dref ? (selected_layout.dref != NoImageComponent
+			                ? AddressF32(ctx, selected, *address, selected_layout.dref)
+			                : ZeroF32(state))
+			         : 0u;
+			uint32_t              selected_operand_mask = 0;
+			std::vector<uint32_t> selected_operands;
+			if (HasFlag(selected, Decoder::ImageSampleFlagDerivative)) {
+				selected_operand_mask |= ImageOperandsGradMask;
+				selected_operands.push_back(CoordF32(ctx, selected, *address,
+				                                     selected_layout.grad_x,
+				                                     ImageViewSpatialComponents(selected_view)));
+				selected_operands.push_back(CoordF32(ctx, selected, *address,
+				                                     selected_layout.grad_y,
+				                                     ImageViewSpatialComponents(selected_view)));
+			} else if (explicit_lod) {
+				selected_operand_mask |= ImageOperandsLodMask;
+				selected_operands.push_back(
+				    HasFlag(selected, Decoder::ImageSampleFlagLod) &&
+				            selected_layout.lod != NoImageComponent
+				        ? AddressF32(ctx, selected, *address, selected_layout.lod)
+				        : ZeroF32(state));
+			} else if (selected_layout.bias != NoImageComponent) {
+				selected_operand_mask |= ImageOperandsBiasMask;
+				selected_operands.push_back(
+				    AddressF32(ctx, selected, *address, selected_layout.bias));
+			}
+
+			const auto sampled = MakeSampledImage(state, selected, pc, selected_view);
+			const auto sample  = state.builder.AllocateId();
+			const auto selected_result_type =
+			    dref ? TypeF32(state)
+			         : (selected_integer ? TypeU32Vector(state, 4) : TypeF32Vector(state, 4));
+			std::vector<uint32_t> words {opcode, selected_result_type, sample, sampled,
+			                             selected_coord};
+			if (dref) {
+				words.push_back(selected_dref);
+			}
+			if (selected_operand_mask != 0u) {
+				words.push_back(selected_operand_mask);
+				words.insert(words.end(), selected_operands.begin(), selected_operands.end());
 			}
 			state.builder.AddFunction(words);
-			return sample;
+			// Normalize every branch to guest-visible u32x4 bits so candidates with different
+			// SPIR-V image result types can meet at one OpPhi.
+			return ResultVector(ctx, dref ? sample : UnpackImageTexel(ctx, selected, sample),
+			                    selected_integer, dref, selected);
 		};
 		const auto& image = state.program.info.images[mem.resource];
 		if (image.indirect_root != mem.resource) {
-			const auto sample = EmitSample(mem.resource);
-			ctx.Define(inst, ResultVector(ctx, dref ? sample : UnpackImageTexel(ctx, mem, sample),
-			                              integer, dref, mem));
+			ctx.Define(inst, EmitSample(mem.resource));
 			return true;
 		}
 		const auto* handle = image_arg.ResolveInstruction();
@@ -773,7 +799,8 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		}
 		state.builder.AddFunction({OpSelectionMerge, merge_label, SelectionControlNone});
 		state.builder.AddFunction(switch_words);
-		std::vector<uint32_t> phi_words {OpPhi, result_type, state.builder.AllocateId()};
+		std::vector<uint32_t> phi_words {OpPhi, TypeU32Vector(state, 4),
+		                                 state.builder.AllocateId()};
 		EmitLabel(state, default_label);
 		phi_words.push_back(EmitSample(image.indirect_resources[0]));
 		phi_words.push_back(default_label);
@@ -786,9 +813,7 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		}
 		EmitLabel(state, merge_label);
 		state.builder.AddFunction(phi_words);
-		ctx.Define(inst,
-		           ResultVector(ctx, dref ? phi_words[2] : UnpackImageTexel(ctx, mem, phi_words[2]),
-		                        integer, dref, mem));
+		ctx.Define(inst, phi_words[2]);
 		return true;
 	}
 	const auto atomic_opcode = ImageAtomicOpcode(op);

--- a/src/graphics/shader/recompiler/ir/ShaderIR.h
+++ b/src/graphics/shader/recompiler/ir/ShaderIR.h
@@ -58,6 +58,9 @@ struct MemoryInfo {
 	ResourceKind            kind                     = ResourceKind::None;
 	uint32_t                resource                 = 0;
 	uint32_t                sampler                  = 0;
+	// Mixed indirect tables can contain both native and format-converted images. Keep the
+	// point-filtered sampler variant separate so each runtime candidate uses the correct sampler.
+	uint32_t                point_sampler            = UINT32_MAX;
 	uint32_t                offset                   = 0;
 	uint32_t                secondary_offset         = 0;
 	uint32_t                dmask                    = 0;

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -87,6 +87,18 @@ bool DescriptorIsCube(const DescriptorValue& descriptor) {
 	       Prospero::ImageType::kCube;
 }
 
+bool CompatibleIndirectImageKinds(const ImageResource& lhs, const ImageResource& rhs) {
+	if (lhs.kind == rhs.kind) {
+		return true;
+	}
+	const auto sampled = [](ResourceKind kind) {
+		return kind == ResourceKind::Image || kind == ResourceKind::ImageUint;
+	};
+	// Sampled float and integer candidates can share the dynamic table because the backend emits
+	// a separately typed image operation for every candidate before merging guest-visible bits.
+	return !lhs.depth_compare && !rhs.depth_compare && sampled(lhs.kind) && sampled(rhs.kind);
+}
+
 uint32_t StorageMipCount(const ImageResource& image, const DescriptorValue& descriptor) {
 	if (image.mip_mode != ImageMipMode::DynamicStorage || NullImageDescriptor(descriptor)) {
 		return 1;
@@ -842,17 +854,34 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 				image.shader_swizzle    = image_class.shader_swizzle;
 				image.cube              = image_class.cube;
 			}
-			if (image.kind != image_class.kind || image.dimension != image_class.dimension ||
+			if (!CompatibleIndirectImageKinds(image_class, image) ||
 			    image.mip_mode != image_class.mip_mode ||
 			    image.mip_count != image_class.mip_count ||
-			    image.conversion_format != image_class.conversion_format ||
-			    image.shader_swizzle != image_class.shader_swizzle ||
-			    image.depth_compare != image_class.depth_compare ||
-			    image.cube != image_class.cube) {
+			    image.depth_compare != image_class.depth_compare) {
 				if (error != nullptr) {
 					*error = fmt::format(
-					    "indirect image table at pc 0x{:08x} has incompatible candidates",
-					    root.first_use_pc);
+					    "indirect image table at pc 0x{:08x} has incompatible candidates: "
+					    "exemplar={} candidate={} kind={}/{} dimension={}/{} mip_mode={}/{} "
+					    "mip_count={}/{} conversion_format={}/{} shader_swizzle=0x{:08x}/"
+					    "0x{:08x} depth_compare={}/{} cube={}/{} descriptor=[{:08x},"
+					    "{:08x},{:08x},{:08x},{:08x},{:08x},{:08x},{:08x}]",
+					    root.first_use_pc, exemplar, candidate,
+					    static_cast<uint32_t>(image_class.kind), static_cast<uint32_t>(image.kind),
+					    static_cast<uint32_t>(image_class.dimension),
+					    static_cast<uint32_t>(image.dimension),
+					    static_cast<uint32_t>(image_class.mip_mode),
+					    static_cast<uint32_t>(image.mip_mode), image_class.mip_count,
+					    image.mip_count, static_cast<uint32_t>(image_class.conversion_format),
+					    static_cast<uint32_t>(image.conversion_format), image_class.shader_swizzle,
+					    image.shader_swizzle, image_class.depth_compare, image.depth_compare,
+					    image_class.cube, image.cube, next_snapshot.images[candidate].dwords[0],
+					    next_snapshot.images[candidate].dwords[1],
+					    next_snapshot.images[candidate].dwords[2],
+					    next_snapshot.images[candidate].dwords[3],
+					    next_snapshot.images[candidate].dwords[4],
+					    next_snapshot.images[candidate].dwords[5],
+					    next_snapshot.images[candidate].dwords[6],
+					    next_snapshot.images[candidate].dwords[7]);
 				}
 				return false;
 			}
@@ -864,6 +893,30 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 		bool native     = false;
 		bool point_only = false;
 	};
+	const auto ImageSamplerUsage = [&](uint32_t image_index) {
+		SamplerUsage usage;
+		if (image_index >= next.images.size()) {
+			return usage;
+		}
+		const auto& image = next.images[image_index];
+		const auto AddImage = [&](uint32_t resource) {
+			if (resource >= next.images.size()) {
+				return;
+			}
+			const bool converted =
+			    next.images[resource].conversion_format != Prospero::BufferFormat::kInvalid;
+			usage.point_only |= converted;
+			usage.native |= !converted;
+		};
+		if (image.indirect_root == image_index && !image.indirect_resources.empty()) {
+			for (const auto resource: image.indirect_resources) {
+				AddImage(resource);
+			}
+		} else {
+			AddImage(image_index);
+		}
+		return usage;
+	};
 	std::vector<SamplerUsage> sampler_usage(next.samplers.size());
 	for (const auto& pair: next.sampled_pairs) {
 		if (pair.image >= next.images.size() || pair.sampler >= next.samplers.size()) {
@@ -874,11 +927,9 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 			return false;
 		}
 		auto& usage = sampler_usage[pair.sampler];
-		if (next.images[pair.image].conversion_format != Prospero::BufferFormat::kInvalid) {
-			usage.point_only = true;
-		} else {
-			usage.native = true;
-		}
+		const auto image_usage = ImageSamplerUsage(pair.image);
+		usage.point_only |= image_usage.point_only;
+		usage.native |= image_usage.native;
 	}
 	std::vector<uint32_t> point_sampler(next.samplers.size(), UINT32_MAX);
 	for (uint32_t i = 0; i < sampler_usage.size(); i++) {
@@ -903,7 +954,8 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 		next_snapshot.samplers.push_back(next_snapshot.samplers[i]);
 	}
 	for (auto& pair: next.sampled_pairs) {
-		if (next.images[pair.image].conversion_format != Prospero::BufferFormat::kInvalid) {
+		const auto usage = ImageSamplerUsage(pair.image);
+		if (usage.point_only && !usage.native) {
 			pair.sampler = point_sampler[pair.sampler];
 		}
 	}
@@ -930,10 +982,13 @@ bool SpecializeResources(Program& program, ResourceSnapshot& snapshot, std::stri
 				return false;
 			}
 			const auto& image = next.images[memory.resource];
-			if (image_opcode.needs_sampler &&
-			    image.conversion_format != Prospero::BufferFormat::kInvalid &&
-			    memory.sampler < point_sampler.size()) {
-				memory.sampler = point_sampler[memory.sampler];
+			if (image_opcode.needs_sampler && memory.sampler < point_sampler.size()) {
+				const auto usage = ImageSamplerUsage(memory.resource);
+				if (usage.point_only && usage.native) {
+					memory.point_sampler = point_sampler[memory.sampler];
+				} else if (usage.point_only) {
+					memory.sampler = point_sampler[memory.sampler];
+				}
 			}
 			if (image.indirect_root == memory.resource &&
 			    inst.GetOpcode() != ValueOpcode::ImageSampleRaw) {

--- a/tests/ResourceTrackingTests.cpp
+++ b/tests/ResourceTrackingTests.cpp
@@ -441,6 +441,70 @@ void TestInvariantIndirectImageMaterialization() {
         "wrapped scalar immediate entered the invariant image proof");
 }
 
+void TestMixedDimensionIndirectImageSpecialization() {
+  auto fixture = MakeIndirectImageFixture(false);
+  fixture->PlanAndTrack();
+  EliminateDeadCode(fixture->program.blocks);
+
+  std::array<uint32_t, 9> user_data{0x1000u,    224u << 16u, 2u, 0u, 0x2000u,
+                                    16u << 16u, 4u,          0u, 7u};
+  LinearTestMemory memory;
+  std::array<uint32_t, 8> descriptor{};
+  descriptor[0] = 0x20u;
+  descriptor[1] = static_cast<uint32_t>(
+                      Libs::Graphics::Prospero::BufferFormat::k32_32_32_32Float)
+                  << 20u;
+  descriptor[2] = 3u | (3u << 14u);
+  descriptor[3] =
+      Libs::Graphics::DstSel(4, 5, 6, 7) |
+      (static_cast<uint32_t>(Libs::Graphics::Prospero::ImageType::kCube)
+       << 28u);
+  for (uint32_t dword = 0; dword < descriptor.size(); dword++) {
+    memory.words[(0x2000u - memory.base) / 4u + dword] = descriptor[dword];
+    memory.words[(0x2020u - memory.base) / 4u + dword] = descriptor[dword];
+  }
+  memory.words[(0x2020u - memory.base) / 4u] = 0x40u;
+  memory.words[(0x2020u - memory.base) / 4u + 1u] =
+      static_cast<uint32_t>(
+          Libs::Graphics::Prospero::BufferFormat::k32_32_32_32UInt)
+      << 20u;
+  memory.words[(0x2020u - memory.base) / 4u + 3u] =
+      Libs::Graphics::DstSel(4, 5, 6, 7) |
+      (static_cast<uint32_t>(Libs::Graphics::Prospero::ImageType::kColor2D)
+       << 28u);
+  memory.words[(0x1000u - memory.base + 36u) / 4u] = 1u;
+
+  SrtRuntime runtime{.user_data = user_data,
+                     .userdata = &memory,
+                     .read_specialization_memory = ReadLinearTestMemory};
+  ResourceSnapshot snapshot;
+  std::string error;
+  Check(MaterializeResources(fixture->program, runtime, snapshot, &error) &&
+            snapshot.indirect_images.size() == 1 &&
+            SpecializeResources(fixture->program, snapshot, &error) &&
+            fixture->program.info.images.size() == 2 &&
+            fixture->program.info.images[0].dimension ==
+                Decoder::ImageDimension::Dim2DArray &&
+            fixture->program.info.images[0].cube &&
+            fixture->program.info.images[1].dimension ==
+                Decoder::ImageDimension::Dim2D &&
+            fixture->program.info.images[1].kind == ResourceKind::ImageUint &&
+            !fixture->program.info.images[1].cube,
+        error.empty()
+            ? "mixed float-cube/uint-2D indirect image table was rejected"
+            : error.c_str());
+
+  ShaderComputeInputInfo compute{};
+  Check(CollectShaderInfo(fixture->program, {.compute = &compute}, &error) &&
+            AllocateBindings(fixture->program, 0, &error) &&
+            FindBinding(fixture->program.bindings,
+                        DescriptorBindingKind::Sampled2DArray) != nullptr &&
+            FindBinding(fixture->program.bindings,
+                        DescriptorBindingKind::SampledUint2D) != nullptr,
+        error.empty() ? "mixed float-cube/uint-2D bindings were not allocated"
+                      : error.c_str());
+}
+
 void TestDenseBufferTracking() {
   Fixture fixture;
   std::array<Value, 8> userdata;
@@ -1375,6 +1439,8 @@ int main() {
     Run("SampleAdjust sampler scratch", TestSampleAdjustSamplerScratch);
     Run("dynamic storage mips", TestDynamicStorageMipTracking);
     Run("invariant indirect images", TestInvariantIndirectImageMaterialization);
+    Run("mixed-dimension indirect images",
+        TestMixedDimensionIndirectImageSpecialization);
     Run("SRT runtime", TestSrtFlatteningAndRuntimeMemoization);
     Run("dynamic SRT", TestDynamicSrtReadRemainsExplicit);
     Run("phi validation", TestPhiValidation);

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -19514,6 +19514,11 @@ void CheckIndirectImageKeySwitch() {
   root.indirect_mapping_capacity = mapping_capacity;
   root.indirect_resources = {0u, 1u};
   auto candidate = root;
+  candidate.kind = ResourceKind::ImageUint;
+  candidate.dimension = ShaderRecompiler::Decoder::ImageDimension::Dim2DArray;
+  candidate.conversion_format = Prospero::BufferFormat::k11_11_10UInt;
+  candidate.shader_swizzle = DstSel(5, 4, 1, 0);
+  candidate.cube = true;
   candidate.indirect_mapping_capacity = 0;
   candidate.indirect_resources.clear();
   program.info.images = {root, candidate};
@@ -19521,7 +19526,12 @@ void CheckIndirectImageKeySwitch() {
   program.info.sampled_pairs.push_back({0u, 0u, 0x10f0u});
 
   std::string error;
-  Require(name, "binding layout", AllocateBindings(program, 0, &error),
+  Require(name, "binding layout",
+          AllocateBindings(program, 0, &error) &&
+              FindBinding(program.bindings, DescriptorBindingKind::Sampled2D) !=
+                  nullptr &&
+              FindBinding(program.bindings,
+                          DescriptorBindingKind::SampledUint2DArray) != nullptr,
           error.c_str());
   ResourceSnapshot snapshot{};
   DescriptorValue descriptor{};
@@ -19535,6 +19545,11 @@ void CheckIndirectImageKeySwitch() {
       (static_cast<uint32_t>(Prospero::ImageType::kColor2D) << 28u);
   snapshot.images = {descriptor, descriptor};
   snapshot.images[1].dwords[0] = 0x40u;
+  snapshot.images[1].dwords[1] =
+      static_cast<uint32_t>(Prospero::BufferFormat::k11_11_10UInt) << 20u;
+  snapshot.images[1].dwords[3] =
+      candidate.shader_swizzle |
+      (static_cast<uint32_t>(Prospero::ImageType::kCube) << 28u);
   snapshot.flattened_srt.resize(1u + mapping_capacity * 2u);
   snapshot.flattened_srt[0] = 2u;
   snapshot.flattened_srt[1] = 0u;
@@ -19544,6 +19559,7 @@ void CheckIndirectImageKeySwitch() {
   DescriptorValue sampler_descriptor{};
   sampler_descriptor.dword_count = 4;
   snapshot.samplers.push_back(sampler_descriptor);
+  program.memory_info[0].point_sampler = 0;
 
   ShaderComputeInputInfo compute{};
   std::vector<u32> spirv;
@@ -19563,8 +19579,10 @@ void CheckIndirectImageKeySwitch() {
           text.find("OpSwitch") != std::string::npos &&
               text.find("OpPhi") != std::string::npos &&
               CountText(text, "OpImageSampleExplicitLod") == 2 &&
+              text.find("OpBitFieldUExtract") != std::string::npos &&
               CountText(text, "OpIEqual") == 11,
-          "dynamic image key did not use a compact two-sample switch");
+          "mixed float-2D/converted-uint-cube image key did not use a compact "
+          "two-sample switch");
 }
 
 TestCase ImageStoreMipSelectsPpsa01340Descriptor() {


### PR DESCRIPTION
## Summary

- Allows sampled float and unsigned-integer images in the same indirect image table.
- Keeps per-candidate dimensionality, cube, conversion format, swizzle, layout, and sampler metadata.
- Emits each candidate with its own typed SPIR-V image operation, normalizes results to guest-visible u32x4, then merges them with OpPhi.
- Selects native or point-filtered samplers per runtime candidate.

## Tests

- Adds resource materialization coverage for a mixed float cube / uint 2D table.
- Extends compute SPIR-V coverage with a float 2D / converted packed-uint cube switch and verifies OpSwitch, OpPhi, both image samples, and bit extraction.
- Clean standalone build from upstream main: resource_tracking and shader_recompiler_compute both pass.

## Runtime validation

Scars Above previously failed while compiling compute shader hash 0xb3ee9eea5b92b870 at PC 0x159c with "indirect image table ... has incompatible candidates". With this change, the same workload ran for more than one minute and reached 873 presented frames without that shader failure.

## Scope

This PR is one isolated commit. It intentionally excludes the ELF tail-size fix, DS bpermute work, sampled-SINT support, and NpCommerce stubs.

## Technical basis

SDK 12 documents image resource constants as typed by their T# dimensionality and format. The dynamic heterogeneous-table behavior implemented here is inferred from the captured shader and validated against the working KytyTouche implementation.