### PR TITLE
renderer: do not treat leftover depth-view write disables as a bound …

### DIFF
--- a/src/graphics/host_gpu/renderer/depthRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/depthRenderTarget.cpp
@@ -127,10 +127,13 @@ void RenderExecutor::ResolveRenderDepthTarget(uint64_t submit_id, CommandBuffer&
 	    z.stencil_info.texture_compatibility == Prospero::TextureCompatibleStencil::kDisable &&
 	    !z.stencil_info.expclear_enabled && !z.stencil_info.partially_resident &&
 	    z.depth_view.slice_start == 0 && z.depth_view.slice_max == 0 &&
-	    z.depth_view.current_mip_level == 0 && !z.depth_view.depth_write_disable &&
-	    !z.depth_view.stencil_write_disable && z.z_read_base_addr == 0 && z.z_write_base_addr == 0 &&
-	    z.stencil_read_base_addr == 0 && z.stencil_write_base_addr == 0 &&
-	    z.htile_data_base_addr == 0 &&
+	    z.depth_view.current_mip_level == 0 &&
+	    // DB_DEPTH_VIEW's write-disable bits describe how an attachment is used, not whether one
+	    // is bound, and they survive an unbind like the rest of the register. Requiring them to be
+	    // clear here turns leftover state into a fatal "unsupported depth register state" on the
+	    // first draw that has no depth attachment at all.
+	    z.z_read_base_addr == 0 && z.z_write_base_addr == 0 && z.stencil_read_base_addr == 0 &&
+	    z.stencil_write_base_addr == 0 && z.htile_data_base_addr == 0 &&
 	    // DB_DEPTH_SIZE_XY is independent state and may remain programmed after the attachment
 	    // formats and addresses are unbound. A zero encoding is the valid 1x1 value, so its
 	    // presence alone must not manufacture a depth attachment.


### PR DESCRIPTION
Summary

Teardown (PPSA15246) exits about a second into boot with:

Depth target fatal: unsupported depth register state
 in src/graphics/host_gpu/renderer/depthRenderTarget.cpp:37

ResolveRenderDepthTarget decides an attachment is unbound only when every field of the
depth-target register block reads back at its reset value. Two of the fields it requires
to be clear are DB_DEPTH_VIEW's Z_WRITE_DISABLE and STENCIL_WRITE_DISABLE. Those bits say
how an attachment is used, not whether one is bound, and they survive an unbind like the
rest of the register.

Dumped with --graphics-debug-dump, the register block at the failing draw is empty apart
from exactly those two bits:

- z_info.format = kInvalid, stencil_info.format = kInvalid, num_samples = 0
- z_read, z_write, stencil_read, stencil_write and htile_data base addresses all 0
- size.x_max = 0, size.y_max = 0, shading_rate_encoding = 0
- depth_view.depth_write_disable = true, depth_view.stencil_write_disable = true

There is no depth attachment: no format, no address, no extent. Because the two
write-disable bits are set, attachment_unbound is false, the early return is skipped, and
the compound check below it trips on z_read_base_addr == 0, which reports as "unsupported
depth register state" and ends the process.

The draw itself is a small depth-less render-to-texture pass, 4 indices into a 42x42
target at mip view 1, issued after a read-only depth pass.

Dropping the two bits cannot mask a real attachment. A read-only depth target still has a
valid z_info.format and a non-zero z_read_base_addr, and both are separate terms in the
same predicate, so it still fails attachment_unbound and is handled by the read-only
paths from 6f9ed6f and 1190d5d.

Same class as 6453baf (#425), fb5ecec and 3005a21: leftover depth/stencil register state
must not be read as a binding.

Test plan

Windows 11, clang-cl 20.1.8, RTX 2060, Release. Baseline and candidate built from the
same tree on 0c4dfd5.

- ctest 34/36, unchanged from the baseline. shader_recompiler_compute and
  texture_cache_image_overlap fail on pristine upstream/main as well, deterministically,
  both on RenderExecutorStencilBindingDiscovery "depth texture compatibility identity".
  Reported separately; this change does not affect them.
- Teardown PPSA15246 (contentVersion 01.070.100): baseline stops at 3 compiled shaders
  with the fatal above. With this change the fatal is gone and it reaches 19 compiled
  shaders before stopping on an unrelated limitation, "storage buffer offset adjustment
  is unsupported" in descriptors.cpp. So this does not make Teardown boot, and none is
  claimed. It removes one blocker.
- Regression, both checked against a screenshot rather than a frame counter:
  Tetris Forever PPSA25646, 60 fps in gameplay, rendering correct.
  PAC-MAN WORLD 2 Re-PAC PPSA18189 (with a local _umtx_op patch, since it does not boot
  without one), Pac-Village in 3D with occlusion, transparency, foliage layering and
  ground shadows all correct. That is the meaningful test here, as Tetris barely
  exercises depth targets.

Only one title is known to hit this. The predicate is on the universal draw path, so any
title issuing a depth-less draw after a read-only depth pass would hit it, but I have not
identified another by name.

AI use

Written with AI assistance (Claude). It found the failure, dumped the registers, isolated
which term of the compound check fired, made the change, and ran the builds, the tests
and the game runs described above on my machine. I reviewed the diff.