### PR TITLE
loader: retry a fault on memory the guest map reports as committed

### DIFF
--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <thread>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -799,6 +800,27 @@ static bool KytyExceptionHandler(const Common::HostException::ExceptionInfo& exc
 		}
 		if (Libs::LibKernel::Memory::HandleGpuFault(access, info->access_violation_vaddr)) {
 			return true;
+		}
+
+		// Remapping guest memory is not atomic: MapBacking/UnmapBacking go through placeholders, so
+		// the pages are briefly absent and a guest thread touching them in that window faults on
+		// memory that is committed both before and after. Retry the instruction rather than abort,
+		// bounded per address so a genuinely bad access still fails.
+		Libs::LibKernel::Memory::VirtualQueryInfo guest {};
+		if (Libs::LibKernel::Memory::KernelVirtualQuery(
+		        reinterpret_cast<const void*>(info->access_violation_vaddr), 0, &guest,
+		        sizeof(guest)) == 0 &&
+		    guest.is_committed != 0) {
+			thread_local uint64_t last_vaddr = 0;
+			thread_local uint32_t retries    = 0;
+			if (info->access_violation_vaddr != last_vaddr) {
+				last_vaddr = info->access_violation_vaddr;
+				retries    = 0;
+			}
+			if (++retries <= 4096) {
+				std::this_thread::yield();
+				return true;
+			}
 		}
 	}
 	EXIT("Unhandled host exception: type=%u code=%u pc=0x%016" PRIx64


### PR DESCRIPTION
## Summary

- Retry a faulting instruction when the guest memory map reports the address as committed, instead of aborting the emulator.
- Covers the window where guest memory is briefly unmapped during a remap.

## Problem

`MapBacking` / `UnmapBacking` remap guest memory through placeholders, so there is a short window in which the pages are not mapped. A guest thread that touches the range during that window takes an access violation on memory that is committed both before and after the remap, and `KytyExceptionHandler` turns any fault it does not recognise into a fatal `EXIT`.

Instrumenting the exception path with `VirtualQuery` showed the state changing underneath two adjacent calls. `at` is queried before `prev`, yet they disagree about the same range:

```
Unhandled host exception: code=0xC0000005 access=write address=0x0000001038 2e6000
  | at   base=0x10382e6000 size=0xa000       state=MEM_RESERVE protect=0
  | prev base=0x10382e5000 end=0x10382f0000  state=MEM_COMMIT  protect=PAGE_READWRITE
  | guest 0x10382e0000-0x10382f0000 committed=1 direct=1
```

Both cover `0x10382e6000-0x10382f0000`. The range was unmapped when the first query ran and mapped when the second did, so the fault is transient rather than a real invalid access. Logging every `MapBacking` failure produced no hits, confirming nothing failed — the fault falls between the unmap and the remap.

Observed in Grand Theft Auto V (PPSA04264) as a reproducible crash while the game streams world data (driving, entering vehicles). With this change the same session completes the first mission with no faults, where previously it aborted every time.

The retry is bounded to 4096 attempts per faulting address, so an address that never becomes valid still reaches the existing fatal path with its diagnostics intact.

## Scope and limits

This is a mitigation, not a removal of the race. The complete fix is to make the remap atomic with respect to guest access — either holding guest threads off during the placeholder window, or mapping new backing over the old without an intermediate unmapped state. That is a larger change to the memory manager and is not attempted here.

## Validation

- Built on Windows with clang-cl/Ninja and verified in game from the same change in my working tree; the PR branch itself was not built in isolation because that checkout lacks the vendored submodules.
- GTA5 previously crashed reproducibly during world streaming; with this change the first mission completes with zero faults.
- No change in behaviour for faults the GPU handler already services, or for addresses the guest map does not report as committed.

## AI assistance

AI assistance was used for this change.
