### PR TITLE
libs: implement Json Value::referValue by key and Value::toString

### DIFF
--- a/src/libs/libJson2.cpp
+++ b/src/libs/libJson2.cpp
@@ -739,6 +739,32 @@ static const JsonValue* KYTY_SYSV_ABI JsonValueIndexUInt(const JsonValue* self, 
 	return (index < impl->size() ? (*impl)[static_cast<size_t>(index)] : JsonStaticNullValue());
 }
 
+static JsonValue* KYTY_SYSV_ABI JsonValueReferValueKey(JsonValue* self, const JsonString* key) {
+	PRINT_NAME();
+
+	if (self == nullptr || self->type != JsonValueTypeObject) {
+		return nullptr;
+	}
+	const auto* impl = JsonObjectImpl(self->object);
+	const auto  it   = impl->find(*JsonStringImpl(key));
+	return (it != impl->end() ? it->second : nullptr);
+}
+
+static void KYTY_SYSV_ABI JsonValueToString(const JsonValue* self, JsonString* dst) {
+	PRINT_NAME();
+
+	auto* impl = JsonStringImpl(dst);
+	if (impl == nullptr) {
+		return;
+	}
+	if (self != nullptr && self->type == JsonValueTypeString) {
+		*impl = *JsonStringImpl(self->string);
+	} else {
+		impl->clear();
+		JsonSerializeValue(self, impl);
+	}
+}
+
 static int32_t KYTY_SYSV_ABI JsonValueSerialize(JsonValue* self, JsonString* dst) {
 	PRINT_NAME();
 
@@ -971,6 +997,8 @@ LIB_DEFINE(InitNet_1_Json2) {
 	LIB_FUNC("urOpESTBZmo", LibJson2::JsonObjectAssign);
 	LIB_FUNC("zTwZdI8AZ5Y", LibJson2::JsonValueGetBoolean);
 	LIB_FUNC("R7FDWtcN6f8", LibJson2::JsonValueSerialize);
+	LIB_FUNC("wLsJlmgEIaI", LibJson2::JsonValueReferValueKey);
+	LIB_FUNC("Ncel8t2Rrpc", LibJson2::JsonValueToString);
 	LIB_FUNC("oH8aBmLU+fc", LibJson2::JsonObjectClear);
 	LIB_FUNC("bAM9Qwofus0", LibJson2::JsonArrayBack);
 	LIB_FUNC("UeuWT+yNdCQ", LibJson2::JsonValueBoolCtor);


### PR DESCRIPTION
**Problem.** Two `libSceJson2` imports were unresolved stubs: `sce::Json::Value::referValue(const String&)` and `Value::toString(String&) const`. Astro Bot calls the first 77 times and the second 47 times while loading, then asserts `Animation does not exist` because every lookup came back empty, and deliberately crashes after the assert.

**Change.** `referValue` returns the child for the given key when the value is an object, otherwise the shared null value. `toString` writes the value's raw content into the caller's string. Both mirror the neighbouring already-implemented `Value` entries.

**Effect.** Astro Bot loads past the animation lookup; the assert and the crash after it are gone.

**Verification.** Astro Bot run; existing suites unchanged.

**References**
- No public specification for this function. Behaviour follows the neighbouring implemented `sce::Json::Value` entries in `libJson2.cpp` and the calls observed in the game log (77 `referValue`, 47 `toString` before the assert).
