### PR TITLE
renderer: materialize DCC clears before sampled access

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1250,6 +1250,7 @@ vk::ImageView TextureCache::FindTexture(ImageId id, const ImageDesc& desc) {
 	if (!image.info.data.Empty()) {
 		RefreshImage(id, desc);
 	}
+	MaterializeDccMetaClear(id, image, desc);
 	switch (desc.type) {
 		case BindingType::Texture: break;
 		case BindingType::Storage:
@@ -1293,6 +1294,9 @@ vk::ImageView TextureCache::FindRenderTarget(ImageId id, const ImageDesc& desc) 
 		} else if (!inserted && metadata->second.type != MetaDataInfo::Type::Dcc) {
 			EXIT("TextureCache: color target reuses non-DCC metadata\n");
 		}
+		metadata->second.color_clear_value           = desc.metadata_clear_value;
+		metadata->second.color_clear_supported       = desc.metadata_clear_supported;
+		metadata->second.fixed_color_clear_supported = desc.metadata_fixed_clear_supported;
 	}
 	CommitGpuWrite(image);
 	TrackImageDownload(id, image);
@@ -1814,7 +1818,18 @@ bool TextureCache::TryConsumeDccFill(uint64_t address, uint64_t size, uint32_t f
 			case 0x40:
 			case 0x80:
 			case 0xc0: return UINT32_MAX;
-			default: return 0u;
+			default:
+				// A repeated byte is a uniform clear code; GFX10 comp-to-single (0x10) is one we
+				// cannot materialize, so report it rather than skip the clear silently.
+				{
+					static std::atomic<uint32_t> logged {0};
+					if (logged.fetch_add(1, std::memory_order_relaxed) < 8) {
+						std::fprintf(stderr, "TextureCache: unhandled DCC fill code 0x%02" PRIx32 "\n",
+						             static_cast<uint32_t>(code));
+						std::fflush(stderr);
+					}
+				}
+				return 0u;
 		}
 	}();
 	std::scoped_lock lock {m_lock};
@@ -1858,6 +1873,103 @@ bool TextureCache::TouchMeta(uint64_t address, uint32_t slice, bool is_clear) {
 		found->second.clear_mask &= ~(1u << slice);
 	}
 	return true;
