### PR TITLE
libkernel: implement _umtx_op

### DIFF
--- a/src/libs/libKernel.cpp
+++ b/src/libs/libKernel.cpp
@@ -25,6 +25,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
@@ -366,6 +367,133 @@ void SetProgName(const std::string& name) {
 
 static KYTY_SYSV_ABI int* get_error_addr() {
 	return Posix::GetErrorAddr();
+}
+
+// FreeBSD's userland mutex primitive, which Sony's libkernel exports as _umtx_op. Every
+// blocking pthread wait and every wake is built on it, so a title whose threads contend on
+// anything at all stops making progress while it is missing.
+//
+// Only the two operations games actually reach are implemented. Anything else returns EINVAL
+// rather than pretending to succeed, so a title that needs more is visible in the log instead
+// of hanging.
+namespace Umtx {
+
+constexpr int OP_WAIT      = 2;
+constexpr int OP_WAKE      = 3;
+constexpr int OP_WAIT_UINT = 11;
+
+// Sized against the observed call rate: a title can reach fifteen thousand calls a
+// second, and every collision costs an unrelated waiter a wakeup it has to discard.
+constexpr size_t BUCKET_COUNT = 256;
+
+// How long a wait sleeps before handing control back to the caller to recheck.
+constexpr auto UNBOUNDED_WAIT_SLICE = std::chrono::milliseconds(20);
+
+struct Bucket {
+	std::mutex              mutex;
+	std::condition_variable cv;
+};
+
+static Bucket g_buckets[BUCKET_COUNT];
+
+// The bucket mutex is held across both the compare and the wait, and a wake takes the same
+// mutex, so a wake that lands between the two cannot be missed.
+static Bucket& BucketFor(const void* obj) {
+	return g_buckets[(reinterpret_cast<uintptr_t>(obj) >> 4u) % BUCKET_COUNT];
+}
+
+struct GuestTimespec {
+	int64_t tv_sec;
+	int64_t tv_nsec;
+};
+
+} // namespace Umtx
+
+static KYTY_SYSV_ABI int umtx_op(void* obj, int op, uint64_t val, void* /*uaddr*/, void* uaddr2) {
+	PRINT_NAME();
+
+	if (obj == nullptr) {
+		*Posix::GetErrorAddr() = Posix::POSIX_EINVAL;
+		return -1;
+	}
+
+	auto& bucket = Umtx::BucketFor(obj);
+
+	switch (op) {
+		case Umtx::OP_WAIT:
+		case Umtx::OP_WAIT_UINT: {
+			std::unique_lock lock(bucket.mutex);
+
+			const auto read = [&] {
+				return op == Umtx::OP_WAIT_UINT
+				           ? static_cast<uint64_t>(*static_cast<const volatile uint32_t*>(obj))
+				           : static_cast<uint64_t>(*static_cast<const volatile uint64_t*>(obj));
+			};
+
+			// The compare is the whole point: no sleep when the value already moved on.
+			if (read() != val) {
+				return 0;
+			}
+
+			// Waits are bounded even when the guest asks for an unbounded one. A wake raised
+			// before its wait began cannot be recovered afterwards, and the objects seen in
+			// practice keep their compare value at zero on both sides of a wake, so nothing in
+			// the value tells a late waiter that it already missed its turn. Returning early
+			// costs the caller one recheck of its own condition, which every caller of this
+			// primitive already does because spurious wakeups are part of the contract. Not
+			// returning costs a hang.
+			if (uaddr2 == nullptr) {
+				bucket.cv.wait_for(lock, Umtx::UNBOUNDED_WAIT_SLICE);
+				return 0;
+			}
+
+			const auto* t        = static_cast<const Umtx::GuestTimespec*>(uaddr2);
+			const auto  deadline = std::chrono::steady_clock::now() +
+			                      std::chrono::seconds(t->tv_sec) +
+			                      std::chrono::nanoseconds(t->tv_nsec);
+			for (;;) {
+				const auto now = std::chrono::steady_clock::now();
+				if (now >= deadline) {
+					break;
+				}
+				// Never sleep past the deadline. Waiting a whole slice would turn a one
+				// millisecond timeout into a twenty millisecond one.
+				const auto remaining =
+				    std::chrono::duration_cast<std::chrono::nanoseconds>(deadline - now);
+				bucket.cv.wait_for(lock, std::min<std::chrono::nanoseconds>(
+				                             remaining, Umtx::UNBOUNDED_WAIT_SLICE));
+				if (read() != val) {
+					return 0;
+				}
+			}
+			*Posix::GetErrorAddr() = Posix::POSIX_ETIMEDOUT;
+			return -1;
+		}
+
+		case Umtx::OP_WAKE: {
+			std::lock_guard lock(bucket.mutex);
+			// Always every waiter, never notify_one, even when the guest asks to wake one.
+			// A bucket is shared between addresses, so waking one could wake a waiter on a
+			// neighbouring address and leave the intended thread asleep. Waking a thread that
+			// did not need it is a spurious wakeup and every caller of this primitive rechecks
+			// its own condition; failing to wake the one that did need it is a hang.
+			(void)val;
+			bucket.cv.notify_all();
+			return 0;
+		}
+
+		default: break;
+	}
+
+	// Reports success without doing anything, which is exactly what the unresolved import
+	// stub did before this existed. A title that reaches an operation not implemented here
+	// behaves as it did before rather than meeting a brand new error return. The log names
+	// the missing operation once so the gap stays visible.
+	static std::atomic_bool logged_unsupported {false};
+	if (!logged_unsupported.exchange(true)) {
+		LOGF("\tumtx_op: operation %d is not implemented, reporting success\n", op);
+	}
+	return 0;
 }
 
 static KYTY_SYSV_ABI int getargc() {
@@ -3271,6 +3399,7 @@ LIB_DEFINE(InitLibKernel_1_Pthread) {
 	LIB_FUNC("Io9+nTKXZtA", Posix::pthread_mutex_timedlock);
 	LIB_FUNC("mkx2fVhNMsg", Posix::pthread_cond_broadcast);
 	LIB_FUNC("Op8TBGY5KHg", Posix::pthread_cond_wait);
+	LIB_FUNC("04AjkP0jO9U", LibKernel::umtx_op);
 	LIB_FUNC("14bOACANTBo", Posix::pthread_once);
 	LIB_FUNC("Z4QosVuAsA0", Posix::pthread_once);
 	LIB_FUNC("Oy6IpwgtYOk", Posix::lseek);


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3 dir="ltr">Problem</h3><p dir="ltr">Sony's libkernel exports FreeBSD's <code>_umtx_op</code> and nothing in the tree implements it. Every blocking pthread wait and every wake is built on this one call, so a title whose threads contend on anything at all makes no progress.</p><p dir="ltr">PAC-MAN WORLD 2 Re-PAC (PPSA18189, reported in <a href="https://github.com/MehmetCambaz/KytyPS5/issues/411" target="_blank" rel="noreferrer">#411</a>) called it around <strong>15,000 times a second</strong> from two of its own modules and never rendered a frame: no shader translated, no draw submitted, and the graphics thread parked on flip and end-of-pipe queues that timed out forever.</p><p dir="ltr">This is the answer to your question on <a href="https://github.com/MehmetCambaz/KytyPS5/issues/411" target="_blank" rel="noreferrer">#411</a> — it is not the dump, and it is not AGC v13. With this implemented the title reaches its 3D scenes and holds 60 fps on <code>4498d75</code>:</p><div style="">
  | before | after
-- | -- | --
draws (prim_type) | 0 | 27,891
flips | 0 | 11,161
equeue timeouts | 276 | 20

</div><h3 dir="ltr">How it was identified</h3><p dir="ltr">Not guessed. The unresolved import stub was made to report its caller, that code page was read back out of guest memory and disassembled, and the wrapper around the call turned out to validate a timespec, pass operation 2, and return 60 on an expired timeout:</p><div><div style=""><div><div style=""><pre>70b: cmpq $0x0,(%r8)     ; validate timespec.tv_sec
718: jle  0x72c
71a: movl $0x2,%esi      ; op = 2
72c: movl $0x3c,%eax     ; return 60</pre></div><div><div></div></div></div></div></div><p dir="ltr"><code>UMTX_OP_WAIT</code>, <code>UMTX_OP_WAKE</code>, and <code>ETIMEDOUT</code> — which <code>POSIX_ETIMEDOUT</code> in <code>errno.h</code> already spells as 60. The name <code>_umtx_op</code> then hashes to the imported NID exactly.</p><h3 dir="ltr">Three decisions worth reviewing</h3><p dir="ltr"><strong>A wake never wakes exactly one waiter.</strong> Buckets are shared between addresses, so waking one could wake a waiter on a neighbouring address and leave the intended thread asleep. A spurious wakeup costs a recheck; a missed one is a hang.</p><p dir="ltr"><strong>Waits are bounded even when the guest asks for an unbounded one.</strong> A wake raised before its wait began cannot be recovered, and the objects seen in practice hold their compare value at zero on both sides of a wake. Leaving the wait unbounded reproducibly hung the title before its first frame.</p><p dir="ltr"><strong>An unimplemented operation reports success, not an error.</strong> That is exactly what the unresolved stub did before, so a title reaching one behaves as it does today rather than meeting a new failure. The log names it once.</p><h3 dir="ltr">Risk to titles that already work</h3><p dir="ltr">A title that never calls <code>_umtx_op</code> is untouched — the only additions are one entry in the Posix table and a static array of buckets. Tetris Forever makes <strong>0</strong> calls to it, and its flips and draw counts are unchanged.</p><h3 dir="ltr">Test plan</h3><p dir="ltr">Windows 11 25H2, clang-cl 20.1.8, RTX 2060, on <code>4498d75</code>.</p><ul dir="ltr"><li style=""><input disabled="" readonly="" type="checkbox" checked=""> <code>ctest</code>: 35/35.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> PAC-MAN WORLD 2 Re-PAC: black screen → 3D scenes at 60 fps.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> Tetris Forever: 0 calls, no change in behaviour, no errors.</li><li style=""><input disabled="" readonly="" type="checkbox" checked=""> No new test — this is a blocking primitive whose effect is only observable in a real title.</li></ul><h3 dir="ltr">AI use</h3><p dir="ltr">Written with AI assistance (Claude). It instrumented the import stub, disassembled the guest caller, wrote the implementation, and ran the builds and measurements on my machine. I reviewed the diff and the results.</p><!--EndFragment-->
</body>
</html>Problem

Sony's libkernel exports FreeBSD's _umtx_op and nothing in the tree implements it. Every blocking pthread wait and every wake is built on this one call, so a title whose threads contend on anything at all makes no progress.

PAC-MAN WORLD 2 Re-PAC (PPSA18189, reported in [#411](https://github.com/MehmetCambaz/KytyPS5/issues/411)) called it around 15,000 times a second from two of its own modules and never rendered a frame: no shader translated, no draw submitted, and the graphics thread parked on flip and end-of-pipe queues that timed out forever.

This is the answer to your question on [#411](https://github.com/MehmetCambaz/KytyPS5/issues/411) — it is not the dump, and it is not AGC v13. With this implemented the title reaches its 3D scenes and holds 60 fps on 4498d75:

	before	after
draws (prim_type)	0	27,891
flips	0	11,161
equeue timeouts	276	20
How it was identified

Not guessed. The unresolved import stub was made to report its caller, that code page was read back out of guest memory and disassembled, and the wrapper around the call turned out to validate a timespec, pass operation 2, and return 60 on an expired timeout:

70b: cmpq $0x0,(%r8)     ; validate timespec.tv_sec
718: jle  0x72c
71a: movl $0x2,%esi      ; op = 2
72c: movl $0x3c,%eax     ; return 60

UMTX_OP_WAIT, UMTX_OP_WAKE, and ETIMEDOUT — which POSIX_ETIMEDOUT in errno.h already spells as 60. The name _umtx_op then hashes to the imported NID exactly.

Three decisions worth reviewing

A wake never wakes exactly one waiter. Buckets are shared between addresses, so waking one could wake a waiter on a neighbouring address and leave the intended thread asleep. A spurious wakeup costs a recheck; a missed one is a hang.

Waits are bounded even when the guest asks for an unbounded one. A wake raised before its wait began cannot be recovered, and the objects seen in practice hold their compare value at zero on both sides of a wake. Leaving the wait unbounded reproducibly hung the title before its first frame.

An unimplemented operation reports success, not an error. That is exactly what the unresolved stub did before, so a title reaching one behaves as it does today rather than meeting a new failure. The log names it once.

Risk to titles that already work

A title that never calls _umtx_op is untouched — the only additions are one entry in the Posix table and a static array of buckets. Tetris Forever makes 0 calls to it, and its flips and draw counts are unchanged.

Test plan

Windows 11 25H2, clang-cl 20.1.8, RTX 2060, on 4498d75.

 ctest: 35/35.
 PAC-MAN WORLD 2 Re-PAC: black screen → 3D scenes at 60 fps.
 Tetris Forever: 0 calls, no change in behaviour, no errors.
 No new test — this is a blocking primitive whose effect is only observable in a real title.
AI use

Written with AI assistance (Claude). It instrumented the import stub, disassembled the guest caller, wrote the implementation, and ran the builds and measurements on my machine. I reviewed the diff and the results.