### PR TITLE
kernel: implement sceKernelClearVirtualRangeName

### DIFF
--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -2445,6 +2445,24 @@ int KYTY_SYSV_ABI KernelSetVirtualRangeName(const void* addr, uint64_t len, cons
 	return OK;
 }
 
+int KYTY_SYSV_ABI KernelClearVirtualRangeName(const void* addr, uint64_t len) {
+	PRINT_NAME();
+
+	std::lock_guard<std::recursive_mutex> memory_operation_lock(g_memory_operation_mutex);
+
+	auto vaddr = reinterpret_cast<uint64_t>(addr);
+
+	LOGF("\t addr = 0x%016" PRIx64 "\n"
+	     "\t len  = 0x%016" PRIx64 "\n",
+	     vaddr, len);
+
+	g_physical_memory->SetVirtualRangeName(vaddr, len, "");
+	g_flexible_memory->SetVirtualRangeName(vaddr, len, "");
+	g_virtual_ranges->Rename(vaddr, len, "");
+
+	return OK;
+}
+
 static bool FreeGuestMemoryOwner(uint64_t vaddr, uint64_t size) {
 	return g_guest_address_space->ReleaseCommitted(vaddr, size) &&
 	       g_virtual_ranges->Remove(vaddr, size);

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -121,6 +121,7 @@ int KYTY_SYSV_ABI KernelMapNamedFlexibleMemory(void** addr_in_out, size_t len, i
                                                const char* name);
 int KYTY_SYSV_ABI KernelMapFlexibleMemory(void** addr_in_out, size_t len, int prot, int flags);
 int KYTY_SYSV_ABI KernelSetVirtualRangeName(const void* addr, uint64_t len, const char* name);
+int KYTY_SYSV_ABI KernelClearVirtualRangeName(const void* addr, uint64_t len);
 int KYTY_SYSV_ABI KernelMunmap(uint64_t vaddr, size_t len);
 size_t KYTY_SYSV_ABI KernelGetDirectMemorySize();
 int KYTY_SYSV_ABI    KernelAvailableDirectMemorySize(int64_t search_start, int64_t search_end,

--- a/src/libs/libKernel.cpp
+++ b/src/libs/libKernel.cpp
@@ -3074,6 +3074,7 @@ LIB_DEFINE(InitLibKernel_1_Mem) {
 	LIB_FUNC("mL8NDH86iQI", Memory::KernelMapNamedFlexibleMemory);
 	LIB_FUNC("IWIBBdTHit4", Memory::KernelMapFlexibleMemory);
 	LIB_FUNC("DGMG3JshrZU", Memory::KernelSetVirtualRangeName);
+	LIB_FUNC("mkgXxsoxWHg", Memory::KernelClearVirtualRangeName);
 	// 6xx
 	LIB_FUNC("4h6F1LLbTiw", Memory::KernelMapFlexibleMemory);
 	LIB_FUNC("cQke9UuBQOk", Memory::KernelMunmap);


### PR DESCRIPTION
**Problem.** `sceKernelClearVirtualRangeName` was unresolved; Astro Bot calls it twice.

**Change.** Implement it as the inverse of `KernelSetVirtualRangeName`: clear the name across physical, flexible and virtual ranges, same argument validation.

**Effect.** The two calls resolve; no other observable change measured.

**Verification.** Suites pass.

**References**
- No public specification for this function. Mirrors the repository's existing `KernelSetVirtualRangeName`; the import was observed unresolved in the relocation log (two calls).
