### PR TITLE
shader: reuse SRT evaluator scratch between draws

### DIFF
--- a/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/SrtWalker.cpp
@@ -8,8 +8,10 @@
 #include <cmath>
 #include <cstring>
 #include <fmt/format.h>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 namespace Libs::Graphics::ShaderRecompiler::IR {
 namespace {
@@ -413,6 +415,55 @@ private:
 	std::vector<Patch> m_patches;
 };
 
+struct EvaluatorScratch {
+	std::unordered_map<const Inst*, std::pair<uint32_t, uint64_t>> cache;
+	std::vector<const Inst*>                                       visiting;
+	uint32_t                                                       generation = 0;
+	bool                                                           in_use     = false;
+
+	void Begin() {
+		visiting.clear();
+		if (++generation == 0) {
+			cache.clear();
+			generation = 1;
+		}
+	}
+};
+
+class ScratchLease final {
+public:
+	ScratchLease() {
+		auto& pool = Pool();
+		for (auto& slot: pool) {
+			if (!slot->in_use) {
+				m_slot = slot.get();
+				break;
+			}
+		}
+		if (m_slot == nullptr) {
+			pool.push_back(std::make_unique<EvaluatorScratch>());
+			m_slot = pool.back().get();
+		}
+		m_slot->in_use = true;
+		m_slot->Begin();
+	}
+
+	~ScratchLease() { m_slot->in_use = false; }
+
+	ScratchLease(const ScratchLease&)            = delete;
+	ScratchLease& operator=(const ScratchLease&) = delete;
+
+	[[nodiscard]] EvaluatorScratch& Get() const { return *m_slot; }
+
+private:
+	static std::vector<std::unique_ptr<EvaluatorScratch>>& Pool() {
+		static thread_local std::vector<std::unique_ptr<EvaluatorScratch>> pool;
+		return pool;
+	}
+
+	EvaluatorScratch* m_slot = nullptr;
+};
+
 class Evaluator {
 public:
 	Evaluator(const ResourcePlan& program, const SrtRuntime& runtime,
@@ -454,17 +505,13 @@ private:
 		if (inst == nullptr) {
 			return false;
 		}
-		if (!m_reserved) {
-			m_cache.reserve(m_program.value_storage.size());
-			m_visiting.reserve(m_program.value_storage.size());
-			m_reserved = true;
-		}
 		if (!m_active_mask.IsEmpty() && IsRuntimeSelect(inst->GetOpcode()) &&
 		    inst->NumArgs() == 3 && inst->Arg(0).Resolve() == m_active_mask) {
 			return EvaluateWide(inst->Arg(1), result);
 		}
-		if (const auto found = m_cache.find(inst); found != m_cache.end()) {
-			result = found->second;
+		if (const auto found = m_cache.find(inst);
+		    found != m_cache.end() && found->second.first == m_generation) {
+			result = found->second.second;
 			return true;
 		}
 		if (std::ranges::find(m_visiting, inst) != m_visiting.end()) {
@@ -476,7 +523,7 @@ private:
 			return false;
 		}
 		m_visiting.pop_back();
-		m_cache.emplace(inst, out);
+		m_cache.insert_or_assign(inst, std::pair {m_generation, out});
 		result = out;
 		return true;
 	}
@@ -918,14 +965,15 @@ private:
 		return false;
 	}
 
-	const ResourcePlan&                       m_program;
-	const SrtRuntime&                         m_runtime;
-	std::span<const uint8_t>                  m_clean_flat_slots;
-	Evaluator*                                m_clean_evaluator = nullptr;
-	Value                                     m_active_mask;
-	std::unordered_map<const Inst*, uint64_t> m_cache;
-	std::vector<const Inst*>                  m_visiting;
-	bool                                      m_reserved = false;
+	const ResourcePlan&                                             m_program;
+	const SrtRuntime&                                               m_runtime;
+	std::span<const uint8_t>                                        m_clean_flat_slots;
+	Evaluator*                                                      m_clean_evaluator = nullptr;
+	Value                                                           m_active_mask;
+	ScratchLease                                                    m_scratch;
+	std::unordered_map<const Inst*, std::pair<uint32_t, uint64_t>>& m_cache = m_scratch.Get().cache;
+	std::vector<const Inst*>& m_visiting   = m_scratch.Get().visiting;
+	uint32_t                  m_generation = m_scratch.Get().generation;
 };
 
 const DescriptorSource* Source(const ResourcePlan& program, uint32_t source) {


### PR DESCRIPTION
`Evaluator` reserves its memo cache and visiting stack to `value_storage.size()` on first use, and `EvaluateRuntimeSourcesImpl` builds two evaluators per call, so every draw allocated bucket storage for the whole program to memoize a handful of instructions.

Both containers now come from a thread-local pool. Cache entries carry a generation stamp, so resetting is an increment rather than a reallocation or a `clear()` — clearing a retained `unordered_map` turned out to cost more than the allocations it saved.

Sampled profile of a terrain scene, xperf, 25s, RTX 4070, applied on top of #483:

| | before | after |
|---|---|---|
| `ntdll.dll` (heap) | 24.3% | 12.5% |
| `_Emplace_reallocate` | 18.5% | out of top |
| `operator new` | 15.3% | out of top |
| `MaterializeResources` | 26.8% | 17.6% |
| `EvaluateDescriptorSources` | 22.0% | 12.5% |

The pool holds `unique_ptr` so growing it does not invalidate slots held by the nested evaluator. Generation wraparound falls back to a real clear.

An alternative would be an index on `Inst` and a flat array instead of a pool, which would be cleaner, but `value_storage` is a `std::list` so that needs an IR change.

`resource_materialization_tests`, `resource_tracking_tests`, `shader_vertex_metadata_tests` and `scalar_provenance_tests` pass. Tested on one title, one GPU, Windows only.
