### PR TITLE
graphics: materialize CMask fast clears and decode wide clear values

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1293,6 +1293,15 @@ vk::ImageView TextureCache::FindRenderTarget(ImageId id, const ImageDesc& desc) 
 		} else if (!inserted && metadata->second.type != MetaDataInfo::Type::Dcc) {
 			EXIT("TextureCache: color target reuses non-DCC metadata\n");
 		}
+	} else if (desc.info.metadata.kind == ImageMetadataKind::Cmask) {
+		image.info.metadata       = desc.info.metadata;
+		auto [metadata, inserted] = m_surface_metas.try_emplace(
+		    desc.info.metadata.range.address, MetaDataInfo {.type = MetaDataInfo::Type::CMask});
+		if (!inserted && metadata->second.type == MetaDataInfo::Type::PendingDcc) {
+			metadata->second.type = MetaDataInfo::Type::CMask;
+		} else if (!inserted && metadata->second.type != MetaDataInfo::Type::CMask) {
+			EXIT("TextureCache: color target reuses non-CMask metadata\n");
+		}
 	}
 	CommitGpuWrite(image);
 	TrackImageDownload(id, image);
@@ -1406,7 +1415,8 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t address
 	float               depth_clear   = 0.0f;
 	uint8_t             stencil_clear = 0;
 	if (aspect == vk::ImageAspectFlagBits::eColor) {
-		if (!DecodePackedColorClear(image.info.pixel_format, packed_clear, color_clear)) {
+		if (PackedColorClearNeedsHighWord(image.info.pixel_format) ||
+		    !DecodePackedColorClear(image.info.pixel_format, packed_clear, 0, color_clear)) {
 			return false;
 		}
 	} else {

--- a/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
@@ -16,17 +16,20 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cstdlib>
 
 namespace Libs::Graphics {
 
 static std::atomic<uint32_t> g_render_color_log_count = 0;
 
+
 static void ResolveDccClearInfo(RenderColorInfo& info, vk::Format format, bool has_dcc,
-                                uint32_t packed_clear) {
+                                bool has_cmask, uint32_t packed_clear, uint32_t packed_clear_hi) {
 	// Register-backed DCC clears use the target's packed clear value. Decode one-word guest
 	// formats here; unsupported encodings remain tracked without unsafe materialization.
 	info.metadata_clear_supported =
-	    has_dcc && DecodePackedColorClear(format, packed_clear, info.color_clear_value);
+	    (has_dcc || has_cmask) &&
+	    DecodePackedColorClear(format, packed_clear, packed_clear_hi, info.color_clear_value);
 	switch (format) {
 		case vk::Format::eR8G8B8A8Unorm:
 		case vk::Format::eR8G8B8A8Srgb:
@@ -139,11 +142,11 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 	r.color_clear_enable = false;
 	r.color_clear_value  = {};
 
-	uint32_t   width  = 0;
-	uint32_t   height = 0;
-	uint32_t   pitch  = 0;
-	uint64_t   size   = 0;
-	bool       tile   = false;
+	uint32_t                    width  = 0;
+	uint32_t                    height = 0;
+	uint32_t                    pitch  = 0;
+	uint64_t                    size   = 0;
+	bool                        tile   = false;
 	static constexpr std::array image_types {Prospero::ImageType::kColor1D,
 	                                         Prospero::ImageType::kColor2D,
 	                                         Prospero::ImageType::kColor3D};
@@ -324,23 +327,28 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 	}
 
 	TextureCache::ImageDesc desc {};
-	desc.type              = TextureCache::BindingType::RenderTarget;
-	desc.info.data         = {rt.base.addr, backing_size};
-	desc.info.pixel_format = target_format.format;
-	desc.info.guest_format = transfer_format;
-	desc.info.type         = image_type;
-	desc.info.extent       = {width, height, depth};
-	desc.info.resources    = {levels, volume ? 1u : view.image_layers};
-	desc.info.pitch        = pitch;
+	desc.type                 = TextureCache::BindingType::RenderTarget;
+	desc.info.data            = {rt.base.addr, backing_size};
+	desc.info.pixel_format    = target_format.format;
+	desc.info.guest_format    = transfer_format;
+	desc.info.type            = image_type;
+	desc.info.extent          = {width, height, depth};
+	desc.info.resources       = {levels, volume ? 1u : view.image_layers};
+	desc.info.pitch           = pitch;
 	desc.info.bytes_per_block = bytes_per_element;
 	desc.info.samples         = samples;
 	desc.info.tile_mode       = rt.attrib3.tile_mode;
 	const bool has_dcc        = rt.info.dcc_compression_enable && rt.dcc_addr.addr != 0;
+	const bool has_cmask = !has_dcc && rt.info.cmask_fast_clear_enable &&
+	                       rt.cmask.addr != 0;
 	if (has_dcc) {
 		// DCC uses a separate metadata allocation. Carry its address through ImageInfo so
 		// TextureCache can associate metadata fills observed before target registration.
 		desc.info.metadata.kind          = ImageMetadataKind::Dcc;
 		desc.info.metadata.range.address = rt.dcc_addr.addr;
+	} else if (has_cmask) {
+		desc.info.metadata.kind          = ImageMetadataKind::Cmask;
+		desc.info.metadata.range.address = rt.cmask.addr;
 	}
 	for (uint32_t level = 0; level < levels; level++) {
 		if (volume) {
@@ -393,7 +401,8 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 	r.samples                  = samples;
 	r.export_mapping           = target_format.export_mapping;
 	r.color_clear_enable       = false;
-	ResolveDccClearInfo(r, target_format.format, has_dcc, rt.clear_word0.word0);
+	ResolveDccClearInfo(r, target_format.format, has_dcc, has_cmask, rt.clear_word0.word0,
+	                    rt.clear_word1.word1);
 	BindRenderTarget(r.image_id);
 }
 

--- a/src/graphics/host_gpu/renderer/image/image.cpp
+++ b/src/graphics/host_gpu/renderer/image/image.cpp
@@ -630,6 +630,14 @@ void Validate(const ImageInfo& info) {
 				EXIT("invalid HTILE metadata\n");
 			}
 			break;
+		case ImageMetadataKind::Cmask:
+			if (info.metadata.range.address == 0 ||
+			    info.metadata.range.address >= TRACKER_ADDRESS_SIZE ||
+			    (info.metadata.range.size != 0 &&
+			     info.metadata.range.size > TRACKER_ADDRESS_SIZE - info.metadata.range.address)) {
+				EXIT("invalid CMask metadata\n");
+			}
+			break;
 		case ImageMetadataKind::Dcc:
 			if (info.metadata.range.address == 0 ||
 			    info.metadata.range.address >= TRACKER_ADDRESS_SIZE ||

--- a/src/graphics/host_gpu/renderer/image/imageInfo.h
+++ b/src/graphics/host_gpu/renderer/image/imageInfo.h
@@ -514,11 +514,18 @@ IsSupportedDisplayRenderTargetTileMode(Prospero::TileMode tile_mode) noexcept {
 			next.float32[1] = DecodeHalfFloat(packed >> 16u);
 			break;
 		case vk::Format::eR32Sfloat: next.float32[0] = std::bit_cast<float>(packed); break;
-		case vk::Format::eR32G32B32A32Sfloat:
-			if (packed != 0 || packed_hi != 0) {
+		case vk::Format::eR32G32B32A32Sfloat: {
+			const auto rgb   = std::bit_cast<float>(packed);
+			const auto alpha = std::bit_cast<float>(packed_hi);
+			if (!std::isfinite(rgb) || !std::isfinite(alpha)) {
 				return false;
 			}
+			next.float32[0] = rgb;
+			next.float32[1] = rgb;
+			next.float32[2] = rgb;
+			next.float32[3] = alpha;
 			break;
+		}
 		default: return false;
 	}
 	for (const auto component: next.float32) {

--- a/src/graphics/host_gpu/renderer/image/imageInfo.h
+++ b/src/graphics/host_gpu/renderer/image/imageInfo.h
@@ -12,12 +12,13 @@
 #include <bit>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 
 namespace Libs::Graphics {
 
 enum class VideoOutCompression : uint8_t { Uncompressed, Dcc256_256_0, Dcc256_64_64, Unsupported };
 
-enum class ImageMetadataKind : uint8_t { None, Htile, Dcc };
+enum class ImageMetadataKind : uint8_t { None, Htile, Dcc, Cmask };
 
 struct ImageMetadataInfo {
 	GuestRange          range;
@@ -422,8 +423,35 @@ IsSupportedDisplayRenderTargetTileMode(Prospero::TileMode tile_mode) noexcept {
 	       IsSupportedStandard64RenderTarget(info);
 }
 
+[[nodiscard]] inline float DecodeSmallFloat(uint32_t bits, uint32_t mantissa_bits) {
+	const auto exponent = (bits >> mantissa_bits) & 0x1fu;
+	const auto mantissa = bits & ((1u << mantissa_bits) - 1u);
+	const auto scale    = 1.0f / static_cast<float>(1u << mantissa_bits);
+	if (exponent == 0) {
+		return std::ldexp(static_cast<float>(mantissa) * scale, -14);
+	}
+	if (exponent == 0x1fu) {
+		return mantissa != 0 ? std::numeric_limits<float>::quiet_NaN()
+		                     : std::numeric_limits<float>::infinity();
+	}
+	return std::ldexp(1.0f + static_cast<float>(mantissa) * scale, static_cast<int>(exponent) - 15);
+}
+
+[[nodiscard]] inline float DecodeHalfFloat(uint32_t bits) {
+	const auto value = DecodeSmallFloat(bits & 0x7fffu, 10);
+	return (bits & 0x8000u) != 0 ? -value : value;
+}
+
+[[nodiscard]] inline bool PackedColorClearNeedsHighWord(vk::Format format) {
+	switch (format) {
+		case vk::Format::eR16G16B16A16Sfloat:
+		case vk::Format::eR32G32B32A32Sfloat: return true;
+		default: return false;
+	}
+}
+
 [[nodiscard]] inline bool DecodePackedColorClear(vk::Format format, uint32_t packed,
-                                                 vk::ClearColorValue& clear) {
+                                                 uint32_t packed_hi, vk::ClearColorValue& clear) {
 	vk::ClearColorValue next {};
 	const auto unorm8 = [](uint32_t value) { return static_cast<float>(value & 0xffu) / 255.0f; };
 	const auto srgb8  = [](uint32_t value) {
@@ -469,7 +497,34 @@ IsSupportedDisplayRenderTargetTileMode(Prospero::TileMode tile_mode) noexcept {
 			next.float32[2] = static_cast<float>(packed & 0x3ffu) / 1023.0f;
 			next.float32[3] = static_cast<float>((packed >> 30u) & 0x3u) / 3.0f;
 			break;
+		case vk::Format::eR16G16B16A16Sfloat:
+			next.float32[0] = DecodeHalfFloat(packed);
+			next.float32[1] = DecodeHalfFloat(packed >> 16u);
+			next.float32[2] = DecodeHalfFloat(packed_hi);
+			next.float32[3] = DecodeHalfFloat(packed_hi >> 16u);
+			break;
+		case vk::Format::eB10G11R11UfloatPack32:
+			next.float32[0] = DecodeSmallFloat(packed & 0x7ffu, 6);
+			next.float32[1] = DecodeSmallFloat((packed >> 11u) & 0x7ffu, 6);
+			next.float32[2] = DecodeSmallFloat((packed >> 22u) & 0x3ffu, 5);
+			next.float32[3] = 1.0f;
+			break;
+		case vk::Format::eR16G16Sfloat:
+			next.float32[0] = DecodeHalfFloat(packed);
+			next.float32[1] = DecodeHalfFloat(packed >> 16u);
+			break;
+		case vk::Format::eR32Sfloat: next.float32[0] = std::bit_cast<float>(packed); break;
+		case vk::Format::eR32G32B32A32Sfloat:
+			if (packed != 0 || packed_hi != 0) {
+				return false;
+			}
+			break;
 		default: return false;
+	}
+	for (const auto component: next.float32) {
+		if (!std::isfinite(component)) {
+			return false;
+		}
 	}
 	clear = next;
 	return true;

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -503,7 +503,34 @@ struct DrawCallInfo {
 
 static bool ResolveDccAttachmentClear(TextureCache& cache, const RenderColorInfo& target,
                                       const ImageViewInfo& view, vk::ClearColorValue& clear_value) {
-	if (target.desc.info.metadata.kind != ImageMetadataKind::Dcc) {
+	const auto metadata_kind = target.desc.info.metadata.kind;
+	if (metadata_kind == ImageMetadataKind::Cmask) {
+		if (!target.metadata_clear_supported) {
+			return false;
+		}
+		for (uint32_t layer = 0; layer < view.layer_count; layer++) {
+			if (!cache.IsMetaCleared(target.desc.info.metadata.range.address,
+			                         view.base_layer + layer)) {
+				return false;
+			}
+		}
+		for (uint32_t layer = 0; layer < view.layer_count; layer++) {
+			if (!cache.TouchMeta(target.desc.info.metadata.range.address, view.base_layer + layer,
+			                     false)) {
+				EXIT("failed to consume CMask clear state\n");
+			}
+		}
+		clear_value = target.color_clear_value;
+		static std::atomic<uint32_t> log_count {0};
+		if (log_count.fetch_add(1, std::memory_order_relaxed) < 8) {
+			LOGF("RenderTarget: materialized CMask fast clear cmask=0x%016" PRIx64
+			     " target=0x%016" PRIx64 " rgba=(%f, %f, %f, %f)\n",
+			     target.desc.info.metadata.range.address, target.base_addr, clear_value.float32[0],
+			     clear_value.float32[1], clear_value.float32[2], clear_value.float32[3]);
+		}
+		return true;
+	}
+	if (metadata_kind != ImageMetadataKind::Dcc) {
 		return false;
 	}
 
@@ -1176,9 +1203,9 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
 		LogDrawPhase(draw.name, "CreatePipeline");
 	}
 	auto& pipeline = m_context.GetPipelineCache().CreateGraphicsPipeline(
-	    std::span {state.color_info, state.color_count}, state.depth_info, state.vs_input_info, buffer,
-	    state.ps_active ? &state.ps_input_info : nullptr, topology, primitive_restart_enable,
-	    state.vertex_program, state.pixel_program);
+	    std::span {state.color_info, state.color_count}, state.depth_info, state.vs_input_info,
+	    buffer, state.ps_active ? &state.ps_input_info : nullptr, topology,
+	    primitive_restart_enable, state.vertex_program, state.pixel_program);
 
 	// Resource preparation above may synchronously finish and restart the scheduler. From this
 	// point onward, every operation targets the current command buffer and cannot touch guest

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -21685,6 +21685,47 @@ void CheckEmbeddedFetchVertexOffset() {
 }
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+void CheckCmaskClearColorWordLayout() {
+  using Libs::Graphics::DecodePackedColorClear;
+  using Libs::Graphics::PackedColorClearNeedsHighWord;
+
+  Require("CmaskClearWords", "high word only for formats above 32bpp",
+          !PackedColorClearNeedsHighWord(vk::Format::eR32Sfloat) &&
+              PackedColorClearNeedsHighWord(vk::Format::eR16G16B16A16Sfloat) &&
+              PackedColorClearNeedsHighWord(vk::Format::eR32G32B32A32Sfloat),
+          "CB_COLOR_CLEAR_WORD1 use does not match the documented per-bit-depth layout");
+
+  vk::ClearColorValue c32 {};
+  Require("CmaskClearWords", "32bpp uses word0 alone",
+          DecodePackedColorClear(vk::Format::eR32Sfloat, std::bit_cast<u32>(0.25f),
+                                 0xdeadbeefu, c32) &&
+              c32.float32[0] == 0.25f,
+          "a 32bpp clear did not decode from word0, or was disturbed by word1");
+
+  vk::ClearColorValue c64 {};
+  const u32 rg = 0x3c00u | (0x4000u << 16u);
+  const u32 ba = 0x4200u | (0x4400u << 16u);
+  Require("CmaskClearWords", "64bpp splits RG into word0 and BA into word1",
+          DecodePackedColorClear(vk::Format::eR16G16B16A16Sfloat, rg, ba, c64) &&
+              c64.float32[0] == 1.0f && c64.float32[1] == 2.0f &&
+              c64.float32[2] == 3.0f && c64.float32[3] == 4.0f,
+          "a 64bpp clear did not take its upper channels from CB_COLOR_CLEAR_WORD1");
+
+  vk::ClearColorValue c128 {};
+  Require("CmaskClearWords", "128bpp replicates word0 across RGB and takes A from word1",
+          DecodePackedColorClear(vk::Format::eR32G32B32A32Sfloat, std::bit_cast<u32>(0.5f),
+                                 std::bit_cast<u32>(1.0f), c128) &&
+              c128.float32[0] == 0.5f && c128.float32[1] == 0.5f &&
+              c128.float32[2] == 0.5f && c128.float32[3] == 1.0f,
+          "a 128bpp clear did not follow setCmaskClearColor: word0 is R/G/B, word1 is A");
+
+  vk::ClearColorValue nonfinite {};
+  Require("CmaskClearWords", "non-finite clear rejected",
+          !DecodePackedColorClear(vk::Format::eR32G32B32A32Sfloat, 0x7f800000u,
+                                  std::bit_cast<u32>(1.0f), nonfinite),
+          "an infinite 128bpp clear value was materialized instead of rejected");
+}
+
 void CheckRenderTargetFormatContract() {
   const auto r8_uint = TextureGetRenderTargetFormat(
       Prospero::ChannelLayout::k8, Prospero::ChannelType::kUInt,
@@ -25270,6 +25311,10 @@ int main(int argc, char **argv) {
     return 0;
   }
 #endif
+  if (argc == 2 && std::strcmp(argv[1], "--cmask-clear-only") == 0) {
+    CheckCmaskClearColorWordLayout();
+    return 0;
+  }
   if (argc == 2 && std::strcmp(argv[1], "--clip-control-only") == 0) {
     CheckClipControlDepthClipState();
     return 0;
@@ -25434,6 +25479,7 @@ int main(int argc, char **argv) {
   }
   if (argc == 2 && std::strcmp(argv[1], "--reverse-rt-only") == 0) {
     CheckRenderTargetFormatContract();
+    CheckCmaskClearColorWordLayout();
     return 0;
   }
   if (argc == 2 && std::strcmp(argv[1], "--standard64-rt-only") == 0) {
@@ -25505,6 +25551,7 @@ int main(int argc, char **argv) {
   }
   VulkanHarness vulkan;
   CheckRenderTargetFormatContract();
+  CheckCmaskClearColorWordLayout();
   CheckSampledColorViews();
   CheckSampledVideoOutView(vulkan.RuntimeRenderer());
   CheckImageTransitionState(vulkan.RuntimeRenderer());


### PR DESCRIPTION
## Problem

A CMask fast clear updates metadata only and leaves the colour allocation stale, so a surface the game believes it cleared keeps its previous contents. `ImageMetadataKind` had no `Cmask`, and the colour target path logged `ignoring PS5 color metadata fast_clear=true cmask=0x...` and dropped the clear.

## Change

Track CMask as an image metadata kind alongside DCC: register the CMask allocation in `FindRenderTarget`, and materialize the register-backed clear when the surface is next bound, the same shape as the existing DCC path. Most of the machinery was already present — `MetaDataInfo::Type` already had `CMask`, and `FindRenderTarget` already carried a comment marking where CMask/FMask would be registered.

`DecodePackedColorClear` now takes both `CB_COLOR_CLEAR_WORD0` and `WORD1` and gains fp16, `B10G11R11`, `R16G16`, `R32` and `R32G32B32A32` decoding. Non-finite results are rejected rather than materialized.

The word layout: up to 32bpp uses word0 alone, 64bpp uses word0 and word1, and 128bpp uses word0 for R/G/B with word1 as A.

`CmaskClearWords` pins that layout — high-word use restricted to the two formats above 32bpp, a 32bpp decode that must ignore word1, the 64bpp RG/BA split, the 128bpp replication, and rejection of a non-finite value. `--cmask-clear-only` runs it alone.

## AI assistance

Claude. It traced the dropped clear from the emulator's own warning, wrote the change, and checked the clear-word layout against the AGC render target headers.


Note: The first commit solved a real issue in gta rendering/warnings, however the 2nd commit is a parity addition after checking source docs. It's untested, because as far as I can tell(and as far as I can get in the games), the two games I'm running neither use 128bpp cmask fast clears(yet). So the test is up and it passes/fails properly, but that is it.