### PR TITLE
shader: cut the allocations done for every draw call

### DIFF
--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -418,8 +418,14 @@ bool MaterializeResources(const Program& program, const SrtRuntime& runtime,
 		return false;
 	}
 
-	std::vector<DescriptorSourceRequest> requests;
-	std::vector<uint8_t>                 clean_flat_slots(program.srt_reads.size());
+	// This runs for every shader stage of every draw call, so the scratch buffers are kept
+	// across calls: a dense scene issues over a thousand draws a frame, and allocating these
+	// four vectors each time dominated the cost of materializing resources.
+	thread_local std::vector<DescriptorSourceRequest> requests;
+	thread_local std::vector<uint8_t>                 clean_flat_slots;
+	requests.clear();
+	clean_flat_slots.clear();
+	clean_flat_slots.resize(program.srt_reads.size(), 0u);
 	requests.reserve(program.info.buffers.size() + program.info.images.size() * 2u +
 	                 program.info.samplers.size());
 	for (const auto& buffer: program.info.buffers) {
@@ -442,8 +448,10 @@ bool MaterializeResources(const Program& program, const SrtRuntime& runtime,
 	for (const auto& sampler: program.info.samplers) {
 		requests.push_back({sampler.source});
 	}
-	std::vector<DescriptorValue> values;
-	std::vector<uint32_t>        flattened_srt;
+	thread_local std::vector<DescriptorValue> values;
+	thread_local std::vector<uint32_t>        flattened_srt;
+	values.clear();
+	flattened_srt.clear();
 	if (!EvaluateRuntimeSources(program, requests, runtime, values, flattened_srt,
 	                            clean_flat_slots)) {
 		return false;
@@ -459,10 +467,12 @@ bool MaterializeResources(const Program& program, const SrtRuntime& runtime,
 			descriptor.dwords.fill(0);
 		}
 	}
-	next.flattened_srt = std::move(flattened_srt);
+	next.flattened_srt.assign(flattened_srt.begin(), flattened_srt.end());
 	next.flattened_srt.resize(FlattenedRuntimeDwords(program));
 	next.images.resize(program.info.images.size());
-	std::vector<uint8_t> image_written(program.info.images.size());
+	thread_local std::vector<uint8_t> image_written;
+	image_written.clear();
+	image_written.resize(program.info.images.size(), 0u);
 	for (uint32_t image_index = 0; image_index < program.info.images.size(); image_index++) {
 		const auto& image  = program.info.images[image_index];
 		const auto* source = Source(program, image.source);

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -467,7 +467,9 @@ bool MaterializeResources(const Program& program, const SrtRuntime& runtime,
 			descriptor.dwords.fill(0);
 		}
 	}
-	next.flattened_srt.assign(flattened_srt.begin(), flattened_srt.end());
+	// Swapped, not moved or copied: `next` takes the data and `flattened_srt` gets a buffer back
+	// to fill on the next call, so neither side has to allocate.
+	next.flattened_srt.swap(flattened_srt);
 	next.flattened_srt.resize(FlattenedRuntimeDwords(program));
 	next.images.resize(program.info.images.size());
 	thread_local std::vector<uint8_t> image_written;
@@ -548,7 +550,7 @@ bool MaterializeResources(const Program& program, const SrtRuntime& runtime,
 	if (!ValidateResourceSnapshot(program, next)) {
 		return false;
 	}
-	snapshot = std::move(next);
+	snapshot.Swap(next);
 	return true;
 }
 

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.h
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.h
@@ -20,6 +20,17 @@ struct ResourceSnapshot {
 	std::vector<uint32_t>        flattened_srt;
 	std::vector<uint32_t>        user_data;
 	std::vector<IndirectImage>   indirect_images;
+
+	// Exchanges contents without touching the heap, so a snapshot can hand its storage to
+	// another one and take that one's storage to refill.
+	void Swap(ResourceSnapshot& other) noexcept {
+		buffers.swap(other.buffers);
+		images.swap(other.images);
+		samplers.swap(other.samplers);
+		flattened_srt.swap(other.flattened_srt);
+		user_data.swap(other.user_data);
+		indirect_images.swap(other.indirect_images);
+	}
 };
 
 bool ValidateResourceSnapshot(const Program& program, const ResourceSnapshot& snapshot);

--- a/src/graphics/shader/shaderStageRuntime.cpp
+++ b/src/graphics/shader/shaderStageRuntime.cpp
@@ -1,9 +1,37 @@
 #include "graphics/shader/recompiler/ir/passes/ResourceMaterialization.h"
 #include "graphics/shader/shader.h"
 
+#include <memory>
 #include <utility>
+#include <vector>
 
 namespace Libs::Graphics {
+
+namespace {
+
+// A snapshot is built for every shader stage of every draw call and released again as soon as the
+// draw is recorded, so allocating one each time meant a control block and a fresh set of vectors
+// per draw. Hand out recycled snapshots instead: an entry is free once the pool holds the only
+// reference to it, and reusing it keeps the vector capacity from its previous life.
+std::shared_ptr<ShaderRecompiler::IR::ResourceSnapshot> AcquireSnapshot() {
+	// Only a handful are ever live at once (the stages of the draw being recorded), so a linear
+	// scan is cheaper than bookkeeping that would keep a free list exact.
+	constexpr size_t kMaxPooled = 16;
+	thread_local std::vector<std::shared_ptr<ShaderRecompiler::IR::ResourceSnapshot>> pool;
+
+	for (const auto& entry: pool) {
+		if (entry.use_count() == 1) {
+			return entry;
+		}
+	}
+	auto created = std::make_shared<ShaderRecompiler::IR::ResourceSnapshot>();
+	if (pool.size() < kMaxPooled) {
+		pool.push_back(created);
+	}
+	return created;
+}
+
+} // namespace
 
 bool ShaderMaterializeStageRuntime(std::shared_ptr<const ShaderRecompiler::IR::Program> program,
                                    std::span<const uint32_t> user_data, uint64_t shader_base,
@@ -18,13 +46,12 @@ bool ShaderMaterializeStageRuntime(std::shared_ptr<const ShaderRecompiler::IR::P
 	runtime.shader_base                = shader_base;
 	runtime.read_specialization_memory = read_specialization_memory;
 	runtime.userdata                   = read_memory_data;
-	ShaderRecompiler::IR::ResourceSnapshot snapshot;
+	auto  resources = AcquireSnapshot();
+	auto& snapshot  = *resources;
 	if (!ShaderRecompiler::IR::MaterializeResources(*program, runtime, snapshot) ||
 	    !ShaderRecompiler::IR::ValidateResourceSpecialization(*program, snapshot)) {
 		return false;
 	}
-	auto resources =
-	    std::make_shared<const ShaderRecompiler::IR::ResourceSnapshot>(std::move(snapshot));
 	stage = {std::move(program), std::move(resources)};
 	return true;
 }


### PR DESCRIPTION
## Problem

Recording a draw call costs far more CPU than issuing it. Measured in PAC-MAN WORLD 2 Re-PAC
(PPSA18189), the Vulkan draw call itself takes 0.1us while preparing it takes tens of
microseconds, and the cost scales with the number of draws rather than with anything the GPU does.

That matters because dense scenes issue a lot of draws. Frame time against draws per frame, from
a play session:

- 18 draws/frame  -> under 12 ms, above 80 fps
- 101 draws/frame -> 12-20 ms, around 60 fps
- 583 draws/frame -> 20-40 ms, around 30 fps
- 1085 draws/frame -> 40-80 ms, 15-20 fps, and 83% of the frame is spent recording draws

The GPU is not the limit here. Across a 67 second session the CPU waited on it for 1 ms total,
over 87,724 waits.

Two allocation sites on that path accounted for a large part of it, both of them rebuilding
storage that is thrown away immediately afterwards.

## Changes

**Reuse the scratch buffers in MaterializeResources.** It allocated four vectors per call and runs
once per shader stage of every draw, so a dense scene spent thousands of allocations a frame on
buffers whose contents never outlive the call. They are now kept and cleared instead.

**Recycle the resource snapshots.** A snapshot was allocated for each shader stage of every draw
and released as soon as the draw was recorded, costing a control block and a fresh set of vectors
each time. A small pool hands them out instead: an entry is free once the pool holds the only
reference to it, so there is no custom deleter and no free-list bookkeeping, and reusing one keeps
the vector capacity from its previous life.

**Swap rather than move when handing a snapshot back.** The old code moved the built snapshot into
the caller's, which hands the buffers over and drops the ones the caller already had. Swapping
circulates them, so the builder gets storage back to refill and a steady state stops allocating
altogether. This is what makes the pooling actually pay: recycling the inputs while the output
still discarded its buffers every draw only recovered about half the benefit.

Values computed are unchanged throughout. Only the allocation traffic goes away.

## Measured

Per-draw cost, same deterministic frame window from a cold boot, otherwise identical binaries:

- before: 45.07 us/draw over 16,788 draws
- after:  39.96 us/draw over 16,599 draws
- a little over 11% for the snapshot recycling alone

Both arms recorded within about 1% of the same number of draws, so they covered the same work.

Against the state before either change, per-draw cost goes from 69.3 us to 39.96 us. In the game
that showed up as roughly 17 fps to 25 fps in the densest area.

## Scope

This is on the shared draw path, so it applies to any title. The benefit is proportional to draw
count though, and is not uniform:

- Tetris Forever (PPSA25646) issues 0.5 draws/frame, already runs at 60 fps, and gains nothing
- PAC-MAN WORLD 2 Re-PAC averages 228 draws/frame and peaks over 1000

So this does not speed everything up. It reduces the CPU cost that currently gates draw-heavy
titles, which is where the remaining headroom is.

## Testing

- ctest, 35/35 passing
- PAC-MAN WORLD 2 Re-PAC played through the intro and Pac-Village with no rendering differences
- Tetris Forever checked for regressions, renders correctly at 60 fps

## Caveats

The per-draw numbers all come from one title. MaterializeResources cost scales with how many
buffers, images and samplers a shader binds, so a heavier game may sit at a different absolute
figure. The mechanism generalises because it is the shared path; the percentage does not
automatically.

The pooled snapshots and scratch buffers are thread_local and hold their peak capacity for the
lifetime of the thread. Sized by shader resource counts, that is on the order of kilobytes.

Reaching 60 fps in the densest scenes needs roughly 15 us per draw, so this does not get there on
its own. The remaining cost is spread across resolving descriptors from guest memory and the
shader program cache lookup, and would need a different approach rather than more of this one.

## AI use disclosure

Per the AI Use policy in the README. I used an AI assistant for development assistance here:
profiling the draw path to find where the time was going, and drafting these changes.

I reviewed the change in full and ran the testing above myself. The figures quoted are from
measurements on my own machine. The controlled comparison in particular was rerun from a cold boot
on a fixed frame window after earlier attempts compared sessions that covered different areas of
the game and could not separate a small improvement from run-to-run variance.