### PR TITLE
graphics: qualify a GPU page fault on the faulting byte

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -12,8 +12,11 @@ GpuResourceManager::GpuResourceManager(GraphicContext& graphics, CommandSchedule
 GpuResourceManager::~GpuResourceManager() = default;
 
 bool GpuResourceManager::HandleFault(PageFaultAccess access, uint64_t fault_vaddr) noexcept {
-	constexpr uint64_t fault_size = 8;
-	if (!IsMapped(fault_vaddr, fault_size)) {
+	// A page fault reports ONE address. Asking whether eight bytes from it are mapped wrongly
+	// declines a fault whose address lies within eight bytes of the end of a mapping, and a declined
+	// fault is fatal. Qualify on the faulting byte, then widen only as far as the mapping allows.
+	const uint64_t fault_size = IsMapped(fault_vaddr, 8) ? 8 : 1;
+	if (!IsMapped(fault_vaddr, 1)) {
 		return false;
 	}
 	if (access == PageFaultAccess::Write) {


### PR DESCRIPTION
## Summary

- Qualify a GPU page fault on the faulting byte instead of an eight-byte window.
- A fault whose address lies within eight bytes of the end of a mapped range is currently declined, which aborts the emulator.

## Problem

`GpuResourceManager::HandleFault` decides whether a fault belongs to the GPU tracker like this:

```cpp
constexpr uint64_t fault_size = 8;
if (!IsMapped(fault_vaddr, fault_size)) {
    return false;
}
```

A page fault reports a single address, but `IsMapped` is asked whether **eight bytes starting at that address** are mapped, and it requires the whole span to be contained in one range:

```cpp
return m_mapped_ranges.Contains(vaddr, size);
```

When the faulting address lies within eight bytes of the end of a mapping, the span runs past that end, `IsMapped` returns false, and `HandleFault` declines. The caller in `runtimeLinker.cpp` then treats the fault as unrecognised and calls `EXIT`, so the emulator aborts on a page the tracker had itself write-protected.

Observed in Grand Theft Auto V (PPSA04264) as a recurring crash while the game streams world data. Instrumenting the exception path with `VirtualQuery` gave:

```
Unhandled host exception: code=0xC0000005 access=write address=0x000000151387fffa
  | at   base=0x151387f000 size=0x1000 state=MEM_COMMIT protect=PAGE_READONLY
  | prev base=0x151387e000 end=0x0000001513880000
```

The faulting page is committed and `PAGE_READONLY` — write-protected by the tracker — so this is a fault the handler was meant to service. `0x151387fffa + 8 = 0x1513880002` crosses the mapping's end at `0x1513880000`, so the eight-byte test fails. Every crash address collected over several sessions sat within eight bytes of a mapping boundary.

After the change the write-protected-page crash no longer occurs; a separate, unrelated fault in that title now surfaces later with a different signature (`MEM_RESERVE`, `protect=0`), which I am still investigating and which is not addressed here.

Nothing else is altered: the widening to eight bytes is kept wherever the mapping actually extends that far, so the invalidation range is unchanged in the common case.

## AI assistance

AI assistance was used for this change.
