### PR TITLE
shader: lower SAMPLE_C to a sample and an ALU compare

### DIFF
--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -806,15 +806,8 @@ static vk::Sampler NativeSampler(RenderContext&                       context,
                                  const ShaderRecompiler::IR::DescriptorValue& value) {
 	ShaderSamplerResource descriptor;
 	CopyNativeDescriptor(value, descriptor.fields);
-	const bool depth_compare = std::any_of(program.info.sampled_pairs.begin(),
-	                                       program.info.sampled_pairs.end(), [&](const auto& pair) {
-		                                       return pair.sampler == index &&
-		                                              pair.image < program.info.images.size() &&
-		                                              program.info.images[pair.image].depth_compare;
-	                                       });
-	if (!depth_compare) {
-		descriptor.fields[0] &= ~(0x7u << 12u);
-	}
+	// SAMPLE_C is lowered to a sample plus a compare in the shader; no host sampler compares.
+	descriptor.fields[0] &= ~(0x7u << 12u);
 	if (program.info.samplers[index].force_point_filtering) {
 		descriptor.SetPointFiltering();
 	}

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
@@ -169,6 +169,38 @@ uint32_t CoordF32(ValueEmitContext& ctx, const IR::MemoryInfo& mem, const IR::In
 	return result;
 }
 
+// SAMPLE_C compares the sampled channel in the shader: host sampled views of depth are colour
+// formats, which cannot be sampled with Vulkan Dref ops.
+uint32_t SamplerCompareFunc(const EmitterState& state, const IR::MemoryInfo& mem) {
+	if (mem.sampler >= state.resources.samplers.size() ||
+	    state.resources.samplers[mem.sampler].dword_count == 0) {
+		return 3u;
+	}
+	return (state.resources.samplers[mem.sampler].dwords[0] >> 12u) & 0x7u;
+}
+
+uint32_t EmitAluDepthCompare(EmitterState& state, uint32_t sampled, uint32_t dref,
+                             uint32_t compare_func) {
+	const auto one    = ConstantF32(state, 0x3f800000u);
+	const auto zero   = ZeroF32(state);
+	uint32_t   opcode = 0;
+	switch (compare_func) {
+		case 0: return sampled;
+		case 1: opcode = OpFOrdLessThan; break;
+		case 2: opcode = OpFOrdEqual; break;
+		case 3: opcode = OpFOrdLessThanEqual; break;
+		case 4: opcode = OpFOrdGreaterThan; break;
+		case 5: opcode = OpFOrdNotEqual; break;
+		case 6: opcode = OpFOrdGreaterThanEqual; break;
+		default: return one;
+	}
+	const auto pass = state.builder.AllocateId();
+	state.builder.AddFunction({opcode, TypeBool(state), pass, dref, sampled});
+	const auto result = state.builder.AllocateId();
+	state.builder.AddFunction({OpSelect, TypeF32(state), result, pass, one, zero});
+	return result;
+}
+
 uint32_t CoordU32(ValueEmitContext& ctx, const IR::MemoryInfo& mem, const IR::Inst& address,
                   ImageDimension dimension) {
 	const auto components = ImageDimensionInfoFor(dimension).coordinate_components;
@@ -704,12 +736,8 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			const auto            sample  = state.builder.AllocateId();
 			std::vector<uint32_t> words;
 			if (dref) {
-				auto dref_value = ZeroF32(state);
-				if (layout.dref != NoImageComponent) {
-					dref_value = AddressF32(ctx, mem, *address, layout.dref);
-				}
-				words = {OpImageDrefGather, TypeF32Vector(state, 4), sample, sampled, coord,
-				         dref_value};
+				words = {OpImageGather, TypeF32Vector(state, 4), sample, sampled, coord,
+				         ConstantU32(state, 0u)};
 			} else {
 				uint32_t component = 0;
 				if (ImageConversionFormat(state, mem).format == Prospero::BufferFormat::kInvalid) {
@@ -727,11 +755,26 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 				words.push_back(PackedOffset(ctx, mem, *address, layout, dimension));
 			}
 			state.builder.AddFunction(words);
-			auto result_numeric_class = numeric_class;
+			auto     result_numeric_class = numeric_class;
+			uint32_t gathered             = sample;
 			if (dref) {
-				result_numeric_class = Prospero::TextureNumericClass::Float;
+				result_numeric_class  = Prospero::TextureNumericClass::Float;
+				auto dref_value       = ZeroF32(state);
+				if (layout.dref != NoImageComponent) {
+					dref_value = AddressF32(ctx, mem, *address, layout.dref);
+				}
+				const auto            func = SamplerCompareFunc(state, mem);
+				std::vector<uint32_t> compared {OpCompositeConstruct, TypeF32Vector(state, 4), 0u};
+				gathered    = state.builder.AllocateId();
+				compared[2] = gathered;
+				for (uint32_t c = 0; c < 4; c++) {
+					const auto texel = state.builder.AllocateId();
+					state.builder.AddFunction({OpCompositeExtract, TypeF32(state), texel, sample, c});
+					compared.push_back(EmitAluDepthCompare(state, texel, dref_value, func));
+				}
+				state.builder.AddFunction(compared);
 			}
-			ctx.Define(inst, ResultVector(ctx, UnpackImageGather(ctx, mem, sample),
+			ctx.Define(inst, ResultVector(ctx, UnpackImageGather(ctx, mem, gathered),
 			                              result_numeric_class, false, mem, true));
 			return true;
 		}
@@ -739,16 +782,11 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		                          HasFlag(mem, Decoder::ImageSampleFlagLod) ||
 		                          HasFlag(mem, Decoder::ImageSampleFlagLevelZero) ||
 		                          state.stage != ShaderType::Pixel;
-		uint32_t opcode = OpImageSampleImplicitLod;
-		if (explicit_lod) {
-			opcode = dref ? OpImageSampleDrefExplicitLod : OpImageSampleExplicitLod;
-		} else if (dref) {
-			opcode = OpImageSampleDrefImplicitLod;
-		}
+		const uint32_t opcode = explicit_lod ? OpImageSampleExplicitLod : OpImageSampleImplicitLod;
 		uint32_t result_type = ImageVectorType(state, numeric_class, 4);
 		uint32_t dref_value  = 0;
 		if (dref) {
-			result_type = TypeF32(state);
+			result_type = TypeF32Vector(state, 4);
 			dref_value  = ZeroF32(state);
 			if (layout.dref != NoImageComponent) {
 				dref_value = AddressF32(ctx, mem, *address, layout.dref);
@@ -777,15 +815,17 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			const auto            sampled = MakeSampledImage(state, resource, mem.sampler);
 			const auto            sample  = state.builder.AllocateId();
 			std::vector<uint32_t> words {opcode, result_type, sample, sampled, coord};
-			if (dref) {
-				words.push_back(dref_value);
-			}
 			if (operand_mask != 0u) {
 				words.push_back(operand_mask);
 				words.insert(words.end(), operands.begin(), operands.end());
 			}
 			state.builder.AddFunction(words);
-			return sample;
+			if (!dref) {
+				return sample;
+			}
+			const auto channel = state.builder.AllocateId();
+			state.builder.AddFunction({OpCompositeExtract, TypeF32(state), channel, sample, 0u});
+			return EmitAluDepthCompare(state, channel, dref_value, SamplerCompareFunc(state, mem));
 		};
 		if (image.indirect_root != mem.resource) {
 			const auto sample = EmitSample(mem.resource);

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -20313,7 +20313,7 @@ TestCase ImageSampleA16CompareBiasRdna2AddressOrder() {
   test.code = code;
   test.opcodes = {O::V_MOV_B32, O::IMAGE_SAMPLE, O::BUFFER_STORE_DWORD,
                   O::S_ENDPGM};
-  test.required_spirv = {"OpImageSampleDrefExplicitLod", "UnpackHalf2x16"};
+  test.required_spirv = {"OpImageSampleExplicitLod", "UnpackHalf2x16"};
   test.compile_only = true;
   return test;
 }
@@ -20357,7 +20357,7 @@ TestCase ImageGatherCompareOpcodes() {
       O::V_MOV_B32,         O::IMAGE_GATHER4_C,      O::IMAGE_GATHER4_C_LZ,
       O::IMAGE_GATHER4_C_O, O::IMAGE_GATHER4_C_LZ_O, O::BUFFER_STORE_DWORD,
       O::S_ENDPGM};
-  test.required_spirv = {"OpImageDrefGather", "OpBitFieldSExtract"};
+  test.required_spirv = {"OpImageGather", "OpBitFieldSExtract"};
   test.compile_only = true;
   return test;
 }

--- a/tests/shaderCfgTests.cpp
+++ b/tests/shaderCfgTests.cpp
@@ -4731,9 +4731,8 @@ void TestNewShaderRecompilerImageSampleVariants() {
   Check(SpirvContainsOpcode(result.spirv, 88),
         "SPIR-V binary does not contain shared OpImageSampleExplicitLod "
         "emission");
-  Check(SpirvContainsOpcode(result.spirv, 90),
-        "SPIR-V binary does not contain shared OpImageSampleDrefExplicitLod "
-        "emission");
+  Check(!SpirvContainsOpcode(result.spirv, 90) && SpirvContainsOpcode(result.spirv, 169),
+        "SPIR-V binary does not lower the compare sample to an ALU select");
   Check(SpirvContainsOpcode(result.spirv, 80),
         "SPIR-V binary does not contain coordinate/gradient composite "
         "construction");
@@ -4846,8 +4845,9 @@ void TestNewShaderRecompilerImageSampleA16ExceptionComponents() {
           "A16 IMAGE_SAMPLE_C did not preserve compare+A16 metadata");
     Check(Common::ContainsStr(result.ir_dump, "image_flags=0x88"),
           "A16 IMAGE_SAMPLE_C did not preserve compare+A16 IR flags");
-    Check(SpirvInstructionOpcodeCount(result.spirv, 90) == 1,
-          "A16 IMAGE_SAMPLE_C should emit one dref sample");
+    Check(SpirvInstructionOpcodeCount(result.spirv, 90) == 0 &&
+              SpirvInstructionOpcodeCount(result.spirv, 88) == 1,
+          "A16 IMAGE_SAMPLE_C should emit one plain sample and compare in ALU");
     Check(SpirvExtInstCount(result.spirv, 62) == 2,
           "PCF reference must remain 32-bit while only xy sampler coords use "
           "A16");
@@ -4968,18 +4968,22 @@ void TestNewShaderRecompilerPixelImageSampleLodSelection() {
   }
   {
     const auto result = compile(0x28, 0x1); // image_sample_c
+    Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleImplicitLod) ==
+              1,
+          "pixel IMAGE_SAMPLE_C must sample with implicit lod and compare in ALU");
     Check(SpirvInstructionOpcodeCount(result.spirv,
-                                      OpImageSampleDrefImplicitLod) == 1,
-          "pixel IMAGE_SAMPLE_C must use OpImageSampleDrefImplicitLod");
-    Check(SpirvInstructionOpcodeCount(result.spirv,
-                                      OpImageSampleDrefExplicitLod) == 0,
-          "pixel IMAGE_SAMPLE_C unexpectedly used explicit dref lod");
+                                      OpImageSampleDrefImplicitLod) == 0 &&
+              SpirvInstructionOpcodeCount(result.spirv,
+                                          OpImageSampleDrefExplicitLod) == 0,
+          "pixel IMAGE_SAMPLE_C unexpectedly used a Dref sample");
   }
   {
     const auto result = compile(0x2f, 0x1); // image_sample_c_lz
-    Check(SpirvInstructionOpcodeCount(result.spirv,
-                                      OpImageSampleDrefExplicitLod) == 1,
-          "pixel IMAGE_SAMPLE_C_LZ must use explicit dref lod");
+    Check(SpirvInstructionOpcodeCount(result.spirv, OpImageSampleExplicitLod) ==
+                  1 &&
+              SpirvInstructionOpcodeCount(result.spirv,
+                                          OpImageSampleDrefExplicitLod) == 0,
+          "pixel IMAGE_SAMPLE_C_LZ must use explicit lod and compare in ALU");
   }
 }
 
@@ -5233,8 +5237,8 @@ void TestNewShaderRecompilerImageGatherVariants() {
         "SPIR-V binary does not request ImageGatherExtended");
   Check(SpirvContainsOpcode(result.spirv, 96),
         "SPIR-V binary does not contain OpImageGather");
-  Check(SpirvContainsOpcode(result.spirv, 97),
-        "SPIR-V binary does not contain OpImageDrefGather");
+  Check(!SpirvContainsOpcode(result.spirv, 97),
+        "SPIR-V binary still contains OpImageDrefGather");
   Check(SpirvContainsOpcode(result.spirv, 202),
         "SPIR-V binary does not contain packed gather offset extraction");
   Check(SpirvContainsOpcode(result.spirv, 81),


### PR DESCRIPTION
**Problem.** `IMAGE_SAMPLE_C*` and `IMAGE_GATHER4_C*` were emitted as Vulkan Dref ops with a comparison sampler. The host samples depth through colour-format views (R16/R32), which do not carry the depth-comparison feature, so every such draw or dispatch is invalid (`VUID-vkCmdDispatch-None-06479` in Astro Bot's volumetric-fog compute shader, and the same VUID on a draw).

**Change.** Sample with the plain opcode, take the red channel and compare it in ALU against the reference using the guest sampler's compare function (dword 0 bits 12–14: 0 passes the texel through, 7 is always-pass), selecting 1.0 or 0.0. Gathers compare each of the four texels. Comparison bits are stripped from every host sampler since no host compare remains. Test expectations updated from Dref ops to the plain sample and select.

**Effect.** Astro Bot's fog-volume writer runs hundreds of dispatches instead of stopping at its third; the validation error is gone on both the compute and the draw path.

**Credit.** The SAMPLE_C lowering follows the approach in #241 by @Pouare514; this is a re-implementation against the current emitter, kept to that one topic.

**Verification.** shader_cfg, resource_tracking, scalar_provenance pass; the compute suite reaches the same pre-existing stencil-discovery failure as main.

**References**
- AMD RDNA 2 Instruction Set Architecture Reference Guide, §8.2.7 "Image Sampler": S# dword 0 bits 14:12 `depth compare func` (0 never … 7 always).
- Vulkan specification: `VUID-vkCmdDispatch-None-06479` / `VUID-vkCmdDraw-None-06479`, Dref sampling requires `VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT`, which colour formats lack.
- Approach from #241 by @Pouare514.
