### PR TITLE
fix(kernel) implement sceKernelGetOperationMode

### DIFF
--- a/src/libs/libKernel.cpp
+++ b/src/libs/libKernel.cpp
@@ -1836,6 +1836,15 @@ uint64_t KYTY_SYSV_ABI KernelGetGPI() {
 	return bits;
 }
 
+int KYTY_SYSV_ABI KernelGetOperationMode(int* mode) {
+	PRINT_NAME();
+	if (mode == nullptr) {
+		return -1;
+	}
+	*mode = 1; // SCE_KERNEL_OPERATION_MODE_GAME
+	return 0;
+}
+
 } // namespace LibKernel
 
 namespace LibKernelWriteThrottling {
@@ -3333,6 +3342,7 @@ LIB_DEFINE(InitLibKernel_1) {
 	LIB_FUNC("bnZxYgAFeA0", LibKernel::KernelGetSanitizerNewReplaceExternal);
 	LIB_FUNC("ca7v6Cxulzs", LibKernel::KernelSetGPO);
 	LIB_FUNC("4oXYe9Xmk0Q", LibKernel::KernelGetGPI);
+	LIB_FUNC("NH6xARDOVv8", LibKernel::KernelGetOperationMode); // SpongeBob PPSA26893
 	LIB_FUNC("DRuBt2pvICk", LibKernel::read);
 	LIB_FUNC("AqBioC2vF3I", LibKernel::read);
 	LIB_FUNC("f7KBOafysXo", LibKernel::KernelGetModuleInfoFromAddr);


### PR DESCRIPTION
## Summary

Fixes two unresolved-import stubs that blocked SpongeBob SquarePants: Titans of the Tide (PPSA26893) from booting on KytyPS5.

## Changes

1. **`src/libs/agc.cpp` + `agc.h` + `libAgcDriver.cpp`** — add and register `AgcDcbCopyDataGetSize` under NID `b5u0Jzm8TF8`.
2. **`src/libs/libKernel.cpp`** — implement and register `sceKernelGetOperationMode` under NID `NH6xARDOVv8` (returns operation mode 1 = Game).

## How the NIDs were identified

The PS5 NID algorithm is `base64(sha1(name + salt))` with a custom alphabet. We reproduced it and matched both NIDs against the community NID database (`ps5rs`):

- `b5u0Jzm8TF8` = `sceAgcDcbCopyDataGetSize`
- `NH6xARDOVv8` = `sceKernelGetOperationMode`

## Evidence

Before: the game printed both `Unresolved import stub called` lines and aborted.
After: both stubs resolve; the game boots much further — RHI threads spawn, VideoOut queue is created and flips, UE5 loads localization/plugins/asset registries. (A separate, later UE5 RHI crash remains on the RHI submission thread; this PR fixes the two stub blockers only.)

## Notes

- This supersedes an earlier draft mapping (`b5u0Jzm8TF8` → `AgcGetRegisterDefaults2`) which was incorrect — the NID signature did not match.
- Tested on Linux (CachyOS), NVIDIA RTX 3060 Ti, official build 1df53b1 + this patch.