### PR TITLE
renderer: ignore inactive stencil registers for depth-only targets

### DIFF
--- a/src/graphics/host_gpu/renderer/depthRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/depthRenderTarget.cpp
@@ -177,10 +177,7 @@ void RenderExecutor::ResolveRenderDepthTarget(uint64_t submit_id, CommandBuffer&
 		    (z.stencil_read_base_addr & 0xffffu) != 0) {
 			DepthFatal("unsupported stencil attachment state");
 		}
-	} else if (z.stencil_read_base_addr != 0 || z.stencil_write_base_addr != 0 ||
-	           !htile_stencil_compat ||
-	           z.stencil_info.texture_compatibility !=
-	               Prospero::TextureCompatibleStencil::kDisable) {
+	} else if (z.stencil_read_base_addr != 0 || z.stencil_write_base_addr != 0) {
 		DepthFatal("stencil state without an active stencil attachment");
 	}
 	if (has_htile) {

--- a/src/graphics/host_gpu/renderer/depthRenderTarget.h
+++ b/src/graphics/host_gpu/renderer/depthRenderTarget.h
@@ -11,9 +11,11 @@
 
 namespace Libs::Graphics {
 
+// Without a stencil plane, Hi-Stencil fields are inactive. An active plane is compatible when
+// Hi-Stencil is disabled or HTile backing is present.
 inline constexpr bool depth_htile_stencil_acceleration_compatible(bool has_stencil, bool has_htile,
                                                                   bool htile_stencil_disabled) {
-	return htile_stencil_disabled || (has_stencil && has_htile);
+	return !has_stencil || htile_stencil_disabled || has_htile;
 }
 
 struct RenderDepthInfo {

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -8358,12 +8358,17 @@ public:
       RenderExecutorTestAccess::ResetBindings(executor);
 
       constexpr uint64_t depth_only_address = base + 0x140000;
+      constexpr uint64_t depth_only_htile_address = base + 0x150000;
+      constexpr uint32_t captured_depth_only_z_info = 0x22900983u;
+      constexpr uint32_t captured_depth_only_stencil_info = 0x00100980u;
       HW::DepthRenderTarget depth_only_target{};
-      depth_only_target.z_info.format = Prospero::DepthFormat::kZ32F;
-      depth_only_target.z_info.z_compare_base = Prospero::ZCompareBase::kZMax;
-      depth_only_target.stencil_info.htile_stencil_disabled = true;
+      depth_only_target.z_info =
+          HW::DepthZInfo::Decode(captured_depth_only_z_info);
+      depth_only_target.stencil_info =
+          HW::DepthStencilInfo::Decode(captured_depth_only_stencil_info);
       depth_only_target.z_read_base_addr = depth_only_address;
       depth_only_target.z_write_base_addr = depth_only_address;
+      depth_only_target.htile_data_base_addr = depth_only_htile_address;
       depth_only_target.size = {63, 63, true};
       registers.SetDepthRenderTarget(depth_only_target);
       HW::DepthControl depth_only_control{};
@@ -8382,6 +8387,7 @@ public:
       Require(
           name, "depth-only target with stale stencil state",
           depth_only.image_id && depth_only.format == vk::Format::eD32Sfloat &&
+              depth_only.htile &&
               depth_only.depth_test_enable && depth_only.depth_write_enable &&
               depth_only.depth_clear_enable &&
               !depth_only.stencil_test_enable &&
@@ -8389,14 +8395,16 @@ public:
               depth_only.stencil_buffer_vaddr == 0 &&
               depth_only.stencil_buffer_size == 0 &&
               depth_only.desc.info.stencil.Empty() &&
+              depth_only.htile_buffer_vaddr == depth_only_htile_address &&
+              depth_only.desc.info.metadata.range.address ==
+                  depth_only_htile_address &&
               depth_only.depth_buffer_size != 0 &&
               depth_only_address + depth_only.depth_buffer_size <=
                   base + allocation_size &&
               depth_only.vaddr_num == 1 &&
               depth_only.AttachmentWriteAspects() ==
                   vk::ImageAspectFlagBits::eDepth,
-          "raw stencil test or clear state leaked into a depth-only "
-          "attachment");
+          "inactive stencil state changed a depth-only HTile attachment");
       RenderExecutorTestAccess::ResetBindings(executor);
 
       const auto sampled_width = depth_only.desc.info.extent.width - 1u;
@@ -23792,18 +23800,18 @@ void CheckNativeMsaaState() {
 }
 
 void CheckDepthHtileStencilCompatibility() {
+  Require("DepthHtileStencilCompatibility", "inactive stencil plane",
+          depth_htile_stencil_acceleration_compatible(false, true, false),
+          "inactive Hi-Stencil state was treated as an attachment");
   Require("DepthHtileStencilCompatibility", "disabled acceleration",
-          depth_htile_stencil_acceleration_compatible(false, false, true),
+          depth_htile_stencil_acceleration_compatible(true, false, true),
           "disabled Hi-Stencil state was rejected");
   Require("DepthHtileStencilCompatibility", "PS5 stencil plus HTile",
           depth_htile_stencil_acceleration_compatible(true, true, false),
           "valid PS5 Hi-Stencil attachment was rejected");
-  Require("DepthHtileStencilCompatibility", "missing stencil plane",
-          !depth_htile_stencil_acceleration_compatible(false, true, false),
-          "Hi-Stencil without a stencil plane was silently admitted");
   Require("DepthHtileStencilCompatibility", "missing HTile metadata",
           !depth_htile_stencil_acceleration_compatible(true, false, false),
-          "Hi-Stencil without HTile metadata was silently admitted");
+          "active Hi-Stencil without HTile metadata was admitted");
   std::printf("[host]    %-32s ok\n", "DepthHtileStencilCompatibility");
 }
 


### PR DESCRIPTION
## Summary

Treat `DB_STENCIL_INFO.format == kInvalid` as the absence of a stencil plane when resolving a depth-only attachment. Retained stencil base addresses, Hi-Stencil compatibility and valid texture-compatibility state must not create a stencil attachment or abort a depth-only draw.

This is general register-state handling, not a Bendy-specific workaround: there are no game IDs, shader hashes or lighting changes. The present-stencil branch is unchanged; missing or misaligned stencil backing, mismatched writable bases and invalid compression combinations remain fatal. Invalid register encodings and depth-address validation remain checked too.

The existing lowering already masks stencil testing, clears, guest ranges, Vulkan aspects and compressed-stencil metadata when the stencil format is invalid. The change removes the contradictory rejection of residual fields and retains a one-time diagnostic.

Public reference: AMD PAL's [DepthStencilView::WriteCommandsCommon](https://github.com/GPUOpen-Drivers/pal/blob/dev/src/core/hw/gfxip/gfx9/gfx9DepthStencilView.cpp) disables stencil by setting its format to zero for depth-only usage without clearing the other stencil state.

## Validation

- Built the isolated Release emulator and test executable on Windows with clang-cl.
- Before the renderer change, the new fixture reproduced the exact `stencil state without an active stencil attachment` fatal (exit 321).
- After the change: **13/13 focused CTests pass** (7 new depth/stencil tests plus image-view, storage/sampled, depth-readback footprint, HTile-clear, scheduler and command-lane regressions).
- Positive Vulkan fixture: **32 inactive-state combinations + 2 active-stencil cases pass**, including actual D16/D32F depth clear/readback. Repeated successfully with `VK_LAYER_KHRONOS_validation`; no Vulkan validation errors reported.
- All six negative cases check both the precise fatal diagnostic and exit status; they do not accept arbitrary crashes.
- Initial runs encountered guest-memory reservation failures while another emulator was open. The complete passing rerun was performed with that session closed; no memory settings or product allocation behavior changed.
- `git diff --check` passes. Full-game and non-Windows runtime compatibility are not claimed.

The added tests cover D16/D32F, HTile on/off, all combinations of stale stencil addresses/Hi-Stencil/texture-compatibility state, real Vulkan depth clears/readback, valid active stencil, and exact fatal guards for invalid active stencil/depth states.

## Scope

Independent branch from official `main`, not stacked on the lighting changes in #423 or #424. Their isolated Bendy startup attempts stopped at the check corrected here. Full-game compatibility is not claimed.

No Inspector, diagnostic tooling, captured game shaders, SDK files, HDR display presentation, FSR, import stubs or unrelated renderer/shader changes.
