### PR TITLE
shader: wave32 lane-mask and compare writes leave vcc_hi and exec_hi untouched

### DIFF
--- a/src/graphics/shader/recompiler/frontend/translate/Compare.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Compare.cpp
@@ -13,7 +13,9 @@ void Translator::EmitCompareResult(const Decoder::Instruction& inst, IR::U1 valu
 		const auto mask = BallotMask(masked);
 		ir.SetExec(masked);
 		ir.SetExecLo(mask[0]);
-		ir.SetExecHi(mask[1]);
+		if (current_wave_size == 64u) {
+			ir.SetExecHi(mask[1]);
+		}
 		return;
 	}
 	WriteMask(inst.dst, masked);

--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -373,7 +373,10 @@ void Translator::WriteOperand(const Decoder::Operand& operand, IR::Value value) 
 				const auto mask = BallotMask(IR::U1(value));
 				ir.SetExec(IR::U1(value));
 				ir.SetExecLo(mask[0]);
-				ir.SetExecHi(mask[1]);
+				// In wave32 a lane-mask write touches only the low half; the high half is a free SGPR.
+				if (current_wave_size != 32u) {
+					ir.SetExecHi(mask[1]);
+				}
 				return;
 			}
 			case Decoder::OperandKind::VccLo:
@@ -381,7 +384,9 @@ void Translator::WriteOperand(const Decoder::Operand& operand, IR::Value value) 
 				const auto mask = BallotMask(IR::U1(value));
 				ir.SetVcc(IR::U1(value));
 				ir.SetVccLo(mask[0]);
-				ir.SetVccHi(mask[1]);
+				if (current_wave_size != 32u) {
+					ir.SetVccHi(mask[1]);
+				}
 				return;
 			}
 			default:

--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -691,7 +691,9 @@ void Translator::WriteMask(const Decoder::Operand& operand, IR::U1 value) {
 			const auto mask = BallotMask(value);
 			ir.SetExec(value);
 			ir.SetExecLo(mask[0]);
-			ir.SetExecHi(mask[1]);
+			if (current_wave_size == 64u) {
+				ir.SetExecHi(mask[1]);
+			}
 			return;
 		}
 		case Decoder::OperandKind::VccLo:
@@ -699,7 +701,9 @@ void Translator::WriteMask(const Decoder::Operand& operand, IR::U1 value) {
 			const auto mask = BallotMask(value);
 			ir.SetVcc(value);
 			ir.SetVccLo(mask[0]);
-			ir.SetVccHi(mask[1]);
+			if (current_wave_size == 64u) {
+				ir.SetVccHi(mask[1]);
+			}
 			return;
 		}
 		case Decoder::OperandKind::Scc: ir.SetScc(value); return;

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -14333,6 +14333,34 @@ TestCase VectorSubrevCoCiU32ExactRawOnGpu() {
   return test;
 }
 
+TestCase VectorCompareWave32KeepsVccHi() {
+  using O = ShaderOpcode;
+
+  std::vector<u32> code;
+  AppendSMovLiteral(&code, 107, 7); // s_mov_b32 vcc_hi, 7
+  code.push_back(EncodeVopc(0xc2, InlineU32(0), 0)); // v_cmp_eq_u32 vcc, 0, v0
+  code.push_back(EncodeVop1(0x01, 3, 107)); // v_mov_b32 v3, vcc_hi
+  code.push_back(EncodeVop2(0x1a, 4, InlineU32(2), 0));
+  AppendBufferStoreDword(&code, 3, 4);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "VectorCompareWave32KeepsVccHi";
+  test.code = code;
+  test.expected = {7, 7, 7, 7, 0, 0, 0, 0};
+  test.opcodes = {O::S_MOV_B32, O::V_CMP_EQ_U32, O::V_MOV_B32, O::V_LSHLREV_B32,
+                  O::BUFFER_STORE_DWORD, O::S_ENDPGM};
+  test.compute_info.threads_num[0] = 4;
+  test.compute_info.threads_num[1] = 1;
+  test.compute_info.threads_num[2] = 1;
+  test.compute_info.group_id[0] = true;
+  test.compute_info.wave_size = 32;
+  test.compute_info.thread_ids_num = 1;
+  test.compute_info.workgroup_register = 0;
+  test.has_compute_info = true;
+  return test;
+}
+
 TestCase VectorVop3BSubrevCoCiUsesEncodedMasks() {
   using O = ShaderOpcode;
 
@@ -21297,6 +21325,7 @@ std::vector<TestCase> MakeCases() {
     cases.push_back(factory());
   };
 
+  AddCase(VectorCompareWave32KeepsVccHi);
   AddCase(IntegerAddSubMul);
   AddCase(BitwiseOps);
   AddCase(Shifts);


### PR DESCRIPTION
**Problem.** In wave32 the lane mask is one dword; `vcc_hi` and `exec_hi` are ordinary SGPRs. Lane-mask writes and compare results (`v_cmp*`, `v_cmpx*`, mask writes) also wrote the high word. An Astro Bot compute shader keeps a loop counter in `vcc_hi`; every compare zeroed it, the loop never terminated, and the GPU hung (`VK_ERROR_DEVICE_LOST` a few frames into the intro).

**Change.** Only write the high mask word in wave64, in `WriteMask`, the U1 `WriteOperand` path and `EmitCompareResult`.

**Effect.** Astro Bot's intro device loss is gone; the game reaches the world and runs for minutes past the former loss.

**Verification.** New compute case `VectorCompareWave32KeepsVccHi` (fails on the old code); suites pass; device-fault report named the shader, and the fix was confirmed in-game.

**References**
- AMD RDNA 2 Instruction Set Architecture Reference Guide, §3.3 "EXECute Mask" and §3.9 "Vector Compares: VCC and VCCZ": in wave32 the masks are 32 bits wide, so `exec_hi`/`vcc_hi` are ordinary SGPRs.
- Captured shader `d97f248195e22298` keeps a loop counter in `vcc_hi`.
