### PR TITLE
tests: fix the GpuCommandLane interrupt races

### DIFF
--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -2209,6 +2209,13 @@ public:
             live_compute_value == 44,
             "compute submission executed a copied PM4 stream");
 
+    // Quiesce everything submitted above before the interrupt queue exists.
+    // Those submissions only called Done(), so their end-of-pipe callbacks can
+    // still be in flight; if one lands after the queue is registered it shows
+    // up in the "no interrupt expected" polls below.
+    gpu.SendCommandSync([&] { context.GetCommandScheduler().Finish(); });
+    context.GetCommandScheduler().DrainPriorityOperations();
+
     LibKernel::EventQueue::KernelEqueue interrupt_queue =
         LibKernel::EventQueue::KERNEL_EQUEUE_INVALID;
     uint32_t graphics_interrupt_udata = 0;
@@ -2243,6 +2250,11 @@ public:
         };
     const auto finish_gpu = [&] {
       gpu.SendCommandSync([&] { context.GetCommandScheduler().Finish(); });
+      // Finish() waits for the GPU tick but does not quiesce the priority
+      // operations thread, which is what delivers end-of-pipe interrupts. The
+      // checks below poll the interrupt queue with a zero timeout, so without
+      // this drain an interrupt can still be in flight and land on a later poll.
+      context.GetCommandScheduler().DrainPriorityOperations();
     };
     const auto wait_for_interrupt =
         [&](LibKernel::EventQueue::KernelEvent &event, int &count) {


### PR DESCRIPTION
`CheckGpuCommandLane` fails intermittently for me. The `gpu_command_lane` entry aborted roughly 1 run in 6, and the `shader_recompiler_compute` aggregate, which runs the same check, failed 5 times out of 8. Three different assertions fired, all inside `GpuCommandLane`:

```
no implicit graphics interrupt: graphics submission completion synthesized an interrupt
no implicit completion interrupt: submission completion synthesized an interrupt absent from the executed PM4 stream
graphics interrupt routing: graphics kOnly interrupt was misrouted or wrote its label
```

The check polls the interrupt queue with a zero timeout and asserts nothing is there, so any end-of-pipe interrupt still in flight reads as a spurious one. Two windows let that happen.

**`Finish()` doesn't quiesce interrupt delivery.** `TriggerEopEventAtEndOfPipe` doesn't deliver the interrupt itself, it queues `TriggerInterrupt` through `DeferPriorityOperation` for the priority operations thread. `Finish()` waits for the GPU tick and drains the ordinary pending queue only. Everywhere else pairs the two — `RenderContext` teardown, `bufferCache`, `gpuResourceManager`, and `CheckSchedulerTimeline` in this same file all follow `Finish()` with `DrainPriorityOperations()` or `WaitPriorityOperations()`. The `finish_gpu` helper didn't.

**The interrupt queue is registered after work that can still interrupt.** The two "borrowed commands" submissions above only call `Done()`, never `Finish()`, and the queue is created after them, so a callback from that work can be delivered once the queue exists and be picked up by the first "no interrupt expected" poll.

Both changes are synchronisation only, no assertion is relaxed.

| | before | after |
|---|--:|--:|
| `gpu_command_lane` | ~1 in 6 | 0 / 40 |
| `shader_recompiler_compute` | 5 / 8 | 0 / 12 |

`ctest` is 33/33. I also applied only this patch to a clean tree to confirm it doesn't depend on anything else I had locally.

Tested on Linux, clang 22.1.8, NVIDIA 610.57.04. Not built on Windows or macOS — the change is test-only and platform-neutral, but I can't run those.
