### PR TITLE
renderer: preserve byte offsets for sub-dword storage buffers

### DIFF
--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -22,6 +22,7 @@
 #include "graphics/host_gpu/renderer/renderContext.h"
 #include "graphics/host_gpu/vma.h"
 #include "graphics/host_gpu/vulkanCommon.h"
+#include "graphics/shader/recompiler/BufferFormat.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 #include "graphics/shader/recompiler/ir/passes/BindingLayout.h"
 #include "graphics/shader/recompiler/ir/passes/ResourceMaterialization.h"
@@ -128,6 +129,27 @@ static bool IsMultisampledTexture(Prospero::ImageType type) {
 	       type == Prospero::ImageType::kColor2DMsaaArray;
 }
 
+// Whether every access the shader can make through this buffer reads or writes fewer than 32 bits
+// at a time. Those go through the sub-word path, which derives both the element index and the byte
+// within the element from one byte address, so a binding whose base is not dword aligned stays
+// exact. Anything that loads a whole dword -- a 32-bit component, a packed bitfield, a scalar
+// buffer read, an atomic -- indexes by dword and would silently straddle two of them instead.
+static bool BufferAccessIsSubDword(const ShaderRecompiler::IR::BufferResource& resource) {
+	if (!resource.formatted || resource.scalar || resource.atomic) {
+		return false;
+	}
+	const auto info = ShaderRecompiler::Format::GetFormatInfo(resource.descriptor_format);
+	if (info.type == ShaderRecompiler::Format::ComponentType::Unknown || info.packed_bitfield) {
+		return false;
+	}
+	for (uint32_t component = 0; component < info.component_count; component++) {
+		if (info.component_bits[component] >= 32u) {
+			return false;
+		}
+	}
+	return info.component_count != 0;
+}
+
 static BufferView NativeStorageBuffer(RenderContext&                              context,
                                       const ShaderBufferResource&                 descriptor,
                                       const ShaderRecompiler::IR::BufferResource& resource,
@@ -159,8 +181,15 @@ static BufferView NativeStorageBuffer(RenderContext&                            
 	const auto aligned_offset = offset - offset % alignment;
 	const auto adjustment     = offset - aligned_offset;
 	const auto max_range      = graphics.GetPhysicalDeviceProperties().limits.maxStorageBufferRange;
-	if (adjustment % sizeof(uint32_t) != 0 || adjustment >= 256 || size > max_range - adjustment) {
-		EXIT("storage buffer offset adjustment is unsupported\n");
+	const bool dword_aligned_adjustment = adjustment % sizeof(uint32_t) == 0;
+	if ((!dword_aligned_adjustment && !BufferAccessIsSubDword(resource)) || adjustment >= 256 ||
+	    size > max_range - adjustment) {
+		EXIT("storage buffer offset adjustment is unsupported: adjustment=0x%" PRIx64
+		     " size=0x%" PRIx64 " format=0x%" PRIx32 " scalar=%d atomic=%d formatted=%d\n",
+		     static_cast<uint64_t>(adjustment), size,
+		     static_cast<uint32_t>(resource.descriptor_format),
+		     static_cast<int>(resource.scalar), static_cast<int>(resource.atomic),
+		     static_cast<int>(resource.formatted));
 	}
 	buffer_offset = static_cast<uint32_t>(adjustment);
 	result.buffer = buffer->Handle();

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
@@ -93,11 +93,22 @@ uint32_t BufferByteAddress(ValueEmitContext& ctx, const IR::Inst& inst, const IR
 	}
 
 	const auto soffset_value = inst.Arg(3).Resolve();
-	if (soffset_value.IsImmediate() && soffset_value.GetType() == IR::Type::U32 &&
-	    soffset_value.U32() == 0u) {
-		return address;
+	if (!(soffset_value.IsImmediate() && soffset_value.GetType() == IR::Type::U32 &&
+	      soffset_value.U32() == 0u)) {
+		address = Binary(state, OpIAdd, TypeU32(state), address, soffset);
 	}
-	return Binary(state, OpIAdd, TypeU32(state), address, soffset);
+
+	// The descriptor is bound at the guest base rounded down to minStorageBufferOffsetAlignment,
+	// and the bytes that were rounded off arrive as the binding's byte offset. Add them here,
+	// before the address is split into an element index and an intra-element byte, so a base that
+	// is not dword aligned stays exact in both halves.
+	if (mem.kind == IR::ResourceKind::Buffer && state.storage_buffer_variable != 0) {
+		const auto array_index =
+		    ResourceForDescriptor(state, IR::DescriptorBindingKind::Buffers, mem.resource);
+		address = Binary(state, OpIAdd, TypeU32(state), address,
+		                 state.memory_byte_offsets[array_index]);
+	}
+	return address;
 }
 
 uint32_t AddU64Low(EmitterState& state, uint32_t low, uint32_t high, uint32_t add_low,
@@ -681,8 +692,7 @@ uint32_t EmitBufferAtomic64(ValueEmitContext& ctx, const IR::Inst& inst,
 	    state, ctx.Arg(inst, inst.NumArgs() - 1), TypeU64(state), ConstantU64(state, 0), [&]() {
 		    const auto resource = PrepareStorageBufferResourceAccess(
 		        state, mem, state.storage_buffer_u64_variable, TypeStorageBufferU64Pointer(state));
-		    const auto byte_address = Binary(state, OpIAdd, TypeU32(state),
-		                                     ByteAddress(ctx, inst, mem), resource.byte_offset);
+		    const auto byte_address = ByteAddress(ctx, inst, mem);
 		    const auto index = Binary(state, OpShiftRightLogical, TypeU32(state), byte_address,
 		                              ConstantU32(state, 3u));
 		    return EmitValueOrDefaultIfCondition(

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemoryHelpers.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemoryHelpers.cpp
@@ -136,10 +136,16 @@ MemoryResourceAccess PrepareMemoryResourceAccess(EmitterState& state, const IR::
 		case IR::ResourceKind::Buffer: {
 			access = PrepareStorageBufferResourceAccess(
 			    state, mem, state.storage_buffer_variable, TypeStorageBufferPointer(state));
-			access.index_offset =
-			    EmitBinaryU32(state, OpShiftRightLogical, access.byte_offset,
-			                  ConstantU32(state, 2u));
-			access.add_index_offset = true;
+			// A Buffer access already folds the binding's byte offset into BufferByteAddress,
+			// where the element index, the sub-word shift and the bounds check all stay exact.
+			// ScalarBuffer/ReadConstBuffer loads a whole dword at address >> 2 and has no byte
+			// address to fold into, so it still needs the offset as a dword index.
+			if (mem.kind == IR::ResourceKind::ScalarBuffer) {
+				access.index_offset =
+				    EmitBinaryU32(state, OpShiftRightLogical, access.byte_offset,
+				                  ConstantU32(state, 2u));
+				access.add_index_offset = true;
+			}
 			return access;
 		}
 		default: EXIT("unsupported memory resource kind: %u\n", static_cast<unsigned>(mem.kind));

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -1318,7 +1318,7 @@ CompiledShader CompileCase(const TestCase &test) {
     if (i < test.storage_buffer_offsets.size()) {
       offset = test.storage_buffer_offsets[i];
     }
-    Require(test.name, "shader data", offset % sizeof(u32) == 0 && offset < 256,
+    Require(test.name, "shader data", offset < 256,
             "storage buffer offset is not representable");
     packed_user_data[result.program.bindings.memory_offset_dword + i / 4u] |=
         offset << ((i % 4u) * 8u);
@@ -17123,6 +17123,65 @@ TestCase BufferStoreDwordAppliesHostOffset() {
   return test;
 }
 
+TestCase BufferStoreByteAppliesByteHostOffset() {
+  using O = ShaderOpcode;
+
+  // The binding's byte offset is 13, which is not a multiple of four. It has to reach both halves
+  // of the address: the element index and the byte within that element. Storing one byte at guest
+  // offset 0 must therefore land at byte 13, which is byte 1 of dword 3.
+  //
+  // Folding the offset in as a dword index instead loses the low two bits and puts the byte at
+  // byte 12, so this case distinguishes the two.
+  std::vector<u32> code;
+  AppendVMovLiteral(&code, 0, 0xabu);
+  code.push_back(EncodeMubuf0(0x18u, 0, false, false));
+  code.push_back(EncodeMubuf1(0, 0, 20));
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "BufferStoreByteAppliesByteHostOffset";
+  test.code = code;
+  test.initial = {0, 0, 0, 0, 0};
+  test.expected = {0, 0, 0, 0x0000ab00u, 0};
+  test.storage_buffer_range_dwords = 1;
+  test.storage_buffer_offsets = {13};
+  test.opcodes = {O::V_MOV_B32, O::BUFFER_STORE_BYTE, O::S_ENDPGM};
+  test.user_data = MakeStructuredStorageBufferData(4, 1);
+  test.has_user_data = true;
+  return test;
+}
+
+TestCase BufferAtomic64AppliesHostOffsetOnce() {
+  using O = ShaderOpcode;
+
+  // A 64-bit buffer atomic reaches its element through EmitBufferAtomic64, which is the one
+  // buffer path that does not go through PrepareMemoryResourceAccess. It must still pick the
+  // binding's byte offset up exactly once.
+  //
+  // The offset here is 8, so one application targets byte 8 (u64 element 1, dwords 2 and 3) and
+  // two applications target byte 16 (u64 element 2, dwords 4 and 5). The bound range covers
+  // three u64 elements, so both land in bounds and the case distinguishes where the write went
+  // rather than whether it happened.
+  std::vector<u32> code;
+  AppendVMovU32(&code, 20, 0);
+  AppendVMovLiteral(&code, 0, 0x11223344u);
+  AppendVMovLiteral(&code, 1, 0xaabbccddu);
+  AppendBufferStoreOpcode(&code, 0x50u, 0, 20);
+  AppendEnd(&code);
+
+  TestCase test;
+  test.name = "BufferAtomic64AppliesHostOffsetOnce";
+  test.code = code;
+  test.initial = {0, 0, 0, 0, 0, 0, 0, 0};
+  test.expected = {0, 0, 0x11223344u, 0xaabbccddu, 0, 0, 0, 0};
+  test.storage_buffer_range_dwords = 4;
+  test.storage_buffer_offsets = {8};
+  test.opcodes = {O::V_MOV_B32, O::BUFFER_ATOMIC_SWAP_X2, O::S_ENDPGM};
+  test.user_data = MakeStructuredStorageBufferData(4, 1);
+  test.has_user_data = true;
+  return test;
+}
+
 TestCase BufferOffsetsUsePackedLaneAndStorageFallback() {
   using O = ShaderOpcode;
 
@@ -21571,6 +21630,8 @@ std::vector<TestCase> MakeCases() {
   AddCase(BufferLoadDwordIdxenUsesDescriptorStride);
   AddCase(BufferStoreDwordIdxenUsesDescriptorStride);
   AddCase(BufferStoreDwordAppliesHostOffset);
+  AddCase(BufferStoreByteAppliesByteHostOffset);
+  AddCase(BufferAtomic64AppliesHostOffsetOnce);
   AddCase(BufferOffsetsUsePackedLaneAndStorageFallback);
   AddCase(BufferLoadVariants);
   AddCase(BufferLoadDwordx2SnapshotsOverlappingAddress);


### PR DESCRIPTION
## Summary

This is the current-upstream port of #448.

The shader-recompiler resource-specialization rework reconstructed the affected code path
without the fix from #448, which had never merged, so the underlying byte-offset bug is still
present on current `main`. This reapplies it in terms of the new
`ResourceForDescriptor`/descriptor-array model.

## Problem

A storage buffer is bound at the guest base rounded down to `minStorageBufferOffsetAlignment`,
and the bytes that were rounded off are handed to the shader as an 8-bit offset per buffer.
The shader takes them as a dword index:

```cpp
access.index_offset = memory_byte_offsets[i] >> 2;
```

so the low two bits are dropped, and `NativeStorageBuffer` rejects any binding that needs them
with `storage buffer offset adjustment is unsupported`. The device alignment here is 16, so
three of every four guest base addresses land in that guard.

Teardown (PPSA15246) hits it about a second into boot. Its first compute shader reads a byte
buffer whose base is 13 bytes past the boundary:

```
stage=Compute stride=0x1 format=k8UInt offset=0x5f4d1d alignment=0x10 adjustment=0xd
scalar=0 atomic=0 written=0 max_byte_extent=0x10
```

An offset of 13 separates byte addressing from dword folding, which is why the regression test
uses it. Storing one byte at guest offset 0 through a binding with a 13-byte offset must land
at byte 13, which is byte 1 of dword 3:

```
expected 0x0000ab00
actual   0x000000ab
```

Folding at dword granularity computes `13 >> 2 == 3` for the element and loses the byte within
it, so the store lands at byte 12 instead — the same dword, the wrong byte.

## Fix

Nothing here needs a new mechanism. A `Buffer` access already derives both its element index
and its byte within that element from one byte address: `LoadSubwordPrepared` computes
`address >> 2` for the index and `LoadSubwordInBounds` uses `address & 3` for the shift. The
offset was being folded in after that split instead of before it.

So fold the full byte adjustment into the byte address, in `BufferByteAddress`, before the
address is split. The element index, the sub-word shift and the bounds check then all stay
exact for any offset, because every `Buffer` consumer derives from that one address.

`ScalarBuffer` keeps its existing dword index. `ReadConstBuffer` loads a whole dword at
`address >> 2` and has no byte address to fold into, so a base that is not dword aligned would
straddle two elements.

The host-side guard is relaxed only for the case that is now provably safe. It still rejects
anything that reads or writes 32 bits at a time — a 32-bit component, a packed bitfield, a
scalar buffer read, an atomic. `BufferAccessIsSubDword` names the safe case rather than
widening the check, and the message now prints its operands so the next title to reach it does
not need a debug build.

## Atomic64 double-application, found in review and fixed

Recording this because it is useful reviewer context.

`EmitBufferAtomic64` is the one buffer path that does not go through
`PrepareMemoryResourceAccess`. It added the binding's byte offset itself, which was correct
while `BufferByteAddress` did not. Once `BufferByteAddress` incorporates the offset, that
manual addition applies it a second time.

An earlier revision of this branch had exactly that defect. A review pass caught it, and it was
reproduced on hardware before anything was changed: with an 8-byte binding offset, a 64-bit
atomic swap landed at byte 16 instead of byte 8.

```
expected [0,0,0x11223344,0xaabbccdd,0,0,0,0]     byte 8,  applied once
actual   [0,0,0,0,0x11223344,0xaabbccdd,0,0]     byte 16, applied twice
```

The redundant addition was removed, so the path reads
`const auto byte_address = ByteAddress(ctx, inst, mem);` and picks the offset up exactly once,
like every other buffer access. `BufferAtomic64AppliesHostOffsetOnce` was added to keep it that
way. **This is a resolved review finding, not a defect in the diff being proposed.**

## Test plan

Windows 11, clang-cl 20.1.8, RTX 2060, Release.

- [x] New `BufferStoreByteAppliesByteHostOffset` — offset 13, one byte stored, expected at byte
      13. Fails without the emitter change with the `0x0000ab00` / `0x000000ab` mismatch above.
      The harness itself asserted `offset % 4 == 0`; that assumption was part of the bug and is
      relaxed.
- [x] New `BufferAtomic64AppliesHostOffsetOnce` — offset 8, 64-bit atomic swap, expected at byte
      8. Fails against the pre-correction revision of this branch with the byte-16 result above
      and passes here, so it genuinely discriminates one application from two. The bound range
      covers both destinations, so the case distinguishes *where* the write went rather than
      whether it happened.
- [x] The existing dword-aligned sibling `BufferStoreDwordAppliesHostOffset` and the
      packed-lane/storage-fallback case `BufferOffsetsUsePackedLaneAndStorageFallback` still
      pass, so the already-working paths are unchanged.
- [x] Full `ctest`: **34/36**, identical across four consecutive runs. Pristine upstream
      `b3c8f91` measures the same 34/36 across three runs, with the same two failures, so this
      introduces none. The two are `shader_recompiler_compute` and `texture_cache_image_overlap`;
      both run the same binary, which aborts at the pre-existing
      `RenderExecutorStencilBindingDiscovery` check — before the buffer suite this PR touches
      ever runs.
- [x] Production build succeeds.

## Teardown

Reaching this blocker at all needs #443, which is a separate open PR and an unrelated
prerequisite; it was applied locally for this comparison only and is not part of this branch.

| build | result |
|---|---|
| #443 alone | **19** compiled shaders, then `descriptors.cpp:163` `storage buffer offset adjustment is unsupported` |
| #443 + this PR | **25** compiled shaders, then `ResourceTracking.cpp:167` `GetBufferResource dword 0 is not a valid runtime value` |

To be precise about what that shows: the 19 to 25 transition demonstrates that the host-side
rejection is cleared and the bindings are accepted. It does **not** by itself establish that the
address arithmetic is right — the regression tests above are what establish that, and the
atomic64 case specifically establishes that the adjustment is applied exactly once. Both halves
are needed; neither is sufficient alone.

**Teardown does not boot.** This removes one blocker. It does not fix the resource-tracking
blocker it then stops on, and it does not address the later PM4 REWIND blocker.

## Secondary validation

PAC-MAN WORLD 2 Re-PAC (PPSA18189), which exercises storage buffers throughout, was booted and
rendered correctly during validation of this port — full 3D overworld, textures, lighting, no
corruption, no storage-buffer errors in the trace.

In fairness, that run was made *before* the atomic64 correction, and it could not be repeated
afterwards. The host GPU state degraded late in the session after many repeated launches and a
force-killed process, and both titles then hung at 0 compiled shaders. That was confirmed
environmental rather than a regression by re-running an earlier build that had worked minutes
before, which hung identically — a hang occurring before any shader compiles cannot be caused by
emitted SPIR-V. So no post-correction PAC-MAN result is being claimed here. The Teardown run
above was made with the corrected build.

## Relationship to #448

This is the current-upstream port of #448. #448 remains open and untouched; it is not superseded
on the merits, only stranded by the rework that landed after it.

Also worth flagging: #427 still edits `NativeStorageBuffer`, for range clamping rather than this
guard, so the two will conflict textually if both land.

## AI use

AI assistance (Claude) was used during investigation, implementation, and test development. The
resulting diff and validation were reviewed and verified before submission.
