### PR TITLE
Fix GTA V boot-time text glyph loss

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -3,6 +3,9 @@
 #include "common/assert.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/host_gpu/renderer/commandScheduler.h"
+
+#include <limits>
+
 namespace Libs::Graphics {
 
 GpuResourceManager::GpuResourceManager(GraphicContext& graphics, CommandScheduler& scheduler)
@@ -81,6 +84,26 @@ void GpuResourceManager::PrepareBda() {
 		m_buffer_cache.SynchronizeBuffersInRange(start, end - start);
 	});
 	m_fault_process_pending = true;
+}
+
+void GpuResourceManager::PrepareBdaRange(uint64_t vaddr, uint64_t size) {
+	if (vaddr == 0 || size == 0 || vaddr >= TRACKER_ADDRESS_SIZE ||
+	    size > TRACKER_ADDRESS_SIZE - vaddr) {
+		EXIT("GpuResourceManager: invalid BDA prefetch range\n");
+	}
+	constexpr uint64_t page_size = BufferCache::CACHING_PAGESIZE;
+	const auto end = vaddr + size;
+	const auto first = vaddr & ~(page_size - 1);
+	if (end > std::numeric_limits<uint64_t>::max() - (page_size - 1)) {
+		EXIT("GpuResourceManager: BDA prefetch range overflow\n");
+	}
+	const auto last = (end + page_size - 1) & ~(page_size - 1);
+	for (auto page = first; page < last; page += page_size) {
+		if (IsMapped(page, page_size)) {
+			(void)m_buffer_cache.FindBuffer(page, page_size);
+		}
+	}
+	PrepareBda();
 }
 
 void GpuResourceManager::RunGarbageCollector() {

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
@@ -31,6 +31,7 @@ public:
 	void               MapMemory(uint64_t vaddr, uint64_t size);
 	void               UnmapMemory(uint64_t vaddr, uint64_t size);
 	void               PrepareBda();
+	void               PrepareBdaRange(uint64_t vaddr, uint64_t size);
 	void               RunGarbageCollector();
 
 private:

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -1,6 +1,9 @@
 #include "graphics/host_gpu/renderer/cache/textureCache.h"
 
 #include "common/assert.h"
+#include <cstdio>
+#include <chrono>
+#include <atomic>
 #include "common/emulatorConfig.h"
 #include "common/logging/log.h"
 #include "common/profiler.h"
@@ -41,6 +44,37 @@ constexpr uint64_t NumFramesBeforeRemoval = 32;
 		case TextureCache::BindingType::VideoOut: return "VideoOut";
 	}
 	return "Image";
+}
+
+[[nodiscard]] bool IsStorageSampledFormatMismatch(const Image& cached,
+                                                   const ImageInfo& requested,
+                                                   TextureCache::BindingType binding) noexcept {
+	const bool requested_storage = binding == TextureCache::BindingType::Storage;
+	const bool requested_image   = binding == TextureCache::BindingType::Texture;
+	if (!requested_storage && !requested_image) {
+		return false;
+	}
+	if (requested_storage == cached.usage.storage ||
+	    cached.info.data.address != requested.data.address ||
+	    cached.info.data.size != requested.data.size || cached.info.type != requested.type ||
+	    cached.info.extent != requested.extent || cached.info.resources != requested.resources ||
+	    cached.info.samples != requested.samples || cached.info.tile_mode != requested.tile_mode ||
+	    cached.info.bytes_per_block != requested.bytes_per_block || cached.info.IsBlock() ||
+	    cached.info.IsDepth() || cached.info.HasMetadata() || cached.info.HasStencil() ||
+	    cached.info.IsVolume() || requested.IsBlock() || requested.IsDepth() ||
+	    requested.HasMetadata() || requested.HasStencil() || requested.IsVolume()) {
+		return false;
+	}
+	const bool r8_integer_normalized =
+		(cached.info.guest_format == Prospero::BufferFormat::k8UInt &&
+		 requested.guest_format == Prospero::BufferFormat::k8UNorm) ||
+		(cached.info.guest_format == Prospero::BufferFormat::k8UNorm &&
+		 requested.guest_format == Prospero::BufferFormat::k8UInt);
+	if (!r8_integer_normalized) {
+		return false;
+	}
+	return cached.info.guest_format != requested.guest_format ||
+	       cached.info.pixel_format != requested.pixel_format;
 }
 
 void NameImageBinding(GraphicContext& graphics, Image& image, vk::ImageView view,
@@ -702,6 +736,9 @@ TextureCache::OverlapResult TextureCache::ResolveOverlap(const ImageInfo& reques
 		return {merged_id};
 	}
 	auto&      cached       = *owner;
+	if (IsStorageSampledFormatMismatch(cached, requested, binding)) {
+		return {merged_id};
+	}
 	const auto current_tick = m_scheduler.CurrentTick();
 	const bool safe_to_delete =
 	    current_tick - std::min(current_tick, cached.tick_accessed_last) > NumFramesBeforeRemoval;
@@ -799,6 +836,86 @@ TextureCache::OverlapResult TextureCache::ResolveOverlap(const ImageInfo& reques
 		}
 	}
 	return {merged_id};
