### PR TITLE
Fix: depth image handling in renderer and shaderOutputViewportIndex

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -951,6 +951,14 @@ void TextureCache::UploadImage(Image& image, const ImageDesc& desc, Buffer& sour
 			     info.extent.height, info.extent.depth, info.pitch, info.resources.levels,
 			     info.resources.layers, info.samples);
 		}
+		// If the host image is in a depth format (e.g., eD16Unorm created by the depth_compare path),
+        // TextureBuildImageCopies produces copies with a hardcoded eColor, which is invalid for depth images.
+        // Let's correct the aspect mask before uploading.
+		if (info.IsDepth()) {
+			for (auto& copy: plan.regions) {
+				copy.imageSubresource.aspectMask = vk::ImageAspectFlagBits::eDepth;
+			}
+		}
 		TileManager::Result linear {source.Handle(), source_offset, info.data.size};
 		if (plan.tiled) {
 			linear = m_tiler.Detile(source.Handle(), source_offset, info.data.size,

--- a/src/graphics/host_gpu/renderer/image/imageView.h
+++ b/src/graphics/host_gpu/renderer/image/imageView.h
@@ -84,12 +84,15 @@ SelectSampledColorView(vk::Format image_format, vk::Format view_format, uint32_t
 	if (!IsSupportedSampledDepthFormat(image_format, view_format)) {
 		return false;
 	}
+	/*
 	switch (swizzle) {
 		case DstSel(4, 4, 4, 4):
 		case DstSel(4, 0, 0, 0):
 		case DstSel(4, 0, 0, 1): return true;
 		default: return false;
 	}
+	*/
+	return IsValidImageSwizzle(swizzle);
 }
 
 [[nodiscard]] inline uint32_t

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -244,7 +244,7 @@ TargetTextureViewInfo ResolveTargetTextureView(const ShaderRecompiler::IR::Image
 			return resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2D &&
 			               base_layer == 0 && image_layers == 1
 			           ? TargetTextureViewInfo {vk::ImageViewType::e2D, 0, 1}
-			           : TargetTextureViewInfo {};
+					   : TargetTextureViewInfo {};
 		case Prospero::ImageType::kCube:
 			if (resource.dimension != ShaderRecompiler::Decoder::ImageDimension::Dim2DArray ||
 			    base_layer >= image_layers || (image_layers - base_layer) % 6u != 0) {
@@ -259,13 +259,13 @@ TargetTextureViewInfo ResolveTargetTextureView(const ShaderRecompiler::IR::Image
 			return resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2DArray &&
 			               base_layer < image_layers
 			           ? TargetTextureViewInfo {vk::ImageViewType::e2DArray, base_layer,
-			                                    image_layers - base_layer}
-			           : TargetTextureViewInfo {};
+					                            image_layers - base_layer}
+					   : TargetTextureViewInfo {};
 		case Prospero::ImageType::kColor2DMsaa:
 			return resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2DMsaa &&
 			               base_layer == 0 && image_layers == 1
 			           ? TargetTextureViewInfo {vk::ImageViewType::e2D, 0, 1}
-			           : TargetTextureViewInfo {};
+					   : TargetTextureViewInfo {};
 		case Prospero::ImageType::kColor2DMsaaArray:
 			if (resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2DMsaa &&
 			    base_layer == 0 && image_layers == 1) {
@@ -275,8 +275,8 @@ TargetTextureViewInfo ResolveTargetTextureView(const ShaderRecompiler::IR::Image
 			                   ShaderRecompiler::Decoder::ImageDimension::Dim2DMsaaArray &&
 			               base_layer < image_layers
 			           ? TargetTextureViewInfo {vk::ImageViewType::e2DArray, base_layer,
-			                                    image_layers - base_layer}
-			           : TargetTextureViewInfo {};
+					                            image_layers - base_layer}
+					   : TargetTextureViewInfo {};
 		default: return {};
 	}
 }
@@ -299,7 +299,7 @@ bool IsSupportedDepthTargetDescriptor(const ShaderTextureResource& descriptor, c
 	const auto samples      = multisampled ? 1u << descriptor.LastLevel() : 1u;
 	const auto pitch =
 	    multisampled ? TileGetDepthPitch(width, image.info.bytes_per_block, descriptor.LastLevel())
-	                 : TileGetTexturePitch(descriptor.Format(), width, descriptor.TileMode());
+		             : TileGetTexturePitch(descriptor.Format(), width, descriptor.TileMode());
 	const bool supported_2d    = type == Prospero::ImageType::kColor2D &&
 	                             image.info.resources.layers == 1 && descriptor.Depth() == 0 &&
 	                             descriptor.BaseArray5() == 0;
@@ -322,8 +322,8 @@ bool IsSupportedDepthTargetDescriptor(const ShaderTextureResource& descriptor, c
 	                       descriptor.LastLevel() <= 3 &&
 	                       (r128 || descriptor.MaxMip() == descriptor.LastLevel()) &&
 	                       image.info.resources.levels == 1 && image.info.samples == samples
-	                 : descriptor.BaseLevel() == 0 && descriptor.LastLevel() == 0 &&
-	                       (r128 || descriptor.MaxMip() == 0) && image.info.samples == 1;
+		             : descriptor.BaseLevel() == 0 && descriptor.LastLevel() == 0 &&
+		                   (r128 || descriptor.MaxMip() == 0) && image.info.samples == 1;
 	return image.info.IsDepth() && width == image.info.extent.width &&
 	       height == image.info.extent.height &&
 	       (supported_2d || supported_array || supported_cube || supported_msaa_2d ||
@@ -385,7 +385,7 @@ static void ValidateDepthTargetBinding(const ShaderRecompiler::IR::ImageResource
 	}
 	const auto descriptor_pitch =
 	    TileGetTexturePitch(descriptor.Format(), static_cast<uint32_t>(descriptor.Width5()) + 1u,
-	                        descriptor.TileMode());
+		                    descriptor.TileMode());
 	EXIT("unsupported sampled depth target: resource=%d descriptor=%d encoding=%d format=%d "
 	     "kind=%u dimension=%u mip_mode=%u read=%d written=%d atomic=%d compare=%d "
 	     "guest_format=%u swizzle=0x%03x image_format=%d view_format=%d image_layers=%u "
@@ -433,7 +433,7 @@ static bool IsSupportedStorageTextureDescriptor(const ShaderRecompiler::IR::Imag
 	const bool is_2d_array =
 	    resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2DArray &&
 	    ((!resource.cube && is_color_2d_array && descriptor.BaseArray5() <= descriptor.Depth()) ||
-	     is_cube);
+		 is_cube);
 	const bool is_3d = resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim3D &&
 	                   descriptor.Type() == Prospero::ImageType::kColor3D &&
 	                   descriptor.BaseArray5() == 0;
@@ -514,8 +514,8 @@ void ValidateStorageTexture(const ShaderRecompiler::IR::ImageResource& resource,
 	                              resource.written && !resource.read && !resource.atomic;
 	const bool format_ok =
 	    raw_sint_storage || (Prospero::IsSampledTextureFormat(format) &&
-	                         uint_resource == Prospero::IsUintTextureFormat(format) &&
-	                         (!resource.atomic || format == Prospero::BufferFormat::k32UInt));
+		                     uint_resource == Prospero::IsUintTextureFormat(format) &&
+		                     (!resource.atomic || format == Prospero::BufferFormat::k32UInt));
 	if (resource_ok && descriptor_ok && encoding_ok && format_ok && size != 0) {
 		return;
 	}
@@ -615,7 +615,7 @@ static void PopulateTextureMipLayout(ImageInfo& info) {
 		    size,
 		    padded[level].width != 0 ? padded[level].width : std::max(info.pitch >> level, 1u),
 		    padded[level].height != 0 ? padded[level].height
-		                              : std::max(info.extent.height >> level, 1u),
+			                          : std::max(info.extent.height >> level, 1u),
 		};
 	}
 }
@@ -625,8 +625,12 @@ static ImageViewInfo TextureViewInfo(const ShaderRecompiler::IR::ImageResource& 
                                      bool shader_conversion, bool storage, uint32_t view_levels,
                                      uint32_t image_layers) {
 	ImageViewInfo view {};
-	view.format      = format;
-	view.aspect      = vk::ImageAspectFlagBits::eColor;
+	view.format = format;
+	// view.aspect      = vk::ImageAspectFlagBits::eColor;
+
+	view.aspect      = DepthAspectTransferFormat(format) != vk::Format::eUndefined
+	                       ? vk::ImageAspectFlagBits::eDepth
+	                       : vk::ImageAspectFlagBits::eColor;
 	view.base_level  = descriptor.BaseLevel();
 	view.level_count = view_levels;
 	view.usage   = storage ? vk::ImageUsageFlagBits::eStorage : vk::ImageUsageFlagBits::eSampled;
@@ -738,8 +742,8 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	    surface_format.conversion_format != Prospero::BufferFormat::kInvalid;
 	const bool sampled_numeric_class =
 	    storage || (Prospero::IsSampledTextureFormat(format) &&
-	                (resource.kind == ShaderRecompiler::IR::ResourceKind::ImageUint) ==
-	                    Prospero::IsUintTextureFormat(format));
+		            (resource.kind == ShaderRecompiler::IR::ResourceKind::ImageUint) ==
+		                Prospero::IsUintTextureFormat(format));
 	if (!storage &&
 	    (resource.kind == ShaderRecompiler::IR::ResourceKind::Image ||
 	     resource.kind == ShaderRecompiler::IR::ResourceKind::ImageUint) &&
@@ -775,7 +779,24 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 		ValidateStorageTexture(resource, descriptor, size.size);
 	}
 
-	const auto pixel_format        = surface_format.vk_format;
+	// const auto pixel_format        = surface_format.vk_format;
+	
+	//  Format override for depth-comparison sampling (depth_compare).
+	//  On PS5/RDNA2, k16UNorm and k32Float can be used as depth textures;
+	//  in Vulkan, the color formats (eR16Unorm, eR32Sfloat) do not have the
+	//  VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT flag required by VUID-06479.
+	auto pixel_format = surface_format.vk_format;
+	if (!storage && resource.depth_compare) {
+		if (const auto* depth_policy = FindGuestDepthFormatPolicy(format)) {
+			pixel_format = depth_policy->depth_attachment_format;
+		} else if (format == Prospero::BufferFormat::k16UNorm ||
+		           format == Prospero::BufferFormat::k16UInt) {
+			pixel_format = vk::Format::eD16Unorm;
+		} else if (format == Prospero::BufferFormat::k32Float ||
+		           format == Prospero::BufferFormat::k32UInt) {
+			pixel_format = vk::Format::eD32Sfloat;
+		}
+	}
 	const auto storage_view_format = storage && format == Prospero::BufferFormat::k32SInt
 	                                     ? vk::Format::eR32Uint
 	                                     : SrgbStorageViewFormat(pixel_format);
@@ -834,8 +855,8 @@ static vk::Sampler NativeSampler(RenderContext&                       context,
 	const bool depth_compare = std::any_of(program.info.sampled_pairs.begin(),
 	                                       program.info.sampled_pairs.end(), [&](const auto& pair) {
 		                                       return pair.sampler == index &&
-		                                              pair.image < program.info.images.size() &&
-		                                              program.info.images[pair.image].depth_compare;
+											          pair.image < program.info.images.size() &&
+											          program.info.images[pair.image].depth_compare;
 	                                       });
 	if (!depth_compare) {
 		descriptor.fields[0] &= ~(0x7u << 12u);
@@ -957,7 +978,6 @@ void RenderExecutor::FindBuffers(PreparedBindings& prepared) {
 		const auto size = Libs::LibKernel::Memory::ClampRangeSize(address, requested_size);
 		prepared.buffer_ids.push_back(cache.FindBuffer(address, size));
 	}
-
 }
 
 void RenderExecutor::RebindBuffers(PreparedBindings& prepared) {
@@ -1078,14 +1098,15 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
                                     const PipelineCache::Pipeline&     pipeline,
                                     std::span<PreparedBindings* const> prepared_bindings) {
 	KYTY_PROFILER_FUNCTION();
-	auto   vk_buffer        = buffer.Handle();
-	size_t descriptor_count = 0;
-	size_t write_count      = 0;
+	auto           vk_buffer        = buffer.Handle();
+	size_t         descriptor_count = 0;
+	size_t         write_count      = 0;
 	constexpr auto GraphicsStages =
 	    vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment;
-	const auto push_constant_stages = pipeline_bind_point == vk::PipelineBindPoint::eGraphics
-	                                      ? vk::ShaderStageFlags {GraphicsStages}
-	                                      : vk::ShaderStageFlags {vk::ShaderStageFlagBits::eCompute};
+	const auto push_constant_stages =
+	    pipeline_bind_point == vk::PipelineBindPoint::eGraphics
+	        ? vk::ShaderStageFlags {GraphicsStages}
+	        : vk::ShaderStageFlags {vk::ShaderStageFlagBits::eCompute};
 	for (const auto* prepared: prepared_bindings) {
 		EXIT_IF(prepared == nullptr || prepared->program == nullptr ||
 		        prepared->snapshot == nullptr || prepared->committed);
@@ -1176,7 +1197,7 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 					break;
 				case BindingKind::BdaPagetable:
 				case BindingKind::FaultBuffer: {
-					auto& cache = m_context.GetBufferCache();
+					auto&       cache      = m_context.GetBufferCache();
 					const auto* bda_buffer = binding.kind == BindingKind::BdaPagetable
 					                             ? cache.GetBdaPageTableBuffer()
 					                             : cache.GetFaultBuffer();
@@ -1188,8 +1209,8 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 				case BindingKind::Gds: {
 					const auto& view =
 					    binding.kind == BindingKind::FlattenedSrt ? descriptors.flattened_srt
-					    : binding.kind == BindingKind::UserData   ? descriptors.user_data
-					                                              : descriptors.gds;
+						: binding.kind == BindingKind::UserData   ? descriptors.user_data
+						                                          : descriptors.gds;
 					EXIT_IF(view.buffer == nullptr);
 					m_descriptor_buffers.emplace_back(view.buffer, view.offset, view.range);
 					break;
@@ -1237,8 +1258,7 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 		}
 	}
 	vk_buffer.pushConstants(pipeline.pipeline_layout, push_constant_stages, 0,
-	                        ShaderRecompiler::IR::NativePushConstantSize,
-	                        m_push_constants.data());
+	                        ShaderRecompiler::IR::NativePushConstantSize, m_push_constants.data());
 
 	if (!m_descriptor_writes.empty()) {
 		EXIT_IF(pipeline.descriptor_set_layout == nullptr);

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -295,6 +295,10 @@ static void VulkanFindPhysicalDevice(vk::Instance instance, vk::SurfaceKHR surfa
 			LOGF("shaderOutputLayer is not supported\n");
 			skip_device = true;
 		}
+		if (features12.shaderOutputViewportIndex != VK_TRUE) {
+			LOGF("shaderOutputViewportIndex is not supported\n");
+			skip_device = true;
+		}
 
 		if (device_features2.features.fragmentStoresAndAtomics != VK_TRUE) {
 			LOGF("fragmentStoresAndAtomics is not supported\n");
@@ -600,12 +604,14 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	EXIT_NOT_IMPLEMENTED(supported_features2.features.shaderInt64 != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(supported_features2.features.vertexPipelineStoresAndAtomics != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(supported_features12.shaderOutputLayer != VK_TRUE);
+	EXIT_NOT_IMPLEMENTED(supported_features12.shaderOutputViewportIndex != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(supported_features12.bufferDeviceAddress != VK_TRUE);
 #if !defined(__APPLE__)
 	EXIT_NOT_IMPLEMENTED(supported_fragment_barycentric.fragmentShaderBarycentric != VK_TRUE);
 #endif
 	features12.timelineSemaphore = VK_TRUE;
 	features12.shaderOutputLayer = VK_TRUE;
+	features12.shaderOutputViewportIndex = VK_TRUE;
 	features12.bufferDeviceAddress = VK_TRUE;
 
 	vk::PhysicalDeviceFeatures device_features {};
@@ -1049,6 +1055,9 @@ void WindowContext::CreateVulkan() {
 		}
 		if (HasExtension(available_extensions, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
 			device_extensions.push_back(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+		}
+		if (HasExtension(available_extensions, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME)) {
+			device_extensions.push_back(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
 		}
 	}
 


### PR DESCRIPTION
**Pull Request Summary:**


- Depth Aspect Flag Fix: Configured vk::ImageAspectFlagBits::eDepth on upload copies for depth formats to resolve invalid color-aspect copy errors.

- Image View Aspect Selection: Updated image view creation to automatically choose the depth aspect when the transfer format indicates a depth format.

- Depth-Format Override: Added an override for depth-compare sampling—utilizing the guest depth policy or falling back to D16/D32—to properly support sampled depth usage.

- Swizzle Validation Update: Switched sampled-color view swizzle validation to use IsValidImageSwizzle.

- Formatting and Cleanup: Included minor formatting and whitespace adjustments across the renderer codebase.

- Introduction of support for the shaderOutputViewportIndex capability, including related checks on the Vulkan device; enablement of version 1.2 features; and inclusion of the VK_EXT_SHADER_VIEWPORT_INDEX_LAYER extension.