### PR TITLE
build: add Arch Linux support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,6 +403,136 @@ jobs:
           path: _Build/linux/install/**
           if-no-files-found: error
 
+  arch_linux:
+    name: Build KytyPS5 (Arch Linux)
+    needs: metadata
+    runs-on: ubuntu-24.04
+    container: archlinux:base-devel
+
+    steps:
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          pacman -Syu --noconfirm --needed \
+            alsa-lib \
+            bzip2 \
+            clang \
+            cmake \
+            dbus \
+            git \
+            glslang \
+            libpulse \
+            libx11 \
+            libxcursor \
+            libxext \
+            libxfixes \
+            libxi \
+            libxkbcommon \
+            libxrandr \
+            libxss \
+            lld \
+            mesa \
+            ninja \
+            qt6-base \
+            qt6-svg \
+            systemd-libs \
+            vulkan-icd-loader \
+            wayland \
+            wayland-protocols \
+            xz \
+            zlib
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Verify toolchain
+        shell: bash
+        run: |
+          git --version
+          cmake --version
+          ninja --version
+          clang++ --version
+          ld.lld --version
+          glslangValidator --version
+          qmake6 -query QT_VERSION QT_INSTALL_PREFIX
+
+      - name: Configure
+        shell: bash
+        run: |
+          mkdir -p _Build
+          cmake -S . -B _Build/arch \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+            -DKYTY_BUILD_ORIGIN="$KYTY_BUILD_ORIGIN" \
+            -DKYTY_BUILD_REPOSITORY="$KYTY_BUILD_REPOSITORY" \
+            -DKYTY_RELEASE_TAG="${{ needs.metadata.outputs.release_tag }}" \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ 2>&1 | tee _Build/configure.log
+          exit "${PIPESTATUS[0]}"
+
+      - name: Verify SDL2 backends
+        shell: bash
+        run: |
+          status=0
+          for feature in SDL_ALSA SDL_PULSEAUDIO SDL_WAYLAND SDL_X11 SDL_LIBUDEV SDL_DBUS; do
+            if grep -qE "^--   ${feature} +\\(Wanted: ON\\): ON" _Build/configure.log; then
+              echo "ok   ${feature}"
+            else
+              echo "FAIL ${feature} is not enabled"
+              status=1
+            fi
+          done
+          exit "$status"
+
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build _Build/arch \
+            --target launcher page_manager_tests memory_tracker_tests \
+              audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests \
+            --parallel
+
+      - name: Test
+        shell: bash
+        run: |
+          ctest --test-dir _Build/arch --output-on-failure \
+            -R '^(audio_out2_port|ime_dialog|page_manager|memory_tracker|virtual_memory_allocation)$'
+
+      - name: Install
+        shell: bash
+        run: cmake --install _Build/arch --prefix _Build/arch/install
+
+      - name: Verify artifacts
+        shell: bash
+        run: |
+          file _Build/arch/install/launcher
+          file _Build/arch/install/kyty_emulator
+          file _Build/arch/install/kyty_emulator | grep -q "ELF 64-bit LSB .*x86-64"
+          for binary in launcher kyty_emulator; do
+            ldd_output="$(ldd "_Build/arch/install/$binary")"
+            if grep -q "not found" <<< "$ldd_output"; then
+              echo "$binary has unresolved runtime dependencies"
+              printf '%s\n' "$ldd_output"
+              exit 1
+            fi
+          done
+          readelf -d _Build/arch/install/launcher | grep -q 'RPATH.*\$ORIGIN/lib'
+          while IFS= read -r -d '' binary; do
+            while read -r dependency; do
+              test -e "_Build/arch/install/lib/$dependency"
+            done < <(
+              readelf -d "$binary" |
+                sed -n 's/.*Shared library: \[\(libQt6[^]]*\|libicu[^]]*\)\].*/\1/p'
+            )
+          done < <(
+            find _Build/arch/install/launcher _Build/arch/install/plugins \
+              -type f \( -name launcher -o -name '*.so' \) -print0
+          )
+          _Build/arch/install/kyty_emulator --help > /dev/null
+
   release:
     name: Release KytyPS5
     if: >-

--- a/src/launcher/CMakeLists.txt
+++ b/src/launcher/CMakeLists.txt
@@ -146,20 +146,41 @@ elseif(LINUX)
 	if(kyty_qt_plugins_dir)
 		message(STATUS "Qt plugins for launcher deployment: ${kyty_qt_plugins_dir}")
 		set(kyty_qt_plugin_files "")
