### PR TITLE
fix(shader): treat all-ones texture address as null binding

### DIFF
--- a/src/graphics/shader/shaderBindings.h
+++ b/src/graphics/shader/shaderBindings.h
@@ -94,7 +94,11 @@ struct ShaderTextureResource {
 	[[nodiscard]] uint64_t Base40() const {
 		return ((fields[0] | (static_cast<uint64_t>(fields[1]) << 32u)) & 0xFFFFFFFFFFu) << 8u;
 	}
-	[[nodiscard]] bool                   IsNull() const { return Base40() == 0; }
+	[[nodiscard]] bool IsNull() const {
+		const uint64_t address =
+		    (fields[0] | (static_cast<uint64_t>(fields[1]) << 32u)) & 0xFFFFFFFFFFu;
+		return address == 0 || address == 0xFFFFFFFFFFu;
+	}
 	[[nodiscard]] Prospero::BufferFormat Format() const {
 		return static_cast<Prospero::BufferFormat>((fields[1] >> 20u) & 0x1FFu);
 	}


### PR DESCRIPTION
## Summary

Neptunia ReVerse (PPSA02721) crashes at the Idea Factory logo with:

    unsupported texture mip view: base=7 last=1 ... dwords=ffffffff,ffffffff,...

in ResolveTexture() (descriptors.cpp).

Root cause: the PS5 texture descriptor uses 0xFFFFFFFFFF (40-bit all-ones) as the null-texture sentinel, matching the RDNA null-descriptor convention. ShaderTextureResource::IsNull() only checked Base40() == 0, so the all-ones sentinel was treated as a real texture. Mip-chain validation then failed and the emulator aborted.

## Change

IsNull() now returns true for address 0 OR 0xFFFFFFFFFF. All-ones descriptors take the existing safe null-texture path instead of crashing.

## Testing

- Platform: Linux (CachyOS, x86_64).
- Built locally (clang + ninja, Qt6) with the patch applied.
- Neptunia ReVerse (PPSA02721) now boots past the Idea Factory logo and runs (verified stable for 1+ minute).
- Stock builds (unpatched) reproduce the crash at the same point with the same dwords signature.
- Formatting verified with clang-format using the repo style (src/.clang-format).

## Risk

Low. IsNull() has a single call site (ResolveTexture). The change only adds a second accepted null value to an existing early exit. Games that already worked are unaffected; games that crashed with the all-ones descriptor now take the null path.

Fixes #317
