### PR TITLE
shader: query host readability once per region during the SRT walk

### DIFF
--- a/src/graphics/host_gpu/hostMemory.cpp
+++ b/src/graphics/host_gpu/hostMemory.cpp
@@ -96,6 +96,32 @@ bool HostMemoryIsReadable(uint64_t addr) {
 	return HostMemoryRangeIsReadable(addr, 1);
 }
 
+bool HostMemoryReadableRegion(uint64_t addr, uint64_t& begin, uint64_t& end) {
+	begin = end = 0;
+	if (addr == 0) {
+		return false;
+	}
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+	MEMORY_BASIC_INFORMATION region {};
+	if (::VirtualQuery(reinterpret_cast<const void*>(static_cast<uintptr_t>(addr)), &region,
+	                   sizeof(region)) == 0 ||
+	    (region.State & MEM_COMMIT) == 0 || !IsAccessible(region.Protect, HostMemoryAccess::Read)) {
+		return false;
+	}
+	begin = reinterpret_cast<uint64_t>(region.BaseAddress);
+	end   = begin + region.RegionSize < begin ? UINT64_MAX : begin + region.RegionSize;
+	return end > addr;
+#else
+	uint64_t readable = 0;
+	if (!HostMemoryQueryReadable(addr, 1, readable) || readable == 0) {
+		return false;
+	}
+	begin = addr;
+	end   = addr + 1;
+	return true;
+#endif
+}
+
 bool HostMemoryRangeIsReadable(uint64_t addr, uint64_t size) {
 	if (addr == 0 || size == 0 || UINT64_MAX - addr < size) {
 		return false;

--- a/src/graphics/host_gpu/hostMemory.h
+++ b/src/graphics/host_gpu/hostMemory.h
@@ -12,6 +12,8 @@ bool HostMemoryQueryRange(uint64_t addr, uint64_t requested_size, HostMemoryAcce
 bool HostMemoryQueryReadable(uint64_t addr, uint64_t requested_size, uint64_t& readable_size);
 bool HostMemoryIsReadable(uint64_t addr);
 bool HostMemoryRangeIsReadable(uint64_t addr, uint64_t size);
+// Bounds of the committed, readable host region containing addr, so callers can cache one query.
+bool HostMemoryReadableRegion(uint64_t addr, uint64_t& begin, uint64_t& end);
 
 } // namespace Libs::Graphics
 

--- a/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
@@ -1,6 +1,7 @@
 #include "graphics/shader/recompiler/ir/passes/SrtWalker.h"
 
 #include "common/assert.h"
+#include "graphics/host_gpu/hostMemory.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 
 #include <algorithm>
@@ -534,6 +535,11 @@ private:
 				return false;
 			}
 		} else {
+			// The address is derived from guest data, so it can be anything; a descriptor that
+			// does not resolve must fail evaluation rather than fault the emulator.
+			if (!RangeReadable(address, sizeof(word))) {
+				return false;
+			}
 			std::memcpy(&word, reinterpret_cast<const void*>(address), sizeof(word));
 		}
 		result = word;
@@ -816,12 +822,29 @@ private:
 		return false;
 	}
 
-	const Program&                            m_program;
-	const SrtRuntime&                         m_runtime;
-	std::span<const uint8_t>                  m_clean_flat_slots;
-	Evaluator*                                m_clean_evaluator = nullptr;
-	std::unordered_map<const Inst*, uint64_t> m_cache;
-	std::vector<const Inst*>                  m_visiting;
+	// One host memory query per region instead of one per word; the same check, cached for this walk.
+	bool RangeReadable(uint64_t address, uint64_t size) {
+		for (const auto& [begin, end]: m_readable_regions) {
+			if (address >= begin && size <= end - address) {
+				return true;
+			}
+		}
+		uint64_t begin = 0;
+		uint64_t end   = 0;
+		if (HostMemoryReadableRegion(address, begin, end) && size <= end - address) {
+			m_readable_regions.emplace_back(begin, end);
+			return true;
+		}
+		return HostMemoryRangeIsReadable(address, size);
+	}
+
+	const Program&                                m_program;
+	const SrtRuntime&                             m_runtime;
+	std::span<const uint8_t>                      m_clean_flat_slots;
+	Evaluator*                                    m_clean_evaluator = nullptr;
+	std::unordered_map<const Inst*, uint64_t>     m_cache;
+	std::vector<const Inst*>                      m_visiting;
+	std::vector<std::pair<uint64_t, uint64_t>>    m_readable_regions;
 };
 
 const DescriptorSource* Source(const Program& program, uint32_t source) {


### PR DESCRIPTION
**Problem.** With no memory reader installed (the draw path installs only the specialization reader), every SRT word the walk read called `HostMemoryRangeIsReadable`, one `VirtualQuery` syscall each. Astro Bot's first scene walks thousands of words per draw: `Srt.EvaluateRuntimeSources` took 1.94 ms per call, 94% of the GPU thread, about 1 fps.

**Change.** Add `HostMemoryReadableRegion`, which returns the bounds of the committed readable region containing an address, and have the evaluator cache those bounds so later words in the same region need no query. Words outside every cached region still query.

**Effect.** Astro Bot's first scene runs at interactive speed instead of ~1 fps.

**Verification.** Suites pass; measured across several Astro Bot runs.

**References**
- Microsoft Docs, `VirtualQuery` and `MEMORY_BASIC_INFORMATION`: one query returns the whole region of pages with identical attributes (`RegionSize`), so it answers every address inside it.
