### PR TITLE
shader: pop the SRT evaluator visit stack when evaluation fails

### DIFF
--- a/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
@@ -424,11 +424,12 @@ private:
 			return false;
 		}
 		m_visiting.push_back(inst);
-		uint64_t out = 0;
-		if (!EvaluateInst(*inst, out)) {
+		uint64_t   out   = 0;
+		const bool valid = EvaluateInst(*inst, out);
+		m_visiting.pop_back();
+		if (!valid) {
 			return false;
 		}
-		m_visiting.pop_back();
 		m_cache.emplace(inst, out);
 		result = out;
 		return true;


### PR DESCRIPTION
**Problem.** `Evaluator::EvaluateWide` pushes the instruction on `m_visiting` (the cycle guard) and returns early when `EvaluateInst` fails, without popping it. The instruction stays permanently "visiting", so every later evaluation that reaches it is treated as a cycle and fails too, and one transient failure poisons the whole materialization.

**Change.** Pop the visit stack on every exit path.

**Effect.** No measured change in Astro Bot on its own; it stops a first failed SRT walk from making later walks fail.

**Verification.** Suites pass.

**References**
- No external specification. Correctness argument only: `m_visiting` is a cycle guard and must be popped on every exit path of `EvaluateWide`.
