### PR TITLE
shader: flush a NaN clamp result to zero

### DIFF
--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAlu.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAlu.cpp
@@ -405,11 +405,17 @@ bool EmitValueAlu(ValueEmitContext& ctx, const IR::Inst& inst) {
 		case IR::ValueOpcode::FPNeg32:
 			ctx.Define(inst, EmitFNegateValue(state, ctx.Arg(inst, 0)));
 			return true;
-		case IR::ValueOpcode::FPSaturate32:
-			ctx.Define(inst, EmitExt(state, TypeF32(state), GlslFClamp,
-			                         {ctx.Arg(inst, 0), ConstantF32(state, 0),
-			                          ConstantF32(state, 0x3f800000u)}));
+		case IR::ValueOpcode::FPSaturate32: {
+			// GLSL FClamp leaves NaN undefined, so the DX10_CLAMP flush to zero is explicit.
+			const auto source = ctx.Arg(inst, 0);
+			const auto clamped =
+			    EmitExt(state, TypeF32(state), GlslFClamp,
+			            {source, ConstantF32(state, 0), ConstantF32(state, 0x3f800000u)});
+			const auto is_nan = EmitClassifyF32(state, source).nan;
+			ctx.Define(inst,
+			           NewSelect(state, TypeF32(state), is_nan, ConstantF32(state, 0), clamped));
 			return true;
+		}
 		case IR::ValueOpcode::BitFieldInsert:
 			ctx.Emit(inst, OpBitFieldInsert, IR::Type::U32,
 			         {ctx.Arg(inst, 0), ctx.Arg(inst, 1), ctx.Arg(inst, 2), ctx.Arg(inst, 3)});

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -13492,6 +13492,25 @@ TestCase VectorVop3MoveAppliesFloatSourceModifiers() {
   return test;
 }
 
+TestCase VectorVop3ClampFlushesNanToZero() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendSMovLiteral(&code, 24, 0x7fc00000u);
+  AppendVop3(&code, 0x103, 1, 24, InlineU32(0), 0, 0, 0, true);
+  AppendStoreVgpr(&code, 1, 0);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "VectorVop3ClampFlushesNanToZero";
+  test.code = code;
+  test.expected = {0x00000000u};
+  test.opcodes = {O::S_MOV_B32, O::V_ADD_F32, O::BUFFER_STORE_DWORD,
+                  O::S_ENDPGM};
+  test.required_spirv = {"2139095040"};
+  return test;
+}
+
 TestCase VectorIntegerOps() {
   using O = ShaderOpcode;
 
@@ -21225,6 +21244,7 @@ std::vector<TestCase> MakeCases() {
   AddCase(ScalarLiteral);
   AddCase(VectorMoves);
   AddCase(VectorVop3MoveAppliesFloatSourceModifiers);
+  AddCase(VectorVop3ClampFlushesNanToZero);
   AddCase(VectorIntegerOps);
   AddCase(VectorFfbhI32NativeAndVop3OnGpu);
   AddCase(Vop1SdwaFfblCapturedHighWordSource);


### PR DESCRIPTION
## Problem

The `CLAMP` output modifier lowers to GLSL `FClamp`, which is undefined for NaN. The hardware flushes a NaN result to +0 when `MODE.DX10_CLAMP` is set, and `shader.cpp` already rejects any shader with `DX10_CLAMP` clear (`EXIT_NOT_IMPLEMENTED(rsrc1.dx10_clamp != true)`), so flushing is the only correct behaviour for every shader the recompiler accepts. On current hardware `FClamp` happens to return 0 for NaN, so this is latent rather than visible — the emitted module just does not say what it means.

See the RDNA2 ISA guide, `DX10_CLAMP`: "Used by the vector ALU to force DX10-style treatment of NaNs: when set, clamp NaN to zero; otherwise, pass NaN through."

## Change

Select the NaN case explicitly in `FPSaturate32` rather than relying on `FClamp`, matching the treatment `V_MIN`/`V_MAX` already get in `EmitMinMaxF32Value`.

`VectorVop3ClampFlushesNanToZero` compiles a `V_ADD_F32` with `CLAMP` set over a NaN source and requires the NaN test to appear in the emitted SPIR-V. It fails on the previous emitter with `missing required text: 2139095040` — the NaN exponent pattern that only the explicit test introduces.

## AI assistance

Confirmed the DX10_CLAMP semantics against the RDNA2 ISA guide, found that the emulator already requires the bit to be set, wrote the change and the regression test.
