### PR TITLE
graphics: quiet two misleading render diagnostics

### DIFF
--- a/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
@@ -2434,10 +2434,13 @@ KYTY_CP_OP_PARSER(CpOpIndirectShRegs) {
 
 		// Not sure if this is correct
 		if (raw_cmd_offset != cmd_offset) {
-			LOGF_COLOR(Log::Color::Red,
-			           "\t temporary: normalized indirect SH register offset 0x%08" PRIx32
-			           " -> 0x%08" PRIx32 "\n",
-			           raw_cmd_offset, cmd_offset);
+			static std::atomic<uint32_t> log_count {0};
+			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
+				LOGF_COLOR(Log::Color::Red,
+				           "\t temporary: normalized indirect SH register offset 0x%08" PRIx32
+				           " -> 0x%08" PRIx32 "\n",
+				           raw_cmd_offset, cmd_offset);
+			}
 		}
 
 		// Not sure if this is correct
@@ -2495,10 +2498,13 @@ KYTY_CP_OP_PARSER(CpOpIndirectUcRegs) {
 
 		// Not sure if this is correct
 		if (raw_cmd_offset != cmd_offset) {
-			LOGF_COLOR(Log::Color::Red,
-			           "\t temporary: normalized indirect UC register offset 0x%08" PRIx32
-			           " -> 0x%08" PRIx32 "\n",
-			           raw_cmd_offset, cmd_offset);
+			static std::atomic<uint32_t> log_count {0};
+			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
+				LOGF_COLOR(Log::Color::Red,
+				           "\t temporary: normalized indirect UC register offset 0x%08" PRIx32
+				           " -> 0x%08" PRIx32 "\n",
+				           raw_cmd_offset, cmd_offset);
+			}
 		}
 		if (HwUcTrySetFakeRegister(cmd_offset, value)) {
 			continue;
@@ -2856,10 +2862,13 @@ KYTY_CP_OP_PARSER(CpOpSetUconfigReg) {
 	}
 
 	if (raw_cmd_offset != cmd_offset) {
-		LOGF_COLOR(Log::Color::Red,
-		           "\t temporary: normalized UC register offset 0x%08" PRIx32 " -> 0x%08" PRIx32
-		           "\n",
-		           raw_cmd_offset, cmd_offset);
+		static std::atomic<uint32_t> log_count {0};
+		if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
+			LOGF_COLOR(Log::Color::Red,
+			           "\t temporary: normalized UC register offset 0x%08" PRIx32 " -> 0x%08" PRIx32
+			           "\n",
+			           raw_cmd_offset, cmd_offset);
+		}
 	}
 	if (HwUcTrySetFakeRegisterRange(cmd_offset, buffer + 1, KYTY_PM4_LEN(cmd_id) - 2u)) {
 		return KYTY_PM4_LEN(cmd_id) - 1u;

--- a/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
@@ -2433,15 +2433,12 @@ KYTY_CP_OP_PARSER(CpOpIndirectShRegs) {
 		auto value          = indirect_buffer[1];
 
 		// Not sure if this is correct
-		if (raw_cmd_offset != cmd_offset) {
-			static std::atomic<uint32_t> log_count {0};
-			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
-				LOGF_COLOR(Log::Color::Red,
-				           "\t temporary: normalized indirect SH register offset 0x%08" PRIx32
-				           " -> 0x%08" PRIx32 "\n",
-				           raw_cmd_offset, cmd_offset);
-			}
-		}
+		// if (raw_cmd_offset != cmd_offset) {
+		// 	LOGF_COLOR(Log::Color::Red,
+		// 	           "\t temporary: normalized indirect SH register offset 0x%08" PRIx32
+		// 	           " -> 0x%08" PRIx32 "\n",
+		// 	           raw_cmd_offset, cmd_offset);
+		// }
 
 		// Not sure if this is correct
 		if (cmd_offset == Pm4::SH_NOP || raw_cmd_offset == 0xffffffffu) {
@@ -2497,15 +2494,12 @@ KYTY_CP_OP_PARSER(CpOpIndirectUcRegs) {
 		auto value          = indirect_buffer[1];
 
 		// Not sure if this is correct
-		if (raw_cmd_offset != cmd_offset) {
-			static std::atomic<uint32_t> log_count {0};
-			if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
-				LOGF_COLOR(Log::Color::Red,
-				           "\t temporary: normalized indirect UC register offset 0x%08" PRIx32
-				           " -> 0x%08" PRIx32 "\n",
-				           raw_cmd_offset, cmd_offset);
-			}
-		}
+		// if (raw_cmd_offset != cmd_offset) {
+		// 	LOGF_COLOR(Log::Color::Red,
+		// 	           "\t temporary: normalized indirect UC register offset 0x%08" PRIx32
+		// 	           " -> 0x%08" PRIx32 "\n",
+		// 	           raw_cmd_offset, cmd_offset);
+		// }
 		if (HwUcTrySetFakeRegister(cmd_offset, value)) {
 			continue;
 		}
@@ -2861,15 +2855,12 @@ KYTY_CP_OP_PARSER(CpOpSetUconfigReg) {
 		cmd_offset = raw_cmd_offset & 0x0fffffffu;
 	}
 
-	if (raw_cmd_offset != cmd_offset) {
-		static std::atomic<uint32_t> log_count {0};
-		if (log_count.fetch_add(1, std::memory_order_relaxed) < 16) {
-			LOGF_COLOR(Log::Color::Red,
-			           "\t temporary: normalized UC register offset 0x%08" PRIx32 " -> 0x%08" PRIx32
-			           "\n",
-			           raw_cmd_offset, cmd_offset);
-		}
-	}
+	// if (raw_cmd_offset != cmd_offset) {
+	// 	LOGF_COLOR(Log::Color::Red,
+	// 	           "\t temporary: normalized UC register offset 0x%08" PRIx32 " -> 0x%08" PRIx32
+	// 	           "\n",
+	// 	           raw_cmd_offset, cmd_offset);
+	// }
 	if (HwUcTrySetFakeRegisterRange(cmd_offset, buffer + 1, KYTY_PM4_LEN(cmd_id) - 2u)) {
 		return KYTY_PM4_LEN(cmd_id) - 1u;
 	}

--- a/src/graphics/host_gpu/renderer/debug.cpp
+++ b/src/graphics/host_gpu/renderer/debug.cpp
@@ -827,7 +827,12 @@ static void EqaaPrint(const char* func, const HW::EqaaControl& c) {
 	     c.static_anchor_associations ? "true" : "false");
 }
 
-static void EqaaCheck(const HW::EqaaControl& c) {
+static void EqaaCheck(const HW::EqaaControl& c, const HW::AaConfig& cf) {
+	// The EQAA controls only take effect while multisampling is on, so a single-sample
+	// target leaves them inert and has nothing to warn about.
+	if (cf.msaa_num_samples == 0) {
+		return;
+	}
 	if (c.max_anchor_samples != 0 || c.ps_iter_samples != 0 || c.mask_export_num_samples != 0 ||
 	    c.alpha_to_mask_num_samples != 0 || c.high_quality_intersections ||
 	    c.incoherent_eqaa_reads || c.interpolate_comp_z || c.static_anchor_associations) {
@@ -1192,7 +1197,7 @@ void hw_check(const CommandBuffer& buffer) {
 	log_phase("blend");
 	BcCheck(bc, bclr, cc);
 	log_phase("eqaa");
-	EqaaCheck(eqaa);
+	EqaaCheck(eqaa, ac);
 	log_phase("aa");
 	AaCheck(aa, ac);
 	log_phase("done");


### PR DESCRIPTION
## Problem

Two render diagnostics point at the wrong thing, and one of them dominates the log.

**Register-offset normalization.** `pm4Handlers.cpp` normalizes a PM4 register offset in three
places -- the direct UCONFIG path and the two indirect SH/UC paths -- and each logs every single
time it happens, with no limit, in `Log::Color::Red`. Normalizing the offset is routine, so a short
session fills the log with it. Both titles I have hit the same path, and in both the message is
always the same one: `normalized UC register offset 0x20000243 -> 0x00000243`.

PAC-MAN WORLD 2 Re-PAC (PPSA18189) emitted 35350 of them in about 40 seconds, carrying exactly one
distinct offset value between them. It grows linearly with session length, and it is coloured as if
something were wrong. The two indirect sites are inside per-register loops, so they have more room
to run away still.

Every neighbouring diagnostic in these same files is already rate-limited -- `< 4`, `< 16`, `< 64`
and `< 128` all appear within `pm4Handlers.cpp`. These three were simply missed.

**EQAA controls.** `EqaaCheck` warns whenever an EQAA control register is non-zero, without
checking whether multisampling is on. Those controls only take effect while multisampling, so on a
single-sample target they are inert. PAC-MAN never multisamples -- all 128 of its render targets
report `samples=1` -- yet it still produced the warning, sending anyone reading the log after an
anti-aliasing problem that cannot exist.

## Fix

Rate-limit all three normalization sites at 16, matching the convention already used throughout
these files. The first occurrences are kept; the repetition is dropped.

Return early from `EqaaCheck` when `msaa_num_samples == 0`, which is how the neighbouring
`AaCheck` already reads that field. A title that does multisample still gets the warning.

Log output only. No rendering path is touched.

## Measured

Same title, same scene, before and after:

- normalization log lines: 24969 -> 16
- EQAA warnings: 16 -> 0
- frame rate: 60 fps -> 59.997 fps

The count is now bounded rather than merely smaller -- it stays at 16 however long the session
runs, where before it grew without limit.

## Testing

- `ctest` -- 35/35 passing.
- PAC-MAN WORLD 2 Re-PAC: 4860 frames at a steady 59.997 fps through the intro video, frames
  captured throughout and compared against the previous build. Rendering is unchanged.
- Tetris Forever (PPSA25646): run on this branch alone, 60.02 fps, renders correctly, normalization
  logs capped at 16.
- Verified separately, with the caps temporarily raised, that all 35350 normalization events in a
  run carry a single distinct offset value, so capping hides nothing in either title.

Two things worth stating plainly. Only the direct UCONFIG site fires in the titles I can test; the
two indirect sites are rate-limited for consistency rather than from an observed problem. And a
plain counter is a count, not a set -- if some other title normalized a second distinct offset only
after the first 16 occurrences, that value would not appear. I kept the simple counter because it
is what the surrounding code does and because it costs nothing on a path that runs tens of
thousands of times a minute, but a per-value cap would be the stricter choice if you prefer it.

## AI use disclosure

Per the AI Use policy in the README. I used an AI assistant for development assistance here:
analysing the emulator log to find what was flooding it, and drafting the change.

I reviewed the change in full and ran the testing above myself. The numbers quoted are measurements
from my own machine, not the model's estimates -- including the distinct-value check, which I ran
specifically to confirm that a plain counter does not discard information before accepting that
approach.