### PR TITLE
kernel: explain a commit-limit failure at startup

### DIFF
--- a/src/kernel/memoryAddressSpace.inc
+++ b/src/kernel/memoryAddressSpace.inc
@@ -659,7 +659,16 @@ public:
 #endif
 		ReserveGuestRegions();
 		m_backing = new GuestBackingStore(backing_size);
-		EXIT_IF(!m_backing->IsAvailable());
+		if (!m_backing->IsAvailable()) {
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+			EXIT("could not reserve %" PRIu64 " MB for guest direct memory. Windows commits\n"
+			     "this up front, so the paging file is usually what needs to be larger.\n",
+			     backing_size / (1024U * 1024U));
+#else
+			EXIT("could not reserve %" PRIu64 " MB for guest direct memory\n",
+			     backing_size / (1024U * 1024U));
+#endif
+		}
 	}
 
 	~GuestAddressSpace() {


### PR DESCRIPTION
Summary
Failing to reserve the guest backing store ended in a bare EXIT_IF(!m_backing->IsAvailable()), so the report named a condition and a line number and nothing else.
Report how much was being asked for, and on Windows name the paging file as the thing to change, since the backing store is committed up front there.

Follows from #390. With SEC_COMMIT now explicit, the up-front reservation is deliberate, so the failure path should say what a user is expected to do about it.

Before:

--- Error ---
Error: condition (!m_backing->IsAvailable()) is true in ...memoryAddressSpace.inc:662

After:

--- Error ---
could not reserve 13824 MB for guest direct memory. Windows commits
this up front, so the paging file is usually what needs to be larger.
 in ...memoryAddressSpace.inc:666
Test plan

Windows 11 25H2, clang-cl 20.1.8, RTX 2060, 16 GB.

 ctest: 35/35.
 Failure path, with default logging. Temporarily raised PhysicalMemory::TotalSize() to 900000 MB so the reservation could not succeed, and ran with no logging flags at all. The new text appears. This matters because printf_direction now defaults to Silent, and anything written through LOGF/LOGF_COLOR would not reach a default user; EXIT goes through Log::WriteFatal, which writes to stdout regardless. Reverted before committing.
 Normal start, with default logging. After reverting, the emulator reaches gameplay and the new message is correctly absent.
 Non-Windows keeps a plain message with no paging-file advice; the Windows wording is inside the existing KYTY_PLATFORM_WINDOWS guard.

On reproducing the original failure directly: with an auto-managed paging file Windows just grows it under pressure. Holding 17 GB of commit here moved the limit from 35.8 GB to 44.4 GB and the emulator started normally, so the real-world failure is a race against that growth rather than a fixed threshold. Forcing the requested size was the reliable way to exercise the path.

AI use

Written with AI assistance (Claude). It located the failure path, drafted the change, and ran the builds, tests and the forced-failure runs on my machine. I hit this failure several times myself while testing, and reviewed the diff.