### PR TITLE
controller: give the DualShock 4 the DualSense pad path and release p…

### DIFF
--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -59,6 +59,7 @@ int DbgExitHandler(const char* file, int line, fmt::text_style style, std::strin
 }
 
 void DbgExit(int status) {
+	Subsystems::EmergencyShutdownActive();
 	std::fflush(nullptr);
 	std::_Exit(status);
 }

--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -29,11 +29,7 @@ void DbgExit(int status);
 
 } // namespace Common
 
-#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS || KYTY_PLATFORM == KYTY_PLATFORM_LINUX
 #define EXIT_HALT() (Common::DbgExit(321), 1)
-#else
-#define EXIT_HALT() (std::_Exit(321), 1)
-#endif
 
 #ifndef KYTY_FINAL
 #define EXIT_IF(x)                                                                                 \

--- a/src/graphics/presentation/window/window.cpp
+++ b/src/graphics/presentation/window/window.cpp
@@ -814,6 +814,7 @@ static void WindowCreate(WindowContext& context) {
 	int width  = static_cast<int>(context.graphic_ctx.screen_width);
 	int height = static_cast<int>(context.graphic_ctx.screen_height);
 
+	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "0");
@@ -899,6 +900,7 @@ void WindowRun() {
 
 void WindowShutdown() {
 	if (g_window != nullptr) {
+		Controller::EmergencyShutdown();
 		g_window.reset();
 	}
 }

--- a/src/libs/controller.cpp
+++ b/src/libs/controller.cpp
@@ -23,8 +23,8 @@ LIB_NAME("Pad", "Pad");
 constexpr int PAD_ERROR_INVALID_ARG    = -2137915391; /* 0x80920001 */
 constexpr int PAD_ERROR_INVALID_HANDLE = -2137915389; /* 0x80920003 */
 
-// SDL limits rumble commands to 0xffff ms; zero strengths stop immediately.
 constexpr uint32_t RUMBLE_DURATION_MS = 0xffff;
+constexpr uint32_t RELEASE_FLUSH_MS   = 50;
 
 struct PadControllerInformation {
 	float    touch_pixel_density;
@@ -102,6 +102,7 @@ public:
 	void RightStick(int id, int x, int y);
 	void TouchPad(int id, int finger, bool down, float x, float y);
 	void ResetInputState();
+	void ReleaseHostPads();
 	void GetConnectionInfo(bool* flag, int* count);
 	void SetVibration(uint8_t large_motor, uint8_t small_motor);
 	void SetLightBar(uint8_t r, uint8_t g, uint8_t b);
@@ -252,8 +253,15 @@ void Initialize() {
 }
 
 void Shutdown() {
+	EmergencyShutdown();
 	delete g_controller;
 	g_controller = nullptr;
+}
+
+void EmergencyShutdown() {
+	if (g_controller != nullptr) {
+		g_controller->ReleaseHostPads();
+	}
 }
 
 void GameController::Connect(int id) {
@@ -402,6 +410,39 @@ void GameController::ResetInputState() {
 	m_first_state   = 0;
 	m_next_touch_id = 1;
 	AddState();
+}
+
+void GameController::ReleaseHostPads() {
+	Common::LockGuard lock(m_mutex);
+
+	std::vector<SDL_GameController*> pads;
+	for (const auto id: m_connected_ids) {
+		if (id == HOST_INPUT_CONTROLLER_ID) {
+			continue;
+		}
+		if (auto* pad = SDL_GameControllerFromInstanceID(static_cast<SDL_JoystickID>(id));
+		    pad != nullptr) {
+			if (SDL_GameControllerGetType(pad) == SDL_CONTROLLER_TYPE_PS5) {
+				DualSenseEffects effect {};
+				effect.enable_bits     = 0x0c;
+				effect.right_trigger[0] = 0x05;
+				effect.left_trigger[0]  = 0x05;
+				(void)SDL_GameControllerSendEffect(pad, &effect, sizeof(effect));
+			}
+			(void)SDL_GameControllerRumble(pad, 0, 0, 0);
+			(void)SDL_GameControllerSetLED(pad, 0, 0, 0);
+			pads.push_back(pad);
+		}
+	}
+
+	if (!pads.empty()) {
+		SDL_Delay(RELEASE_FLUSH_MS);
+		for (auto* pad: pads) {
+			SDL_GameControllerClose(pad);
+		}
+	}
+
+	m_connected_ids.clear();
 }
 
 void GameController::SetVibration(uint8_t large_motor, uint8_t small_motor) {

--- a/src/libs/controller.h
+++ b/src/libs/controller.h
@@ -7,11 +7,13 @@ namespace Libs::Controller {
 
 void Initialize();
 void Shutdown();
+void EmergencyShutdown();
 
 struct Lifecycle {
-	static constexpr const char* name       = "Controller";
-	static constexpr auto        initialize = Libs::Controller::Initialize;
-	static constexpr auto        shutdown   = Libs::Controller::Shutdown;
+	static constexpr const char* name               = "Controller";
+	static constexpr auto        initialize         = Libs::Controller::Initialize;
+	static constexpr auto        shutdown           = Libs::Controller::Shutdown;
+	static constexpr auto        emergency_shutdown = Libs::Controller::EmergencyShutdown;
 };
 
 constexpr int HOST_INPUT_CONTROLLER_ID = -1000;


### PR DESCRIPTION
Fixes #441.

## What was wrong

Two problems that only appear together, on a real Bluetooth DualShock 4.

**1. The DS4 was never given SDL's extended report mode.** Rumble, the light bar, touch pad
coordinates and the motion sensors are only reported by a PlayStation pad in the mode SDL calls
"enhanced". `window.cpp` asked for it for the DualSense (`SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE`)
and never for the DualShock 4. Over USB this is masked, because `HIDAPI_DriverPS4_InitDevice`
enables enhanced mode unconditionally for a Sony vendor id. Over Bluetooth the pad stays in the
simple report mode, so a DS4 silently lost all four features — `scePadSetVibration` and
`scePadSetLightBar` returned success and did nothing.

**2. Host pads were never released at exit.** The emulator ends via `std::quick_exit(0)`, which
runs `at_quick_exit` handlers only, so the `Subsystems` destructor and every lifecycle shutdown
are skipped. The controller lifecycle declared no `emergency_shutdown`, so
`SDL_GameControllerClose()` and `SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER)` never ran. SDL sends
the stop-rumble command from `SDL_JoystickClose()`, so **a pad vibrating when the window closes
keeps vibrating, with no process left alive to stop it** — only powering the pad off ends it. SDL
also never restores the light bar, and enhanced mode is (in SDL's own comment) "a one-way trip",
so the bar stays lit at the last colour sent.

The second problem is what #441 describes. The first is why it was invisible over Bluetooth: with
effects never enabled, there was nothing left running to notice.

## The fix

- Set `SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE` alongside the existing PS5 hint.
- Declare `emergency_shutdown` on the controller lifecycle and release host pads there: stop the
  motors, put the light bar out, allow SDL's rumble thread a bounded window to drain the queued
  reports, then close the pads.

## Hardware validation

DualShock 4 v2 (`054C:09CC`) over **Bluetooth**, Windows 11, Tetris Forever. The window was closed
with a real `WM_CLOSE` every time, which is the `SDL_QUIT` -> `quick_exit` path under test.

Light bar after the emulator exits:

| enhanced mode | pad release | light bar |
| --- | --- | --- |
| off (before) | no | sky blue — the pad's own colour, SDL never touched it |
| off | yes | sky blue — nothing to release |
| on | no | **dark blue**, i.e. SDL's player-0 `{0x00,0x00,0x40}`, left lit |
| on (after) | yes | **off** |

Rumble, driven through `GameController::SetVibration`:

| pad release | after the emulator exits |
| --- | --- |
| before | **still vibrating at full strength**, indefinitely |
| after | **stops immediately** |

Capabilities, read from SDL rather than judged by eye:

| | before | after |
| --- | --- | --- |
| `SDL_GameControllerHasLED` | 0 | 1 |
| `SDL_GameControllerHasRumble` | 0 | 1 |
| `SDL_GameControllerSetLED` | -1 "That operation is not supported" | 0 |
| touch pad coordinates | never delivered | 226 events, x 0.065..0.973, y 0.057..1.000 |

No regression in what already worked: all four face buttons, D-pad, L1/R1, L3/R3, Options, PS,
touch pad click, both sticks at full range, and L2/R2 analog 0..32767 were verified before and
after by the existing `KYTY_DBG_INPUT` trace.

## Tests

New `tests/SubsystemsTests.cpp` (`ctest -R subsystems`) covers the mechanism the fix relies on:
emergency shutdown must run exactly the lifecycles that declare a handler, in reverse
initialization order, must not run them twice, and the controller lifecycle must be one of them.
It fails to compile against the unfixed tree, with the static assertion naming the reason.

`ctest` goes from 34/36 to 35/37 on Windows. The two failures
(`shader_recompiler_compute`, `texture_cache_image_overlap`, both `0xc0000409`) are pre-existing
on `fc91fd2` and unrelated.

## Limitations

- Motion sensors still do nothing. `PadData` has the orientation, acceleration and angular
  velocity fields and `scePadSetMotionSensorState` returns OK, but there is no SDL sensor plumbing
  at all, so the guest still receives zeros. Enhanced mode is a precondition for fixing that, not
  a fix for it.
- `scePadResetLightBar` remains a stub that returns OK without touching the pad.
- Rumble and the light bar were confirmed through SDL's capability bits and return codes plus
  direct observation of the physical pad; no test title was found that calls
  `scePadSetVibration`, so the guest-initiated path was exercised through
  `GameController::SetVibration` directly rather than by a game.
- Tested on a DualShock 4 over Bluetooth. The USB path and the DualSense are unchanged by
  reasoning about the driver source, not by measurement — I have neither to hand.

## AI use

This change was produced with AI assistance (Claude). The investigation, the SDL driver analysis,
the patch and the test were AI-generated; I reviewed the diff, ran the build and `ctest` myself,
and performed all of the physical DualShock 4 testing above by hand.