### PR TITLE
renderer: skip GPU sync when unmapping non-GPU memory

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -51,6 +51,15 @@ void GpuResourceManager::MapMemory(uint64_t vaddr, uint64_t size) {
 }
 
 void GpuResourceManager::UnmapMemory(uint64_t vaddr, uint64_t size) {
+	if (!GuestRange {vaddr, size}.Valid()) {
+		return;
+	}
+	{
+		std::shared_lock lock(m_mapped_ranges_mutex);
+		if (!m_mapped_ranges.Intersects(vaddr, size)) {
+			return;
+		}
+	}
 	if (CommandScheduler::InDeferredOperation()) {
 		EXIT("unsupported memory unmap from an asynchronous GPU completion, "
 		     "addr=0x%016" PRIx64 " size=0x%016" PRIx64 "\n",


### PR DESCRIPTION
`UnmapMemory` runs `SendCommandSync` and a full `CommandScheduler::Finish` for every guest unmap below the GPU address limit, including ranges that were never GPU-mapped. On a title that streams (tested with Minecraft Bedrock) that is a GPU idle several times a frame.

This returns early when the range does not intersect `m_mapped_ranges`. `HandleFault` and `InvalidateMemory` already gate on the same set, so mapped ranges still take the full path unchanged.

Sampled profile of a terrain scene, xperf, 25s, RTX 4070:

| | before | after |
|---|---|---|
| `ntkrnlmp.exe` | 49.3% | 8.0% |
| `KiPageFault` | 21.3% | out of top |
| `NtFreeVirtualMemory` | 6.5% | out of top |
| `GpuResourceManager::UnmapMemory` | 8.1% | out of top |

One thing worth a second opinion: this assumes `m_mapped_ranges` is authoritative for "the GPU holds resources here". If some path creates buffer or texture cache entries without a matching `MapMemory`, the invalidation would now be skipped.

Tested on one title, one GPU, Windows only.
