### PR TITLE
Fix: VK_EXT_shader_viewport_index_layer

### DIFF
--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -65,12 +65,13 @@ struct VulkanExtensions {
 
 vk::PhysicalDeviceVulkan12Features WindowContext::RequiredVulkan12Features() noexcept {
 	vk::PhysicalDeviceVulkan12Features features {};
-	features.sType                    = vk::StructureType::ePhysicalDeviceVulkan12Features;
-	features.samplerMirrorClampToEdge = VK_TRUE;
-	features.timelineSemaphore        = VK_TRUE;
-	features.shaderOutputLayer        = VK_TRUE;
-	features.bufferDeviceAddress      = VK_TRUE;
-	features.shaderBufferInt64Atomics = VK_TRUE;
+	features.sType                     = vk::StructureType::ePhysicalDeviceVulkan12Features;
+	features.samplerMirrorClampToEdge  = VK_TRUE;
+	features.timelineSemaphore         = VK_TRUE;
+	features.shaderOutputLayer         = VK_TRUE;
+	features.shaderOutputViewportIndex = VK_TRUE;
+	features.bufferDeviceAddress       = VK_TRUE;
+	features.shaderBufferInt64Atomics  = VK_TRUE;
 	return features;
 }
 
@@ -274,6 +275,11 @@ static void VulkanFindPhysicalDevice(vk::Instance instance, vk::SurfaceKHR surfa
 		if (required_features12.shaderOutputLayer == VK_TRUE &&
 		    features12.shaderOutputLayer != VK_TRUE) {
 			LOGF("shaderOutputLayer is not supported\n");
+			skip_device = true;
+		}
+		if (required_features12.shaderOutputViewportIndex == VK_TRUE &&
+		    features12.shaderOutputViewportIndex != VK_TRUE) {
+			LOGF("shaderOutputViewportIndex is not supported\n");
 			skip_device = true;
 		}
 		if (required_features12.bufferDeviceAddress == VK_TRUE &&
@@ -523,8 +529,7 @@ static void VulkanInitSubgroupSizeControl(vk::PhysicalDevice physical_device,
 	graphics.compute_subgroup_size_control_enabled =
 	    features13.subgroupSizeControl == VK_TRUE &&
 	    (graphics.required_subgroup_size_stages & vk::ShaderStageFlagBits::eCompute) &&
-	    subgroup_size_control.minSubgroupSize <= 64 &&
-	    subgroup_size_control.maxSubgroupSize >= 64;
+	    subgroup_size_control.minSubgroupSize <= 64 && subgroup_size_control.maxSubgroupSize >= 64;
 	graphics.compute_wave64_supported =
 	    graphics.subgroup_size == 64u || graphics.compute_subgroup_size_control_enabled;
 
@@ -627,6 +632,8 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	EXIT_NOT_IMPLEMENTED(supported_features2.features.vertexPipelineStoresAndAtomics != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(required_features12.shaderOutputLayer == VK_TRUE &&
 	                     supported_features12.shaderOutputLayer != VK_TRUE);
+	EXIT_NOT_IMPLEMENTED(required_features12.shaderOutputViewportIndex == VK_TRUE &&
+	                     supported_features12.shaderOutputViewportIndex != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(required_features12.bufferDeviceAddress == VK_TRUE &&
 	                     supported_features12.bufferDeviceAddress != VK_TRUE);
 	EXIT_NOT_IMPLEMENTED(required_features12.shaderBufferInt64Atomics == VK_TRUE &&
@@ -652,7 +659,7 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 	device_features.largePoints                          = VK_TRUE;
 	device_features.vertexPipelineStoresAndAtomics       = VK_TRUE;
 	graphics.sample_rate_shading_enabled                 = true;
-	device_features.shaderInt64 = VK_TRUE;
+	device_features.shaderInt64                          = VK_TRUE;
 
 	vk::PhysicalDeviceRobustness2FeaturesEXT robustness2 {};
 	robustness2.sType = vk::StructureType::ePhysicalDeviceRobustness2FeaturesEXT;
@@ -672,9 +679,8 @@ static vk::Device VulkanCreateDevice(vk::PhysicalDevice physical_device, const V
 		robustness2.nullDescriptor      = supported_robustness2.nullDescriptor;
 	}
 
-	const bool subgroup_size_control_enabled =
-	    graphics.compute_subgroup_size_control_enabled &&
-	    supported_features13.subgroupSizeControl == VK_TRUE;
+	const bool subgroup_size_control_enabled = graphics.compute_subgroup_size_control_enabled &&
+	                                           supported_features13.subgroupSizeControl == VK_TRUE;
 
 	auto features13 = required_features13;
 #if defined(__APPLE__)
@@ -785,7 +791,7 @@ static void VulkanGetExtensions(SDL_Window* window, VulkanExtensions& r) {
 		    "vkEnumerateInstanceExtensionProperties",
 		    [](uint32_t* count, vk::ExtensionProperties* values) {
 			    return vk::enumerateInstanceExtensionProperties("VK_LAYER_KHRONOS_validation",
-			                                                    count, values);
+				                                                count, values);
 		    });
 
 		for (const auto& ext: available_extensions) {
@@ -969,9 +975,9 @@ void WindowContext::CreateVulkan() {
 	dbg_create_info.pUserData       = nullptr;
 
 	vk::InstanceCreateInfo inst_info {};
-	inst_info.sType                   = vk::StructureType::eInstanceCreateInfo;
-	inst_info.pNext                   = (r.enable_validation_layers ? &dbg_create_info : nullptr);
-	inst_info.flags                   = {};
+	inst_info.sType = vk::StructureType::eInstanceCreateInfo;
+	inst_info.pNext = (r.enable_validation_layers ? &dbg_create_info : nullptr);
+	inst_info.flags = {};
 #if defined(__APPLE__)
 	// MoltenVK requires VK_KHR_portability_enumeration + flag to surface
 	// portability devices. Without this, enumeratePhysicalDevices hides the


### PR DESCRIPTION
# Fix: VK_EXT_shader_viewport_index_layer

Crash in `Tetris Forever` on the first `vkCreateShaderModule()`:

```text
[Vulkan][E][2]: vkCreateShaderModule(): SPIR-V Capability ShaderViewportIndexLayerEXT
was declared, but one of the following requirements is required
(VK_EXT_shader_viewport_index_layer [when using Vulkan 1.0 or 1.1] OR VK_NV_viewport_array2).
```

The SPIR-V module compiled by the game declares the `ShaderViewportIndexLayerEXT` capability.

On Vulkan 1.2+, this capability no longer requires the extension to be explicitly enabled as a string (`VK_EXT_shader_viewport_index_layer` was promoted to core), but the two corresponding boolean fields in `VkPhysicalDeviceVulkan12Features` — `shaderOutputLayer` and `shaderOutputViewportIndex` — still have to be explicitly enabled when creating the device.

`RequiredVulkan12Features()` was only enabling `shaderOutputLayer`:
`shaderOutputViewportIndex` remained `VK_FALSE`, so the driver considered the capability unavailable, causing shader module creation to fail.

`shaderOutputLayer` covers `SPV_EXT_shader_viewport_index_layer`'s `ShaderLayerEXT` (writing `gl_Layer` from stages other than the fragment stage), while `shaderOutputViewportIndex` covers `ShaderViewportIndexEXT` (`gl_ViewportIndex`). They are two separate bits in the same struct: enabling one does not imply the other.

## Fix

`src/graphics/presentation/window/vulkanWindow.cpp`:

- `RequiredVulkan12Features()`: added `features.shaderOutputViewportIndex = VK_TRUE;` next to `shaderOutputLayer`, so the feature is requested and propagated through the same `pNext` chain already used to build the actual `VkDevice`.
- Physical device selection: added a `skip_device` check mirroring the one for `shaderOutputLayer`, so a GPU/driver that does not support the feature is rejected with an explicit log instead of reaching `vkCreateShaderModule()` and crashing further down the line.
- Device creation: added the corresponding `EXIT_NOT_IMPLEMENTED` check to the second set of checks (the one performed after the physical device has already been selected), for consistency with the other `VkPhysicalDeviceVulkan12Features` fields already validated there.

No additional device extension needs to be enabled: since the application is already using Vulkan 1.3 and already building the `VkPhysicalDeviceVulkan12Features` chain, setting the feature bit in the struct is sufficient.

## Test

Verified that `Tetris Forever` now launches and compiles the pipeline without the validation error.
I tested the change on other titles (which had previously worked), and there was **no decline in performance.**