### PR TITLE
common: report crashes that reach no handler

### DIFF
--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -2,11 +2,15 @@
 
 #include "common/debug.h"
 #include "common/logging/log.h"
+#include "common/platform/sysDbg.h"
 #include "common/subsystems.h"
 #include "kytyGitVersion.h"
 
+#include <atomic>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <exception>
 #include <fmt/format.h>
 #include <string>
 
@@ -31,6 +35,75 @@ static std::string BuildFatalReport(const char* title, std::string_view text, co
 	}
 	report += fmt::format("{}\n{} in {}:{}\n", title, text, file, line);
 	return report;
+}
+
+// A fault that reaches none of the emulator's own handlers used to end the process with nothing
+// written: the log tail was still in the file buffer and no report was produced. These hooks
+// leave the same kind of record EXIT() leaves, then hand the fault back to the default handling
+// so dump collection is unchanged.
+static std::atomic_bool g_reported {false};
+
+static std::string BuildCrashReport(std::string_view headline, std::string_view detail) {
+	DebugStack stack;
+	DebugStack::Trace(&stack);
+
+	std::string report = "--- Build ---\n" KYTY_BUILD_LABEL "\n--- Stack Trace ---\n";
+	for (int i = PRINT_STACK_FROM; i < stack.depth; i++) {
+		report += fmt::format("[{}] {:016x}\n", i - PRINT_STACK_FROM,
+		                      static_cast<uint64_t>(stack.GetAddr(i)));
+	}
+	report += fmt::format("--- Crash ---\n{}\n", headline);
+	if (!detail.empty()) {
+		report += fmt::format("{}\n", detail);
+	}
+	return report;
+}
+
+// Faults the guest page-fault handler did not claim: stack overflow, divide by zero and the rest.
+// Access violations and illegal instructions are already reported by KytyExceptionHandler and
+// never reach here.
+static void ReportCrash(const sys_dbg_crash_info_t& info) {
+	if (g_reported.exchange(true)) {
+		return;
+	}
+
+	auto headline = fmt::format("{} (0x{:08x}) at 0x{:016x}", info.description, info.native_code,
+	                            info.fault_addr);
+	std::string detail;
+	if (info.access != nullptr) {
+		detail = fmt::format("{} of 0x{:016x}", info.access, info.access_addr);
+	}
+
+	// Writes to stdout and the log file, then flushes. Without the flush the tail of the log is
+	// still sitting in the file buffer when the process dies.
+	Log::WriteFatal(BuildCrashReport(headline, detail));
+}
+
+// An uncaught throw never reaches the fault hook, it goes to std::terminate. The Microsoft CRT
+// keeps the terminate handler per thread, so this alone would only cover the thread that
+// installed it. The exception text is not read back here: the project builds with
+// -fno-exceptions on clang, and by the time SIGABRT arrives there is no active exception to
+// describe anyway.
+static void ReportTerminate() {
+	if (!g_reported.exchange(true)) {
+		Log::WriteFatal(BuildCrashReport("terminate called", {}));
+	}
+	std::abort(); // what the default handler would have done
+}
+
+// SIGABRT is process-wide, so this is what actually covers an uncaught throw on a guest or
+// graphics thread, along with any direct abort().
+static void ReportAbort(int sig) {
+	if (!g_reported.exchange(true)) {
+		Log::WriteFatal(BuildCrashReport("aborted", {}));
+	}
+	std::signal(sig, SIG_DFL);
+}
+
+void InstallCrashReporter() {
+	SysInstallCrashHandler(ReportCrash);
+	std::set_terminate(ReportTerminate);
+	std::signal(SIGABRT, ReportAbort);
 }
 
 static int DbgReport(const char* title, std::string_view text, const char* file, int line) {

--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -27,6 +27,10 @@ int  DbgNotImplementedHandler(char const* expr, char const* file, int line);
 void DbgExit(int status);
 #endif
 
+// Records a fault that nothing else handled, so a crash leaves the same kind of report in the log
+// that EXIT() leaves. Safe to call once at startup; a platform without a hook does nothing.
+void InstallCrashReporter();
+
 } // namespace Common
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS || KYTY_PLATFORM == KYTY_PLATFORM_LINUX

--- a/src/common/platform/sysDbg.h
+++ b/src/common/platform/sysDbg.h
@@ -30,6 +30,22 @@ struct sys_dbg_stack_info_t {
 #endif
 };
 
