### PR TITLE
kernel: stop sign-extending batch-map protection and type

### DIFF
--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -3804,8 +3804,8 @@ int KYTY_SYSV_ABI KernelBatchMap2(KernelBatchMapEntry* entries, int num_entries,
 		LOGF("\t [%d] start = %p, offset = 0x%016" PRIx64 ", length = 0x%016" PRIx64
 		     ", prot = 0x%02" PRIx32 ", type = 0x%02" PRIx32 ", op = %d\n",
 		     i, entry->start, entry->offset, entry->length,
-		     static_cast<uint32_t>(static_cast<unsigned char>(entry->protection)),
-		     static_cast<uint32_t>(static_cast<unsigned char>(entry->type)), entry->operation);
+		     static_cast<uint32_t>(entry->protection), static_cast<uint32_t>(entry->type),
+		     entry->operation);
 
 		if (entry->length == 0 || entry->operation < MAP_OP_MAP_DIRECT ||
 		    entry->operation > MAP_OP_TYPE_PROTECT) {

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -47,13 +47,13 @@ struct VirtualQueryInfo {
 static_assert(sizeof(VirtualQueryInfo) == 72, "VirtualQueryInfo struct size is incorrect");
 
 struct KernelBatchMapEntry {
-	void*    start;
-	uint64_t offset;
-	uint64_t length;
-	char     protection;
-	char     type;
-	int16_t  reserved;
-	int32_t  operation;
+	void*         start;
+	uint64_t      offset;
+	uint64_t      length;
+	unsigned char protection;
+	unsigned char type;
+	int16_t       reserved;
+	int32_t       operation;
 };
 
 static_assert(sizeof(KernelBatchMapEntry) == 32, "KernelBatchMapEntry struct size is incorrect");


### PR DESCRIPTION
## Problem

`KernelBatchMapEntry::protection` and `::type` are `char`, signed on the build platforms, and every use passes them to an `int`. A protection of `0xf3` widens to `0xfffffff3`.

Harmless for mapping, where only bits 0-5 are tested, but `KernelQueryMemoryProtection` returns the stored value straight to the guest — so a guest that maps with `0xf3` reads back `0xfffffff3`. The `LOGF` in `KernelBatchMap2` already casts both fields through `unsigned char`.

## Change

`char` -> `unsigned char`. `sizeof` is unchanged and the existing `static_assert` still holds; the now-redundant cast in `LOGF` is removed.

Found while chasing an unrelated crash, with no game symptom to attribute to it.

## AI assistance
Let me know if this is slop, claude caught and noted this whilst looking into an unrelated problem. 