### PR TITLE
tests: bind Hi-Stencil explicitly in the stencil discovery case

### DIFF
--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -8346,6 +8346,14 @@ public:
       phased_depth_target.stencil_info.format = Prospero::StencilFormat::k8UInt;
       phased_depth_target.stencil_info.texture_compatibility =
           Prospero::TextureCompatibleStencil::kEnable;
+      // Hi-Stencil has to be on for this case: the assertion below requires
+      // metadata.stencil_compressed, which ResolveRenderDepthTarget derives from
+      // has_stencil && has_htile && !htile_stencil_disabled. Production always
+      // reaches that field through DepthStencilInfo::Decode, which writes every
+      // member, so only a directly constructed register like this one depends on
+      // the member default, and depending on it is what made this case silently
+      // change meaning when the default flipped.
+      phased_depth_target.stencil_info.htile_stencil_disabled = false;
       phased_depth_target.z_read_base_addr = phased_depth_address;
       phased_depth_target.z_write_base_addr = phased_depth_address;
       phased_depth_target.stencil_read_base_addr = phased_stencil_address;


### PR DESCRIPTION
## Problem

`RenderExecutorStencilBindingDiscovery` fails on `main`, which fails both
`shader_recompiler_compute` and `texture_cache_image_overlap`. It fails during the host
phase, so the binary never reaches its compute cases: **56 of 343 cases run before the
abort, and all 272 compute cases are skipped.**

Seven open PRs currently have to explain this failure in their test plans, and no issue
tracks it.

## Root cause

The assertion names twelve conditions and reports one message. Instrumenting them
individually shows exactly one is false:

```
c1_image_id=1 c2_htile=1 c3_same_id=1 c4_data=1 c5_stencil=1 c6_range=1
c7_stencil_compressed=0 c8_no_depth_clear=1 c9_no_meta_clear=1 c10_not_meta=1
c11_not_gpu_mod=1 c12_not_depth_target=1
```

So the logical depth image identity the case is named for is intact. What is false is
`metadata.stencil_compressed`, which `ResolveRenderDepthTarget` derives from:

```
has_stencil && has_htile && !z.stencil_info.htile_stencil_disabled
```

The case builds an `HW::DepthRenderTarget` directly and sets format, texture compatibility,
HTile acceleration, the addresses and the extent, but never sets `htile_stencil_disabled`,
so it takes the member default. `1df06e2` ("guest_gpu: remove stale PS4/GCN era gpu
registers") flipped that default from `false` to `true`. It updated other cases in this file
for its register changes but not this one, so the setup silently came to describe a target
with Hi-Stencil disabled while the assertion still required stencil compression.

Confirmed by building and running the case either side of it:

- `39a34fa` (parent): passes
- `1df06e2`: fails with this assertion

## Fix

The default is not observable in production. `stencil_info` is only ever populated by
`DepthStencilInfo::Decode`, at both of its call sites in `pm4Handlers.cpp`, and `Decode`
assigns every member including `htile_stencil_disabled` from bit `0x20000000`. Before any
`DB_STENCIL_INFO` write the format is `kInvalid`, so `has_stencil` is false and
`stencil_compressed` is false whichever default is in place. Only a directly constructed
register, which is to say a test, can depend on it.

So the derivation is right and the setup was stale. This states the field instead of
inheriting it, the way the same case already states `z_compare_base` — which is why the
other default `1df06e2` changed did not break it.

The assertion is unchanged, and the diff touches no file under `src/`.

## Test plan

Windows 11, clang-cl 20.1.8, RTX 2060, Release, built on `8022501`.

- [x] `ctest`: **34/36 to 36/36**. `shader_recompiler_compute` and
      `texture_cache_image_overlap` both pass.
- [x] The shader binary now runs its suite instead of aborting: **56 executed cases to 343**
      (272 compute, 9 graphics, 6 gpu, 56 host), exit 0, "all cases passed".
- [x] The 287 newly reachable cases expose no further failures, so nothing was hidden behind
      the abort.
- [x] Tetris Forever `PPSA25646`: 60 fps, checked against a screenshot, rendering correct.

No runtime behaviour can change here — the diff contains no production file.

**Not addressed:** whether `htile_stencil_disabled` defaulting to `true` is the right reset
value for the register is a separate question. It is inert in production either way, so I
left the deliberate change from `1df06e2` alone rather than revert it to make a test pass.

## AI use

Developed with AI assistance (Claude). It instrumented the twelve conditions to find which
one failed, bisected the default change to `1df06e2` by building and running the case either
side of it, checked that `Decode` makes the default unobservable in production, and ran the
builds, ctest runs and the game check above on my machine. I reviewed the diff and confirmed
it changes no production code.