### PR TITLE
kernel: retry guest faults inside a MAP_FIXED replacement window

### DIFF
--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
@@ -818,6 +819,51 @@ static void                               MemoryPoolSubtractCommitted(uint64_t l
 // Keep host mappings, physical blocks, placeholders, and virtual ranges in step.
 static std::recursive_mutex g_memory_operation_mutex;
 
+struct FixedRemapWindow {
+	std::atomic<uint64_t> start {0};
+	std::atomic<uint64_t> end {0};
+};
+static std::array<FixedRemapWindow, 8> g_fixed_remap_windows;
+
+class FixedRemapGuard {
+public:
+	FixedRemapGuard() = default;
+	~FixedRemapGuard() {
+		if (m_window != nullptr) {
+			m_window->start.store(0, std::memory_order_release);
+			m_window->end.store(0, std::memory_order_relaxed);
+		}
+	}
+	KYTY_CLASS_NO_COPY(FixedRemapGuard);
+
+	void Arm(uint64_t start, uint64_t size) {
+		if (m_window != nullptr || start == 0 || size == 0) {
+			return;
+		}
+		for (auto& window: g_fixed_remap_windows) {
+			if (window.start.load(std::memory_order_relaxed) == 0) {
+				window.end.store(start + size, std::memory_order_relaxed);
+				window.start.store(start, std::memory_order_release);
+				m_window = &window;
+				return;
+			}
+		}
+	}
+
+private:
+	FixedRemapWindow* m_window = nullptr;
+};
+
+static bool IsInFixedRemapWindow(uint64_t vaddr) noexcept {
+	for (const auto& window: g_fixed_remap_windows) {
+		const auto start = window.start.load(std::memory_order_acquire);
+		if (start != 0 && vaddr >= start && vaddr < window.end.load(std::memory_order_relaxed)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // The base address the PS5 kernel hands out for hint-less user mappings. Guest code can
 // assume mappings it did not place explicitly are at or above this (Sony's libc rejects a
 // heap below it), so hint-less searches must not fall back to the low system-managed range.
@@ -917,6 +963,20 @@ void InstallGpuResources(Graphics::GpuResourceManager* resources) noexcept {
 
 bool HandleGpuFault(Graphics::PageFaultAccess access, uint64_t fault_vaddr) noexcept {
 	return g_gpu_resources != nullptr && g_gpu_resources->HandleFault(access, fault_vaddr);
+}
+
+bool WaitForFixedRemap(uint64_t fault_vaddr) noexcept {
+	constexpr uint32_t MAX_ATTEMPTS = 200000;
+	if (!IsInFixedRemapWindow(fault_vaddr)) {
+		return false;
+	}
+	for (uint32_t attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+		if (!IsInFixedRemapWindow(fault_vaddr)) {
+			return true;
+		}
+		std::this_thread::yield();
+	}
+	return false;
 }
 
 struct PrtAperture {
@@ -2966,6 +3026,10 @@ int KYTY_SYSV_ABI KernelMapDirectMemory(void** addr, size_t len, int prot, int f
 				consumed_reservation = true;
 				map_consumed_reserved_fixed();
 			}
+		}
+		FixedRemapGuard remap_guard;
+		if (!consumed_reservation) {
+			remap_guard.Arm(in_addr, len);
 		}
 		if (!consumed_reservation && ReplaceFixedRangeWithReserved(in_addr, len) &&
 		    g_virtual_ranges->ConsumeReservedSpan(in_addr, len, &consumed_range)) {

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -116,6 +116,7 @@ void                   WriteBacking(uint64_t vaddr, const void* data, uint64_t s
 void                   InvalidateMemory(uint64_t vaddr, uint64_t size);
 void                   InstallGpuResources(Graphics::GpuResourceManager* resources) noexcept;
 [[nodiscard]] bool HandleGpuFault(Graphics::PageFaultAccess access, uint64_t fault_vaddr) noexcept;
+[[nodiscard]] bool     WaitForFixedRemap(uint64_t fault_vaddr) noexcept;
 
 int KYTY_SYSV_ABI KernelMapNamedFlexibleMemory(void** addr_in_out, size_t len, int prot, int flags,
                                                const char* name);

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -800,6 +800,10 @@ static bool KytyExceptionHandler(const Common::HostException::ExceptionInfo& exc
 		if (Libs::LibKernel::Memory::HandleGpuFault(access, info->access_violation_vaddr)) {
 			return true;
 		}
+		// A MAP_FIXED replacement leaves the range unbacked until the new view lands.
+		if (Libs::LibKernel::Memory::WaitForFixedRemap(info->access_violation_vaddr)) {
+			return true;
+		}
 	}
 	EXIT("Unhandled host exception: type=%u code=%u pc=0x%016" PRIx64
 	     " access=%u address=0x%016" PRIx64 "\n",


### PR DESCRIPTION
This has some overlap with #432, though are complementary. 432 stop it from opening when no-op, this one survives it when it does open. 432 is narrower while this one is more a safety.


## Summary

- Publish the address range a `MAP_FIXED` replacement is tearing down, and retry a guest fault that lands inside it once the replacement finishes.

## Problem

`KernelMapDirectMemory` handles a fixed map over a live range through `ReplaceFixedRangeWithReserved`, which does `UnmapGpuRange` → `Remove` → `UnmapBacking` → `ReserveFixed` before the caller maps the new content. In that window the range is a bare reserved placeholder with no access.

`MAP_FIXED` replacement is meant to be atomic — from the guest's point of view the old mapping is never withdrawn. Doing it as unmap-then-remap means another guest thread reading the range faults on memory it has every reason to believe is mapped, and the emulator then kills the process on an unhandled access violation.

This is observed, not inferred. With the window instrumented, a guest thread faulted inside a block that was mid-replacement:

```
[diag-R] map-fixed replace 0x00000010a7660000 +0x10000 offset=0xd9660000 prot=0xf3
[diag-R] live chunk      0x00000010a7660000 +0x10000 type=Direct offset=0xd9660000 prot=0xf3
[diag-R] retry after remap window at 0x00000010a7660f49
```

The fault address `0x10a7660f49` is inside `[0x10a7660000, +0x10000)`, the range being replaced.

It is rare within a very common path: 1 live teardown per load against 4430 and 7039 replacements across two runs, and zero across 2634 gameplay-phase replacements. That matches where the crash was seen — during game load, not during play.

## Implementation

- `FixedRemapGuard` publishes `[addr, addr + len)` to a fixed 8-slot table for the duration of the replacement, and clears it on scope exit. All publishers already hold `g_memory_operation_mutex`, so claiming a slot needs no extra synchronization; the slots are atomic only for the reader.
- The exception handler consults `WaitForFixedRemap` after the existing GPU-fault path. If the faulting address is inside a live window, it yields until the window closes and then retries the instruction; otherwise it falls straight through to the existing fatal path.
- The wait is bounded at 200k yields rather than unbounded, because the thread closing the window can be inside `SendCommandSync` and could in principle be waiting on the faulting thread. On expiry the original fatal path runs, so the worst case is the behaviour before this change.
- Self-limiting against a genuinely bad pointer: a stray address is only retried if it happens to fall inside a window that is open at that instant, and the window is gone by the time the retry runs.

## Sources

- The platform's headers are FreeBSD-derived (`MAP_EXCL` as an alias of `MAP_NO_OVERWRITE`, `MAP_NOSYNC`, `MAP_PREFAULT_READ`), so FreeBSD `mmap(2)` is the reference for the atomicity expectation: a `MAP_FIXED` mapping replaces an existing one with no intervening window.
- `MAP_FIXED` = `0x10`, matching the constant this path already hardcodes.

## Testing

- Builds clean on Windows (clang-cl) off `1342c6f`.
- All suites pass except `RenderExecutorStencilBindingDiscovery`, which fails identically on clean `origin/main`.
- The mechanism is confirmed by the trace above: the fault landed in the window and the retry recovered it instead of killing the process.
- In GTA V (PPSA04264) the load crash previously reproduced at roughly one attempt in ten. It has not recurred in any session since this change went into the tree I play on. **This is an uncontrolled observation, not a matched A/B** — there is no arm without the fix over the same number of loads, so treat it as strong practical evidence rather than a measurement.
- The crash also reproduces on clean `origin/main`, so it is not something this tree introduced.

## Scope

This makes the window survivable; it does not eliminate it. Making `MAP_FIXED` replacement genuinely atomic would mean holding the old view until the new one is ready, which is a larger change to the mapping path.
