### PR TITLE
graphics: resolve table border colors from the guest border color table

### DIFF
--- a/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
@@ -334,8 +334,7 @@ static void HwCtxIgnoreCbDccControl([[maybe_unused]] uint32_t value) {}
 static void HwCtxIgnorePointState([[maybe_unused]] uint32_t cmd_offset,
                                   [[maybe_unused]] uint32_t value) {}
 
-static void HwCtxIgnoreBorderColorTableAddr([[maybe_unused]] uint32_t cmd_offset,
-                                            [[maybe_unused]] uint32_t value) {}
+static std::atomic<uint64_t> g_border_color_table_base[2] {};
 
 static void HwCtxIgnoreSpiTmpringSize(uint32_t value) {
 	static std::atomic<uint32_t> log_count {0};
@@ -400,7 +399,7 @@ KYTY_HW_CTX_PARSER(HwCtxSetBorderColorTableAddr) {
 	auto num_values = KYTY_PM4_LEN(cmd_id) - 2u;
 
 	for (uint32_t i = 0; i < num_values; i++) {
-		HwCtxIgnoreBorderColorTableAddr(cmd_offset + i, buffer[i]);
+		SetBorderColorTableAddress(cmd_offset + i, buffer[i]);
 	}
 
 	return num_values;
@@ -1249,16 +1248,13 @@ KYTY_HW_UC_PARSER(HwUcSetMultiPrimIbReset) {
 	return 1;
 }
 
-static void HwUcIgnoreBorderColorTableAddr([[maybe_unused]] uint32_t cmd_offset,
-                                           [[maybe_unused]] uint32_t value) {}
-
 KYTY_HW_UC_PARSER(HwUcSetBorderColorTableAddr) {
 	auto num_values = KYTY_PM4_LEN(cmd_id) - 2u;
 	EXIT_NOT_IMPLEMENTED(num_values == 0 || cmd_offset < Pm4::TA_CS_BC_BASE_ADDR ||
 	                     cmd_offset + num_values - 1u > Pm4::TA_CS_BC_BASE_ADDR_HI);
 
 	for (uint32_t i = 0; i < num_values; i++) {
-		HwUcIgnoreBorderColorTableAddr(cmd_offset + i, buffer[i]);
+		SetBorderColorTableAddress(cmd_offset + i, buffer[i]);
 	}
 
 	return num_values;
@@ -3039,10 +3035,10 @@ void GraphicsInitJmpTablesCxIndirect() {
 		HwCtxIgnoreDepthMetadataRegister(cmd_offset, value);
 	};
 	g_hw_ctx_indirect_func[Pm4::TA_BC_BASE_ADDR] = [](KYTY_HW_CTX_INDIRECT_ARGS) {
-		HwCtxIgnoreBorderColorTableAddr(cmd_offset, value);
+		SetBorderColorTableAddress(cmd_offset, value);
 	};
 	g_hw_ctx_indirect_func[Pm4::TA_BC_BASE_ADDR_HI] = [](KYTY_HW_CTX_INDIRECT_ARGS) {
-		HwCtxIgnoreBorderColorTableAddr(cmd_offset, value);
+		SetBorderColorTableAddress(cmd_offset, value);
 	};
 	g_hw_ctx_indirect_func[Pm4::PA_SU_POINT_SIZE] = [](KYTY_HW_CTX_INDIRECT_ARGS) {
 		HwCtxIgnorePointState(cmd_offset, value);
@@ -3849,10 +3845,10 @@ void GraphicsInitJmpTablesUcIndirect() {
 		cp.GetUcfg().SetPrimitiveResetControl(value);
 	};
 	g_hw_uc_indirect_func[Pm4::TA_CS_BC_BASE_ADDR] = [](KYTY_HW_UC_INDIRECT_ARGS) {
-		HwUcIgnoreBorderColorTableAddr(cmd_offset, value);
+		SetBorderColorTableAddress(cmd_offset, value);
 	};
 	g_hw_uc_indirect_func[Pm4::TA_CS_BC_BASE_ADDR_HI] = [](KYTY_HW_UC_INDIRECT_ARGS) {
-		HwUcIgnoreBorderColorTableAddr(cmd_offset, value);
+		SetBorderColorTableAddress(cmd_offset, value);
 	};
 
 	g_hw_uc_indirect_func[Pm4::GE_INDX_OFFSET] = [](KYTY_HW_UC_INDIRECT_ARGS) {
@@ -3876,6 +3872,26 @@ void GraphicsInitJmpTablesUcIndirect() {
 			     cmd_offset, value);
 		}
 	};
+}
+
+void SetBorderColorTableAddress(uint32_t reg_offset, uint32_t value) {
+	const bool compute =
+	    (reg_offset == Pm4::TA_CS_BC_BASE_ADDR || reg_offset == Pm4::TA_CS_BC_BASE_ADDR_HI);
+	const bool high =
+	    (reg_offset == Pm4::TA_BC_BASE_ADDR_HI || reg_offset == Pm4::TA_CS_BC_BASE_ADDR_HI);
+	const uint64_t mask = (high ? 0xffffffff00000000ull : 0x00000000ffffffffull);
+	const uint64_t bits =
+	    (high ? (static_cast<uint64_t>(value) << 32u) : static_cast<uint64_t>(value));
+	auto& slot = g_border_color_table_base[compute ? 1u : 0u];
+	auto  base = slot.load(std::memory_order_relaxed);
+	while (!slot.compare_exchange_weak(base, (base & ~mask) | bits, std::memory_order_relaxed,
+	                                   std::memory_order_relaxed)) {
+	}
+}
+
+uint64_t GetBorderColorTableAddress(bool compute) {
+	const auto base = g_border_color_table_base[compute ? 1u : 0u].load(std::memory_order_relaxed);
+	return (base & 0xffffffffffull) << 8u;
 }
 
 } // namespace Libs::Graphics

--- a/src/graphics/guest_gpu/gpu_defs.h
+++ b/src/graphics/guest_gpu/gpu_defs.h
@@ -519,4 +519,11 @@ enum class VertexAttribFormat : uint32_t {
 
 } // namespace Libs::Graphics::Prospero
 
+namespace Libs::Graphics {
+
+void     SetBorderColorTableAddress(uint32_t reg_offset, uint32_t value);
+uint64_t GetBorderColorTableAddress(bool compute);
+
+} // namespace Libs::Graphics
+
 #endif /* EMULATOR_INCLUDE_EMULATOR_GRAPHICS_GUEST_GPU_GPU_DEFS_H_ */

--- a/src/graphics/host_gpu/graphicContext.h
+++ b/src/graphics/host_gpu/graphicContext.h
@@ -33,6 +33,7 @@ struct GraphicContext {
 	bool                               compute_subgroup_size_control_enabled = false;
 	bool                               compute_wave64_supported              = false;
 	bool                               sample_rate_shading_enabled           = false;
+	bool                               custom_border_color_enabled           = false;
 	uint32_t                           subgroup_size                         = 0;
 	uint32_t                           min_subgroup_size                     = 0;
 	uint32_t                           max_subgroup_size                     = 0;

--- a/src/graphics/host_gpu/renderer/cache/samplerCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/samplerCache.cpp
@@ -5,6 +5,10 @@
 #include "graphics/guest_gpu/gpu_defs.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
 
+#include <array>
+#include <atomic>
+#include <bit>
+
 namespace Libs::Graphics {
 
 SamplerCache::~SamplerCache() {
@@ -14,13 +18,8 @@ SamplerCache::~SamplerCache() {
 	}
 }
 
-vk::Sampler SamplerCache::GetSampler(const ShaderSamplerResource& r) {
+vk::Sampler SamplerCache::GetSampler(const ShaderSamplerResource& r, bool compute) {
 	Common::LockGuard lock(m_mutex);
-
-	const SamplerKey key {r.fields[0], r.fields[1], r.fields[2], r.fields[3]};
-	if (auto iter = m_samplers.find(key); iter != m_samplers.end()) {
-		return iter->second;
-	}
 
 	float      aniso_ratio = 1.0f;
 	const auto mag_filter  = r.XyMagFilter();
@@ -95,29 +94,60 @@ vk::Sampler SamplerCache::GetSampler(const ShaderSamplerResource& r) {
 		return vk::SamplerAddressMode::eClampToBorder;
 	};
 
-	vk::BorderColor border = vk::BorderColor::eIntTransparentBlack;
+	vk::BorderColor                           border = vk::BorderColor::eFloatTransparentBlack;
+	std::array<float, 4>                      custom_color {0.0f, 0.0f, 0.0f, 0.0f};
+	vk::SamplerCustomBorderColorCreateInfoEXT custom_border {};
 	switch (static_cast<Prospero::SamplerBorderColor>(r.BorderColorType())) {
 		case Prospero::SamplerBorderColor::kTransBlack:
-			border = vk::BorderColor::eIntTransparentBlack;
+			border = vk::BorderColor::eFloatTransparentBlack;
 			break;
 		case Prospero::SamplerBorderColor::kOpaqueBlack:
-			border = vk::BorderColor::eIntOpaqueBlack;
+			border = vk::BorderColor::eFloatOpaqueBlack;
 			break;
 		case Prospero::SamplerBorderColor::kOpaqueWhite:
-			border = vk::BorderColor::eIntOpaqueWhite;
+			border = vk::BorderColor::eFloatOpaqueWhite;
 			break;
-		case Prospero::SamplerBorderColor::kFromTable:
-			LOGF(
-			    "temporary: approximating table border color as transparent black, index = %" PRIu16
-			    "\n",
-			    r.BorderColorPtr());
-			border = vk::BorderColor::eIntTransparentBlack;
+		case Prospero::SamplerBorderColor::kFromTable: {
+			const auto table = GetBorderColorTableAddress(compute);
+			if (table != 0 && m_graphics.custom_border_color_enabled) {
+				const auto* entry =
+				    reinterpret_cast<const float*>(table) + (r.BorderColorPtr() * 4u);
+				custom_color = {entry[0], entry[1], entry[2], entry[3]};
+				border       = vk::BorderColor::eFloatCustomEXT;
+			} else {
+				static std::atomic<uint32_t> log_count {0};
+				if (log_count.fetch_add(1, std::memory_order_relaxed) < 4) {
+					LOGF("temporary: approximating table border color as transparent black, index "
+					     "= %" PRIu16 ", table = 0x%016" PRIx64 "\n",
+					     r.BorderColorPtr(), table);
+				}
+				border = vk::BorderColor::eFloatTransparentBlack;
+			}
 			break;
+		}
 		default: EXIT("unknown border color: %d", static_cast<int>(r.BorderColorType()));
 	}
 
-	sampler_info.sType     = vk::StructureType::eSamplerCreateInfo;
-	sampler_info.pNext     = nullptr;
+	const SamplerKey key {r.fields[0],
+	                      r.fields[1],
+	                      r.fields[2],
+	                      r.fields[3],
+	                      std::bit_cast<uint32_t>(custom_color[0]),
+	                      std::bit_cast<uint32_t>(custom_color[1]),
+	                      std::bit_cast<uint32_t>(custom_color[2]),
+	                      std::bit_cast<uint32_t>(custom_color[3])};
+	if (auto iter = m_samplers.find(key); iter != m_samplers.end()) {
+		return iter->second;
+	}
+
+	if (border == vk::BorderColor::eFloatCustomEXT) {
+		custom_border.sType = vk::StructureType::eSamplerCustomBorderColorCreateInfoEXT;
+		custom_border.customBorderColor.float32 = custom_color;
+		custom_border.format                    = vk::Format::eUndefined;
+	}
+
+	sampler_info.sType = vk::StructureType::eSamplerCreateInfo;
+	sampler_info.pNext = (border == vk::BorderColor::eFloatCustomEXT ? &custom_border : nullptr);
 	sampler_info.flags     = {};
 	sampler_info.magFilter = to_vk_filter(mag_filter);
 	sampler_info.minFilter = to_vk_filter(min_filter);

--- a/src/graphics/host_gpu/renderer/cache/samplerCache.h
+++ b/src/graphics/host_gpu/renderer/cache/samplerCache.h
@@ -24,10 +24,10 @@ public:
 	~SamplerCache();
 	KYTY_CLASS_NO_COPY(SamplerCache);
 
-	vk::Sampler GetSampler(const ShaderSamplerResource& r);
+	vk::Sampler GetSampler(const ShaderSamplerResource& r, bool compute);
 
 private:
-	using SamplerKey = std::array<uint32_t, 4>;
+	using SamplerKey = std::array<uint32_t, 8>;
 
 	struct SamplerKeyHash {
 		std::size_t operator()(const SamplerKey& key) const {

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -843,7 +843,8 @@ static vk::Sampler NativeSampler(RenderContext&                       context,
 	if (program.info.samplers[index].force_point_filtering) {
 		descriptor.SetPointFiltering();
 	}
-	return context.GetSamplerCache().GetSampler(descriptor);
+	return context.GetSamplerCache().GetSampler(descriptor,
+	                                            program.stage == ShaderType::Compute);
 }
 
 static BufferView NativeUpload(RenderContext& context, std::span<const uint32_t> data) {

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -582,9 +582,19 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 #endif
 	}
 
+	const auto custom_border_color_ext_enabled =
+	    HasExtension(device_extensions, VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
+
+	vk::PhysicalDeviceCustomBorderColorFeaturesEXT supported_custom_border_color {};
+	supported_custom_border_color.sType =
+	    vk::StructureType::ePhysicalDeviceCustomBorderColorFeaturesEXT;
+	supported_custom_border_color.pNext = &supported_features13;
+
 	vk::PhysicalDeviceFeatures2 supported_features2 {};
 	supported_features2.sType = vk::StructureType::ePhysicalDeviceFeatures2;
-	supported_features2.pNext = &supported_features13;
+	supported_features2.pNext =
+	    (custom_border_color_ext_enabled ? static_cast<void*>(&supported_custom_border_color)
+	                                     : static_cast<void*>(&supported_features13));
 	physical_device.getFeatures2(&supported_features2);
 	const auto required_features13 = WindowContext::RequiredVulkan13Features();
 	EXIT_NOT_IMPLEMENTED(supported_features12.timelineSemaphore != VK_TRUE);
@@ -665,9 +675,21 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	     features13.robustImageAccess == VK_TRUE ? "true" : "false",
 	     robustness2_ext_enabled && robustness2.robustImageAccess2 == VK_TRUE ? "true" : "false");
 
+	vk::PhysicalDeviceCustomBorderColorFeaturesEXT custom_border_color {};
+	custom_border_color.sType = vk::StructureType::ePhysicalDeviceCustomBorderColorFeaturesEXT;
+	custom_border_color.pNext = &features13;
+	custom_border_color.customBorderColors = supported_custom_border_color.customBorderColors;
+	custom_border_color.customBorderColorWithoutFormat =
+	    supported_custom_border_color.customBorderColorWithoutFormat;
+	graphics.custom_border_color_enabled =
+	    custom_border_color_ext_enabled && custom_border_color.customBorderColors == VK_TRUE &&
+	    custom_border_color.customBorderColorWithoutFormat == VK_TRUE;
+
 	vk::DeviceCreateInfo create_info {};
 	create_info.sType                   = vk::StructureType::eDeviceCreateInfo;
-	create_info.pNext                   = &features13;
+	create_info.pNext =
+	    (graphics.custom_border_color_enabled ? static_cast<void*>(&custom_border_color)
+	                                          : static_cast<void*>(&features13));
 	create_info.flags                   = {};
 	create_info.pQueueCreateInfos       = &queue_create_info;
 	create_info.queueCreateInfoCount    = 1;
@@ -1049,6 +1071,9 @@ void WindowContext::CreateVulkan() {
 		}
 		if (HasExtension(available_extensions, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
 			device_extensions.push_back(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+		}
+		if (HasExtension(available_extensions, VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME)) {
+			device_extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Record the border color table base from `TA_BC_BASE_ADDR` / `TA_CS_BC_BASE_ADDR` instead of discarding it.
- Resolve `border_color_type == 3` by reading that table and creating the sampler through `VK_EXT_custom_border_color`.
- Use the float border color constants instead of the integer ones.

## Problem

The sampler descriptor's border color type selects opaque black, transparent black, opaque white, or a color at an index into a guest-resident table. Kyty handled the first three and substituted transparent black for the fourth:

```
temporary: approximating table border color as transparent black, index = %u
```

The registers holding the table base were already being parsed and then thrown away by `HwCtxIgnoreBorderColorTableAddr` / `HwUcIgnoreBorderColorTableAddr`, so everything needed to do this properly was already reaching the command processor.

Separately, every sampler was created with `VK_BORDER_COLOR_INT_*`. Those are only valid for a sampler used with an integer-format image, and the surfaces sampled through this path are float or normalized. On the driver I tested it happens not to matter, since the int and float constants carry the same values, but the combination is unspecified.

## Implementation

- `TA_BC_BASE_ADDR` / `_HI` (graphics) and `TA_CS_BC_BASE_ADDR` / `_HI` (compute) now store the table base, on both the direct and indirect paths. The two are kept as separate state and selected by shader stage, matching the register split.
- The register pair holds the base shifted right by 8, so the address is reassembled as `(lo << 8) | ((hi & 0xff) << 40)`. The remaining bits of the high register are reserved and masked off.
- `kFromTable` reads four floats at `base + border_color_ptr * 16` and sets `VK_BORDER_COLOR_FLOAT_CUSTOM_EXT`. `VK_EXT_custom_border_color` is enabled when the device exposes it with both `customBorderColors` and `customBorderColorWithoutFormat`; without it the transparent-black approximation stays, now rate-limited to four lines instead of one per sampler.
- The sampler cache key grows from the four descriptor words to those plus the resolved color, so two identical descriptors resolved against different table contents no longer collide.
- The three fixed types move to the `FLOAT` constants. Happy to split that into its own PR if you would rather keep the two apart.

## Sources

- AMD RDNA2 Instruction Set Architecture Reference Guide, image sampler resource (S#): `107:96 border color ptr`, `127:126 border color type` — "Opaque-black, transparent-black, white, use border color ptr".
- The numeric ordering for those four kinds is the one already in `gpu_defs.h` (`kTransBlack` = 0 through `kFromTable` = 3); the guide lists the kinds without assigning values.
- The register offsets, the shift, and the reserved bits in the high register were checked against the platform's own graphics register definitions.

## Testing

- Builds clean on Windows (clang-cl) off `6453baf`.
- All suites pass except `RenderExecutorStencilBindingDiscovery`, which fails identically on clean `origin/main`, so this adds no new failure.
- **The table path is unverified in a real title.** In GTA V (PPSA04264), which is what is tested against, `border_color_type == 3` never occurs — a run with warnings unsuppressed logged zero "approximating table border color" lines. So the read is correct against the descriptor layout and by construction, not by observation. Titles that do not use the table are unaffected apart from the int-to-float constant change.
- No automated regression is included. Exercising this needs a guest-resident table at a live GPU address, which the existing host/GPU fixtures do not construct.

## Not covered

`bc_swizzle` (T# `123:121`), which reorders border color channels independently of the `dst_sel_*` fields, is not applied — identity ordering is assumed. Worth adding if a title turns up that both uses the table and sets it.

## AI assistance

Entirely