### PR TITLE
shader: support S_WQM_B32

### DIFF
--- a/src/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp
@@ -40,6 +40,7 @@ constexpr OpcodeMap SOP1_OPCODE_LIST[] = {
     {0x04u, Opcode::S_MOV_B64},
     {0x07u, Opcode::S_NOT_B32},
     {0x08u, Opcode::S_NOT_B64},
+    {0x09u, Opcode::S_WQM_B32},
     {0x0au, Opcode::S_WQM_B64},
     {0x0bu, Opcode::S_BREV_B32},
     {0x0fu, Opcode::S_BCNT1_I32_B32},

--- a/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.cpp
@@ -482,6 +482,7 @@ std::string InstructionToString(const Instruction& inst) {
 		case Opcode::S_BITSET0_B64:
 		case Opcode::S_BITSET1_B64:
 		case Opcode::S_NOT_B64:
+		case Opcode::S_WQM_B32:
 		case Opcode::S_WQM_B64:
 		case Opcode::S_QUADMASK_B64:
 		case Opcode::S_AND_SAVEEXEC_B32:

--- a/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.h
+++ b/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.h
@@ -59,6 +59,7 @@ enum class Opcode {
 	S_ANDN1_SAVEEXEC_B64,
 	S_NOT_B32,
 	S_NOT_B64,
+	S_WQM_B32,
 	S_WQM_B64,
 	S_ADD_U32,
 	S_ADDC_U32,

--- a/src/graphics/shader/recompiler/frontend/translate/Control.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Control.cpp
@@ -276,6 +276,32 @@ void Translator::S_WQM_B64(const Decoder::Instruction& inst) {
 	ir.SetScc(result);
 }
 
+void Translator::S_WQM_B32(const Decoder::Instruction& inst) {
+	if (!IsExecOrVcc(inst.dst) && !IsExecOrVcc(inst.src0)) {
+		const auto mask_valid = ReadMaskValid(inst.src0);
+		const auto invocation_result =
+		    IR::U1(ir.Emit(IR::ValueOpcode::WqmMask, {ReadMask(inst.src0)}));
+		const auto wide = IR::U64(ir.Emit(
+		    IR::ValueOpcode::WqmU64, {ir.ConstructU64(ReadU32(inst.src0), IR::U32(IR::Value(0u)))}));
+		const auto result = ir.CompositeExtract(wide, 0);
+		WriteOperand(DestinationOperand(inst), result);
+		if (inst.dst.kind == Decoder::OperandKind::Sgpr) {
+			const auto dst = static_cast<IR::ScalarReg>(inst.dst.reg);
+			ir.SetThreadBitScalarReg(dst, invocation_result);
+			ir.SetScalarMaskTag(dst, mask_valid);
+			const auto raw_nonzero = ir.INotEqual(result, IR::U32(IR::Value(0u)));
+			ir.SetScc(IR::U1(
+			    ir.Emit(IR::ValueOpcode::SelectU1, {mask_valid, invocation_result, raw_nonzero})));
+		} else {
+			ir.SetScc(ir.INotEqual(result, IR::U32(IR::Value(0u))));
+		}
+		return;
+	}
+	const auto result = IR::U1(ir.Emit(IR::ValueOpcode::WqmMask, {ReadMask(inst.src0)}));
+	WriteMask(inst.dst, result);
+	ir.SetScc(result);
+}
+
 void Translator::V_MOVRELS_B32(const Decoder::Instruction& inst) {
 	if (inst.dst.kind != Decoder::OperandKind::Vgpr ||
 	    inst.src0.kind != Decoder::OperandKind::Vgpr) {

--- a/src/graphics/shader/recompiler/frontend/translate/Scalar.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Scalar.cpp
@@ -8,6 +8,7 @@ bool Translator::EmitScalar(const Decoder::Instruction& inst) {
 		case O::S_MOV_B32:
 		case O::S_MOVK_I32: MOV_B32(inst, false); return true;
 		case O::S_MOV_B64: S_MOV_B64(inst); return true;
+		case O::S_WQM_B32: S_WQM_B32(inst); return true;
 		case O::S_WQM_B64: S_WQM_B64(inst); return true;
 		case O::S_GETPC_B64: S_GETPC_B64(inst); return true;
 		case O::S_SETPC_B64: return true;

--- a/src/graphics/shader/recompiler/frontend/translate/Translator.h
+++ b/src/graphics/shader/recompiler/frontend/translate/Translator.h
@@ -236,6 +236,7 @@ private:
 	void S_CSELECT_B64(const Decoder::Instruction& inst);
 	void MOV_B32(const Decoder::Instruction& inst, bool apply_float_modifiers);
 	void S_MOV_B64(const Decoder::Instruction& inst);
+	void S_WQM_B32(const Decoder::Instruction& inst);
 	void S_WQM_B64(const Decoder::Instruction& inst);
 	void V_MOVRELS_B32(const Decoder::Instruction& inst);
 	void V_MOVRELD_B32(const Decoder::Instruction& inst);


### PR DESCRIPTION
**Problem.** An Astro Bot wave32 shader executes `s_wqm_b32 exec_lo, exec_lo` (SOP1 opcode 9, `raw=[0xbefe097e]`), which had no decode; translation failed and the emulator exited.

**Change.** Add the decode and translate it like `S_WQM_B64`: the mask form for EXEC/VCC operands, the whole-quad-mask on the zero-extended word for SGPRs.

**Effect.** The shader compiles and the scene renders.

**Verification.** Suites pass.

**References**
- AMD RDNA 2 Instruction Set Architecture Reference Guide, §15.3 "SOP1 Instructions": opcode 9 `S_WQM_B32`.
- Captured instruction word: `0xbefe097e`.
