### PR TITLE
shader: return zero from the clamp output modifier for NaN

### DIFF
--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAlu.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAlu.cpp
@@ -405,11 +405,17 @@ bool EmitValueAlu(ValueEmitContext& ctx, const IR::Inst& inst) {
 		case IR::ValueOpcode::FPNeg32:
 			ctx.Define(inst, EmitFNegateValue(state, ctx.Arg(inst, 0)));
 			return true;
-		case IR::ValueOpcode::FPSaturate32:
-			ctx.Define(inst, EmitExt(state, TypeF32(state), GlslFClamp,
-			                         {ctx.Arg(inst, 0), ConstantF32(state, 0),
-			                          ConstantF32(state, 0x3f800000u)}));
+		case IR::ValueOpcode::FPSaturate32: {
+			// The clamp output modifier returns 0 for NaN; GLSL FClamp leaves that undefined.
+			const auto source = ctx.Arg(inst, 0);
+			const auto clamped =
+			    EmitExt(state, TypeF32(state), GlslFClamp,
+			            {source, ConstantF32(state, 0), ConstantF32(state, 0x3f800000u)});
+			const auto is_nan = EmitClassifyF32(state, source).nan;
+			ctx.Define(inst,
+			           NewSelect(state, TypeF32(state), is_nan, ConstantF32(state, 0), clamped));
 			return true;
+		}
 		case IR::ValueOpcode::BitFieldInsert:
 			ctx.Emit(inst, OpBitFieldInsert, IR::Type::U32,
 			         {ctx.Arg(inst, 0), ctx.Arg(inst, 1), ctx.Arg(inst, 2), ctx.Arg(inst, 3)});

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -15095,6 +15095,26 @@ TestCase VectorFloatArithmeticOps() {
            O::BUFFER_STORE_DWORD, O::S_ENDPGM}};
 }
 
+TestCase VectorClampF32ReturnsZeroForNan() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0x7fc00000u);
+  AppendVMovLiteral(&code, 1, 0x3f800000u);
+  AppendVop3(&code, 0x108, 10, Vgpr(0), Vgpr(1), 0, 0, 0, true);
+  AppendStoreVgpr(&code, 10, 0);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "VectorClampF32ReturnsZeroForNan";
+  test.code = std::move(code);
+  test.expected = {0x00000000u};
+  test.opcodes = {O::V_MOV_B32, O::V_MUL_F32, O::BUFFER_STORE_DWORD,
+                  O::S_ENDPGM};
+  test.ir_counts = {{" = FPSaturate32 ", 1}};
+  return test;
+}
+
 TestCase VectorMinMaxF32NanAndSignedZeroEdges() {
   using O = ShaderOpcode;
 
@@ -20748,6 +20768,7 @@ std::vector<TestCase> MakeCases() {
   AddCase(FloatInlineConstantF16UsesNumericValue);
   AddCase(VectorFloatControlContractPreservesInfNan);
   AddCase(VectorFloatArithmeticOps);
+  AddCase(VectorClampF32ReturnsZeroForNan);
   AddCase(VectorMinMaxF32NanAndSignedZeroEdges);
   AddCase(VectorMed3F32NanUsesMin3Path);
   AddCase(VectorFloatConversionOps);


### PR DESCRIPTION
## Summary

- Return 0 from the clamp output modifier when the result is NaN.
- Match the NaN handling `V_MIN`/`V_MAX` already have in `EmitMinMaxF32Value`.

## Problem

`FPSaturate32` lowered the clamp output modifier to a bare GLSL `FClamp`:

```cpp
case IR::ValueOpcode::FPSaturate32:
    ctx.Define(inst, EmitExt(state, TypeF32(state), GlslFClamp,
                             {ctx.Arg(inst, 0), ConstantF32(state, 0),
                              ConstantF32(state, 0x3f800000u)}));
```

The clamp output modifier is specified to return 0 when the result is NaN. `FClamp` with a
NaN operand is undefined in GLSL/SPIR-V, so this relied on unspecified driver behaviour and a
NaN could survive saturation and propagate into whatever consumed it.

`EmitMinMaxF32Value` already selects the NaN case explicitly for `V_MIN`/`V_MAX`. Saturate was
the one float path that did not.

No known game symptom. On the driver I tested, `FClamp` already returns 0 for NaN, so the old
code happened to produce the right answer; a driver that returns the NaN or a clamp bound
instead would propagate it.

## AI assistance

AI assistance was used because I'm a smooth brained javascript dev :)