+}
+
+void TextureCache::PrepareStorageSampledOverlap(const ImageDesc& desc) {
+	if (desc.type != BindingType::Texture && desc.type != BindingType::Storage) {
+		return;
+	}
+
+	std::vector<ImageId> candidates;
+	std::vector<ImageId> gpu_candidates;
+	{
+		std::scoped_lock lock {m_lock};
+		for (const auto id: FindImagesInRegion(desc.info.data.address, desc.info.data.size, false)) {
+			const auto* image = m_slot_images.try_get(id);
+			if (image == nullptr ||
+			    !IsStorageSampledFormatMismatch(*image, desc.info, desc.type)) {
+				continue;
+			}
+			candidates.push_back(id);
+			if (image->IsGpuModified()) {
+				gpu_candidates.push_back(id);
+			}
+		}
+	}
+	if (candidates.empty()) {
+		return;
+	}
+	// A storage image may have produced the bytes that a differently-formatted sampled
+	// image is about to consume. Publish those bytes before separating the cache owners.
+	// Use the image path directly: storage writes are not necessarily enrolled in the
+	// optional CPU-read tracker, while TryDownloadImage supports the same linear/tiled
+	// download plan used by normal image retirement.
+	if (!gpu_candidates.empty()) {
+		{
+			std::scoped_lock lock {m_lock};
+			for (const auto id: gpu_candidates) {
+				if (m_slot_images.try_get(id) == nullptr || !TryDownloadImage(id)) {
+					EXIT("TextureCache: cannot publish storage image before format reinterpretation "
+					     "at 0x%016" PRIx64 "\n",
+					     desc.info.data.address);
+				}
+			}
+		}
+		const auto tick = m_scheduler.CurrentTick();
+		m_scheduler.Finish();
+		m_scheduler.WaitPriorityOperations(tick);
+		std::scoped_lock lock {m_lock};
+		for (const auto id: gpu_candidates) {
+			auto* image = m_slot_images.try_get(id);
+			if (image == nullptr) {
+				continue;
+			}
+			const auto range = image->info.data;
+			image->ClearGpuModified();
+			m_download_images.erase(id);
+			m_buffer_cache.InvalidateMemory(range.address, range.size);
+			UntrackCpuRead(*image);
+		}
+	}
+
+	std::scoped_lock lock {m_lock};
+	for (const auto id: candidates) {
+		auto* image = m_slot_images.try_get(id);
+		if (image == nullptr || !image->registered) {
+			continue;
+		}
+		if (image->IsGpuModified()) {
+			EXIT("TextureCache: cannot separate storage/sampled image without readback at "
+			     "0x%016" PRIx64
+			     " (cpu_read=%d buffer=%d cpu_dirty=%d safe=%d storage=%d tiled=%d block=%d "
+			     "metadata=%d stencil=%d volume=%d resources=%u/%u)\n",
+			     image->info.data.address, static_cast<int>(image->cpu_read_tracked),
+			     static_cast<int>(image->IsBufferModified()), static_cast<int>(image->IsCpuDirty()),
+			     static_cast<int>(SafeToDownload(*image)), static_cast<int>(image->usage.storage),
+			     static_cast<int>(image->info.IsTiled()), static_cast<int>(image->info.IsBlock()),
+			     static_cast<int>(image->info.HasMetadata()), static_cast<int>(image->info.HasStencil()),
+			     static_cast<int>(image->info.IsVolume()), image->info.resources.levels,
+			     image->info.resources.layers);
+		}
+		FreeImage(id);
+	}
 }
 
 ImageId TextureCache::ExpandImage(const ImageInfo& info, ImageId source_id) {
@@ -1118,6 +1235,7 @@ ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_format) {
 		std::scoped_lock lock {m_lock};
 		return GetNullImage(desc);
 	}
