### PR TITLE
libs: make the per-library tracing flag reach the traced code

### DIFF
--- a/src/libs/libAgcDriver.cpp
+++ b/src/libs/libAgcDriver.cpp
@@ -167,7 +167,7 @@ LIB_VERSION("Graphics5Driver", 1, "Graphics5Driver", 1, 1);
 namespace Gen5Driver = Graphics::Gen5Driver;
 
 LIB_DEFINE(InitAgcDriver_1) {
-	PRINT_NAME_ENABLE(true);
+	PRINT_NAME_ENABLE_ALL(true);
 
 	LIB_FUNC("UglJIZjGssM", Gen5Driver::AgcDriverSubmitDcb);
 	LIB_FUNC("AhGvpITrf4M", Gen5Driver::AgcDriverSubmitDcb);

--- a/src/libs/libPad.cpp
+++ b/src/libs/libPad.cpp
@@ -169,7 +169,7 @@ static int KYTY_SYSV_ABI PadUnknownN3kSX62fgNo(uint64_t arg0, uint64_t arg1, uin
 }
 
 LIB_DEFINE(InitPad_1) {
-	PRINT_NAME_ENABLE(true);
+	PRINT_NAME_ENABLE_ALL(true);
 
 	LIB_FUNC("hv1luiJrqQM", Controller::PadInit);
 	LIB_FUNC("xk0AcarP3V4", Controller::PadOpen);

--- a/src/libs/libPngDec.cpp
+++ b/src/libs/libPngDec.cpp
@@ -369,7 +369,7 @@ static int32_t KYTY_SYSV_ABI PngDecParseHeader(const PngDecParseParam* param,
 } // namespace PngDec
 
 LIB_DEFINE(InitPngDec_1) {
-	PRINT_NAME_ENABLE(true);
+	PRINT_NAME_ENABLE_ALL(true);
 
 	LIB_FUNC("-6srIGbLTIU", PngDec::PngDecQueryMemorySize);
 	LIB_FUNC("m0uW+8pFyaw", PngDec::PngDecCreate);

--- a/src/libs/libVideoDec2.cpp
+++ b/src/libs/libVideoDec2.cpp
@@ -651,7 +651,7 @@ static int32_t KYTY_SYSV_ABI GetPictureInfo(const Videodec2OutputInfo* output_in
 }
 
 LIB_DEFINE(InitVideoDec2_1) {
-	PRINT_NAME_ENABLE(true);
+	PRINT_NAME_ENABLE_ALL(true);
 
 	LIB_FUNC("RnDibcGCPKw", QueryComputeMemoryInfo);
 	LIB_FUNC("eD+X2SmxUt4", AllocateComputeQueue);

--- a/src/libs/libVideoOut.cpp
+++ b/src/libs/libVideoOut.cpp
@@ -10,7 +10,7 @@ namespace LibGen5 {
 LIB_VERSION("VideoOut", 1, "VideoOut", 1, 1);
 
 LIB_DEFINE(InitVideoOut_1) {
-	PRINT_NAME_ENABLE(true);
+	PRINT_NAME_ENABLE_ALL(true);
 
 	LIB_FUNC("Up36PTk687E", VideoOut::VideoOutOpen);
 	LIB_FUNC("uquVH4-Du78", VideoOut::VideoOutClose);

--- a/src/libs/libs.h
+++ b/src/libs/libs.h
@@ -7,6 +7,33 @@
 #include "common/threads.h"
 #include "loader/timer.h" // IWYU pragma: keep
 
+#include <atomic>
+#include <cstddef>
+
+namespace Libs {
+
+// Key for the tracing flag below. A library is usually split over two translation units, one
+// holding its LIB_DEFINE and one holding the traced functions, so the flag cannot live in
+// either of them. Keying a variable template on the library name gives both the same object.
+template <std::size_t N>
+struct PrintNameKey {
+	char value[N] {};
+	consteval PrintNameKey(const char (&text)[N]) { // NOLINT(google-explicit-constructor)
+		for (std::size_t i = 0; i < N; i++) {
+			value[i] = text[i];
+		}
+	}
+};
+
+template <std::size_t N>
+PrintNameKey(const char (&)[N]) -> PrintNameKey<N>;
+
+// Shared by every translation unit naming the same library.
+template <PrintNameKey Library>
+inline std::atomic<bool> g_print_name_shared {false};
+
+} // namespace Libs
+
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define PRINT_NAME_ENABLED g_print_name
 
@@ -14,12 +41,27 @@
 #define PRINT_NAME_ENABLE(flag) PRINT_NAME_ENABLED = flag;
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define PRINT_NAME_SHARED ::Libs::g_print_name_shared<g_print_name_key>
+
+// Enable tracing for the whole library. LIB_DEFINE runs on the initialising thread and often
+// sits in a different translation unit from the traced functions, so a per-thread per-file
+// flag never reaches them. This sets the value every thread and unit starts from.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define PRINT_NAME_ENABLE_ALL(flag)                                                                \
+	do {                                                                                           \
+		PRINT_NAME_SHARED.store((flag), std::memory_order_relaxed);                                \
+		PRINT_NAME_ENABLE(flag)                                                                    \
+	} while (false)
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define LIB_DEFINE(name) void name(Loader::SymbolDatabase* s)
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define LIB_NAME(l, m)                                                                             \
-	[[maybe_unused]] static thread_local bool PRINT_NAME_ENABLED = false;                          \
-	static constexpr char                     g_library[]        = l;                              \
-	static constexpr char                     g_module[]         = m;
+	static constexpr auto                     g_print_name_key = ::Libs::PrintNameKey {l};         \
+	[[maybe_unused]] static thread_local bool PRINT_NAME_ENABLED =                                 \
+	    PRINT_NAME_SHARED.load(std::memory_order_relaxed);                                         \
+	static constexpr char g_library[] = l;                                                         \
+	static constexpr char g_module[]  = m;
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define LIB_VERSION(l, lv, m, mv1, mv2)                                                            \
 	LIB_NAME(l, m);                                                                                \


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3 dir="ltr">Summary</h3><p dir="ltr">Five libraries call <code>PRINT_NAME_ENABLE(true)</code> from their <code>LIB_DEFINE</code> to switch on call tracing. None of them have ever traced anything.</p><p dir="ltr">Two reasons, and both have to be fixed for the opt-in to work:</p><ul dir="ltr"><li style=""><code>PRINT_NAME_ENABLED</code> is <code>thread_local</code>, and <code>LIB_DEFINE</code> runs once on the initialising thread during <code>Libs::InitAll()</code>. The guest threads that actually call in never see it set.</li><li style="">It is also a file-scope static, so each translation unit gets its own. A library is split in two: <code>libPad.cpp</code> holds the <code>LIB_DEFINE</code>, <code>controller.cpp</code> holds the traced functions. Setting the flag in one cannot reach the other.</li></ul><p dir="ltr">The second is the dominant one. Fixing only the thread-local reach produces exactly one extra line in a full session, because every library keeps its hot functions in the other unit.</p><p dir="ltr"><code>PrintNameKey</code> lets a variable template be instantiated on the library name, so both units naming the same library share one <code>std::atomic&lt;bool&gt;</code>, and the thread-local is seeded from it. <code>consteval</code> is already used this way in <code>OpcodeTable.h</code>.</p><p dir="ltr"><code>PRINT_NAME_ENABLE</code> is unchanged and keeps its per-thread meaning — <code>pthread.cpp</code> uses it to silence a noisy section on the calling thread. <code>PRINT_NAME_ENABLE_ALL</code> is the new library-wide form.</p><h3 dir="ltr">Effect</h3><p dir="ltr">A twenty-five second run of the same title, counting only <code>PRINT_NAME</code> output:</p><div dir="ltr" style="">
Library | Before | After
-- | -- | --
Pad | 0 | 15195
Graphics5Driver | 0 | 1511
VideoOut | 0 | 4
libkernel | 1886 | 1886
Total | 1949 | 18596

</div><p dir="ltr">The <code>Pad</code> figure is the one that shows the cross-unit part working: those calls are in <code>controller.cpp</code>, while the opt-in is in <code>libPad.cpp</code>.</p><p dir="ltr">Log size was 33 MB, against 39 MB for the same run before, so the extra tracing is lost in the noise of the existing output. <code>printf_direction</code> also defaults to <code>Silent</code> now, so none of this reaches anyone who has not asked for logging.</p><h3 dir="ltr">One judgement call</h3><p dir="ltr"><code>Graphics5</code> is left on the per-thread form. Its traced functions in <code>agc.cpp</code> build command packets, and switching it on emitted about <strong>620000</strong> lines in the same twenty-five seconds and doubled the log to 77 MB. That is not a useful default, so its current behaviour is preserved and the mechanism is there to flip it with a one word change. Happy to enable it if you would rather have it on.</p><h3 dir="ltr">Test plan</h3><p dir="ltr">Windows 11 25H2, clang-cl 20.1.8, RTX 2060.</p><ul dir="ltr"><li style=""><input disabled="" readonly="" type="checkbox" checked=""> <code>ctest</code>: 35/35.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> Counts above measured from real runs of the same title, before and after.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> Builds clean, including the three <code>LIB_USING</code> sites that import the library symbols into another namespace.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> No test covers this directly — it is diagnostic output, observable only in a real run.</li></ul><p dir="ltr">This changes no emulation behaviour. It is a debugging fix: at the moment a contributor looking at <code>Pad</code> or <code>VideoOut</code> sees no calls logged and can reasonably conclude the guest is not calling them, which is not true.</p><h3 dir="ltr">AI use</h3><p dir="ltr">Written with AI assistance (Claude). It found both halves of the problem, wrote the change, and ran the builds, tests and before/after measurements on my machine. I reviewed the diff and the measurements.</p><!--EndFragment-->
</body>
</html>