### PR TITLE
graphics: ignore writes to the removed ES and LS shader registers

### DIFF
--- a/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
@@ -2028,6 +2028,11 @@ KYTY_CP_OP_PARSER(CpOpIndirectCxRegs) {
 	return KYTY_PM4_LEN(cmd_id) - 1u;
 }
 
+// The GCN ES/LS resource registers no longer exist; shader binaries still carry writes to them.
+static bool IsRemovedShaderRegister(uint32_t offset) {
+	return offset >= Pm4::SPI_SHADER_PGM_RSRC1_ES && offset <= Pm4::SPI_SHADER_PGM_LO_LS_END;
+}
+
 KYTY_CP_OP_PARSER(CpOpIndirectShRegs) {
 	KYTY_PROFILER_FUNCTION();
 
@@ -2069,6 +2074,10 @@ KYTY_CP_OP_PARSER(CpOpIndirectShRegs) {
 			EXIT("unsupported indirect SH register offset 0x%08" PRIx32 " (raw 0x%08" PRIx32
 			     "), value = 0x%08" PRIx32 "\n",
 			     cmd_offset, raw_cmd_offset, value);
+		}
+
+		if (IsRemovedShaderRegister(cmd_offset)) {
+			continue;
 		}
 
 		auto pfunc = g_hw_sh_indirect_func[cmd_offset];
@@ -2433,6 +2442,9 @@ KYTY_CP_OP_PARSER(CpOpSetShaderReg) {
 		auto num_values = KYTY_PM4_LEN(cmd_id) - 2u;
 		bool handled    = num_values != 0;
 		for (uint32_t i = 0; i < num_values; i++) {
+			if (IsRemovedShaderRegister(cmd_offset + i)) {
+				continue;
+			}
 			if (cmd_offset + i >= Pm4::SH_NUM || g_hw_sh_indirect_func[cmd_offset + i] == nullptr) {
 				handled = false;
 				break;
@@ -2440,6 +2452,9 @@ KYTY_CP_OP_PARSER(CpOpSetShaderReg) {
 		}
 		if (handled) {
 			for (uint32_t i = 0; i < num_values; i++) {
+				if (IsRemovedShaderRegister(cmd_offset + i)) {
+					continue;
+				}
 				g_hw_sh_indirect_func[cmd_offset + i](cp, cmd_offset + i, buffer[1 + i]);
 			}
 			return num_values + 1u;

--- a/src/graphics/guest_gpu/pm4.h
+++ b/src/graphics/guest_gpu/pm4.h
@@ -834,6 +834,8 @@ constexpr uint32_t SPI_SHADER_USER_ACCUM_ESGS_0                   = 0xB2;
 constexpr uint32_t SPI_SHADER_USER_ACCUM_ESGS_3                   = 0xB5;
 constexpr uint32_t SPI_SHADER_PGM_LO_ES                           = 0xC8;
 constexpr uint32_t SPI_SHADER_PGM_HI_ES                           = 0xC9;
+constexpr uint32_t SPI_SHADER_PGM_RSRC1_ES                        = 0xCA;
+constexpr uint32_t SPI_SHADER_PGM_LO_LS_END                       = 0xEB;
 // Private AGC registers used by shader binaries submitted through SET_SH_REG_INDIRECT.
 constexpr uint32_t SPI_SHADER_PGM_CHKSUM_HS                       = 0x100;
 constexpr uint32_t SPI_SHADER_PGM_RSRC4_HS                        = 0x101;


### PR DESCRIPTION
**Problem.** Astro Bot's first command buffer writes SH registers in the range of the removed ES/LS shader stages, both directly and through `SET_SH_REG_INDIRECT`. The emulator treated those offsets as an error and exited at frame 3. Hardware without the stages ignores the writes.

**Change.** Skip writes into that range in both the direct and the indirect SH loaders (`IsRemovedShaderRegister`). The register holes that `Pm4NativeTargetGeometry` asserts stay holes; nothing is registered for them.

**Effect.** Astro Bot runs past frame 3 (to frame 90 and beyond in the same run).

**Verification.** Suites pass, including the geometry hole test.

**References**
- PAL (GPUOpen-Drivers/pal), `src/core/hw/gfxip/gfx9/chip/gfx9_plus_merged_offset.h`: no `SPI_SHADER_*_ES`/`_LS` registers on GFX10.3; the offsets are holes.
- Upstream's own `Pm4NativeTargetGeometry` test asserts those holes.
