### PR TITLE
cfg: sweep post-dominators in reverse block order

### DIFF
--- a/src/graphics/shader/recompiler/frontend/cfg/ShaderCFG.cpp
+++ b/src/graphics/shader/recompiler/frontend/cfg/ShaderCFG.cpp
@@ -788,7 +788,9 @@ void ComputePostDominators(Graph& graph) {
 	bool changed = true;
 	while (changed) {
 		changed = false;
-		for (auto& block: graph.blocks) {
+		// Post-dominance flows from successors, so a reverse sweep converges in a few passes.
+		for (auto it = graph.blocks.rbegin(); it != graph.blocks.rend(); ++it) {
+			auto&                 block = *it;
 			std::vector<uint32_t> next;
 			if (block.successors.empty()) {
 				next = {block.id};


### PR DESCRIPTION
**Problem.** `ComputePostDominators` iterates blocks in forward order while the post-dominance dataflow propagates from successors, so each sweep moves information one block. A 133-block Astro Bot pixel shader needed about 338 fixpoint sweeps per call and the structurizer calls it 655 times: 148 seconds compiling one shader.

**Change.** Iterate in reverse block order. The framework is monotone with a unique maximal fixpoint, so the result is order-independent; only the sweep count changes.

**Effect.** The 148-second stall on Astro Bot's first scene is gone (3.7 s for the whole dumped shader set offline, bit-identical results on every shader).

**Verification.** Suites pass; offline comparison over all dumped shaders.

**References**
- Post-dominance is a monotone dataflow problem with a unique maximal fixpoint, so iteration order changes only the sweep count: Cooper, Harvey, Kennedy, "A Simple, Fast Dominance Algorithm" (2001).