+// A fault nothing else handled. The process is already dying when this is reported.
+// NOLINTNEXTLINE(readability-identifier-naming)
+struct sys_dbg_crash_info_t {
+	uint64_t    native_code; // Windows exception code, or the POSIX signal number
+	uint64_t    fault_addr;  // the faulting instruction
+	uint64_t    access_addr; // data address for a memory fault, 0 otherwise
+	const char* description; // "access violation", "illegal instruction", ...
+	const char* access;      // "read", "write", "execute", or nullptr
+};
+
+using SysCrashHandler = void (*)(const sys_dbg_crash_info_t& info);
+
+// Installs a last-resort reporter for faults that reach nobody else. Returns false when the
+// platform has no hook, which leaves the process behaving exactly as it did before.
+bool SysInstallCrashHandler(SysCrashHandler handler);
+
 void SysStackWalk(void** stack, int* depth);
 void SysStackUsage(sys_dbg_stack_info_t& s);          // NOLINT(google-runtime-references)
 void SysStackUsagePrint(sys_dbg_stack_info_t& stack); // NOLINT(google-runtime-references)

--- a/src/common/platform/sysLinuxDbg.cpp
+++ b/src/common/platform/sysLinuxDbg.cpp
@@ -43,6 +43,16 @@ static bool OnOwnStack() {
 #endif
 }
 
