### PR TITLE
graphics: do not arm a fast clear from a read-modify-write dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,8 @@ if(BUILD_TESTING)
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --storage-sampled-only)
 	add_test(NAME texture_cache_depth_readback
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --depth-readback-only)
+	add_test(NAME compute_meta_clear_classification
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --compute-meta-clear-only)
 	add_test(NAME buffer_cache_dirty_gc
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --buffer-cache-gc-only)
 

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -54,7 +54,9 @@ bool RenderExecutor::TryConsumeComputeMetaClear(const ShaderComputeInputInfo& in
 	for (uint32_t i = 0; i < program.info.buffers.size(); i++) {
 		const auto& resource   = program.info.buffers[i];
 		const auto  descriptor = DecodeNativeDescriptor<ShaderBufferResource>(resources.buffers[i]);
-		if (!resource.written && cache.IsMeta(descriptor.Base48())) {
+		// A dispatch that also reads the metadata it writes is a read-modify-write, not a fill:
+		// it keeps every tile that already holds depth, so it cannot arm a full-surface clear.
+		if (cache.IsMeta(descriptor.Base48()) && (!resource.written || resource.read)) {
 			return false;
 		}
 	}

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -54,8 +54,8 @@ bool RenderExecutor::TryConsumeComputeMetaClear(const ShaderComputeInputInfo& in
 	for (uint32_t i = 0; i < program.info.buffers.size(); i++) {
 		const auto& resource   = program.info.buffers[i];
 		const auto  descriptor = DecodeNativeDescriptor<ShaderBufferResource>(resources.buffers[i]);
-		// A dispatch that also reads the metadata it writes is a read-modify-write, not a fill:
-		// it keeps every tile that already holds depth, so it cannot arm a full-surface clear.
+		// A metadata resource that is also read is not proven to be a full overwrite. Execute it
+		// conservatively instead of replacing the dispatch with a coarse full-surface clear.
 		if (cache.IsMeta(descriptor.Base48()) && (!resource.written || resource.read)) {
 			return false;
 		}

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -357,10 +357,23 @@ struct TextureCacheTestAccess {
     return cache.TryDownloadImage(id);
   }
 
+  static void RegisterHtileMeta(TextureCache &cache, uint64_t address) {
+    std::lock_guard lock(cache.m_lock);
+    auto &metadata = cache.m_surface_metas[address];
+    metadata.type = TextureCache::MetaDataInfo::Type::HTile;
+    metadata.clear_mask = 0;
+  }
+
   static TileManager &Tiler(TextureCache &cache) { return cache.m_tiler; }
 };
 
 struct RenderExecutorTestAccess {
+  static bool TryConsumeComputeMetaClear(RenderExecutor &executor,
+                                         const ShaderComputeInputInfo &input,
+                                         const CommandBuffer &buffer) {
+    return executor.TryConsumeComputeMetaClear(input, buffer);
+  }
+
   static TextureBinding
   ResolveTexture(RenderExecutor &executor,
                  const ShaderRecompiler::IR::ImageResource &resource,
@@ -3775,6 +3788,92 @@ public:
             Libs::LibKernel::Memory::KernelReleaseDirectMemory(
                 direct_offset, allocation_size) == 0,
             "dirty-GC direct-memory allocation release failed");
+    std::printf("[host]    %-32s ok\n", name);
+  }
+
+  void CheckComputeMetaClearClassification() {
+    constexpr const char *name = "ComputeMetaClearClassification";
+    constexpr uint64_t read_only_meta = 0x0000000204201f00ull;
+    constexpr uint64_t read_write_meta = 0x0000000204202000ull;
+    constexpr uint64_t write_only_meta = 0x0000000204202100ull;
+    EnsureRuntimeContext();
+    RenderContext context(m_runtime_context);
+    auto &scheduler = context.GetCommandScheduler();
+    HW::Context registers{};
+    HW::UserConfig user_config{};
+    HW::Shader shaders{};
+    scheduler.Begin(registers, user_config, shaders);
+    auto &texture_cache = context.GetTextureCache();
+    TextureCacheTestAccess::RegisterHtileMeta(texture_cache, read_only_meta);
+    TextureCacheTestAccess::RegisterHtileMeta(texture_cache, read_write_meta);
+    TextureCacheTestAccess::RegisterHtileMeta(texture_cache, write_only_meta);
+    Require(name, "HTile fixture",
+            texture_cache.IsMeta(read_only_meta) &&
+                texture_cache.IsMeta(read_write_meta) &&
+                texture_cache.IsMeta(write_only_meta) &&
+                !texture_cache.IsMetaCleared(read_only_meta, 0) &&
+                !texture_cache.IsMetaCleared(read_write_meta, 0) &&
+                !texture_cache.IsMetaCleared(write_only_meta, 0),
+            "test HTile entries were not registered in their initial state");
+
+    const auto MakeInput = [](uint64_t address, bool read, bool written) {
+      auto program = std::make_shared<ShaderRecompiler::IR::Program>();
+      program->stage = ShaderType::Compute;
+      ShaderRecompiler::IR::BufferResource resource{};
+      resource.read = read;
+      resource.written = written;
+      resource.formatted = true;
+      program->info.buffers.push_back(resource);
+
+      ShaderBufferResource descriptor{};
+      descriptor.UpdateAddress48(address);
+      descriptor.fields[1] |= 16u << 16u;
+      descriptor.fields[2] = 8;
+      descriptor.fields[3] =
+          DstSel(4, 5, 6, 7) |
+          (static_cast<uint32_t>(Prospero::BufferFormat::k32_32_32_32UInt)
+           << 12u);
+      ShaderRecompiler::IR::DescriptorValue value{};
+      value.dword_count = 4;
+      std::copy_n(descriptor.fields, value.dword_count, value.dwords.begin());
+      auto snapshot =
+          std::make_shared<ShaderRecompiler::IR::ResourceSnapshot>();
+      snapshot->buffers.push_back(value);
+
+      ShaderComputeInputInfo input{};
+      input.stage.program = std::move(program);
+      input.stage.resources = std::move(snapshot);
+      return input;
+    };
+    auto &executor = context.GetRenderExecutor();
+    auto &command = scheduler.Current();
+    const auto read_only_input = MakeInput(read_only_meta, true, false);
+    const bool read_only_consumed =
+        RenderExecutorTestAccess::TryConsumeComputeMetaClear(
+            executor, read_only_input, command);
+    Require(name, "read-only dispatch preserved",
+            !read_only_consumed &&
+                !texture_cache.IsMetaCleared(read_only_meta, 0),
+            "a metadata read-only dispatch changed logical clear state");
+
+    const auto read_write_input = MakeInput(read_write_meta, true, true);
+    const bool read_write_consumed =
+        RenderExecutorTestAccess::TryConsumeComputeMetaClear(
+            executor, read_write_input, command);
+    Require(name, "read/write dispatch preserved",
+            !read_write_consumed &&
+                !texture_cache.IsMetaCleared(read_write_meta, 0),
+            "a metadata read/modify/write dispatch was replaced by a clear");
+
+    const auto write_only_input = MakeInput(write_only_meta, false, true);
+    const bool write_only_consumed =
+        RenderExecutorTestAccess::TryConsumeComputeMetaClear(
+            executor, write_only_input, command);
+    Require(name, "write-only fill consumed",
+            write_only_consumed &&
+                texture_cache.IsMetaCleared(write_only_meta, 0),
+            "a metadata write-only fill was not consumed as a clear");
+    scheduler.Finish();
     std::printf("[host]    %-32s ok\n", name);
   }
 
@@ -25335,6 +25434,11 @@ int main(int argc, char **argv) {
   if (argc == 2 && std::strcmp(argv[1], "--htile-clear-only") == 0) {
     VulkanHarness vulkan;
     vulkan.CheckUnifiedTextureCacheFlow();
+    return 0;
+  }
+  if (argc == 2 && std::strcmp(argv[1], "--compute-meta-clear-only") == 0) {
+    VulkanHarness vulkan;
+    vulkan.CheckComputeMetaClearClassification();
     return 0;
   }
   if (argc == 2 && std::strcmp(argv[1], "--layered-image-only") == 0) {


### PR DESCRIPTION

<img width="1280" height="720" alt="baseline-restored" src="https://github.com/user-attachments/assets/64feb719-47d8-46c8-b133-f2a24e2386e6" />
<img width="1280" height="720" alt="variantA" src="https://github.com/user-attachments/assets/046b832a-71d3-4dee-ad33-ca954d554c7d" />

## Problem
`TryConsumeComputeMetaClear` decides a compute dispatch is a metadata fast clear from coverage alone — it writes the whole metadata surface and contains no `BitwiseXor32`. It never checks that the dispatch is actually a fill.

GTA V runs a dispatch over the whole HTILE surface that reads each dword and writes back `(d & 0xF) == 0 ? clear_word : d`. `d & 0xF` is ZMASK, so it re-stamps only tiles that are already clear and preserves every tile that holds real depth. Treating it as a fast clear discards the dispatch and arms a full-surface depth clear, wiping g-buffer depth mid-frame — a pixel measured `0.02722705` before that pass and `0.0` after, so the distant sky plane (depth `6e-8`, reverse-Z `GEQUAL`) then passed in front of the world. Every depth test after that point is affected, not only the sky.

A second dispatch on the same path is a genuine fill — four SGPRs stored with one `BUFFER_STORE_FORMAT_XYZW` — and must keep arming.

## Change

Reject a dispatch that also reads the metadata surface it writes. A read-modify-write preserves existing contents by definition, so it cannot be a clear. `BufferResource::read` is already tracked, so this is one condition.

The DCC path already requires a validated fill value before treating a compute write as a clear; HTILE had no equivalent check.

Note the rejected dispatch now executes rather than being discarded.

## AI assistance

Claude. It found the cause by disassembling the guest shader's recompiled SPIR-V and comparing it to emulator code, after we traced it by bisecting(enabling/disabling) the shaders to find the offending pass.