### PR TITLE
renderer: name the depth register field that rejected a draw

### DIFF
--- a/src/graphics/host_gpu/renderer/depthRenderTarget.cpp
+++ b/src/graphics/host_gpu/renderer/depthRenderTarget.cpp
@@ -96,6 +96,126 @@ static bool UsesStencilOpValue(uint8_t fail, uint8_t pass, uint8_t depth_fail) {
 	return vk::Format::eUndefined;
 }
 
+// The three reporters below name the term that rejected the draw. Each is called only from inside
+// a branch whose condition has already evaluated true, so the accepted path never runs any of this
+// and the deciding conditions themselves are left untouched. They re-test the terms in the order
+// the original condition evaluates them and report the first that holds.
+
+[[noreturn]] static void ReportDepthRegisterRejection(const HW::DepthRenderTarget& z,
+                                                      const HW::RenderControl&     rc,
+                                                      const HW::DepthControl&      dc) {
+	if (rc.copy_depth_to_color) {
+		DepthFatal("DB_RENDER_CONTROL.COPY_DEPTH_TO_COLOR is set");
+	}
+	if (rc.copy_stencil_to_color) {
+		DepthFatal("DB_RENDER_CONTROL.COPY_STENCIL_TO_COLOR is set");
+	}
+	if (rc.copy_centroid) {
+		DepthFatal("DB_RENDER_CONTROL.COPY_CENTROID is set");
+	}
+	if (rc.copy_sample != 0) {
+		DepthFatal("DB_RENDER_CONTROL.COPY_SAMPLE = %" PRIu8 ", expected 0", rc.copy_sample);
+	}
+	if (z.z_info.expclear_enabled) {
+		DepthFatal("DB_Z_INFO.ALLOW_EXPCLEAR is set");
+	}
+	if (z.stencil_info.expclear_enabled) {
+		DepthFatal("DB_STENCIL_INFO.ALLOW_EXPCLEAR is set");
+	}
+	if (z.z_info.partially_resident) {
+		DepthFatal("DB_Z_INFO reports a partially resident depth surface");
+	}
+	if (z.stencil_info.partially_resident) {
+		DepthFatal("DB_STENCIL_INFO reports a partially resident stencil surface");
+	}
+	if (z.z_info.max_mip_level != 0) {
+		DepthFatal("DB_Z_INFO.MAXMIP = %" PRIu8 ", expected 0", z.z_info.max_mip_level);
+	}
+	if (z.depth_view.current_mip_level != 0) {
+		DepthFatal("DB_DEPTH_VIEW.MIPID = %" PRIu8 ", expected 0", z.depth_view.current_mip_level);
+	}
+	if (z.shading_rate_encoding != 0) {
+		DepthFatal("DB_Z_INFO variable-rate shading encoding = 0x%02" PRIx8 ", expected 0",
+		           z.shading_rate_encoding);
+	}
+	if (z.z_read_base_addr == 0) {
+		DepthFatal("DB_Z_READ_BASE is 0 while depth or stencil is active");
+	}
+	if (!z.depth_view.depth_write_disable && z.z_write_base_addr != z.z_read_base_addr) {
+		DepthFatal("DB_Z_WRITE_BASE = 0x%016" PRIx64 " differs from DB_Z_READ_BASE = 0x%016" PRIx64
+		           " while depth writes are enabled",
+		           z.z_write_base_addr, z.z_read_base_addr);
+	}
+	if ((z.z_read_base_addr & 0xffffu) != 0) {
+		DepthFatal("DB_Z_READ_BASE = 0x%016" PRIx64 " is not 64 KiB aligned", z.z_read_base_addr);
+	}
+	if (dc.zfunc > static_cast<uint8_t>(vk::CompareOp::eAlways)) {
+		DepthFatal("DB_DEPTH_CONTROL.ZFUNC = %" PRIu8 ", expected at most %u", dc.zfunc,
+		           static_cast<unsigned>(vk::CompareOp::eAlways));
+	}
+	DepthFatal("unsupported depth register state");
+}
+
+[[noreturn]] static void ReportStencilAttachmentRejection(const HW::DepthRenderTarget& z,
+                                                          bool htile_stencil_compat) {
+	if (z.stencil_info.format != Prospero::StencilFormat::k8UInt) {
+		DepthFatal("DB_STENCIL_INFO.FORMAT = 0x%02" PRIx32 ", only 8-bit unsigned is supported",
+		           static_cast<uint32_t>(z.stencil_info.format));
+	}
+	if (!htile_stencil_compat) {
+		DepthFatal("DB_STENCIL_INFO.TILE_STENCIL_DISABLE = %s does not match HTile "
+		           "acceleration = %s",
+		           z.stencil_info.htile_stencil_disabled ? "true" : "false",
+		           z.z_info.htile_acceleration ? "true" : "false");
+	}
+	if (z.stencil_read_base_addr == 0) {
+		DepthFatal("DB_STENCIL_READ_BASE is 0 while a stencil attachment is bound");
+	}
+	if (!z.depth_view.stencil_write_disable &&
+	    z.stencil_write_base_addr != z.stencil_read_base_addr) {
+		DepthFatal("DB_STENCIL_WRITE_BASE = 0x%016" PRIx64
+		           " differs from DB_STENCIL_READ_BASE = 0x%016" PRIx64
+		           " while stencil writes are enabled",
+		           z.stencil_write_base_addr, z.stencil_read_base_addr);
+	}
+	if ((z.stencil_read_base_addr & 0xffffu) != 0) {
+		DepthFatal("DB_STENCIL_READ_BASE = 0x%016" PRIx64 " is not 64 KiB aligned",
+		           z.stencil_read_base_addr);
+	}
+	DepthFatal("unsupported stencil attachment state");
+}
+
+[[noreturn]] static void ReportStencilOpRejection(const HW::DepthControl&   dc,
+                                                  const HW::StencilControl& sc,
+                                                  const HW::StencilMask&    sm,
+                                                  uint8_t                   front_write_mask,
+                                                  uint8_t                   back_write_mask) {
+	constexpr auto always = static_cast<uint8_t>(vk::CompareOp::eAlways);
+	if (dc.stencilfunc > always) {
+		DepthFatal("DB_DEPTH_CONTROL.STENCILFUNC = %" PRIu8 ", expected at most %" PRIu8,
+		           dc.stencilfunc, always);
+	}
+	if (dc.backface_enable && dc.stencilfunc_bf > always) {
+		DepthFatal("DB_DEPTH_CONTROL.STENCILFUNC_BF = %" PRIu8 ", expected at most %" PRIu8,
+		           dc.stencilfunc_bf, always);
+	}
+	if (front_write_mask != 0 &&
+	    UsesStencilOpValue(sc.stencil_fail, sc.stencil_zpass, sc.stencil_zfail) &&
+	    sm.stencil_opval != sm.stencil_testval) {
+		DepthFatal("front face replaces stencil with DB_STENCILREFMASK.STENCILOPVAL = 0x%02" PRIx8
+		           " while STENCILTESTVAL = 0x%02" PRIx8 "; only a matching pair is supported",
+		           sm.stencil_opval, sm.stencil_testval);
+	}
+	if (dc.backface_enable && back_write_mask != 0 &&
+	    UsesStencilOpValue(sc.stencil_fail_bf, sc.stencil_zpass_bf, sc.stencil_zfail_bf) &&
+	    sm.stencil_opval_bf != sm.stencil_testval_bf) {
+		DepthFatal("back face replaces stencil with DB_STENCILREFMASK_BF.STENCILOPVAL = 0x%02" PRIx8
+		           " while STENCILTESTVAL = 0x%02" PRIx8 "; only a matching pair is supported",
+		           sm.stencil_opval_bf, sm.stencil_testval_bf);
+	}
+	DepthFatal("unsupported stencil compare or replacement state");
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void RenderExecutor::ResolveRenderDepthTarget(uint64_t submit_id, CommandBuffer& buffer,
                                               RenderDepthInfo& r) {
@@ -167,7 +287,7 @@ void RenderExecutor::ResolveRenderDepthTarget(uint64_t submit_id, CommandBuffer&
 	    (!z.depth_view.depth_write_disable && z.z_write_base_addr != z.z_read_base_addr) ||
 	    (z.z_read_base_addr & 0xffffu) != 0 ||
 	    dc.zfunc > static_cast<uint8_t>(vk::CompareOp::eAlways)) {
-		DepthFatal("unsupported depth register state");
+		ReportDepthRegisterRejection(z, rc, dc);
 	}
 	if (has_stencil) {
 		if (z.stencil_info.format != Prospero::StencilFormat::k8UInt || !htile_stencil_compat ||
@@ -175,10 +295,12 @@ void RenderExecutor::ResolveRenderDepthTarget(uint64_t submit_id, CommandBuffer&
 		    (!z.depth_view.stencil_write_disable &&
 		     z.stencil_write_base_addr != z.stencil_read_base_addr) ||
 		    (z.stencil_read_base_addr & 0xffffu) != 0) {
-			DepthFatal("unsupported stencil attachment state");
+			ReportStencilAttachmentRejection(z, htile_stencil_compat);
 		}
 	} else if (z.stencil_read_base_addr != 0 || z.stencil_write_base_addr != 0) {
-		DepthFatal("stencil state without an active stencil attachment");
+		DepthFatal("stencil state without an active stencil attachment: DB_STENCIL_READ_BASE = "
+		           "0x%016" PRIx64 ", DB_STENCIL_WRITE_BASE = 0x%016" PRIx64,
+		           z.stencil_read_base_addr, z.stencil_write_base_addr);
 	}
 	if (has_htile) {
 		if (z.htile_data_base_addr == 0 || (z.htile_data_base_addr & 0x7fffu) != 0) {
@@ -272,7 +394,7 @@ void RenderExecutor::ResolveRenderDepthTarget(uint64_t submit_id, CommandBuffer&
 		    (dc.backface_enable && back_write_mask != 0 &&
 		     UsesStencilOpValue(sc.stencil_fail_bf, sc.stencil_zpass_bf, sc.stencil_zfail_bf) &&
 		     sm.stencil_opval_bf != sm.stencil_testval_bf)) {
-			DepthFatal("unsupported stencil compare or replacement state");
+			ReportStencilOpRejection(dc, sc, sm, front_write_mask, back_write_mask);
 		}
 		r.stencil_static_front = {
 		    ConvertStencilOp(sc.stencil_fail, front_write_mask, sm.stencil_opval),


### PR DESCRIPTION
## Problem

`ResolveRenderDepthTarget` rejects a draw through four compound conditions, and each reports a
single fixed string:

- `unsupported depth register state` -- **15 terms**
- `unsupported stencil attachment state` -- 5 terms
- `stencil state without an active stencil attachment` -- 2 terms
- `unsupported stencil compare or replacement state` -- 4 terms

Twenty-seven register terms between them, four messages. Nothing in the log says which register
was responsible, so a report of one of these cannot be acted on without a local debug build, and
no issue on the tracker names a specific depth condition.

That is not hypothetical. Working out that one title was rejected by `z_read_base_addr == 0` took
a `--graphics-debug-dump` run, a 2.9 MB register dump, and a process of elimination against the
conditions `hw_check` already reports individually -- `hw_check` uses one
`EXIT_NOT_IMPLEMENTED(expr)` per condition, so it prints the expression that failed. This function
does not.

## Fix

Report the term, with the register name and the observed value.

Before:

```
Depth target fatal: unsupported depth register state
```

After:

```
Depth target fatal: DB_Z_READ_BASE is 0 while depth or stencil is active
```

Other examples of the new output:

```
DB_DEPTH_VIEW.MIPID = 3, expected 0
DB_Z_WRITE_BASE = 0x0000000201040000 differs from DB_Z_READ_BASE = 0x0000000201000000 while depth writes are enabled
DB_DEPTH_CONTROL.ZFUNC = 9, expected at most 7
DB_STENCIL_READ_BASE = 0x0000000201234567 is not 64 KiB aligned
```

**What is accepted or rejected does not change.** The deciding conditions are not edited. Each
reporter is `[[noreturn]]` and is called from inside a branch whose condition has already
evaluated true; it re-tests the terms in the order that condition evaluates them and reports the
first that holds, ending with the original fixed string as a fallback.

Two things follow from doing it that way rather than splitting the conditions apart:

- **The accepted path runs none of it.** This function runs once per draw, so a rejection check
  that costs anything on the way through would not be worth a better message.
- **The equivalence is checkable rather than argued.** The only lines this commit removes are the
  four fixed-string calls:

```
$ git diff -U0 upstream/main | grep '^-' | grep -v '^---'
-		DepthFatal("unsupported depth register state");
-			DepthFatal("unsupported stencil attachment state");
-		DepthFatal("stencil state without an active stencil attachment");
-			DepthFatal("unsupported stencil compare or replacement state");
```

Left alone on purpose: the footprint, overflow and backing-range checks below these report derived
computations rather than register fields, so they are a different problem and would only have
widened the diff.

## Test plan

Windows 11, clang-cl 20.1.8, RTX 2060, Release, built on `0c4dfd5`.

- [x] `ctest`: 34/36, unchanged from the baseline built from the same tree.
- [x] Real rejection path. Teardown (PPSA15246) is rejected by this function on `upstream/main`.
      Before: `unsupported depth register state`. After: `DB_Z_READ_BASE is 0 while depth or
      stencil is active`. That is the term that previously needed a register dump to identify.
- [x] Accepted path, Tetris Forever (PPSA25646): 60 fps, screenshot checked, rendering correct.
- [x] Accepted path, PAC-MAN WORLD 2 Re-PAC (PPSA18189): Pac-Village in 3D with correct occlusion,
      layering and shadows, screenshot checked, and **no `Depth target fatal` line anywhere in the
      run**. It passes through these checks constantly and is never rejected.

`shader_recompiler_compute` and `texture_cache_image_overlap` are the two failures in that 34/36.
They fail identically on pristine `upstream/main`, deterministically, both on
`RenderExecutorStencilBindingDiscovery` at `depth texture compatibility identity`. Nothing to do
with this change; I will report them separately.

One measurement worth passing on. `gpu_command_lane` failed 3 of 42 sequential runs on this branch
while the baseline passed 42/42, which looked like a regression -- it is built from the same test
binary as the file being changed. Alternating the two binaries under identical conditions, 50 runs
each, gives baseline **42 pass / 8 fail** and this branch **46 pass / 4 fail**, so the baseline
flakes more and the sequential result was machine drift. The assertion is `compute kOnly interrupt
was misrouted, broadcast, or lost a label write`, which is a race and unrelated to depth
diagnostics. Mentioning it because that test appears to be flaky on main at roughly 8 to 16
percent, which is worth knowing when reading anyone's CI.

**Not verified:** only one title is known to reach these rejections, so only the
`z_read_base_addr == 0` message has been produced by a real guest. The other twenty-six are
reached by the same reporters and mirror the terms directly above them, but I have not exercised
them individually. PAC-MAN covers the accepted side of all four conditions.

## AI use

Developed with AI assistance (Claude). It hit the generic message while investigating an unrelated
depth rejection, wrote the change, and ran the builds, the `ctest` runs, the interleaved flake A/B
and the game runs above on my machine. I reviewed the diff, checked that the deciding conditions
are untouched and that each reporter re-tests its terms in the same order as the condition it
reports for, and looked at the before and after output myself.