### PR TITLE
shader: do not dereference an unresolved descriptor address

### DIFF
--- a/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
@@ -1,6 +1,7 @@
 #include "graphics/shader/recompiler/ir/passes/SrtWalker.h"
 
 #include "common/assert.h"
+#include "graphics/host_gpu/hostMemory.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 
 #include <algorithm>
@@ -534,6 +535,11 @@ private:
 				return false;
 			}
 		} else {
+			// The address is derived from guest data, so it can be anything; a descriptor that
+			// does not resolve must fail evaluation rather than fault the emulator.
+			if (!HostMemoryRangeIsReadable(address, sizeof(word))) {
+				return false;
+			}
 			std::memcpy(&word, reinterpret_cast<const void*>(address), sizeof(word));
 		}
 		result = word;


### PR DESCRIPTION
**Problem.** `Evaluator::EvaluateRawRead` reads a descriptor dword from guest memory. When no memory reader is installed it falls back to a raw `memcpy` from an address computed out of guest data, with no check. That path is live in normal draws, so a descriptor chain that does not resolve faults the emulator instead of failing the evaluation.

**Change.** Check readability of the address before the raw read and fail evaluation when it is not readable, matching what the reader-backed path already does.

**Effect.** No measured change in Astro Bot; this closes a host-crash path on any guest-derived address.

**Verification.** Suites pass; the unreadable-address case was exercised empirically during the Astro Bot runs.

**References**
- No external specification. Correctness argument only: `EvaluateRawRead` reads from an address derived from guest data without a readability check when no memory reader is installed.
