### PR TITLE
libs: implement sceConvertKeycodeGetImeKeyboardType

### DIFF
--- a/src/libs/libConvertKeycode.cpp
+++ b/src/libs/libConvertKeycode.cpp
@@ -1,0 +1,37 @@
+#include "common/abi.h"
+#include "common/logging/log.h"
+#include "libs/errno.h"
+#include "libs/libs.h"
+#include "loader/symbolDatabase.h"
+
+namespace Libs {
+
+LIB_VERSION("ConvertKeycode", 1, "ConvertKeycode", 1, 0);
+
+namespace ConvertKeycode {
+
+constexpr int CONVERT_KEYCODE_ERROR_INVALID_ADDRESS = -2134900687; // 0x80bc0031
+constexpr int CONVERT_KEYCODE_ERROR_INVALID_USER_ID = -2134900720; // 0x80bc0010
+
+static int KYTY_SYSV_ABI ConvertKeycodeGetImeKeyboardType(int32_t user_id, uint32_t* type) {
+	PRINT_NAME();
+
+	LOGF("\t user_id = %d\n", user_id);
+
+	if (type == nullptr) {
+		return CONVERT_KEYCODE_ERROR_INVALID_ADDRESS;
+	}
+	if (user_id < 0) {
+		return CONVERT_KEYCODE_ERROR_INVALID_USER_ID;
+	}
+	*type = 0;
+	return OK;
+}
+
+} // namespace ConvertKeycode
+
+LIB_DEFINE(InitConvertKeycode_1) {
+	LIB_FUNC("mUuUOWI-C+0", ConvertKeycode::ConvertKeycodeGetImeKeyboardType);
+}
+
+} // namespace Libs

--- a/src/libs/libConvertKeycode.cpp
+++ b/src/libs/libConvertKeycode.cpp
@@ -10,8 +10,8 @@ LIB_VERSION("ConvertKeycode", 1, "ConvertKeycode", 1, 0);
 
 namespace ConvertKeycode {
 
-constexpr int CONVERT_KEYCODE_ERROR_INVALID_ADDRESS = -2134900687; // 0x80bc0031
-constexpr int CONVERT_KEYCODE_ERROR_INVALID_USER_ID = -2134900720; // 0x80bc0010
+constexpr int CONVERT_KEYCODE_ERROR_INVALID_ADDRESS = -2135162831; // 0x80bc0031
+constexpr int CONVERT_KEYCODE_ERROR_INVALID_USER_ID = -2135162864; // 0x80bc0010
 
 static int KYTY_SYSV_ABI ConvertKeycodeGetImeKeyboardType(int32_t user_id, uint32_t* type) {
 	PRINT_NAME();

--- a/src/libs/libs.cpp
+++ b/src/libs/libs.cpp
@@ -72,6 +72,7 @@ LIB_DEFINE(InitVideoOut_1);
 
 LIB_DEFINE(InitAppContent_1);
 LIB_DEFINE(InitAudio_1);
+LIB_DEFINE(InitConvertKeycode_1);
 LIB_DEFINE(InitDbgAddressSanitizer_1);
 LIB_DEFINE(InitDialog_1);
 LIB_DEFINE(InitFont_1);
@@ -93,6 +94,7 @@ LIB_DEFINE(InitUserService_1);
 
 void InitAll(Loader::SymbolDatabase* s) {
 	InitAudio_1(s);
+	InitConvertKeycode_1(s);
 	LibAmpr::InitAmpr_1(s);
 	InitAppContent_1(s);
 	Coredump::InitCoredump_1(s);


### PR DESCRIPTION
**Problem.** `sceConvertKeycodeGetImeKeyboardType` (module `ConvertKeycode`) was Astro Bot's one unresolved import. An unresolved import resolves to target address 0, so the first call jumps to 0.

**Change.** New `libConvertKeycode.cpp` modelled on `libTextToSpeech2.cpp`: returns keyboard type 0 with OK, and the IME error codes for a null pointer or a negative user id.

**Effect.** No unresolved imports remain for Astro Bot.

**Verification.** Astro Bot run (import resolved); build clean.

**References**
- No public specification for this function. The import was observed unresolved in the relocation log, and `runtimeLinker.cpp` resolves unresolved imports to address 0. Return values follow the module's other stubs in this repository.
