### PR TITLE
kernel: skip a fixed map that already matches the mapped range

### DIFF
--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -2891,6 +2891,18 @@ int KYTY_SYSV_ABI KernelCheckedReleaseDirectMemory(int64_t start, size_t len) {
 	return result == KERNEL_ERROR_EACCES ? KERNEL_ERROR_ENOENT : result;
 }
 
+static bool FixedMapMatchesExistingRange(uint64_t vaddr, uint64_t size, int64_t phys_offset,
+                                         int prot) {
+	std::vector<VirtualRanges::Range> ranges;
+	if (!g_virtual_ranges->QuerySpan(vaddr, size, &ranges) || ranges.size() != 1) {
+		return false;
+	}
+	const auto& r = ranges.front();
+	return r.type == VirtualRangeType::Direct && r.start == vaddr && r.size == size &&
+	       r.offset == static_cast<uint64_t>(phys_offset) && r.protection == prot &&
+	       g_guest_address_space->BackingContains(vaddr, size);
+}
+
 int KYTY_SYSV_ABI KernelMapDirectMemory(void** addr, size_t len, int prot, int flags,
                                         int64_t direct_memory_start, size_t alignment) {
 	PRINT_NAME();
@@ -2953,6 +2965,11 @@ int KYTY_SYSV_ABI KernelMapDirectMemory(void** addr, size_t len, int prot, int f
 		}
 		if (no_overwrite && g_virtual_ranges->HasOverlap(in_addr, len)) {
 			return KERNEL_ERROR_ENOMEM;
+		}
+
+		if (FixedMapMatchesExistingRange(in_addr, len, direct_memory_start, prot)) {
+			*addr = reinterpret_cast<void*>(in_addr);
+			return OK;
 		}
 
 		std::vector<VirtualRanges::Range> reserved_ranges;

--- a/tests/VirtualMemoryAllocationTests.cpp
+++ b/tests/VirtualMemoryAllocationTests.cpp
@@ -1670,6 +1670,52 @@ void TestHintlessDirectMapUsesCanonicalGuestBase() {
 	std::printf("[host]    %-48s ok\n", test);
 }
 
+void TestFixedMapOverIdenticalRangeIsNoOp() {
+	const char* test = "FixedMapOverIdenticalRangeIsNoOp";
+
+	constexpr uint64_t MapSize = SceKernelPageSize * 2;
+
+	int64_t phys_addr = 0;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelAllocateDirectMemory(
+	            SceKernelDirectMemoryStart, Libs::LibKernel::Memory::KernelGetDirectMemorySize(),
+	            MapSize, SceKernelPageSize, SceKernelMtypeC, &phys_addr),
+	        "KernelAllocateDirectMemory");
+
+	void* address = nullptr;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelMapNamedDirectMemory(&address, MapSize,
+	                                                            SceKernelProtCpuRw, 0, phys_addr,
+	                                                            SceKernelPageSize, "noop_probe"),
+	        "KernelMapNamedDirectMemory");
+	const auto base = reinterpret_cast<uint64_t>(address);
+	*reinterpret_cast<uint64_t*>(base) = 0x4b5954594e4f4f50ull; // "KYTYNOOP"
+
+	void* again = address;
+	CheckOk(test,
+	        Libs::LibKernel::Memory::KernelMapDirectMemory(&again, MapSize, SceKernelProtCpuRw,
+	                                                       SceKernelMapFixed, phys_addr, 0),
+	        "KernelMapDirectMemory(fixed over identical range)");
+	Check(test, reinterpret_cast<uint64_t>(again) == base, "identical fixed map moved the mapping");
+
+	const auto info = Query(test, base);
+	Check(test, info.start == base && info.end == base + MapSize,
+	      "identical fixed map changed the range bounds");
+	Check(test, info.offset == static_cast<uint64_t>(phys_addr),
+	      "identical fixed map changed the physical offset");
+	Check(test, info.protection == SceKernelProtCpuRw,
+	      "identical fixed map changed the protection");
+	Check(test, info.is_direct == 1, "identical fixed map changed the range type");
+	Check(test, std::strcmp(info.name, "noop_probe") == 0,
+	      "identical fixed map replaced the live mapping instead of leaving it alone");
+	Check(test, *reinterpret_cast<const uint64_t*>(base) == 0x4b5954594e4f4f50ull,
+	      "identical fixed map lost the mapped contents");
+
+	CheckOk(test, Libs::LibKernel::Memory::KernelMunmap(base, MapSize), "KernelMunmap");
+	CheckOk(test, Libs::LibKernel::Memory::KernelReleaseDirectMemory(phys_addr, MapSize),
+	        "KernelReleaseDirectMemory");
+}
+
 void TestDirectMemoryContentPersistsAcrossRemap() {
 	const char* test = "DirectMemoryContentPersistsAcrossRemap";
 
@@ -2549,6 +2595,7 @@ int main(int argc, char** argv) {
 	RunTest(TestDefaultDirectMapUsesSystemAddressRange);
 	RunTest(TestLargeDirectMapAliasesAcrossChunks);
 	RunTest(TestHintlessDirectMapUsesCanonicalGuestBase);
+	RunTest(TestFixedMapOverIdenticalRangeIsNoOp);
 	RunTest(TestDirectMemoryContentPersistsAcrossRemap);
 	RunTest(TestDirectMapUnmapReusesHostAddress);
 	RunTest(TestFixedReserveReplacesPartialDirectMapping);


### PR DESCRIPTION
This fixed a game-load crash that was reported by multiple people, happened intermittently, like 10% of the time, but it was a reliable cause.


```
Unhandled host exception: type=1 code=3221225477 pc=0x00000009028aa5e0
  access=2 address=0x00000010a7671ecb  in src/loader/runtimeLinker.cpp:807
```

## Summary

- When a `MAP_FIXED` direct map requests exactly the mapping that is already there, return success without touching it.

## Problem

`KernelMapDirectMemory` handles a fixed map over a live range by falling through to `ReplaceFixedRangeWithReserved`, which does `UnmapGpuRange` → `Remove` → `UnmapBacking` → `ReserveFixed` before the caller maps the new content. For the duration of that sequence the address range is reserved and inaccessible.

`MAP_FIXED` replacement is supposed to be atomic — there should be no window in which the address is unmapped. Doing it as unmap-then-remap means a guest thread reading the range concurrently can fault on memory the guest has every reason to believe is mapped, because from its point of view nothing was ever unmapped.

The case that makes this worth fixing is that the replacement is frequently a no-op: the game re-maps a range with the same address, length, physical offset and protection it already has. The teardown destroys a live mapping only to rebuild an identical one, so the window is opened for no benefit at all.

## Implementation

- Before the replacement path, check whether the request already describes the current state: a single `Direct` range covering exactly `[addr, addr + len)`, with the same physical offset and protection, and with the backing still present.
- If so, write the address back and return `OK`.
- The check sits after the `MAP_NO_OVERWRITE` handling, so a caller that asked to fail on an existing mapping still gets `ENOMEM` rather than success.
- Exact match only: a fixed map covering part of a larger existing range, or changing protection or offset, still goes through the normal replacement path. This narrows the window rather than removing it in general.

## Sources

- `MAP_FIXED` = `0x10` and `MAP_NO_OVERWRITE` = `0x80`, matching the constants this function already hardcodes. `MAP_EXCL` is documented as an alias of `MAP_NO_OVERWRITE`, "for MAP_FIXED, fail if address is used", which is why the new check is placed after that test and not before it.
- The platform's headers are FreeBSD-derived, so FreeBSD `mmap(2)` is the reference for the atomicity expectation above: a `MAP_FIXED` mapping replaces any existing mapping without an intervening window.

## Testing

- Builds clean on Windows (clang-cl) off `1342c6f`.
- All suites pass except `RenderExecutorStencilBindingDiscovery`, which fails identically on clean `origin/main`, so this adds no new failure.
- `FixedMapOverIdenticalRangeIsNoOp` is a real regression test, not a contract test — **it fails on `origin/main` and passes with the change**, verified by reverting the source hunk and rebuilding:

```
VirtualMemoryAllocationTests: FixedMapOverIdenticalRangeIsNoOp failed: identical fixed map
replaced the live mapping instead of leaving it alone
```

  It maps a named direct range, re-maps it fixed with identical parameters, and checks the range survived: bounds, physical offset, protection, type, contents, and the range name. The name is what discriminates — the replacement path re-adds the range with an empty name, so a surviving name proves no teardown happened.

## Scope

This removes the window for the identical-remap case, which is the one observed in practice. It does not make `MAP_FIXED` replacement atomic in general; a fixed map that changes the mapping still tears down and rebuilds.