+bool SysInstallCrashHandler(SysCrashHandler /*handler*/) {
+	// Not wired up here yet. SIGSEGV, SIGBUS and SIGILL already carry the guest page-fault
+	// handler installed by HostException, so a second handler for those signals would have to
+	// chain to it rather than replace it. Reporting the fault from the point where that handler
+	// gives up is the right hook, and it needs a POSIX machine to verify. Until then this
+	// hook returns false. The terminate and SIGABRT hooks in InstallCrashReporter are portable
+	// and do run here.
+	return false;
+}
+
 void SysStackWalk(void** stack, int* depth) {
 	if (stack == nullptr || depth == nullptr || *depth <= 0) {
 		if (depth != nullptr) {

--- a/src/common/platform/sysWindowsDbg.cpp
+++ b/src/common/platform/sysWindowsDbg.cpp
@@ -15,6 +15,78 @@
 #include "common/assert.h"
 #include "common/platform/sysDbg.h"
 
+#include <atomic>
+
+namespace {
+
+std::atomic<SysCrashHandler> g_crash_handler {nullptr};
+
+static_assert(decltype(g_crash_handler)::is_always_lock_free);
+
+const char* ExceptionDescription(DWORD code) {
+	switch (code) {
+		case EXCEPTION_ACCESS_VIOLATION: return "access violation";
+		case EXCEPTION_IN_PAGE_ERROR: return "in-page error";
+		case EXCEPTION_ILLEGAL_INSTRUCTION: return "illegal instruction";
+		case EXCEPTION_PRIV_INSTRUCTION: return "privileged instruction";
+		case EXCEPTION_STACK_OVERFLOW: return "stack overflow";
+		case EXCEPTION_INT_DIVIDE_BY_ZERO: return "integer divide by zero";
+		case EXCEPTION_FLT_DIVIDE_BY_ZERO: return "float divide by zero";
+		case EXCEPTION_DATATYPE_MISALIGNMENT: return "datatype misalignment";
+		case EXCEPTION_NONCONTINUABLE_EXCEPTION: return "noncontinuable exception";
+		case 0xe06d7363u: return "unhandled C++ exception";
+		default: return "unhandled exception";
+	}
+}
+
+LONG WINAPI CrashFilter(PEXCEPTION_POINTERS pointers) {
+	// The reporter itself may fault. Report the first one and let any later fault pass straight
+	// through, so a broken reporter cannot turn a crash into a hang.
+	static LONG reporting = 0;
+	if (InterlockedExchange(&reporting, 1) != 0) {
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	const auto* record  = pointers->ExceptionRecord;
+	const auto  handler = g_crash_handler.load(std::memory_order_acquire);
+
+	if (handler != nullptr && record != nullptr) {
+		sys_dbg_crash_info_t info {};
+		info.native_code = record->ExceptionCode;
+		info.fault_addr  = reinterpret_cast<uint64_t>(record->ExceptionAddress);
+		info.description = ExceptionDescription(record->ExceptionCode);
+
+		if ((record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION ||
+		     record->ExceptionCode == EXCEPTION_IN_PAGE_ERROR) &&
+		    record->NumberParameters >= 2) {
+			info.access_addr = record->ExceptionInformation[1];
+			switch (record->ExceptionInformation[0]) {
+				case 0: info.access = "read"; break;
+				case 1: info.access = "write"; break;
+				case 8: info.access = "execute"; break;
+				default: break;
+			}
+		}
+
+		handler(info);
+	}
+
+	// Hand the fault back to the default handling so Windows Error Reporting and any configured
+	// dump collection behave exactly as they did before.
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+} // namespace
+
+bool SysInstallCrashHandler(SysCrashHandler handler) {
+	if (handler == nullptr) {
+		return false;
+	}
+	g_crash_handler.store(handler, std::memory_order_release);
+	SetUnhandledExceptionFilter(CrashFilter);
+	return true;
+}
+
 void SysStackWalk(void** stack, int* depth) {
 	*depth = static_cast<int>(CaptureStackBackTrace(0, static_cast<DWORD>(*depth), stack, nullptr));
 }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -193,6 +193,10 @@ void Run(const RunOptions& options) {
 	Common::Subsystems subsystems(true);
 	Init(options.config, param_json, subsystems);
 
+	// Init() configures the log, so this is the first point where a crash report has somewhere
+	// to go. Everything after it is covered.
+	Common::InstallCrashReporter();
+
 	ClearDebugTextureFolder();
 
 	PrintSystemInfo();


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3 dir="ltr">Problem</h3><p dir="ltr"><code>KytyExceptionHandler</code> reports access violations and illegal instructions, which is why a null dereference already produces a stack trace. Nothing else does. <code>HostException</code>'s filter returns <code>EXCEPTION_CONTINUE_SEARCH</code> for every other exception code, so those faults never reach that handler, and an uncaught throw never goes near it at all — it goes to <code>std::terminate</code>.</p><p dir="ltr">The result is a class of session that ends with no record of why. <a href="https://github.com/KytyPS5/KytyPS5/issues/307" target="_blank" rel="noreferrer">#307</a> describes it exactly: <em>"The process terminates before Kyty can flush a crash record to the log"</em>, and that reporter had to inspect a minidump to find <code>RIP=0</code>.</p><p dir="ltr">Measured on Tetris Forever with a fault injected at a fixed point, before and after:</p><div style="">
  | before | after
-- | -- | --
access violation | reported | unchanged
stack overflow | nothing | reported
integer divide by zero | nothing | reported
uncaught throw | nothing | reported
.at() out of range | nothing | reported

</div><p dir="ltr">The bottom two are the ones I would worry about. The tree has one <code>catch</code> site against 129 <code>new</code> expressions and 52 <code>.at()</code> calls, so a <code>bad_alloc</code> or an <code>out_of_range</code> is a realistic way to lose a session silently.</p><h3 dir="ltr">The fix</h3><p dir="ltr">Three hooks, because no single one covers the ground:</p><ul dir="ltr"><li style=""><code>SetUnhandledExceptionFilter</code> takes the faults the guest page-fault handler declined.</li><li style=""><code>std::terminate</code> covers an uncaught throw — but the Microsoft CRT keeps that handler <strong>per thread</strong>, so on Windows it only covers the thread that installed it. I found this by testing, not by reading: the first version reported nothing when the throw happened on a guest thread.</li><li style=""><code>SIGABRT</code> is process-wide and is what actually catches a throw on a guest or graphics thread.</li></ul><p dir="ltr">All three build the same report <code>EXIT()</code> builds, and hand the fault back to the default handling afterwards, so Windows Error Reporting and dump collection are unchanged. Reporting is latched so a fault inside the reporter cannot loop.</p><p dir="ltr">The terminate and SIGABRT hooks are portable and run everywhere; on POSIX <code>std::terminate</code> is process-wide, so uncaught throws are covered there without the per-thread caveat. Only the fault hook is Windows-only — <code>SIGSEGV</code>, <code>SIGBUS</code> and <code>SIGILL</code> already carry the guest page-fault handler, so a second handler there has to chain rather than replace it, and I have no POSIX machine to verify that on. <code>SysInstallCrashHandler</code> returns false until someone does.</p><h3 dir="ltr">What this does not cover</h3><p dir="ltr">If the fault happens <em>inside the logger itself</em>, no report is produced. I tested that case specifically by faulting inside <code>RawFormatter::format</code> while the sink mutex was held: nothing is written, with or without this change, because the handler does not run. That is pre-existing and unchanged here, not something this patch introduces.</p><p dir="ltr">I also checked whether re-entering the logger from a crashing thread could hang, since that would be worse than the silence it replaces. It cannot: MSVC's <code>std::mutex</code> detects recursive acquisition and throws <code>resource deadlock would occur</code> rather than blocking, and spdlog swallows it.</p><h3 dir="ltr">Test plan</h3><p dir="ltr">Windows 11 25H2, clang-cl 20.1.8, RTX 2060.</p><ul dir="ltr"><li style=""><input disabled="" readonly="" type="checkbox" checked=""> <code>ctest</code>: 35/35.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> Each row of the table above produced by injecting that fault into a real run and reading the log, before and after.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> Normal run unaffected: 1531 flips in 25 s, zero spurious reports, log size unchanged.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> No new test — this only produces diagnostic output on a dying process, which the suite has no way to observe.</li></ul><h3 dir="ltr">AI use</h3><p dir="ltr">Written with AI assistance (Claude). It traced the existing fault paths, found that access violations were already covered and the gap was elsewhere, wrote the change, and ran the builds, injected-fault runs and measurements on my machine. I reviewed the diff and the results.</p><!--EndFragment-->
</body>
</html>Problem

KytyExceptionHandler reports access violations and illegal instructions, which is why a null dereference already produces a stack trace. Nothing else does. HostException's filter returns EXCEPTION_CONTINUE_SEARCH for every other exception code, so those faults never reach that handler, and an uncaught throw never goes near it at all — it goes to std::terminate.

The result is a class of session that ends with no record of why. [#307](https://github.com/KytyPS5/KytyPS5/issues/307) describes it exactly: "The process terminates before Kyty can flush a crash record to the log", and that reporter had to inspect a minidump to find RIP=0.

Measured on Tetris Forever with a fault injected at a fixed point, before and after:

	before	after
access violation	reported	unchanged
stack overflow	nothing	reported
integer divide by zero	nothing	reported
uncaught throw	nothing	reported
.at() out of range	nothing	reported

The bottom two are the ones I would worry about. The tree has one catch site against 129 new expressions and 52 .at() calls, so a bad_alloc or an out_of_range is a realistic way to lose a session silently.

The fix

Three hooks, because no single one covers the ground:

SetUnhandledExceptionFilter takes the faults the guest page-fault handler declined.
std::terminate covers an uncaught throw — but the Microsoft CRT keeps that handler per thread, so on Windows it only covers the thread that installed it. I found this by testing, not by reading: the first version reported nothing when the throw happened on a guest thread.
SIGABRT is process-wide and is what actually catches a throw on a guest or graphics thread.

All three build the same report EXIT() builds, and hand the fault back to the default handling afterwards, so Windows Error Reporting and dump collection are unchanged. Reporting is latched so a fault inside the reporter cannot loop.

The terminate and SIGABRT hooks are portable and run everywhere; on POSIX std::terminate is process-wide, so uncaught throws are covered there without the per-thread caveat. Only the fault hook is Windows-only — SIGSEGV, SIGBUS and SIGILL already carry the guest page-fault handler, so a second handler there has to chain rather than replace it, and I have no POSIX machine to verify that on. SysInstallCrashHandler returns false until someone does.

What this does not cover

If the fault happens inside the logger itself, no report is produced. I tested that case specifically by faulting inside RawFormatter::format while the sink mutex was held: nothing is written, with or without this change, because the handler does not run. That is pre-existing and unchanged here, not something this patch introduces.

I also checked whether re-entering the logger from a crashing thread could hang, since that would be worse than the silence it replaces. It cannot: MSVC's std::mutex detects recursive acquisition and throws resource deadlock would occur rather than blocking, and spdlog swallows it.

Test plan

Windows 11 25H2, clang-cl 20.1.8, RTX 2060.

 ctest: 35/35.
 Each row of the table above produced by injecting that fault into a real run and reading the log, before and after.
 Normal run unaffected: 1531 flips in 25 s, zero spurious reports, log size unchanged.
 No new test — this only produces diagnostic output on a dying process, which the suite has no way to observe.
AI use

Written with AI assistance (Claude). It traced the existing fault paths, found that access violations were already covered and the gap was elsewhere, wrote the change, and ran the builds, injected-fault runs and measurements on my machine. I reviewed the diff and the results.