### PR TITLE
renderer: track constant-buffer DCC clears for RGBA16F targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,6 +549,10 @@ if(BUILD_TESTING)
 	add_test(NAME sync_on_address COMMAND $<TARGET_FILE:sync_on_address_tests>)
 	add_test(NAME audio_out2_port COMMAND $<TARGET_FILE:audio_out2_port_tests>)
 	add_test(NAME shader_recompiler_compute COMMAND $<TARGET_FILE:shader_recompiler_compute_tests>)
+	add_test(NAME shader_recompiler_dcc_fill_host
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --dcc-fill-host-only)
+	add_test(NAME shader_recompiler_dcc_attachment_clear
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --dcc-attachment-clear-only)
 	add_test(NAME shader_recompiler_alignbyte
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --alignbyte-only)
 	add_test(NAME virtual_memory_allocation

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1361,6 +1361,37 @@ void TextureCache::CommitGpuWrite(Image& image) {
 	image.MarkGpuModified();
 }
 
+bool TextureCache::TrackFullDccAttachmentFill(uint64_t address, uint64_t size, uint32_t value) {
+	if (!GuestRange {address, size}.Valid() || value != 0x40404040u) return false;
+	{
+		std::scoped_lock lock {m_lock};
+		const auto       meta = m_surface_metas.find(address);
+		if (meta == m_surface_metas.end() || meta->second.type != MetaDataInfo::Type::Dcc)
+			return false;
+		const ImageInfo* first       = nullptr;
+		bool             unsupported = false;
+		m_slot_images.ForEach([&](ImageId, const Image& image) {
+			if (!image.registered || image.info.metadata.kind != ImageMetadataKind::Dcc ||
+			    image.info.metadata.range.address != address)
+				return;
+			const auto& info = image.info;
+			if (image.depth_id || image.binding.needs_rebind || !image.usage.render_target ||
+			    info.metadata.range.size == 0 || info.metadata.range.size != size ||
+			    info.pixel_format != vk::Format::eR16G16B16A16Sfloat ||
+			    info.type != Prospero::ImageType::kColor2D || info.samples != 1 ||
+			    info.resources != ImageSubresources {1, 1})
+				unsupported = true;
+			if (first && (info.data != first->data || info.extent != first->extent ||
+			              info.pixel_format != first->pixel_format))
+				unsupported = true;
+			first = &info;
+		});
+		if (!first || unsupported) return false;
+	}
+	// GPU-thread serialization protects the association between this check and the update.
+	return TryConsumeDccFill(address, size, value);
+}
+
 bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t address, uint64_t size,
                                         uint32_t packed_clear) {
 	if (command.IsInvalid() || !GuestRange {address, size}.Valid()) {

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -75,6 +75,8 @@ public:
 	// Returns true when registered DCC absorbed the fill and the caller may skip the dispatch.
 	// False may still record PendingDcc state, but the guest dispatch must execute.
 	[[nodiscard]] bool TryConsumeDccFill(uint64_t address, uint64_t size, uint32_t fill_value);
+	// Only complete, registered single-plane HDR attachments are eligible.
+	[[nodiscard]] bool TrackFullDccAttachmentFill(uint64_t address, uint64_t size, uint32_t value);
 	[[nodiscard]] bool TouchMeta(uint64_t address, uint32_t slice, bool is_clear);
 
 	void UnmapMemory(uint64_t address, uint64_t size);

--- a/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
@@ -34,8 +34,7 @@ static void ResolveDccClearInfo(RenderColorInfo& info, vk::Format format, bool h
 		case vk::Format::eB8G8R8A8Srgb:
 		case vk::Format::eA2B10G10R10UnormPack32:
 		case vk::Format::eA2R10G10B10UnormPack32:
-			info.metadata_fixed_clear_supported = has_dcc;
-			break;
+		case vk::Format::eR16G16B16A16Sfloat: info.metadata_fixed_clear_supported = has_dcc; break;
 		default: info.metadata_fixed_clear_supported = false; break;
 	}
 	if (!info.metadata_clear_supported) {
@@ -351,6 +350,8 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 		// TextureCache can associate metadata fills observed before target registration.
 		desc.info.metadata.kind          = ImageMetadataKind::Dcc;
 		desc.info.metadata.range.address = rt.dcc_addr.addr;
+		desc.info.metadata.range.size =
+		    SinglePlaneDccClearSize(desc.info, rt.attrib3.dcc_pipe_aligned);
 	}
 	for (uint32_t level = 0; level < levels; level++) {
 		if (volume) {

--- a/src/graphics/host_gpu/renderer/image/imageInfo.h
+++ b/src/graphics/host_gpu/renderer/image/imageInfo.h
@@ -188,6 +188,27 @@ struct ImageInfo {
 	}
 };
 
+// Bounded pipe-aligned R_X layout: 4 KiB metadata blocks, one byte per 256 data
+// bytes. Dimensions follow AMD addrlib Gfx10 GetMetaBlkSize/HwlComputeDccInfo.
+// Other layouts must not use this estimate.
+[[nodiscard]] inline uint64_t SinglePlaneDccClearSize(const ImageInfo& info,
+                                                      bool attachment_pipe_aligned = false) {
+	const uint32_t control = info.metadata.control & ~((1u << 20u) | (1u << 22u) | (1u << 23u));
+	if (info.metadata.kind != ImageMetadataKind::Dcc ||
+	    (control != 0x002b0000u && !(attachment_pipe_aligned && control == 0)) ||
+	    info.type != Prospero::ImageType::kColor2D ||
+	    info.tile_mode != Prospero::TileMode::kRenderTarget ||
+	    info.resources != ImageSubresources {1, 1} || info.samples != 1 || info.extent.depth != 1 ||
+	    info.extent.width == 0 || info.extent.height == 0 || info.IsDepth() || info.IsBlock() ||
+	    (info.bytes_per_block != 4 && info.bytes_per_block != 8))
+		return 0;
+	const uint32_t texel_bits   = 20u - std::countr_zero(info.bytes_per_block);
+	const uint64_t block_width  = uint64_t {1} << ((texel_bits + 1) / 2);
+	const uint64_t block_height = uint64_t {1} << (texel_bits / 2);
+	return ((info.extent.width + block_width - 1) / block_width) *
+	       ((info.extent.height + block_height - 1) / block_height) * 4096;
+}
+
 struct ImageViewInfo {
 	vk::Format           format      = vk::Format::eUndefined;
 	vk::ImageViewType    type        = vk::ImageViewType::e2D;

--- a/src/graphics/host_gpu/renderer/render.h
+++ b/src/graphics/host_gpu/renderer/render.h
@@ -201,6 +201,13 @@ private:
                                             ShaderBufferResource& descriptor,
                                             uint32_t& packed_clear, uint64_t& size);
 
+// Proves a straight-line uint4 constant-buffer fill without reading guest memory.
+[[nodiscard]] bool ResolveComputeConstantBufferFill(const ShaderComputeInputInfo& input,
+                                                    uint32_t group_x, uint32_t group_y,
+                                                    uint32_t group_z, uint32_t mode,
+                                                    ShaderBufferResource& destination,
+                                                    ShaderBufferResource& constants);
+
 } // namespace Libs::Graphics
 
 #endif /* EMULATOR_INCLUDE_EMULATOR_GRAPHICS_GRAPHICSRENDER_H_ */

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -21,6 +21,7 @@
 #include "graphics/shader/recompiler/ir/passes/ResourceMaterialization.h"
 #include "graphics/shader/shader.h"
 #include "kernel/eventQueue.h"
+#include "kernel/memory.h"
 #include "kernel/pthread.h"
 #include "libs/errno.h"
 
@@ -124,6 +125,144 @@ bool ResolveComputeImageClear(const ShaderComputeInputInfo& input, uint32_t grou
 	return true;
 }
 
+bool ResolveComputeConstantBufferFill(const ShaderComputeInputInfo& input, uint32_t group_x,
+                                      uint32_t group_y, uint32_t group_z, uint32_t mode,
+                                      ShaderBufferResource& destination,
+                                      ShaderBufferResource& constants) {
+	using namespace ShaderRecompiler;
+	using namespace ShaderRecompiler::IR;
+	if (!input.stage.program || !input.stage.resources) {
+		return false;
+	}
+	const auto& program   = *input.stage.program;
+	const auto& resources = *input.stage.resources;
+	if (program.dispatcher_fallback || program.block_info.empty() ||
+	    program.info.buffers.size() != 2 || resources.buffers.size() != 2 ||
+	    !program.info.images.empty() || !program.info.samplers.empty() || program.info.uses_dma ||
+	    input.threads_num[0] != 64 || input.threads_num[1] != 1 || input.threads_num[2] != 1 ||
+	    input.wave_size != 64 || !input.group_id[0] || input.group_id[1] || input.group_id[2] ||
+	    input.thread_ids_num != 1 || input.tg_size_en || group_x == 0 || group_y != 1 ||
+	    group_z != 1 || mode != (input.dispatch_thread_dimensions ? 0x61u : 0x41u)) {
+		return false;
+	}
+	// No branches, loops, discard/EXEC predicates, atomics or extra side effects may be skipped.
+	for (size_t i = 0; i < program.block_info.size(); ++i) {
+		const auto& term = program.block_info[i].terminator;
+		if (i + 1 == program.block_info.size()
+		        ? term.kind != CFG::TerminatorKind::Return
+		        : !(term.kind == CFG::TerminatorKind::Branch &&
+		            term.true_block == program.block_info[i + 1].id)) {
+			return false;
+		}
+	}
+	const Inst* store = nullptr;
+	for (const auto* block: program.blocks) {
+		for (const auto& inst: *block) {
+			switch (inst.GetOpcode()) {
+				case ValueOpcode::Void:
+				case ValueOpcode::Identity:
+				case ValueOpcode::GetUserData:
+				case ValueOpcode::GetBuiltin:
+				case ValueOpcode::GetBufferResource:
+				case ValueOpcode::ShiftLeftLogical32:
+				case ValueOpcode::IAdd32:
+				case ValueOpcode::ReadConstBuffer:
+				case ValueOpcode::CompositeConstructU32x4: break;
+				case ValueOpcode::StoreBufferU32x4:
+					if (store != nullptr) return false;
+					store = &inst;
+					break;
+				default: return false;
+			}
+		}
+	}
+	const auto imm = [](Value value, uint32_t expected) {
+		value = value.Resolve();
+		return value.IsImmediate() && value.GetType() == Type::U32 && value.U32() == expected;
+	};
+	const auto memory = [&](const Inst& inst) -> const MemoryInfo* {
+		const auto index = inst.Flags<MemoryFlags>().index;
+		return index < program.memory_info.size() ? &program.memory_info[index] : nullptr;
+	};
+	const auto builtin = [&](Value value, StageInputKind kind) {
+		const auto* inst = value.Resolve().TryInstruction();
+		return inst && inst->GetOpcode() == ValueOpcode::GetBuiltin &&
+		       imm(inst->Arg(0), static_cast<uint32_t>(kind)) && imm(inst->Arg(1), 0);
+	};
+	if (!store || !imm(store->Arg(2), 0) || !imm(store->Arg(3), 0) ||
+	    store->Arg(5).Resolve() != Value(true))
+		return false;
+	const auto* write = memory(*store);
+	if (!write || write->resource >= 2 || write->offset != 0 || !write->idxen || write->offen ||
+	    !write->formatted || write->data_bits != 32 || write->data_dwords != 4)
+		return false;
+	const auto  dst_index = write->resource;
+	const auto  src_index = 1u - dst_index;
+	const auto& dst_info  = program.info.buffers[dst_index];
+	const auto& src_info  = program.info.buffers[src_index];
+	if (dst_info.read || !dst_info.written || dst_info.atomic || dst_info.scalar ||
+	    !src_info.read || src_info.written || src_info.atomic || !src_info.scalar ||
+	    resources.buffers[dst_index].dword_count != 4 ||
+	    resources.buffers[src_index].dword_count != 4)
+		return false;
+	const auto* index = store->Arg(1).Resolve().TryInstruction();
+	if (!index || index->GetOpcode() != ValueOpcode::IAdd32 ||
+	    !builtin(index->Arg(1), StageInputKind::LocalInvocationId))
+		return false;
+	const auto* shift = index->Arg(0).Resolve().TryInstruction();
+	if (!shift || shift->GetOpcode() != ValueOpcode::ShiftLeftLogical32 || !imm(shift->Arg(1), 6) ||
+	    !builtin(shift->Arg(0), StageInputKind::WorkgroupId))
+		return false;
+	const auto* values = store->Arg(4).Resolve().TryInstruction();
+	if (!values || values->GetOpcode() != ValueOpcode::CompositeConstructU32x4) return false;
+	for (uint32_t i = 0; i < 4; ++i) {
+		const auto* read = values->Arg(i).Resolve().TryInstruction();
+		if (!read || read->GetOpcode() != ValueOpcode::ReadConstBuffer || !imm(read->Arg(1), 0))
+			return false;
+		const auto* mem = memory(*read);
+		if (!mem || mem->resource != src_index || mem->offset != i * 4 || mem->data_bits != 32 ||
+		    mem->data_dwords != 1 || mem->planning_only)
+			return false;
+	}
+	destination = DecodeNativeDescriptor<ShaderBufferResource>(resources.buffers[dst_index]);
+	constants   = DecodeNativeDescriptor<ShaderBufferResource>(resources.buffers[src_index]);
+	const uint64_t records = input.dispatch_thread_dimensions ? group_x : uint64_t {group_x} * 64;
+	const auto     plain   = [](const ShaderBufferResource& descriptor) {
+		return !descriptor.SwizzleEnabled() && descriptor.IndexStride() == 0 &&
+		       !descriptor.AddTid();
+	};
+	return records != 0 && records % 64 == 0 && destination.NumRecords() == records &&
+	       (destination.Base48() & 3u) == 0 && (constants.Base48() & 3u) == 0 &&
+	       destination.Stride() == 16 && dst_info.packed_stride == destination.PackedStride() &&
+	       destination.Format() == Prospero::BufferFormat::k32_32_32_32UInt &&
+	       destination.DstSelXYZW() == ShaderImageIdentitySwizzle && plain(destination) &&
+	       plain(constants) && BufferDescriptorSize(constants) == 16 &&
+	       GuestRange {destination.Base48(), BufferDescriptorSize(destination)}.Valid() &&
+	       GuestRange {constants.Base48(), 16}.Valid() &&
+	       (constants.Base48() + 16 <= destination.Base48() ||
+	        destination.Base48() + BufferDescriptorSize(destination) <= constants.Base48());
+}
+
+static void TrackComputeDccAttachmentFill(const ShaderComputeInputInfo& input,
+                                          CommandBuffer& command, uint32_t group_x,
+                                          uint32_t group_y, uint32_t group_z, uint32_t mode) {
+	ShaderBufferResource destination, constants;
+	if (!ResolveComputeConstantBufferFill(input, group_x, group_y, group_z, mode, destination,
+	                                      constants)) {
+		return;
+	}
+	std::array<uint32_t, 4> value {};
+	// A CPU mirror must not specialize a fill whose constants are still GPU-owned.
+	if (!LibKernel::Memory::TryReadGpuCleanBacking(constants.Base48(), value.data(),
+	                                               sizeof(value)) ||
+	    !std::ranges::all_of(value, [](uint32_t word) { return word == 0x40404040u; })) {
+		return;
+	}
+	(void)command.GetContext().GetTextureCache().TrackFullDccAttachmentFill(
+	    destination.Base48(), BufferDescriptorSize(destination), value[0]);
+	// The original dispatch always runs, including its writes to the metadata buffer.
+}
+
 static bool TryConsumeComputeImageClear(const ShaderComputeInputInfo& input, CommandBuffer& command,
                                         uint32_t group_x, uint32_t group_y, uint32_t group_z,
                                         uint32_t mode) {
@@ -223,6 +362,8 @@ void RenderExecutor::DispatchDirect(uint64_t submit_id, CommandBuffer& buffer,
 	    (input_info.threads_num[0] * input_info.threads_num[1] * input_info.threads_num[2] >= 512);
 	const auto& program   = *input_info.stage.program;
 	const auto& resources = *input_info.stage.resources;
+	TrackComputeDccAttachmentFill(input_info, buffer, thread_group_x, thread_group_y,
+	                              thread_group_z, mode);
 	if (TryConsumeComputeMetaClear(input_info, buffer)) {
 		ResetBindings();
 		return;

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -2866,6 +2866,139 @@ public:
     std::printf("[host]    %-32s ok\n", "GpuCommandLane");
   }
 
+  void CheckDccFloatAttachmentClear() {
+    constexpr const char *name = "DccFloatAttachmentClear";
+    constexpr uint64_t base = 0x0000000208000000ull;
+    constexpr uint64_t bytes = 0x200000;
+    constexpr uint64_t metadata = base + 0x100000;
+    EnsureRuntimeContext();
+    int64_t direct_offset = -1;
+    Require(name, "allocate",
+            LibKernel::Memory::KernelAllocateDirectMemory(
+                0, LibKernel::Memory::KernelGetDirectMemorySize(), bytes, bytes,
+                0, &direct_offset) == 0,
+            "direct allocation failed");
+    void *mapped = reinterpret_cast<void *>(base);
+    Require(name, "map",
+            LibKernel::Memory::KernelMapDirectMemory(
+                &mapped, bytes, 0x3, 0x10, direct_offset, bytes) == 0 &&
+                mapped == reinterpret_cast<void *>(base),
+            "fixed mapping failed");
+    std::memset(mapped, 0, bytes);
+    {
+      RenderContext context(m_runtime_context);
+      context.InitializeGpu(nullptr);
+      auto &scheduler = context.GetCommandScheduler();
+      HW::Context registers{};
+      HW::UserConfig user_config{};
+      HW::Shader shaders{};
+      registers.SetColorBase(0, {.addr = base});
+      registers.SetColorInfo(
+          0, {.dcc_compression_enable = true,
+              .format = Prospero::ChannelLayout::k16_16_16_16,
+              .channel_type = Prospero::ChannelType::kFloat,
+              .channel_order = Prospero::ChannelOrder::kStandard});
+      registers.SetColorAttrib2(0, {.height = 63, .width = 127});
+      registers.SetColorAttrib3(0,
+                                {.tile_mode = Prospero::TileMode::kRenderTarget,
+                                 .dimension = 1,
+                                 .cmask_pipe_aligned = true,
+                                 .dcc_pipe_aligned = true});
+      registers.SetColorDccAddr(0, {.addr = metadata});
+      registers.SetRenderTargetMask(0x0f);
+      scheduler.Begin(registers, user_config, shaders);
+      auto &resources = context.GetGpuResources();
+      resources.MapMemory(base, bytes);
+      auto &cache = context.GetTextureCache();
+      auto &executor = context.GetRenderExecutor();
+      Require(name, "unknown metadata",
+              !cache.TrackFullDccAttachmentFill(metadata, 4096, 0x40404040),
+              "unknown metadata accepted");
+      RenderColorInfo color{};
+      RenderExecutorTestAccess::ResolveRenderColorTarget(
+          executor, 1, scheduler.Current(), color, 0);
+      (void)cache.FindRenderTarget(color.image_id, color.desc);
+      Require(name, "HDR layout",
+              color.metadata_fixed_clear_supported &&
+                  !color.metadata_clear_supported &&
+                  color.desc.info.metadata.range.size == 4096,
+              "fixed HDR clear layout was not recognized independently of "
+              "packed clear registers");
+      Require(name, "partial or unrelated fill",
+              !cache.TrackFullDccAttachmentFill(metadata, 2048, 0x40404040) &&
+                  !cache.TrackFullDccAttachmentFill(metadata + 4096, 4096,
+                                                    0x40404040) &&
+                  !cache.TrackFullDccAttachmentFill(metadata, 4096, 0xffffffff),
+              "unsupported fill accepted");
+      Require(name, "complete opaque black",
+              cache.TrackFullDccAttachmentFill(metadata, 4096, 0x40404040),
+              "known full HDR plane was not tracked");
+      RenderDepthInfo depth{};
+      auto rendering = RenderExecutorTestAccess::AcquireRenderTargets(
+          executor, scheduler.Current(), &color, 1, depth);
+      const vk::ClearColorValue opaque(std::array<float, 4>{0, 0, 0, 1});
+      Require(name, "attachment clear",
+              rendering.color_attachments[0].is_clear &&
+                  rendering.color_attachments[0].clear_value == opaque.uint32 &&
+                  !cache.IsMetaCleared(metadata, 0),
+              "opaque-black clear was wrong or not consumed");
+      scheduler.BeginRendering(rendering);
+      scheduler.EndRendering();
+      auto read = [&] {
+        auto &image = cache.GetImage(color.image_id);
+        auto output = CreateHostBuffer(
+            name, 8, vk::BufferUsageFlagBits::eTransferDst, {0, 0});
+        image.Transit(vk::ImageLayout::eTransferSrcOptimal,
+                      vk::AccessFlagBits2::eTransferRead, {},
+                      scheduler.Current().Handle());
+        vk::BufferImageCopy copy{};
+        copy.imageSubresource = {vk::ImageAspectFlagBits::eColor, 0, 0, 1};
+        copy.imageExtent = {1, 1, 1};
+        scheduler.Current().Handle().copyImageToBuffer(
+            image.backing.image, vk::ImageLayout::eTransferSrcOptimal,
+            output.buffer, 1, &copy);
+        scheduler.Finish();
+        auto result = ReadBuffer(name, output, 2);
+        DestroyBuffer(&output);
+        return result;
+      };
+      Require(name, "native float pixels",
+              read() == std::vector<u32>{0, 0x3c000000},
+              "RGBA16 pixels are not (0,0,0,1)");
+      auto &image = cache.GetImage(color.image_id);
+      image.Transit(vk::ImageLayout::eTransferDstOptimal,
+                    vk::AccessFlagBits2::eTransferWrite, {},
+                    scheduler.Current().Handle());
+      const vk::ClearColorValue later(
+          std::array<float, 4>{0.5f, 0.5f, 0.5f, 0.5f});
+      const vk::ImageSubresourceRange range{vk::ImageAspectFlagBits::eColor, 0,
+                                            1, 0, 1};
+      scheduler.Current().Handle().clearColorImage(
+          image.backing.image, vk::ImageLayout::eTransferDstOptimal, &later, 1,
+          &range);
+      cache.MarkGpuWritten(color.image_id);
+      rendering = RenderExecutorTestAccess::AcquireRenderTargets(
+          executor, scheduler.Current(), &color, 1, depth);
+      Require(name, "consume once", !rendering.color_attachments[0].is_clear,
+              "old metadata clear replayed");
+      scheduler.BeginRendering(rendering);
+      scheduler.EndRendering();
+      Require(name, "later contents survive",
+              read() == std::vector<u32>{0x38003800, 0x38003800},
+              "a later valid write was erased");
+      resources.UnmapMemory(base, bytes);
+      scheduler.Finish();
+      context.ShutdownGpu();
+    }
+    Require(name, "unmap", LibKernel::Memory::KernelMunmap(base, bytes) == 0,
+            "unmap failed");
+    Require(
+        name, "release",
+        LibKernel::Memory::KernelReleaseDirectMemory(direct_offset, bytes) == 0,
+        "release failed");
+    std::printf("[vulkan]  %-32s ok\n", name);
+  }
+
   void CheckUnifiedImageViewCache() {
     EnsureRuntimeContext();
     constexpr const char *name = "UnifiedImageViewCache";
@@ -21387,6 +21520,120 @@ std::vector<GraphicsCase> MakeGraphicsCases() {
   };
 }
 
+void CheckConstantBufferDccFillShape() {
+  constexpr const char *name = "ConstantBufferDccFill";
+  std::array<u32, 8> user_data{
+      0x10000u,
+      16u << 16u,
+      18432u,
+      (static_cast<u32>(Prospero::BufferFormat::k32_32_32_32UInt) << 12u) |
+          0xfacu,
+      0x80000u,
+      16u << 16u,
+      1u,
+      (static_cast<u32>(Prospero::BufferFormat::k32_32_32_32UInt) << 12u) |
+          0xfacu};
+  ShaderComputeInputInfo input{};
+  input.threads_num[0] = 64;
+  input.threads_num[1] = input.threads_num[2] = 1;
+  input.group_id[0] = true;
+  input.wave_size = 64;
+  input.thread_ids_num = 1;
+  input.workgroup_register = 8;
+  auto compile = [&](bool changed_index, bool changed_value) {
+    std::vector<u32> code;
+    AppendVop3(&code, 0x346u, 4, 8, InlineU32(changed_index ? 5 : 6), Vgpr(0));
+    code.push_back(
+        EncodeSmem0(0x0au, 12, 2)); // s_buffer_load_dwordx4 s[12:15], s[4:7]
+    code.push_back(EncodeSmem1(0, 125)); // null scalar offset, not s0
+    for (u32 i = 0; i < 4; ++i)
+      code.push_back(EncodeVop1(0x01u, i, 12u + i));
+    if (changed_value)
+      code.push_back(EncodeVop1(0x01u, 0, InlineU32(1)));
+    code.push_back(EncodeMubuf0(0x07u, 0, true, false));
+    code.push_back(EncodeMubuf1(0, 0, 4));
+    AppendEnd(&code);
+    ShaderRecompiler::CompileOptions options;
+    options.stage = ShaderType::Compute;
+    options.wave_size = 64;
+    options.user_data_base = 0;
+    options.user_data_count = user_data.size();
+    options.user_data = user_data.data();
+    options.input_info.compute = &input;
+    auto result = ShaderRecompiler::Recompile(code, options);
+    ValidateSpirv(name, result.spirv);
+    input.stage.program = std::make_shared<const ShaderRecompiler::IR::Program>(
+        std::move(result.program));
+    input.stage.resources =
+        std::make_shared<const ShaderRecompiler::IR::ResourceSnapshot>(
+            result.resources);
+  };
+  ShaderBufferResource destination, constants;
+  compile(false, false);
+  Require(name, "full buffer",
+          ResolveComputeConstantBufferFill(input, 288, 1, 1, 0x41, destination,
+                                           constants) &&
+              destination.Base48() == 0x10000 && constants.Base48() == 0x80000,
+          "synthetic uint4 constant-buffer kernel was not recognized:\n" +
+              ShaderRecompiler::IR::ProgramToString(*input.stage.program));
+  Require(name, "partial dispatch",
+          !ResolveComputeConstantBufferFill(input, 287, 1, 1, 0x41, destination,
+                                            constants),
+          "partial dispatch accepted");
+  Require(name, "extra dimension",
+          !ResolveComputeConstantBufferFill(input, 288, 2, 1, 0x41, destination,
+                                            constants),
+          "nonlinear coverage accepted");
+  Require(name, "initiator flags",
+          !ResolveComputeConstantBufferFill(input, 288, 1, 1, 0x49, destination,
+                                            constants),
+          "unsupported initiator accepted");
+  input.dispatch_thread_dimensions = true;
+  Require(name, "thread dimensions",
+          ResolveComputeConstantBufferFill(input, 18432, 1, 1, 0x61,
+                                           destination, constants),
+          "full thread-sized dispatch rejected");
+  input.dispatch_thread_dimensions = false;
+  compile(true, false);
+  Require(name, "overlapping stores",
+          !ResolveComputeConstantBufferFill(input, 288, 1, 1, 0x41, destination,
+                                            constants),
+          "overlapping index was treated as a full fill");
+  compile(false, true);
+  Require(name, "different value",
+          !ResolveComputeConstantBufferFill(input, 288, 1, 1, 0x41, destination,
+                                            constants),
+          "transformed uint4 value accepted");
+  ImageInfo image{};
+  image.pixel_format = vk::Format::eR16G16B16A16Sfloat;
+  image.guest_format = Prospero::BufferFormat::k16_16_16_16Float;
+  image.extent = {3840, 2160, 1};
+  image.bytes_per_block = 8;
+  image.tile_mode = Prospero::TileMode::kRenderTarget;
+  image.metadata.kind = ImageMetadataKind::Dcc;
+  image.metadata.control = 0x006b0000;
+  Require(name, "HDR DCC footprint", SinglePlaneDccClearSize(image) == 294912,
+          "HDR metadata size disagrees with synthetic full buffer");
+  image.extent = {960, 540, 1};
+  image.metadata.control = 0;
+  Require(
+      name, "HDR attachment footprint",
+      SinglePlaneDccClearSize(image, true) == 24576 &&
+          SinglePlaneDccClearSize(image) == 0,
+      "unknown layout accepted or synthetic pipe-aligned HDR plane rejected");
+  image.metadata.control = 0x006b0000;
+  image.extent = {3840, 2160, 1};
+  image.bytes_per_block = 4;
+  image.pixel_format = vk::Format::eR8G8B8A8Unorm;
+  image.guest_format = Prospero::BufferFormat::k8_8_8_8UNorm;
+  Require(name, "RGBA8 DCC footprint", SinglePlaneDccClearSize(image) == 163840,
+          "RGBA8 metadata size disagrees with synthetic full buffer");
+  image.resources.levels = 2;
+  Require(name, "mip chain", SinglePlaneDccClearSize(image) == 0,
+          "unsupported mip chain accepted");
+  std::printf("[host]    %-32s ok\n", name);
+}
+
 void CheckPs5GameExampleImageClearRuntimeShape() {
   const auto MakeCode = [] {
     std::vector<u32> code;
@@ -25032,6 +25279,15 @@ int main(int argc, char **argv) {
 
   std::setvbuf(stdout, nullptr, _IONBF, 0);
   EnsureConfigInitialized();
+  if (argc == 2 && std::strcmp(argv[1], "--dcc-fill-host-only") == 0) {
+    Libs::Graphics::CheckConstantBufferDccFillShape();
+    return 0;
+  }
+  if (argc == 2 && std::strcmp(argv[1], "--dcc-attachment-clear-only") == 0) {
+    Libs::Graphics::VulkanHarness vulkan;
+    vulkan.CheckDccFloatAttachmentClear();
+    return 0;
+  }
   CheckLeastRecentlyUsedCacheOrdering();
 #if KYTY_PLATFORM != KYTY_PLATFORM_WINDOWS
   if (argc == 2 && std::strcmp(argv[1], "--shader-fatal-only") == 0) {


### PR DESCRIPTION
## Summary

Recognize complete, straight-line `uint4` metadata fills sourced from a 16-byte constant buffer and track opaque-black DCC clears for registered RGBA16F attachments. This addresses the growing-light accumulation observed in Bendy and the Ink Machine without changing lighting math or selecting a game/shader hash.

The original compute dispatch always executes. Only four equal `0x40404040` words from CPU-current backing can update the existing deferred attachment-clear state. A complete known single-plane, single-sample HDR metadata range and compatible image aliases are required; unknown, partial and unsupported fills keep their existing behavior.

Fixed DCC clear values are enabled for RGBA16F separately from packed clear-register support. The metadata footprint helper is intentionally limited to the supported pipe-aligned R_X layout, not a general DCC layout implementation.

Public references: [AMD PAL non-GFX11 black/white clear codes](https://github.com/GPUOpen-Drivers/pal/blob/dev/src/core/hw/gfxip/gfx9/gfx9MaskRam.cpp), [AMD addrlib Gfx10 metadata dimensions](https://github.com/GPUOpen-Drivers/pal/blob/dev/src/core/imported/addrlib/src/gfx10/gfx10addrlib.cpp).

## Validation

- Release emulator and test executable built independently on Windows with clang-cl/Ninja from `a9166f8`.
- 8/8 focused CTests passed: the two new DCC tests plus image views, storage sampling, HTILE clear, command scheduling, GPU command lane and stream-buffer regressions.
- The new tests cover structural recognition/rejection, exact metadata coverage, native Vulkan RGBA16F `(0,0,0,1)` pixels, one-time clear consumption, and preservation of later image writes. Synthetic kernel compilation also validates SPIR-V.
- Repeated the new Vulkan clear test with `VK_LAYER_KHRONOS_validation`; passed with no reported validation errors.
- Earlier combined local builds were visually verified in Bendy, with no expanding white wash during sampled gameplay. An isolated run of this branch stops before the menu on the unchanged `depthRenderTarget.cpp` check: `stencil state without an active stencil attachment`. The local depth/stencil prerequisite is deliberately excluded, so this PR does **not** claim standalone gameplay validation on current upstream.

## Scope

Independent branch from official `main`; no dependency on the separate image-to-CPU coherence change. No Inspector, diagnostic tooling, captured game shaders, SDK files, HDR display presentation, FSR, import stubs or unrelated shader changes are included. General DCC emulation and full-game compatibility are not claimed.
