### PR TITLE
libkernel: register scePthreadRwlockTryrdlock and the timed rwlock variants

### DIFF
--- a/src/kernel/pthread.cpp
+++ b/src/kernel/pthread.cpp
@@ -2573,6 +2573,11 @@ int KYTY_SYSV_ABI PthreadRwlockRdlock(PthreadRwlock* rwlock) {
 int KYTY_SYSV_ABI PthreadRwlockTimedrdlock(PthreadRwlock* rwlock, KernelUseconds usec) {
 	PRINT_NAME();
 
+	auto* pthread_static_objects = g_pthread_context->GetPthreadStaticObjects();
+
+	rwlock = static_cast<PthreadRwlock*>(
+	    pthread_static_objects->CreateObject(rwlock, PthreadStaticObject::Type::Rwlock));
+
 	if (rwlock == nullptr) {
 		return KERNEL_ERROR_EINVAL;
 	}
@@ -2585,6 +2590,11 @@ int KYTY_SYSV_ABI PthreadRwlockTimedrdlock(PthreadRwlock* rwlock, KernelUseconds
 int KYTY_SYSV_ABI PthreadRwlockTimedwrlock(PthreadRwlock* rwlock, KernelUseconds usec) {
 	PRINT_NAME();
 
+	auto* pthread_static_objects = g_pthread_context->GetPthreadStaticObjects();
+
+	rwlock = static_cast<PthreadRwlock*>(
+	    pthread_static_objects->CreateObject(rwlock, PthreadStaticObject::Type::Rwlock));
+
 	if (rwlock == nullptr) {
 		return KERNEL_ERROR_EINVAL;
 	}
@@ -2596,6 +2606,11 @@ int KYTY_SYSV_ABI PthreadRwlockTimedwrlock(PthreadRwlock* rwlock, KernelUseconds
 
 int KYTY_SYSV_ABI PthreadRwlockTryrdlock(PthreadRwlock* rwlock) {
 	PRINT_NAME();
+
+	auto* pthread_static_objects = g_pthread_context->GetPthreadStaticObjects();
+
+	rwlock = static_cast<PthreadRwlock*>(
+	    pthread_static_objects->CreateObject(rwlock, PthreadStaticObject::Type::Rwlock));
 
 	if (rwlock == nullptr) {
 		return KERNEL_ERROR_EINVAL;

--- a/src/libs/libKernel.cpp
+++ b/src/libs/libKernel.cpp
@@ -3226,6 +3226,9 @@ LIB_DEFINE(InitLibKernel_1_Pthread) {
 	LIB_FUNC("mqdNorrB+gI", LibKernel::PthreadRwlockWrlock);
 	LIB_FUNC("sIlRvQqsN2Y", LibKernel::PthreadRwlockWrlock);
 	LIB_FUNC("bIHoZCTomsI", LibKernel::PthreadRwlockTrywrlock);
+	LIB_FUNC("XD3mDeybCnk", LibKernel::PthreadRwlockTryrdlock);
+	LIB_FUNC("iPtZRWICjrM", LibKernel::PthreadRwlockTimedrdlock);
+	LIB_FUNC("adh--6nIqTk", LibKernel::PthreadRwlockTimedwrlock);
 	LIB_FUNC("i2ifZ3fS2fo", LibKernel::PthreadRwlockattrDestroy);
 	LIB_FUNC("yOfGg-I1ZII", LibKernel::PthreadRwlockattrInit);
 	LIB_FUNC("qsdmgXjqSgk", LibKernel::PthreadRwlockattrDestroy);


### PR DESCRIPTION
**Problem.** `scePthreadRwlockTryrdlock`, `scePthreadRwlockTimedrdlock` and `scePthreadRwlockTimedwrlock` were unresolved and patched to a stub returning 0, i.e. a try-lock that reports success without taking the lock. Astro Bot and its libc import all three.

**Change.** Register the three exports; the implementations already existed.

**Effect.** The imports resolve to the real implementations. Not reached in the runs so far, so no measured game change.

**Verification.** Build clean; suites unchanged.

**References**
- No public specification needed: the three imports were observed unresolved in the relocation log; the implementations already existed in this repository and only the registrations were missing.
