### PR TITLE
graphics: hold HTile fast clears on depth-read-only passes

### DIFF
--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -639,8 +639,11 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 		if (depth.htile && depth.depth_clear_enable && !cache.ClearMeta(depth.htile_buffer_vaddr)) {
 			EXIT("failed to acquire HTile metadata for a depth clear\n");
 		}
+		// A pass with depth writes disabled only tests against depth, so materializing the HTile
+		// fast clear on it would discard the depth earlier passes wrote and make every later
+		// test fail. Leave the clear armed for the next pass that writes depth.
 		depth.depth_meta_clear_enable =
-		    depth.htile &&
+		    depth.htile && depth.depth_write_enable &&
 		    cache.IsMetaCleared(depth.htile_buffer_vaddr, depth.desc.view_info.base_layer);
 		depth.depth_load_clear_enable = depth.depth_clear_enable || depth.depth_meta_clear_enable;
 		if (depth.depth_meta_clear_enable &&


### PR DESCRIPTION
This is a huge improvement in GTA. It goes from 70% of the things in the scene not being drawn(no walls no ceiling, floor is invisible, no objects) to basically all of them.

## Summary

- Consume an armed HTile fast clear only on a pass that writes depth.
- Leave the clear armed when the binding pass has depth writes disabled, so the next
  writing pass still receives it.
- No change to passes that already write depth, including the clearing prepass.

## Problem

HTile fast clears are emulated by recording that a depth surface is logically cleared,
then discharging that as a Vulkan `loadOp = CLEAR` on the next bind of the target. The
consume site tested only whether a clear was armed, never whether the binding pass
writes depth:

```cpp
depth.depth_meta_clear_enable =
    depth.htile &&
    cache.IsMetaCleared(depth.htile_buffer_vaddr, depth.desc.view_info.base_layer);
```

A pass with `Z_WRITE_ENABLE` cleared only reads depth. Discharging the clear there
destroys the depth it is about to test against, so every fragment fails, no fragment
writes depth, and the surface stays at the clear value for the rest of the frame. On
hardware this cannot happen: the fast clear is a change to metadata state, not an
operation attached to a pass.

In GTA V (PPSA04264) the main scene depth target is cleared to 0.0 and written by a
GEQUAL prepass (reversed-Z), then bound by a read-only pass using LESS. That pass
consumed the clear, leaving the buffer uniformly 0.0:

```text
[diag] depth=0x0246B40000 htile=0x0247E00000 2560x1440 clear=0.000000 test=1 write=1 func=GEQUAL load_clear=1
[diag] depth=0x0246B40000 htile=0x0247E00000 2560x1440 clear=0.000000 test=1 write=0 func=LESS   load_clear=1
```

A RenderDoc capture of the same frame showed the depth attachment uniformly 0.0 with
`Func = Less, Write = off`, and geometry rejected with "Depth test failed".

## Implementation

- Gate `depth_meta_clear_enable` on `depth_write_enable` in `AcquireRenderTargets`.
- The existing `TouchMeta(..., false)` consume is already gated on the same flag, so a
  held clear stays armed rather than being silently discarded.

## AI assistance

AI assistance was used because I'm a smooth brained javascript dev
