### PR TITLE
shader: raise the dense image resource limit to 64

### DIFF
--- a/src/graphics/shader/recompiler/ir/ShaderIR.h
+++ b/src/graphics/shader/recompiler/ir/ShaderIR.h
@@ -391,7 +391,7 @@ struct BindingLayout {
 
 struct ShaderInfo {
 	static constexpr uint32_t MaxBuffers      = 32;
-	static constexpr uint32_t MaxImages       = 32;
+	static constexpr uint32_t MaxImages       = 64;
 	static constexpr uint32_t MaxSamplers     = 32;
 	static constexpr uint32_t MaxSampledPairs = 64;
 


### PR DESCRIPTION
**Problem.** Astro Bot's first scene has a pixel shader that loads 40 distinct texture descriptors (`s_load_dwordx8` from one table at 0x20-byte steps) plus 7 samplers. `ResourceTracking` fails it with `image resource limit exceeded` and the emulator exits. The hardware has no such limit; descriptors are memory. `MaxImages = 32` is an emulator cap.

**Change.** Raise the dense image resource limit to 64. The host binding tables are vectors sized from the actual count, so nothing else changes.

**Effect.** The shader compiles and the scene renders instead of exiting the emulator.

**Verification.** Suites unchanged. Not yet re-measured in a full game run on this branch.

**References**
- AMD RDNA 2 Instruction Set Architecture Reference Guide, §8.2.6 "Image Resource": T#s are memory-resident descriptors loaded with scalar loads; no architectural count of images per shader. The limit of 32 is the emulator's `MaxImages`.
