### PR TITLE
ci: run the recompiler unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,12 +105,15 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          cmake --build _Build/windows --target launcher audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests --parallel
+          cmake --build _Build/windows --target launcher ^
+            audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests ^
+            resource_tracking_tests scalar_provenance_tests ^
+            shader_stage_runtime_tests shader_vertex_metadata_tests --parallel
 
       - name: Test
         shell: cmd
         run: |
-          ctest --test-dir _Build/windows --output-on-failure -R "^(audio_out2_port|ime_dialog|virtual_memory_allocation)$"
+          ctest --test-dir _Build/windows --output-on-failure -R "^(audio_out2_port|ime_dialog|resource_tracking|scalar_provenance|shader_stage_runtime|shader_vertex_metadata|virtual_memory_allocation)$"
 
       - name: Install
         shell: cmd
@@ -187,13 +190,15 @@ jobs:
         run: |
           cmake --build _Build/macos \
             --target launcher audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests \
+              resource_tracking_tests scalar_provenance_tests \
+              shader_stage_runtime_tests shader_vertex_metadata_tests \
             --parallel
 
       - name: Test
         shell: bash
         run: |
           ctest --test-dir _Build/macos --output-on-failure \
-            -R '^(audio_out2_port|ime_dialog|virtual_memory_allocation)$'
+            -R '^(audio_out2_port|ime_dialog|resource_tracking|scalar_provenance|shader_stage_runtime|shader_vertex_metadata|virtual_memory_allocation)$'
 
       - name: Install
         shell: bash
@@ -362,13 +367,15 @@ jobs:
           cmake --build _Build/linux \
             --target launcher page_manager_tests memory_tracker_tests \
               audio_out2_port_tests ime_dialog_tests virtual_memory_allocation_tests \
+              resource_tracking_tests scalar_provenance_tests \
+              shader_stage_runtime_tests shader_vertex_metadata_tests \
             --parallel
 
       - name: Test
         shell: bash
         run: |
           ctest --test-dir _Build/linux --output-on-failure \
-            -R '^(audio_out2_port|ime_dialog|page_manager|memory_tracker|virtual_memory_allocation)$'
+            -R '^(audio_out2_port|ime_dialog|memory_tracker|page_manager|resource_tracking|scalar_provenance|shader_stage_runtime|shader_vertex_metadata|virtual_memory_allocation)$'
 
       - name: Install
         shell: bash


### PR DESCRIPTION
## What CI runs today

Five of the thirty-six registered tests:

- Windows and macOS: `audio_out2_port`, `ime_dialog`, `virtual_memory_allocation`
- Linux: those three plus `page_manager`, `memory_tracker`

Everything else is only ever run locally.

## Why that matters

`shader_recompiler_compute` was failing on `main` and every CI build reported green. It is
not the only one: `resource_tracking` currently fails on an open PR whose CI is also green,
because that test does not run either.

## Why shader_recompiler_compute cannot simply be added

All sixteen tests built from `shader_recompiler_compute_tests` go through `VulkanHarness`,
which does:

```cpp
Require("VulkanHarness", "dispatch", physical_count != 0, "no Vulkan physical devices");
```

`Require` is fatal. `windows-2022`, `macos-15` and `ubuntu-24.04` have no GPU and this
workflow installs no ICD, so those sixteen would abort rather than run.

That is also why the current five are what they are: they are the CPU-only tests. Only
`ShaderRecompilerComputeTests.cpp` touches Vulkan; every other test source has no reference
to it. Running the GPU suite would mean adding a software rasterizer to all three jobs, and
lavapipe would still have to cover the texel-pointer atomics, subgroup operations and buffer
device addresses these tests use. That is a bigger change than this one and I have not
attempted it.

## What this adds

Of the twenty CPU-only tests, fifteen do not run in CI. This adds the four that cover the
shader recompiler:

- `resource_tracking` — resource specialization and validation
- `scalar_provenance` — scalar and SRT provenance
- `shader_stage_runtime` — stage runtime and snapshot rematerialization
- `shader_vertex_metadata` — vertex metadata

CI builds only the targets it runs, so each is added to both the `--target` list and the
`-R` filter, on all three jobs.

`shader_cfg` is left out on purpose. It is also CPU-only and also a recompiler test, but it
is declared with `add_kyty_full_emulator_test`, which compiles `${kyty_emulator_src}` into
the target — 952 objects, the same weight as `virtual_memory_allocation_tests`. Including it
means a second whole-emulator compile in every job for one more test. Happy to add it if you
would rather have the coverage than the build time.

## Validation

Windows 11, clang-cl 20.1.8, Release, on `04b404f`.

- [x] `ctest -N` before and after, both filter shapes: no existing test is dropped, exactly
      four are added.
- [x] The exact new Linux selection runs 9 tests, all pass, 0.52 s total. The four new ones
      account for 0.22 s.
- [x] The exact new `--target` list builds with exit 0, so every target name is valid.
- [x] The workflow still parses, and all three jobs' Build and Test steps were re-read after
      the edit.

**No CI run yet.** This workflow triggers on `workflow_dispatch`, push to main/master and
`pull_request`, so pushing the branch to my fork ran nothing, and Actions is not enabled on
my fork. The first real run will be this pull request. The build cost above is measured from
object counts and local timings, not from a CI run.

Worth noting for whoever rebases: #413 adds an Arch Linux job that reuses the current
five-test filter. Whichever of the two lands second should carry the wider filter across.

## AI use

Developed with AI assistance (Claude). It traced the Vulkan device requirement to
`VulkanHarness::Init`, classified all thirty-six tests by whether their binary needs a
device, measured the object counts and runtimes quoted above, and made the workflow edit on
my machine. I reviewed the diff and confirmed no existing test is removed from any job.