### PR TITLE
shader: model EXEC and VCC words as subgroup ballots

### DIFF
--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -110,8 +110,8 @@ Decoder::Operand Translator::PlainOperand(const Decoder::Operand& operand) {
 }
 
 std::array<IR::U32, 2> Translator::BallotMask(IR::U1 value) {
-	return {ir.Select(value, IR::U32(IR::Value(1u)), IR::U32(IR::Value(0u))),
-	        IR::U32(IR::Value(0u))};
+	const auto ballot = ir.Emit(IR::ValueOpcode::Ballot, {value});
+	return {ir.CompositeExtract(ballot, 0), ir.CompositeExtract(ballot, 1)};
 }
 
 IR::U32 Translator::ReadRawU32(const Decoder::Operand& operand) {
@@ -318,7 +318,9 @@ void Translator::WriteRawU32(const Decoder::Operand& operand, IR::U32 value) {
 			break;
 		case Decoder::OperandKind::VccHi:
 			ir.SetVccHi(IR::U32(value));
-			ir.SetVcc(ThreadBit(ir.GetVccLo()));
+			if (current_wave_size != 32u) {
+				ir.SetVcc(ThreadBit(ir.GetVccLo()));
+			}
 			break;
 		case Decoder::OperandKind::M0: ir.SetM0(IR::U32(value)); break;
 		case Decoder::OperandKind::ExecLo:
@@ -327,7 +329,9 @@ void Translator::WriteRawU32(const Decoder::Operand& operand, IR::U32 value) {
 			break;
 		case Decoder::OperandKind::ExecHi:
 			ir.SetExecHi(IR::U32(value));
-			ir.SetExec(ThreadBit(ir.GetExecLo()));
+			if (current_wave_size != 32u) {
+				ir.SetExec(ThreadBit(ir.GetExecLo()));
+			}
 			break;
 		case Decoder::OperandKind::Scc:
 			ir.SetScc(ir.INotEqual(value, IR::U32(IR::Value(0u))));
@@ -596,7 +600,10 @@ void Translator::WriteU32Pair(const Decoder::Operand&       operand,
 }
 
 IR::U1 Translator::ThreadBit(IR::U32 low) {
-	return ir.INotEqual(low, IR::U32(IR::Value(0u)));
+	const auto lane = ir.BitwiseAnd(IR::U32(ir.Emit(IR::ValueOpcode::LaneId, {})),
+	                                IR::U32(IR::Value(31u)));
+	return ir.INotEqual(ir.BitwiseAnd(ir.ShiftRightLogical(low, lane), IR::U32(IR::Value(1u))),
+	                    IR::U32(IR::Value(0u)));
 }
 
 IR::U1 Translator::ReadCondition(const Decoder::Operand& operand) {
@@ -623,10 +630,12 @@ IR::U1 Translator::ReadMask(const Decoder::Operand& operand) {
 			const auto reg = static_cast<IR::ScalarReg>(operand.reg);
 			return ir.GetThreadBitScalarReg(reg);
 		}
-		case Decoder::OperandKind::ExecLo:
-		case Decoder::OperandKind::ExecHi: return ir.GetExec();
-		case Decoder::OperandKind::VccLo:
-		case Decoder::OperandKind::VccHi: return ir.GetVcc();
+		case Decoder::OperandKind::ExecLo: return ir.GetExec();
+		case Decoder::OperandKind::ExecHi:
+			return current_wave_size == 32u ? ThreadBit(ir.GetExecHi()) : ir.GetExec();
+		case Decoder::OperandKind::VccLo: return ir.GetVcc();
+		case Decoder::OperandKind::VccHi:
+			return current_wave_size == 32u ? ThreadBit(ir.GetVccHi()) : ir.GetVcc();
 		case Decoder::OperandKind::Scc: return ir.GetScc();
 		case Decoder::OperandKind::VccZ: return ir.LogicalNot(ir.GetVcc());
 		case Decoder::OperandKind::ExecZ: return ir.LogicalNot(ir.GetExec());
@@ -681,16 +690,26 @@ void Translator::WriteMask(const Decoder::Operand& operand, IR::U1 value) {
 			}
 			return;
 		}
-		case Decoder::OperandKind::ExecLo:
-		case Decoder::OperandKind::ExecHi: {
+		case Decoder::OperandKind::ExecHi:
+			if (current_wave_size == 32u) {
+				ir.SetExecHi(BallotMask(value)[0]);
+				return;
+			}
+			[[fallthrough]];
+		case Decoder::OperandKind::ExecLo: {
 			const auto mask = BallotMask(value);
 			ir.SetExec(value);
 			ir.SetExecLo(mask[0]);
 			ir.SetExecHi(mask[1]);
 			return;
 		}
-		case Decoder::OperandKind::VccLo:
-		case Decoder::OperandKind::VccHi: {
+		case Decoder::OperandKind::VccHi:
+			if (current_wave_size == 32u) {
+				ir.SetVccHi(BallotMask(value)[0]);
+				return;
+			}
+			[[fallthrough]];
+		case Decoder::OperandKind::VccLo: {
 			const auto mask = BallotMask(value);
 			ir.SetVcc(value);
 			ir.SetVccLo(mask[0]);

--- a/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Translate.cpp
@@ -109,6 +109,12 @@ Decoder::Operand Translator::PlainOperand(const Decoder::Operand& operand) {
 	return result;
 }
 
+// A scalar branch on EXEC or VCC is taken by the whole wave, so it tests every lane's bit.
+IR::U1 Translator::AnyLane(IR::U32 low, IR::U32 high) {
+	const auto word = current_wave_size == 32u ? low : ir.BitwiseOr(low, high);
+	return ir.INotEqual(word, IR::U32(IR::Value(0u)));
+}
+
 std::array<IR::U32, 2> Translator::BallotMask(IR::U1 value) {
 	const auto ballot = ir.Emit(IR::ValueOpcode::Ballot, {value});
 	return {ir.CompositeExtract(ballot, 0), ir.CompositeExtract(ballot, 1)};
@@ -600,8 +606,8 @@ void Translator::WriteU32Pair(const Decoder::Operand&       operand,
 }
 
 IR::U1 Translator::ThreadBit(IR::U32 low) {
-	const auto lane = ir.BitwiseAnd(IR::U32(ir.Emit(IR::ValueOpcode::LaneId, {})),
-	                                IR::U32(IR::Value(31u)));
+	const auto lane =
+	    ir.BitwiseAnd(IR::U32(ir.Emit(IR::ValueOpcode::LaneId, {})), IR::U32(IR::Value(31u)));
 	return ir.INotEqual(ir.BitwiseAnd(ir.ShiftRightLogical(low, lane), IR::U32(IR::Value(1u))),
 	                    IR::U32(IR::Value(0u)));
 }
@@ -637,8 +643,10 @@ IR::U1 Translator::ReadMask(const Decoder::Operand& operand) {
 		case Decoder::OperandKind::VccHi:
 			return current_wave_size == 32u ? ThreadBit(ir.GetVccHi()) : ir.GetVcc();
 		case Decoder::OperandKind::Scc: return ir.GetScc();
-		case Decoder::OperandKind::VccZ: return ir.LogicalNot(ir.GetVcc());
-		case Decoder::OperandKind::ExecZ: return ir.LogicalNot(ir.GetExec());
+		case Decoder::OperandKind::VccZ:
+			return ir.LogicalNot(AnyLane(ir.GetVccLo(), ir.GetVccHi()));
+		case Decoder::OperandKind::ExecZ:
+			return ir.LogicalNot(AnyLane(ir.GetExecLo(), ir.GetExecHi()));
 		default: return ir.INotEqual(ReadRawU32(operand), IR::U32(IR::Value(0u)));
 	}
 }
@@ -780,17 +788,23 @@ void Translator::AddBranchCondition(const CFG::BasicBlock& source, IR::BlockInfo
 	if (source.terminator.kind != CFG::TerminatorKind::ConditionalBranch) {
 		return;
 	}
-	// EXEC and VCC are invocation-local Boolean masks. Branching on that Boolean lets inactive
-	// invocations leave the region without reconstructing a host-subgroup mask.
 	IR::U1 condition;
 	switch (source.terminator.condition) {
 		case CFG::BranchCondition::Always: condition = IR::U1(IR::Value(true)); break;
 		case CFG::BranchCondition::SccZero: condition = ir.LogicalNot(ir.GetScc()); break;
 		case CFG::BranchCondition::SccNonZero: condition = ir.GetScc(); break;
-		case CFG::BranchCondition::VccZero: condition = ir.LogicalNot(ir.GetVcc()); break;
-		case CFG::BranchCondition::VccNonZero: condition = ir.GetVcc(); break;
-		case CFG::BranchCondition::ExecZero: condition = ir.LogicalNot(ir.GetExec()); break;
-		case CFG::BranchCondition::ExecNonZero: condition = ir.GetExec(); break;
+		case CFG::BranchCondition::VccZero:
+			condition = ir.LogicalNot(AnyLane(ir.GetVccLo(), ir.GetVccHi()));
+			break;
+		case CFG::BranchCondition::VccNonZero:
+			condition = AnyLane(ir.GetVccLo(), ir.GetVccHi());
+			break;
+		case CFG::BranchCondition::ExecZero:
+			condition = ir.LogicalNot(AnyLane(ir.GetExecLo(), ir.GetExecHi()));
+			break;
+		case CFG::BranchCondition::ExecNonZero:
+			condition = AnyLane(ir.GetExecLo(), ir.GetExecHi());
+			break;
 		case CFG::BranchCondition::GotoVariable:
 			if (source.terminator.goto_variable == UINT32_MAX) {
 				EXIT("block %u reads an invalid goto variable", source.id);
@@ -1044,8 +1058,9 @@ IR::Program TranslateProgram(const Decoder::Program& decoded, const CFG::Graph& 
 			entry_ir.SetScalarMaskTag(reg, IR::U1(IR::Value(false)));
 		}
 		entry_ir.SetExec(IR::U1(IR::Value(true)));
-		entry_ir.SetExecLo(IR::U32(IR::Value(1u)));
-		entry_ir.SetExecHi(IR::U32(IR::Value(0u)));
+		const auto entry_exec = entry_ir.Emit(IR::ValueOpcode::Ballot, {IR::U1(IR::Value(true))});
+		entry_ir.SetExecLo(entry_ir.CompositeExtract(entry_exec, 0));
+		entry_ir.SetExecHi(entry_ir.CompositeExtract(entry_exec, 1));
 		if (options.stage == ShaderType::Compute) {
 			const auto* cs = options.compute;
 			const auto  thread_ids =

--- a/src/graphics/shader/recompiler/frontend/translate/Translator.h
+++ b/src/graphics/shader/recompiler/frontend/translate/Translator.h
@@ -24,6 +24,7 @@ private:
 	Decoder::Operand OffsetOperand(const Decoder::Operand& operand, uint32_t offset);
 	Decoder::Operand ScalarDestinationOperand(const Decoder::Operand& operand, uint32_t offset);
 	Decoder::Operand PlainOperand(const Decoder::Operand& operand);
+	IR::U1                 AnyLane(IR::U32 low, IR::U32 high);
 	std::array<IR::U32, 2> BallotMask(IR::U1 value);
 	IR::U32                ReadRawU32(const Decoder::Operand& operand);
 	IR::U32                ReadScalarCode(uint32_t code);

--- a/tests/shaderCfgTests.cpp
+++ b/tests/shaderCfgTests.cpp
@@ -11862,8 +11862,8 @@ void TestNewShaderRecompilerSpirvSizeBaselines() {
       EncodeSopp(0x01),
   };
   const auto wqm_result = compile("wqm", wqm,
-                                  {.words = 407,
-                                   .instructions = 98,
+                                  {.words = 411,
+                                   .instructions = 99,
                                    .variables = 4,
                                    .loads = 3,
                                    .stores = 1,
@@ -11871,7 +11871,7 @@ void TestNewShaderRecompilerSpirvSizeBaselines() {
                                    .selection_merges = 1,
                                    .branches = 4,
                                    .conditional_branches = 1,
-                                   .ballots = 1},
+                                   .ballots = 2},
                                   ShaderType::Vertex);
   Check(Common::ContainsStr(wqm_result.ir_dump, "WqmMask"),
         "WQM size fixture no longer reaches per-invocation WqmMask IR");


### PR DESCRIPTION
**Problem.** EXEC and VCC words were modelled per lane, so branches on EXECZ/VCCZ and scalar arithmetic on the masks saw one lane's bit rather than the wave-wide word the hardware has. Wave32 shaders in Astro Bot took the wrong branches.

**Change.** Two commits. First: `BallotMask` emits a real subgroup ballot, `ThreadBit` tests `(word >> lane) & 1`, the entry block seeds EXEC with `Ballot(true)`, and in wave32 `vcc_hi`/`exec_hi` are ordinary registers. S

econd: EXECZ/VCCZ branches and the `execz`/`vccz` operands read the whole-wave value.

**Effect.** Astro Bot's wave32 shaders branch as the hardware does; needed to reach the game world.

**Verification.** Suites pass; the `wqm` SPIR-V budget test updated for the one extra entry ballot.

**References**
- AMD RDNA 2 Instruction Set Architecture Reference Guide, §3.3 "EXECute Mask", §3.9 "Vector Compares: VCC and VCCZ" and §4.2 "Branching" (`S_CBRANCH_EXECZ`/`VCCZ`): EXEC and VCC are wave-wide masks and the Z flags test the whole word.