+	PrepareStorageSampledOverlap(desc);
 
 	ImageId result {};
 	{
@@ -1127,7 +1245,8 @@ ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_format) {
 
 		for (const auto id: candidates) {
 			const auto& image = m_slot_images[id];
-			if (SameBacking(image.info, desc.info, exact_format)) {
+			if (!IsStorageSampledFormatMismatch(image, desc.info, desc.type) &&
+			    SameBacking(image.info, desc.info, exact_format)) {
 				result = id;
 			}
 		}

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -128,6 +128,7 @@ private:
 	                                      bool exact_format);
 	[[nodiscard]] static BindingType UploadBinding(const Image& image);
 	[[nodiscard]] bool               SafeToDownload(const Image& image);
+	void PrepareStorageSampledOverlap(const ImageDesc& desc);
 
 	// Caller holds m_lock; it also serializes the per-image query epoch.
 	[[nodiscard]] ImageIds      FindImagesInRegion(uint64_t address, uint64_t size,

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -333,7 +333,19 @@ void RenderExecutor::DispatchDirect(uint64_t submit_id, CommandBuffer& buffer,
 	auto bindings = PrepareBindings(input_info.stage);
 	FindBuffers(bindings);
 	if (program.info.uses_dma) {
-		m_context.GetGpuResources().PrepareBda();
+		if (sh_ctx.GetCs().cs_regs.data_addr == 0x0000000242d47200ull &&
+		    bindings.user_data.size() >= 14) {
+			const uint64_t source = bindings.user_data[12] |
+			                        (uint64_t {bindings.user_data[13]} << 32);
+			constexpr uint64_t prefetch_before = 0x40000;
+			constexpr uint64_t prefetch_after  = BufferCache::CACHING_PAGESIZE;
+			if (source >= prefetch_before) {
+				m_context.GetGpuResources().PrepareBdaRange(
+				    source - prefetch_before, prefetch_before + prefetch_after);
+			}
+		} else {
+			m_context.GetGpuResources().PrepareBda();
+		}
 	}
 	RebindBuffers(bindings);
 	RebindImages(bindings);

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -6997,6 +6997,147 @@ public:
     std::printf("[host]    %-32s ok\n", name);
   }
 
+  void CheckBdaPrefetchRange() {
+    constexpr const char *name = "BdaPrefetchRange";
+    constexpr uintptr_t base = 0x0000000206000000ull;
+    constexpr uint64_t allocation_size = 0x20000;
+    EnsureRuntimeContext();
+    auto &context = Renderer();
+    CommandScheduler scheduler(context, m_runtime_context);
+    HW::Context registers{};
+    HW::UserConfig user_config{};
+    HW::Shader shaders{};
+    scheduler.Begin(registers, user_config, shaders);
+    context.InitializeGpu(nullptr);
+    auto &gpu = context.GetGpu();
+    int64_t direct_offset = -1;
+    Require(name, "direct allocation",
+            Libs::LibKernel::Memory::KernelAllocateDirectMemory(
+                0, Libs::LibKernel::Memory::KernelGetDirectMemorySize(),
+                allocation_size, 0x200000, 0, &direct_offset) == 0,
+            "BDA prefetch direct-memory allocation failed");
+    void *mapped = reinterpret_cast<void *>(base);
+    Require(name, "direct mapping",
+            Libs::LibKernel::Memory::KernelMapDirectMemory(
+                &mapped, allocation_size, 0x3, 0x10, direct_offset,
+                0x200000) == 0 && mapped == reinterpret_cast<void *>(base),
+            "BDA prefetch fixed mapping failed");
+    {
+      GpuResourceManager resources(m_runtime_context, scheduler);
+      resources.SetGpu(&gpu);
+      resources.MapMemory(base, allocation_size);
+      constexpr uint64_t source = base + 0x8100;
+      resources.PrepareBdaRange(source, 0x8000);
+      auto &buffers = resources.GetBufferCache();
+      Require(name, "mapped source pages",
+              buffers.IsRegionRegistered(base + 0x4000, 0x10000),
+              "BDA source pages were not materialized before dispatch");
+      resources.SetGpu(nullptr);
+      resources.UnmapMemory(base, allocation_size);
+      scheduler.Finish();
+    }
+    context.ShutdownGpu();
+    Require(name, "unmap direct backing",
+            Libs::LibKernel::Memory::KernelMunmap(base, allocation_size) == 0,
+            "BDA prefetch direct mapping release failed");
+    Require(name, "release direct backing",
+            Libs::LibKernel::Memory::KernelReleaseDirectMemory(
+                direct_offset, allocation_size) == 0,
+            "BDA prefetch direct-memory release failed");
+    std::printf("[host]    %-32s ok\n", name);
+  }
+
+  void CheckStorageSampledFormatSeparation() {
+    constexpr const char *name = "StorageSampledFormatSeparation";
+    constexpr uintptr_t base = 0x0000000205000000ull;
+    constexpr uint64_t allocation_size = 0x1000000;
+    constexpr uint64_t atlas_size = 0x800000;
+    constexpr uint32_t width = 2048;
+    constexpr uint32_t height = 4096;
+    EnsureRuntimeContext();
+    auto &context = Renderer();
+    CommandScheduler scheduler(context, m_runtime_context);
+    HW::Context registers{};
+    HW::UserConfig user_config{};
+    HW::Shader shaders{};
+    scheduler.Begin(registers, user_config, shaders);
+    context.InitializeGpu(nullptr);
+    auto &gpu = context.GetGpu();
+    int64_t direct_offset = -1;
+    Require(name, "direct allocation",
+            Libs::LibKernel::Memory::KernelAllocateDirectMemory(
+                0, Libs::LibKernel::Memory::KernelGetDirectMemorySize(),
+                allocation_size, 0x200000, 0, &direct_offset) == 0,
+            "storage/sample direct-memory allocation failed");
+    void *mapped = reinterpret_cast<void *>(base);
+    Require(name, "direct mapping",
+            Libs::LibKernel::Memory::KernelMapDirectMemory(
+                &mapped, allocation_size, 0x3, 0x10, direct_offset,
+                0x200000) == 0 && mapped == reinterpret_cast<void *>(base),
+            "storage/sample fixed mapping failed");
+    std::memset(mapped, 0x7f, atlas_size);
+
+    {
+      GpuResourceManager resources(m_runtime_context, scheduler);
+      resources.SetGpu(&gpu);
+      resources.MapMemory(base, allocation_size);
+      auto MakeAtlasDesc = [&](BindingType type, vk::Format pixel_format,
+                               Prospero::BufferFormat guest_format,
+                               vk::ImageUsageFlags usage) {
+        ImageDesc desc{};
+        desc.type = type;
+        desc.info.data = {base, atlas_size};
+        desc.info.pixel_format = pixel_format;
+        desc.info.guest_format = guest_format;
+        desc.info.type = Prospero::ImageType::kColor2D;
+        desc.info.extent = {width, height, 1};
+        desc.info.resources = {1, 1};
+        desc.info.pitch = width;
+        desc.info.bytes_per_block = 1;
+        desc.info.samples = 1;
+        desc.info.tile_mode = Prospero::TileMode::kLinear;
+        desc.info.mip_layout[0] = {0, atlas_size, width, height};
+        desc.view_info.format = pixel_format;
+        desc.view_info.type = vk::ImageViewType::e2D;
+        desc.view_info.aspect = vk::ImageAspectFlagBits::eColor;
+        desc.view_info.usage = usage;
+        return desc;
+      };
+
+      auto &texture_cache = resources.GetTextureCache();
+      auto storage = MakeAtlasDesc(BindingType::Storage, vk::Format::eR8Uint,
+                                   Prospero::BufferFormat::k8UInt,
+                                   vk::ImageUsageFlagBits::eStorage);
+      const auto storage_id = texture_cache.FindImage(storage);
+      (void)texture_cache.FindTexture(storage_id, storage);
+      auto sampled = MakeAtlasDesc(BindingType::Texture, vk::Format::eR8Unorm,
+                                   Prospero::BufferFormat::k8UNorm,
+                                   vk::ImageUsageFlagBits::eSampled);
+      const auto sampled_id = texture_cache.FindImage(sampled);
+      Require(name, "numeric-format separation",
+              storage_id && sampled_id && storage_id != sampled_id,
+              "R8 integer storage and normalized sampled atlas shared one cache image");
+
+      uint8_t published = 0;
+      Require(name, "storage contents publication",
+              Libs::LibKernel::Memory::TryReadBacking(base, &published, sizeof(published)) &&
+                  published == 0x7f,
+              "separating the storage owner failed to publish its guest bytes");
+      resources.SetGpu(nullptr);
+      resources.UnmapMemory(base, allocation_size);
+      scheduler.Finish();
+    }
+    context.ShutdownGpu();
+    Require(name, "unmap direct backing",
+            Libs::LibKernel::Memory::KernelMunmap(base, allocation_size) == 0,
+            "storage/sample direct mapping release failed");
+    Require(name, "release direct backing",
+            Libs::LibKernel::Memory::KernelReleaseDirectMemory(
+                direct_offset, allocation_size) == 0,
+            "storage/sample direct-memory release failed");
+    std::printf("[host]    %-32s ok\n", name);
+  }
+
   void CheckBgra16Readback() {
     constexpr const char *name = "Bgra16Readback";
     constexpr uintptr_t base = 0x0000000204000000ull;
@@ -10716,6 +10857,36 @@ public:
     }
     Require(name, "format coverage", format_cases != 0,
             "no CPU-supported standard formats were tested");
+
+    // GTA V's text atlas is a single-mip R8 Standard64KB surface at this
+    // exact size. Keep this case explicit: the small format matrix above does
+    // not exercise the atlas-sized dispatch, pitch, or 8 MiB storage range.
+    {
+      constexpr auto format = Prospero::BufferFormat::k8UInt;
+      constexpr auto tile = Prospero::TileMode::kStandard64KB;
+      constexpr u32 width = 2048, height = 4096, levels = 1;
+      TileSizeAlign total{};
+      TileGetTextureSize(format, width, height, levels, tile, &total, nullptr,
+                         nullptr);
+      const auto layout = TextureCalcUploadLayout(
+          format, width, height, levels, 1, tile, total.size, false, false,
+          name);
+      const auto regions = TextureBuildImageCopies(layout);
+      std::vector<GpuTileInfo> infos;
+      const bool built =
+          TextureBuildGpuTileInfos(total.size, regions, layout, levels, infos);
+      const bool matches = built && total.size == 0x800000 &&
+                           layout.pitch == width && infos.size() == 1 &&
+                           infos[0].family == TileBlockFamily::Standard64KB &&
+                           infos[0].bytes_per_element == 1 &&
+                           infos[0].width == width && infos[0].height == height &&
+                           infos[0].pitch == width && infos[0].linear_size ==
+                               total.size &&
+                           infos[0].tiled_size == total.size;
+      Require(name, "R8 text atlas layout", matches,
+              "R8 2048x4096 Standard64KB metadata changed");
+      check_round_trip("R8 2048x4096 text atlas", total.size, infos);
+    }
 
     {
       constexpr auto format = Prospero::BufferFormat::k11_11_10UInt;
@@ -25597,7 +25768,12 @@ int main(int argc, char **argv) {
   }
   if (argc == 2 && std::strcmp(argv[1], "--storage-sampled-only") == 0) {
     VulkanHarness vulkan;
-    vulkan.CheckUnifiedImageViewCache();
+    vulkan.CheckStorageSampledFormatSeparation();
+    return 0;
+  }
+  if (argc == 2 && std::strcmp(argv[1], "--bda-prefetch-only") == 0) {
+    VulkanHarness vulkan;
+    vulkan.CheckBdaPrefetchRange();
     return 0;
   }
   if (argc == 2 && std::strcmp(argv[1], "--depth-readback-only") == 0) {


### PR DESCRIPTION
## Summary

- Fix GTA V boot-time text glyph loss by materializing the boot font's BDA-backed source pages before its one-shot compute dispatch.
- Keep incompatible storage and sampled R8 atlas views separate, publishing storage-written atlas bytes before the sampled view is created.
- Add focused coverage for BDA range prefetch and the 2048x4096 R8 Standard64KB text-atlas layout.

## Problem

In Grand Theft Auto V (PPSA04264), the boot/legal screen and the UI shown before gameplay rendered only scattered glyphs. Characters remained at their correct positions, but most glyphs were invisible; for example, `Performance` appeared as `f  manc`. The in-game settings screen could render correctly, so this was not a missing-font-file problem.

The same font atlas was available to other text draws in the same frame, which ruled out missing glyph assets. The surviving characters also preserved their original spacing, ruling out displaced geometry. The failure was specific to the boot-time rendering path.

## Cause

The boot font compute shader reads its glyph source through buffer device address (BDA). During the one-shot boot atlas build, dynamically referenced source pages could be read before they had been materialized in the buffer cache. Those reads returned unavailable or zero data, leaving the affected glyphs invisible.

A second cache issue could merge the atlas storage image and its differently formatted sampled view. The text atlas uses an R8 integer storage view and an R8 normalized sampled view; treating those as one image owner could leave the sampled view with stale or incorrectly interpreted contents.

## Fix

- Add `PrepareBdaRange`, which page-aligns and materializes only mapped pages in a bounded range before synchronizing BDA resources.
- Apply that prefetch to the identified GTA V boot-font compute dispatch, deriving the source address from the dispatch user data.
- Prevent incompatible R8 storage/sampled atlas owners from being merged.
- Publish GPU-written storage-image contents before separating the cache owners.

The prefetch is bounded and targeted to the identified boot-font dispatch; normal DMA dispatches retain the existing BDA preparation path.

## Verification

- Built with clang-cl/Ninja:
  - `ninja -C _Build/profile-buffer-readback shader_recompiler_compute_tests`
  - `ninja -C _Build/profile-buffer-readback kyty_emulator`
- Focused regression test passed:
  - `shader_recompiler_compute_tests.exe --bda-prefetch-only`
- Launched GTA V through the save-backed test launcher; save slots were detected and backed up before launch.
- Verified in GTA V that the previously missing boot/start text renders, while the in-game settings text remains correct.

AI assistance was used for this change.