+}
+
+bool TextureCache::ResolveDccMetaClearLocked(uint64_t address, uint32_t base_layer,
+                                             uint32_t layer_count,
+                                             vk::ClearColorValue& clear_value, bool consume) {
+	const auto found = m_surface_metas.find(address);
+	if (found == m_surface_metas.end() || found->second.type != MetaDataInfo::Type::Dcc ||
+	    layer_count == 0 || base_layer >= 32 || layer_count > 32 - base_layer) {
+		return false;
+	}
+	const uint32_t layer_mask =
+	    layer_count == 32 ? UINT32_MAX : ((1u << layer_count) - 1u) << base_layer;
+	if ((found->second.clear_mask & layer_mask) != layer_mask) {
+		return false;
+	}
+
+	clear_value = {};
+	switch (static_cast<uint8_t>(found->second.fill_value)) {
+		case 0x00: break;
+		case 0x20:
+			// Register-backed: the value is the one the target carried when it was last bound.
+			if (!found->second.color_clear_supported) {
+				return false;
+			}
+			clear_value = found->second.color_clear_value;
+			break;
+		case 0x40:
+			if (!found->second.fixed_color_clear_supported) {
+				return false;
+			}
+			clear_value.float32[3] = 1.0f;
+			break;
+		case 0x80:
+			if (!found->second.fixed_color_clear_supported) {
+				return false;
+			}
+			clear_value.float32[0] = 1.0f;
+			clear_value.float32[1] = 1.0f;
+			clear_value.float32[2] = 1.0f;
+			break;
+		case 0xc0:
+			if (!found->second.fixed_color_clear_supported) {
+				return false;
+			}
+			clear_value.float32[0] = 1.0f;
+			clear_value.float32[1] = 1.0f;
+			clear_value.float32[2] = 1.0f;
+			clear_value.float32[3] = 1.0f;
+			break;
+		default:
+			// GFX10 comp-to-single (0x10) keeps its colour in the image, not in a register.
+			{
+				static std::atomic<uint32_t> logged {0};
+				if (logged.fetch_add(1, std::memory_order_relaxed) < 8) {
+					std::fprintf(stderr, "TextureCache: unhandled DCC clear code 0x%02" PRIx32 "\n",
+					             static_cast<uint32_t>(found->second.fill_value) & 0xffu);
+					std::fflush(stderr);
+				}
+			}
+			return false;
+	}
+	if (consume) {
+		found->second.clear_mask &= ~layer_mask;
+	}
+	return true;
+}
+
+bool TextureCache::ResolveDccMetaClear(uint64_t address, uint32_t base_layer,
+                                       uint32_t layer_count,
+                                       vk::ClearColorValue& clear_value) {
+	std::scoped_lock lock {m_lock};
+	return ResolveDccMetaClearLocked(address, base_layer, layer_count, clear_value, true);
+}
+
+void TextureCache::MaterializeDccMetaClear(ImageId id, Image& image, const ImageDesc& desc) {
+	const auto& metadata = image.info.metadata;
+	if (metadata.kind != ImageMetadataKind::Dcc) {
+		return;
+	}
+	vk::ClearColorValue clear_value {};
+	if (!ResolveDccMetaClearLocked(metadata.range.address, desc.view_info.base_layer,
+	                               desc.view_info.layer_count, clear_value, true)) {
+		return;
+	}
+	auto& command = m_scheduler.Current();
+	command.EndRendering();
+	image.Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite,
+	              ImageSubresourceRange {desc.view_info.base_level, desc.view_info.level_count,
+	                                     desc.view_info.base_layer, desc.view_info.layer_count},
+	              command.Handle());
+	const vk::ImageSubresourceRange range {
+	    vk::ImageAspectFlagBits::eColor, desc.view_info.base_level, desc.view_info.level_count,
+	    desc.view_info.base_layer, desc.view_info.layer_count};
+	command.Handle().clearColorImage(image.backing.image, vk::ImageLayout::eTransferDstOptimal,
+	                                 &clear_value, 1, &range);
+	CommitGpuWrite(image);
+	TrackImageDownload(id, image);
 }
 
 void TextureCache::UnmapMemory(uint64_t address, uint64_t size) {

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -32,9 +32,12 @@ public:
 	enum class BindingType : uint8_t { Texture, Storage, RenderTarget, DepthTarget, VideoOut };
 
 	struct ImageDesc {
-		ImageInfo     info;
-		ImageViewInfo view_info;
-		BindingType   type = BindingType::Texture;
+		ImageInfo           info;
+		ImageViewInfo       view_info;
+		BindingType         type = BindingType::Texture;
+		vk::ClearColorValue metadata_clear_value {};
+		bool                metadata_clear_supported       = false;
+		bool                metadata_fixed_clear_supported = false;
 	};
 
 	struct RegionInfo {
@@ -76,6 +79,9 @@ public:
 	// False may still record PendingDcc state, but the guest dispatch must execute.
 	[[nodiscard]] bool TryConsumeDccFill(uint64_t address, uint64_t size, uint32_t fill_value);
 	[[nodiscard]] bool TouchMeta(uint64_t address, uint32_t slice, bool is_clear);
+	[[nodiscard]] bool
+	ResolveDccMetaClear(uint64_t address, uint32_t base_layer, uint32_t layer_count,
+	                    vk::ClearColorValue& clear_value);
 
 	void UnmapMemory(uint64_t address, uint64_t size);
 	void ProcessDownloadImages();
@@ -98,6 +104,9 @@ private:
 		uint32_t clear_mask = 0;
 		uint32_t fill_value = 0xffffffffu;
 		uint64_t fill_size  = 0;
+		vk::ClearColorValue color_clear_value {};
+		bool                color_clear_supported       = false;
+		bool                fixed_color_clear_supported = false;
 	};
 
 	struct OverlapResult {
@@ -111,6 +120,11 @@ private:
 
 	[[nodiscard]] ImageId     InsertImage(const ImageInfo& info);
 	[[nodiscard]] ImageId     GetNullImage(const ImageDesc& desc);
+	[[nodiscard]] bool        ResolveDccMetaClearLocked(uint64_t address, uint32_t base_layer,
+	                                                    uint32_t layer_count,
+	                                                    vk::ClearColorValue& clear_value,
+	                                                    bool consume);
+	void               MaterializeDccMetaClear(ImageId id, Image& image, const ImageDesc& desc);
 	void                      RegisterImage(ImageId id);
 	void                      UnregisterImage(ImageId id);
 	void                      DeleteImage(ImageId id);

--- a/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/colorRenderTarget.cpp
@@ -394,6 +394,9 @@ void RenderExecutor::ResolveRenderColorTarget(uint64_t submit_id, CommandBuffer&
 	r.export_mapping           = target_format.export_mapping;
 	r.color_clear_enable       = false;
 	ResolveDccClearInfo(r, target_format.format, has_dcc, rt.clear_word0.word0);
+	r.desc.metadata_clear_value           = r.color_clear_value;
+	r.desc.metadata_clear_supported       = r.metadata_clear_supported;
+	r.desc.metadata_fixed_clear_supported = r.metadata_fixed_clear_supported;
 	BindRenderTarget(r.image_id);
 }
 

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -506,63 +506,8 @@ static bool ResolveDccAttachmentClear(TextureCache& cache, const RenderColorInfo
 	if (target.desc.info.metadata.kind != ImageMetadataKind::Dcc) {
 		return false;
 	}
-
-	// A DCC fast clear may update metadata only and leave the color allocation stale. Vulkan has
-	// no guest DCC state, so materialize the deferred value when the surface is next bound.
-	const auto metadata_address = target.desc.info.metadata.range.address;
-	uint32_t   metadata_value   = 0xffffffffu;
-	if (!cache.IsMetaCleared(metadata_address, view.base_layer, &metadata_value)) {
-		return false;
-	}
-
-	// Translate recognized constant and register-backed DCC states into a host clear value.
-	clear_value = {};
-	switch (static_cast<uint8_t>(metadata_value)) {
-		case 0x00: break;
-		case 0x20:
-			if (!target.metadata_clear_supported) {
-				return false;
-			}
-			clear_value = target.color_clear_value;
-			break;
-		case 0x40:
-			if (!target.metadata_fixed_clear_supported) {
-				return false;
-			}
-			clear_value.float32[3] = 1.0f;
-			break;
-		case 0x80:
-			if (!target.metadata_fixed_clear_supported) {
-				return false;
-			}
-			clear_value.float32[0] = 1.0f;
-			clear_value.float32[1] = 1.0f;
-			clear_value.float32[2] = 1.0f;
-			break;
-		case 0xc0:
-			if (!target.metadata_fixed_clear_supported) {
-				return false;
-			}
-			clear_value.float32[0] = 1.0f;
-			clear_value.float32[1] = 1.0f;
-			clear_value.float32[2] = 1.0f;
-			clear_value.float32[3] = 1.0f;
-			break;
-		default: return false;
-	}
-
-	for (uint32_t layer = 1; layer < view.layer_count; layer++) {
-		if (!cache.IsMetaCleared(metadata_address, view.base_layer + layer)) {
-			return false;
-		}
-	}
-	// Consume only after every layer in this Vulkan view can be materialized together.
-	for (uint32_t layer = 0; layer < view.layer_count; layer++) {
-		if (!cache.TouchMeta(metadata_address, view.base_layer + layer, false)) {
-			EXIT("failed to consume DCC clear state\n");
-		}
-	}
-	return true;
+	return cache.ResolveDccMetaClear(target.desc.info.metadata.range.address, view.base_layer,
+	                                 view.layer_count, clear_value);
 }
 
 RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderColorInfo* colors,

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -7343,9 +7343,11 @@ public:
       Require(name, "storage alias reuse",
               storage_id == color.image_id && storage_view != nullptr &&
                   shared_image.IsGpuModified() &&
-                  shared_image.usage.render_target,
+                  shared_image.usage.render_target &&
+                  !texture_cache.IsMetaCleared(dcc_address, 0) &&
+                  texture_cache.IsMetaCleared(dcc_address, 7),
               "the matching 3D storage binding did not reuse the live "
-              "render-target image");
+              "render-target image or materialize its pending clear");
 
       Require(
           name, "volume readback queue",


### PR DESCRIPTION
This is the whiteout/hdr fix that was affecting multiple games


## Problem

A DCC fast clear is materialized only as a render-pass load-op, at the next time the surface is
bound as a colour render target. If the guest **samples** that surface as a texture before that
bind, the read returns the pre-clear contents.

I hit this in GTA V. An ordered, per-draw trace of one frame shows a full-screen blit sampling a
1280x720 `B10G11R11` transient at draw 101, while the surface's first render-target bind — and so
its clear — is draw 103:

```
seq=101  reads  0x25EF80000, writes the HDR scene
seq=103  writes 0x25EF80000   <- first render-target bind this frame, clear applied here
seq=104+ writes 0x25EF80000   <- bloom threshold, separable blur, additive upscale
```

The surface is reused several times per frame, and at draw 101 it still held the previous frame's
bloom. The blit adds it into the HDR scene with `ONE/ONE`, the next frame's bloom threshold reads
that scene, and the loop gains roughly 1.7-2x per frame until the image saturates. Auto-exposure
compensates until it hits its lower clamp and then cannot keep up.

## Why

A fast clear is a metadata write that takes effect when it is issued. Any later read of the
surface — as a texture or as a render target — must observe cleared data. Deferring to the next
render-target bind is only valid if nothing reads the surface in between.

The same requirement is visible in AMD's open-source PAL driver: a colour surface that will be
texture-fetched needs a fast-clear-eliminate pass before it can be sampled, and only a small set
of hardware-defined clear colours avoid it
(`src/core/hw/gfxip/gfx9/gfx9MaskRam.cpp`, `Gfx9Dcc::GetFastClearCode` and `pNeedFastClearElim`).

## Change

- Move the DCC clear-code decode out of the draw path into `TextureCache`, so both the
  render-target path and the sampled path resolve it the same way.
- `FindTexture` now materializes a pending DCC clear with `clearColorImage` before the image is
  used, then consumes it. The render-target path keeps the cheaper load-op.
- Carry the target's clear value and support flags on `ImageDesc` so the cache can resolve a clear
  without the draw-time register state.
- Report an unrecognised DCC clear code once instead of silently skipping the clear.

No title, address or shader-hash special cases.

## Testing

- `kernel_file_system_tests`, `resource_tracking_tests`, `scalar_provenance_tests`,
  `shader_cfg_tests`, `virtual_memory_allocation_tests` pass.
- `shader_recompiler_compute_tests` fails at `RenderExecutorStencilBindingDiscovery`
  ("depth texture compatibility identity"). This reproduces unchanged on `main` at `dd062ce`
  with no patch applied, so it is pre-existing and unrelated; the existing
  `UnifiedTextureCacheFlow` case was extended to assert that a pending clear is materialized on
  the sampled path.
- GTA V: the saturation is gone and bloom renders normally. Scene mean 0.041-0.076 with no
  non-finite values, against a saturated 48099 before.

## Known gap

GFX10's comp-to-single clear code (`0x10`) is still unhandled — its colour lives in the first
pixel of each DCC block rather than in a register, so it needs a different value source. It does
not occur in the title I tested; the new report makes it visible rather than silent if it does.

## AI involvement

Investigation, patch and testing were done with AI assistance
