### PR TITLE
shader: apply a storage buffer's host offset at byte granularity

### DIFF
--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -22,6 +22,7 @@
 #include "graphics/host_gpu/renderer/renderContext.h"
 #include "graphics/host_gpu/vma.h"
 #include "graphics/host_gpu/vulkanCommon.h"
+#include "graphics/shader/recompiler/BufferFormat.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 #include "graphics/shader/recompiler/ir/passes/BindingLayout.h"
 #include "graphics/shader/recompiler/ir/passes/ResourceMaterialization.h"
@@ -167,6 +168,27 @@ static bool IsMultisampledTexture(Prospero::ImageType type) {
 	       type == Prospero::ImageType::kColor2DMsaaArray;
 }
 
+// Whether every access the shader can make through this buffer reads or writes fewer than 32 bits
+// at a time. Those go through the sub-word path, which derives both the element index and the byte
+// within the element from one byte address, so a binding whose base is not dword aligned stays
+// exact. Anything that loads a whole dword -- a 32-bit component, a packed bitfield, a scalar
+// buffer read, an atomic -- indexes by dword and would silently straddle two of them instead.
+static bool BufferAccessIsSubDword(const ShaderRecompiler::IR::BufferResource& resource) {
+	if (!resource.formatted || resource.scalar || resource.atomic) {
+		return false;
+	}
+	const auto info = ShaderRecompiler::Format::GetFormatInfo(resource.descriptor_format);
+	if (info.type == ShaderRecompiler::Format::ComponentType::Unknown || info.packed_bitfield) {
+		return false;
+	}
+	for (uint32_t component = 0; component < info.component_count; component++) {
+		if (info.component_bits[component] >= 32u) {
+			return false;
+		}
+	}
+	return info.component_count != 0;
+}
+
 static BufferView NativeStorageBuffer(RenderContext&                              context,
                                       const ShaderBufferResource&                 descriptor,
                                       const ShaderRecompiler::IR::BufferResource& resource,
@@ -198,8 +220,15 @@ static BufferView NativeStorageBuffer(RenderContext&                            
 	const auto aligned_offset = offset - offset % alignment;
 	const auto adjustment     = offset - aligned_offset;
 	const auto max_range      = graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange;
-	if (adjustment % sizeof(uint32_t) != 0 || adjustment >= 256 || size > max_range - adjustment) {
-		EXIT("storage buffer offset adjustment is unsupported\n");
+	const bool dword_aligned_adjustment = adjustment % sizeof(uint32_t) == 0;
+	if ((!dword_aligned_adjustment && !BufferAccessIsSubDword(resource)) || adjustment >= 256 ||
+	    size > max_range - adjustment) {
+		EXIT("storage buffer offset adjustment is unsupported: adjustment=0x%" PRIx64
+		     " size=0x%" PRIx64 " format=0x%" PRIx32 " scalar=%d atomic=%d formatted=%d\n",
+		     static_cast<uint64_t>(adjustment), size,
+		     static_cast<uint32_t>(resource.descriptor_format),
+		     static_cast<int>(resource.scalar), static_cast<int>(resource.atomic),
+		     static_cast<int>(resource.formatted));
 	}
 	buffer_offset = static_cast<uint32_t>(adjustment);
 	result.buffer = buffer->Handle();

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
@@ -93,11 +93,22 @@ uint32_t BufferByteAddress(ValueEmitContext& ctx, const IR::Inst& inst, const IR
 	}
 
 	const auto soffset_value = inst.Arg(3).Resolve();
-	if (soffset_value.IsImmediate() && soffset_value.GetType() == IR::Type::U32 &&
-	    soffset_value.U32() == 0u) {
-		return address;
+	if (!(soffset_value.IsImmediate() && soffset_value.GetType() == IR::Type::U32 &&
+	      soffset_value.U32() == 0u)) {
+		address = Binary(state, OpIAdd, TypeU32(state), address, soffset);
 	}
-	return Binary(state, OpIAdd, TypeU32(state), address, soffset);
+
+	// The descriptor is bound at the guest base rounded down to minStorageBufferOffsetAlignment,
+	// and the bytes that were rounded off arrive as the binding's byte offset. Add them here,
+	// before the address is split into an element index and an intra-element byte, so a base that
+	// is not dword aligned stays exact in both halves.
+	if (state.storage_buffer_variable != 0) {
+		const auto binding =
+		    ResourceForDescriptor(state, IR::DescriptorBindingKind::Buffers, mem.resource);
+		address = Binary(state, OpIAdd, TypeU32(state), address,
+		                 state.memory_byte_offsets[binding.array_index]);
+	}
+	return address;
 }
 
 uint32_t AddU64Low(EmitterState& state, uint32_t low, uint32_t high, uint32_t add_low,

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemoryHelpers.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemoryHelpers.cpp
@@ -123,10 +123,20 @@ MemoryResourceAccess PrepareMemoryResourceAccess(EmitterState& state, const IR::
 			state.builder.AddFunction({OpAccessChain, TypeStorageBufferPointer(state),
 			                           access.object_pointer, state.storage_buffer_variable,
 			                           ConstantU32(state, binding.array_index)});
-			access.index_offset     = EmitBinaryU32(state, OpShiftRightLogical,
-			                                        state.memory_byte_offsets[binding.array_index],
-			                                        ConstantU32(state, 2u));
-			access.add_index_offset = true;
+			// A Buffer access derives its element index and its intra-element byte from one byte
+			// address, so BufferByteAddress folds the binding's byte offset in there instead and
+			// no index offset is needed. That keeps the low two bits of the offset, which a
+			// dword index cannot carry.
+			//
+			// ScalarBuffer has no byte address to fold into: ReadConstBuffer loads a whole dword
+			// at address >> 2, so it still takes the offset as a dword index and still requires
+			// the binding to be dword aligned.
+			if (mem.kind == IR::ResourceKind::ScalarBuffer) {
+				const auto byte_offset  = state.memory_byte_offsets[binding.array_index];
+				access.index_offset     = EmitBinaryU32(state, OpShiftRightLogical, byte_offset,
+				                                        ConstantU32(state, 2u));
+				access.add_index_offset = true;
+			}
 			break;
 		}
 		default: EXIT("unsupported memory resource kind: %u\n", static_cast<unsigned>(mem.kind));

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -1307,7 +1307,7 @@ CompiledShader CompileCase(const TestCase &test) {
     if (i < test.storage_buffer_offsets.size()) {
       offset = test.storage_buffer_offsets[i];
     }
-    Require(test.name, "shader data", offset % sizeof(u32) == 0 && offset < 256,
+    Require(test.name, "shader data", offset < 256,
             "storage buffer offset is not representable");
     packed_user_data[result.program.bindings.memory_offset_dword + i / 4u] |=
         offset << ((i % 4u) * 8u);
@@ -16892,6 +16892,34 @@ TestCase BufferStoreDwordAppliesHostOffset() {
   return test;
 }
 
+TestCase BufferStoreByteAppliesByteHostOffset() {
+  using O = ShaderOpcode;
+
+  // The binding's byte offset is 13, which is not a multiple of four. It has to reach both halves
+  // of the address: the element index and the byte within that element. Storing one byte at guest
+  // offset 0 must therefore land at byte 13, which is byte 1 of dword 3.
+  //
+  // Folding the offset in as a dword index instead loses the low two bits and puts the byte at
+  // byte 12, so this case distinguishes the two.
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0xabu);
+  code.push_back(EncodeMubuf0(0x18u, 0, false, false));
+  code.push_back(EncodeMubuf1(0, 0, 20));
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "BufferStoreByteAppliesByteHostOffset";
+  test.code = code;
+  test.initial = {0, 0, 0, 0, 0};
+  test.expected = {0, 0, 0, 0x0000ab00u, 0};
+  test.storage_buffer_range_dwords = 1;
+  test.storage_buffer_offsets = {13};
+  test.opcodes = {O::V_MOV_B32, O::BUFFER_STORE_BYTE, O::S_ENDPGM};
+  test.user_data = MakeStructuredStorageBufferData(4, 1);
+  test.has_user_data = true;
+  return test;
+}
+
 TestCase BufferOffsetsUsePackedLaneAndStorageFallback() {
   using O = ShaderOpcode;
 
@@ -21299,6 +21327,7 @@ std::vector<TestCase> MakeCases() {
   AddCase(BufferStoreDwordIdxenUsesDescriptorStride);
   AddCase(BufferStoreDwordAppliesHostOffset);
   AddCase(BufferOffsetsUsePackedLaneAndStorageFallback);
+  AddCase(BufferStoreByteAppliesByteHostOffset);
   AddCase(BufferLoadVariants);
   AddCase(BufferLoadDwordx2SnapshotsOverlappingAddress);
   AddCase(BufferLoadDwordx3SnapshotsOverlappingAddress);


### PR DESCRIPTION
## Problem

A storage buffer is bound at the guest base rounded down to `minStorageBufferOffsetAlignment`,
and the bytes that were rounded off are handed to the shader as an 8-bit offset per buffer.
The shader took them as a dword index:

```cpp
access.index_offset = memory_byte_offsets[i] >> 2;
```

so the low two bits were dropped, and `NativeStorageBuffer` rejected any binding that needed
them with `storage buffer offset adjustment is unsupported`. The device alignment here is 16,
so three of every four guest base addresses land in that guard.

Teardown (PPSA15246) hits it about a second into boot. Its first compute shader reads a byte
buffer whose base is 13 bytes past the boundary:

```
stage=Compute stride=0x1 format=k8UInt offset=0x5f4d1d alignment=0x10 adjustment=0xd
scalar=0 atomic=0 written=0 max_byte_extent=0x10
```

## Fix

Nothing here needs a new mechanism. A `Buffer` access already derives both its element index
and its byte within that element from one byte address: `LoadSubwordPrepared` computes
`address >> 2` for the index and `LoadSubwordInBounds` uses `address & 3` for the shift. The
offset was being folded in after that split instead of before it.

So fold it into the byte address, in `BufferByteAddress`, which every `Buffer` consumer
derives from. The element index, the sub-word shift and the bounds check then all stay exact
for any offset.

`ScalarBuffer` keeps the dword index. `ReadConstBuffer` loads a whole dword at `address >> 2`
and has no byte address to fold into, so a base that is not dword aligned would straddle two
elements. The guard still rejects that, and still rejects anything else that touches 32 bits
at a time — a 32-bit component, a packed bitfield, an atomic. `BufferAccessIsSubDword` names
the case that is safe rather than widening the check, and the message now prints its operands
so the next title to reach it does not need a debug build.

## Test plan

Windows 11, clang-cl 20.1.8, RTX 2060, Release.

- [x] New `BufferStoreByteAppliesByteHostOffset`: offset 13, one byte stored, expected at byte
      13. Reverting just the emitter change makes it fail with
      `expected [...0x0000ab00...] actual [...0x000000ab...]` — the byte lands at 12 instead
      of 13, which is exactly the two bits the shift discarded. The harness itself asserted
      `offset % 4 == 0`; that assumption was part of the bug and is relaxed.
- [x] `shader_recompiler_compute_tests`: 344 cases, all pass, including all 272 compute cases.
- [x] `ctest` 36/36 with #446 applied. On plain `main` it is 34/36, unchanged from baseline —
      the two failures are the pre-existing `RenderExecutorStencilBindingDiscovery` ones.
- [x] Teardown PPSA15246: **19 compiled shaders to 25**, and the storage message is gone. It
      then stops in resource tracking with
      `GetBufferResource dword 0 is not a valid runtime value`, which is unrelated to this.
      **Teardown still does not boot** — this removes one blocker and nothing more is claimed.
- [x] PAC-MAN WORLD 2 Re-PAC PPSA18189, which exercises storage buffers throughout: renders
      correctly, checked against a screenshot, with no shader or storage errors in the log.

Reaching the Teardown blocker at all needs #443, which is still open; the fix here is
independent of it and is based on plain `main`.

Worth flagging: #427 also edits `NativeStorageBuffer`, for range clamping rather than this
guard, so the two will conflict textually if both land.

## AI use

Developed with AI assistance (Claude). It reproduced the blocker, added the diagnostic that
exposed the format and access flags, traced the address path to `BufferByteAddress`, wrote the
change and the regression test, and ran the builds, the test suite and the game runs above on
my machine. I reviewed the diff and confirmed the `ScalarBuffer` path still takes the dword
index.