-		foreach(kyty_qt_plugin platforms tls imageformats xcbglintegrations wayland-shell-integration)
+		foreach(kyty_qt_plugin platforms tls iconengines imageformats xcbglintegrations wayland-shell-integration)
 			if(IS_DIRECTORY "${kyty_qt_plugins_dir}/${kyty_qt_plugin}")
-				file(GLOB kyty_qt_plugin_group
-					"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/*.so"
-					"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/*.so.*")
-				list(APPEND kyty_qt_plugin_files ${kyty_qt_plugin_group})
-				install(DIRECTORY "${kyty_qt_plugins_dir}/${kyty_qt_plugin}" DESTINATION "plugins")
+				# Distribution plugin directories can also contain unrelated third-party
+				# modules (for example KDE image format plugins on Arch Linux). Deploy
+				# Qt-owned modules only, so an optional system plugin cannot make the
+				# portable install fail because one of its own dependencies is absent.
+				file(GLOB kyty_qt_plugin_group LIST_DIRECTORIES FALSE
+					"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/libq*.so"
+					"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/libq*.so.*")
+				if(kyty_qt_plugin STREQUAL "wayland-shell-integration")
+					# Qt's Wayland shell modules predate its libq* plugin naming convention.
+					file(GLOB kyty_qt_wayland_shell_plugins LIST_DIRECTORIES FALSE
+						"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/libfullscreen-shell-v1.so*"
+						"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/libivi-shell.so*"
+						"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/libqt-shell.so*"
+						"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/libwl-shell-plugin.so*"
+						"${kyty_qt_plugins_dir}/${kyty_qt_plugin}/libxdg-shell.so*")
+					list(APPEND kyty_qt_plugin_group ${kyty_qt_wayland_shell_plugins})
+				endif()
+				if(kyty_qt_plugin_group)
+					list(REMOVE_DUPLICATES kyty_qt_plugin_group)
+					list(APPEND kyty_qt_plugin_files ${kyty_qt_plugin_group})
+					install(FILES ${kyty_qt_plugin_group}
+						DESTINATION "plugins/${kyty_qt_plugin}")
+				endif()
 			endif()
 		endforeach()
 		install(CODE "
+			if(POLICY CMP0207)
+				cmake_policy(SET CMP0207 NEW)
+			endif()
 			set(kyty_plugin_files \"${kyty_qt_plugin_files}\")
 			file(GET_RUNTIME_DEPENDENCIES
 				EXECUTABLES \"${CMAKE_CURRENT_BINARY_DIR}/${launcher_name}\"
-				LIBRARIES \${kyty_plugin_files}
+				MODULES \${kyty_plugin_files}
 				RESOLVED_DEPENDENCIES_VAR kyty_resolved
 				POST_INCLUDE_REGEXES \"libQt6\" \"libicu\"
 				POST_EXCLUDE_REGEXES \".*\")


### PR DESCRIPTION
## Summary

- document the Arch Linux build dependencies, Vulkan driver requirement, and system Qt configuration
- add an Arch Linux CI job that verifies the toolchain, required SDL backends, regression tests, installation, RPATH, and runtime dependencies
- deploy only Qt-owned plugins on Linux so unrelated distribution plugins cannot break packaging
- include the Qt SVG icon engine and supported Qt Wayland shell integrations
- show separate Ubuntu Linux and Arch Linux status badges in the README

## Motivation

Arch installs Qt and third-party plugins into shared plugin directories. Copying the entire imageformats directory pulled KDE kimageformat modules into the KytyPS5 bundle. The install then failed when resolving optional dependencies such as libraw. Filtering the deployment set to Qt-owned modules fixes that failure while preserving the required platform, TLS, image format, XCB, and Wayland plugins.

## Validation

- configured and built the launcher and selected regression targets on a native Arch Linux host
- completed a clean build and install in the official archlinux:base-devel container
- passed audio_out2_port, ime_dialog, page_manager, memory_tracker, and virtual_memory_allocation tests (5/5)
- verified ALSA, PulseAudio, Wayland, X11, udev, and DBus SDL backends are enabled
- verified ELF architecture, launcher RPATH, staged Qt/ICU dependencies, and emulator --help
- verified that KDE kimg and layer-shell plugins are not staged
- passed actionlint and git diff --check

## Scope

This validates Arch build and deployment support. An interactive game boot was not part of this change.