### PR TITLE
renderer: bind vertex buffers with the size of their descriptor

### DIFF
--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -781,6 +781,7 @@ struct PreparedVertexBuffers {
 
 	std::array<vk::Buffer, MaxBuffers>     buffers {};
 	std::array<vk::DeviceSize, MaxBuffers> offsets {};
+	std::array<vk::DeviceSize, MaxBuffers> sizes {};
 	uint32_t                               count = 0;
 };
 
@@ -850,6 +851,7 @@ static PreparedVertexBuffers AcquireVertexBuffers(CommandBuffer&               b
 			}
 			prepared.buffers[i] = null_buffer;
 			prepared.offsets[i] = 0;
+			prepared.sizes[i]   = VK_WHOLE_SIZE;
 			continue;
 		}
 
@@ -865,6 +867,7 @@ static PreparedVertexBuffers AcquireVertexBuffers(CommandBuffer&               b
 
 		prepared.buffers[i] = range->binding.first->Handle();
 		prepared.offsets[i] = range->binding.second + vertex.addr - range->base_address;
+		prepared.sizes[i]   = std::min(size, range->acquired_end - vertex.addr);
 		SetVulkanObjectNameF(
 		    buffer.GetContext().GetGraphics().device, prepared.buffers[i],
 		    "Kyty.VertexBuffer[slot={} guest=0x{:016x} size=0x{:x} stride={} records={}]", i,
@@ -1081,8 +1084,8 @@ static void CommitVertexBuffers(vk::CommandBuffer            vk_buffer,
 		EXIT_IF(prepared.buffers[i] == nullptr);
 	}
 	if (prepared.count != 0) {
-		vk_buffer.bindVertexBuffers(0, prepared.count, prepared.buffers.data(),
-		                            prepared.offsets.data());
+		vk_buffer.bindVertexBuffers2(0, prepared.count, prepared.buffers.data(),
+		                             prepared.offsets.data(), prepared.sizes.data(), nullptr);
 	}
 }
 


### PR DESCRIPTION
**Problem.** Vertex buffers were bound with a size derived from the draw rather than from the V#. A fetch past `num_records` then read whatever memory followed the buffer, where the hardware returns zero for out-of-range records (buffer descriptor clamping, RDNA2 ISA "buffer resource" section).

**Change.** Bind the vertex buffer with the descriptor's own size so the host's bounds behaviour lines up with the guest's.

**Effect.** No isolated measured change; part of the GTA V rendering bring-up where out-of-range vertex fetches showed up as garbage attributes.

**Verification.** Suites pass.

**References**
- AMD RDNA 2 Instruction Set Architecture Reference Guide, §8.1.5 "Buffer Addressing" (range checking) and §8.1.8 "Buffer Resource": out-of-range reads return zero and out-of-range writes are dropped, judged against the V#'s `num_records`.
