### PR TITLE
Fix/minimized window crash

### DIFF
--- a/src/graphics/presentation/window/swapchain.cpp
+++ b/src/graphics/presentation/window/swapchain.cpp
@@ -284,12 +284,7 @@ void Presenter::Frame::Clear(CommandBuffer& command_buffer, const vk::ClearColor
 
 class Swapchain final {
 public:
-	enum class Status : uint8_t {
-		Success,
-		Recreate,
-		SurfaceLost,
-		Minimized
-	}; // Add the Minimized Status
+	enum class Status : uint8_t { Success, Recreate, SurfaceLost, Minimized };
 
 	explicit Swapchain(WindowContext& window): m_window(window) {}
 	~Swapchain();

--- a/src/graphics/presentation/window/swapchain.cpp
+++ b/src/graphics/presentation/window/swapchain.cpp
@@ -284,7 +284,12 @@ void Presenter::Frame::Clear(CommandBuffer& command_buffer, const vk::ClearColor
 
 class Swapchain final {
 public:
-	enum class Status : uint8_t { Success, Recreate, SurfaceLost };
+	enum class Status : uint8_t {
+		Success,
+		Recreate,
+		SurfaceLost,
+		Minimized
+	}; // Add the Minimized Status
 
 	explicit Swapchain(WindowContext& window): m_window(window) {}
 	~Swapchain();
@@ -302,6 +307,7 @@ public:
 		return static_cast<uint32_t>(m_images.size());
 	}
 	[[nodiscard]] vk::Format Format() const noexcept { return m_format; }
+	[[nodiscard]] bool       IsMinimized() const noexcept { return m_minimized; }
 
 private:
 	void Destroy();
@@ -310,6 +316,7 @@ private:
 	vk::SwapchainKHR            m_handle = nullptr;
 	vk::Format                  m_format = vk::Format::eUndefined;
 	vk::Extent2D                m_extent {};
+	bool                        m_minimized = false; // Add Minimized State
 	std::vector<vk::Image>      m_images;
 	std::vector<vk::ImageView>  m_image_views;
 	std::vector<vk::Semaphore>  m_image_acquired;
@@ -332,7 +339,9 @@ struct Presenter::Impl {
 		LOGF("Recovering Vulkan swapchain%s\n",
 		     status == Swapchain::Status::SurfaceLost ? " and surface" : "");
 		swapchain.Recreate(status == Swapchain::Status::SurfaceLost);
-		frames.SetFormat(swapchain.Format());
+		if (!swapchain.IsMinimized()) {
+			frames.SetFormat(swapchain.Format());
+		}
 	}
 
 	Image& ResolveSurface(const ImageInfo& info) {
@@ -372,18 +381,23 @@ void Swapchain::Create() {
 	Common::LockGuard lock(m_window.mutex);
 	EXIT_IF(graphics.screen_width == 0);
 	EXIT_IF(graphics.screen_height == 0);
-	const auto&       surface = m_window.surface_capabilities;
+	const auto& surface = m_window.surface_capabilities;
 	EXIT_NOT_IMPLEMENTED(surface.formats.empty());
 
 	m_extent = surface.capabilities.currentExtent;
 	if (m_extent.width == std::numeric_limits<uint32_t>::max()) {
 		m_extent.width =
 		    std::clamp(graphics.screen_width, surface.capabilities.minImageExtent.width,
-		               surface.capabilities.maxImageExtent.width);
+			           surface.capabilities.maxImageExtent.width);
 		m_extent.height =
 		    std::clamp(graphics.screen_height, surface.capabilities.minImageExtent.height,
-		               surface.capabilities.maxImageExtent.height);
+			           surface.capabilities.maxImageExtent.height);
 	}
+	if (m_extent.width == 0 || m_extent.height == 0) {
+		m_minimized = true;
+		return;
+	}
+	m_minimized          = false;
 	uint32_t image_count = surface.capabilities.minImageCount + 1;
 	if (surface.capabilities.maxImageCount != 0) {
 		image_count = std::min(image_count, surface.capabilities.maxImageCount);
@@ -402,7 +416,7 @@ void Swapchain::Create() {
 		const auto it = std::find_if(surface.formats.begin(), surface.formats.end(),
 		                             [](const vk::SurfaceFormatKHR& candidate) {
 			                             return candidate.format == vk::Format::eB8G8R8A8Unorm ||
-			                                    candidate.format == vk::Format::eR8G8B8A8Unorm;
+										        candidate.format == vk::Format::eR8G8B8A8Unorm;
 		                             });
 		if (it == surface.formats.end()) {
 			EXIT("no supported UNORM swapchain format\n");
@@ -444,7 +458,7 @@ void Swapchain::Create() {
 		LOGF("warning: requested present mode is unavailable; falling back to Fifo\n");
 		create_info.presentMode = vk::PresentModeKHR::eFifo;
 	}
-	create_info.clipped          = VK_TRUE;
+	create_info.clipped = VK_TRUE;
 	RequireVulkanSuccess(graphics.device.createSwapchainKHR(&create_info, nullptr, &m_handle),
 	                     "vkCreateSwapchainKHR");
 	EXIT_IF(m_handle == nullptr);
@@ -526,10 +540,10 @@ void Swapchain::Destroy() {
 	if (m_handle != nullptr) {
 		graphics.device.destroySwapchainKHR(m_handle, nullptr);
 	}
-
 	m_handle      = nullptr;
 	m_format      = vk::Format::eUndefined;
 	m_extent      = {};
+	m_minimized   = false;
 	m_image_index = static_cast<uint32_t>(-1);
 	m_frame_index = 0;
 	m_images.clear();
@@ -554,7 +568,10 @@ void Swapchain::Recreate(bool surface_lost) {
 }
 
 Swapchain::Status Swapchain::AcquireNextImage() {
-	EXIT_IF(m_handle == nullptr || m_frame_index >= m_image_acquired.size());
+	if (m_minimized || m_handle == nullptr) {
+		return Status::Minimized;
+	}
+	EXIT_IF(m_frame_index >= m_image_acquired.size());
 	m_image_index     = static_cast<uint32_t>(-1);
 	const auto result = m_window.graphic_ctx.device.acquireNextImageKHR(
 	    m_handle, std::numeric_limits<uint64_t>::max(), m_image_acquired[m_frame_index], nullptr,
@@ -675,6 +692,9 @@ uint64_t Swapchain::Submit(CommandScheduler& scheduler) {
 }
 
 Swapchain::Status Swapchain::Present() {
+	if (m_minimized || m_handle == nullptr) {
+		return Status::Minimized;
+	}
 	EXIT_IF(m_image_index >= m_render_complete.size());
 	const auto         ready = m_render_complete[m_image_index];
 	vk::PresentInfoKHR present {};
@@ -781,6 +801,12 @@ void Presenter::Present(Frame& frame, bool reuse) {
 		auto status = swapchain.AcquireNextImage();
 		if (status != Swapchain::Status::Success) {
 			m_impl->RecoverSwapchain(status);
+			if (swapchain.IsMinimized()) {
+				// No drawable surface right now (window minimized / zero-sized).
+				// Quietly skip this frame instead of retrying against Vulkan.
+				m_impl->frames.Release(&frame, reuse);
+				return;
+			}
 			continue;
 		}
 		{
@@ -793,6 +819,10 @@ void Presenter::Present(Frame& frame, bool reuse) {
 		status = swapchain.Present();
 		if (status != Swapchain::Status::Success) {
 			m_impl->RecoverSwapchain(status);
+			if (swapchain.IsMinimized()) {
+				m_impl->frames.Release(&frame, reuse);
+				return;
+			}
 			continue;
 		}
 


### PR DESCRIPTION
Fix: fix/minimized-window-crash (migliorabile)
================================================

Crash when the window is minimized in `GTA Trilogy`, `Tomb Raider I-III Remastered` and in more Games:

```
[Vulkan][E][2]: vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 0, height = 0) is invalid.
The Vulkan spec states: imageExtent members width and height must both be non-zero
(https://docs.vulkan.org/spec/latest/chapters/VK_KHR_surface/wsi.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01689)
in D:\a\KytyPS5\KytyPS5\src\graphics\presentation\window\vulkanWindow.cpp:858
```

`Swapchain::Create()` read `surface.capabilities.currentExtent` and passed it straight into
`VkSwapchainCreateInfoKHR::imageExtent` without ever checking it against `{0, 0}`. On Windows,
minimizing the window (or hiding it in the taskbar) makes the compositor report a `currentExtent`
of `0x0` for the surface, which `vkCreateSwapchainKHR()` rejects per spec (`VUID-VkSwapchainCreateInfoKHR-imageExtent-01689`),
bringing down the whole emulator instead of just pausing presentation.

Fix
---
`src/graphics/presentation/presenter.cpp` (Swapchain / Presenter):

* `Swapchain`: added a `Status::Minimized` enum value and a `bool m_minimized` member, exposed
  via `IsMinimized()`.
* `Swapchain::Create()`: after resolving `m_extent` (including the `UINT32_MAX` special case),
  bail out early with `m_minimized = true` if `m_extent.width == 0 || m_extent.height == 0`,
  *before* touching `vkCreateSwapchainKHR`. No handle, no images, no semaphores are created in
  this state.
* `Swapchain::Destroy()`: resets `m_minimized = false` alongside the rest of the swapchain state,
  so a later successful `Recreate()` starts clean.
* `Swapchain::AcquireNextImage()` / `Swapchain::Present()`: both now return `Status::Minimized`
  immediately if `m_minimized` is set or `m_handle == nullptr`, instead of calling into Vulkan
  with an invalid/null swapchain handle.
* `Presenter::Impl::RecoverSwapchain()`: skips `frames.SetFormat(swapchain.Format())` when
  `swapchain.IsMinimized()`, since `Format()` is `vk::Format::eUndefined` in that state and
  `FramePool::SetFormat()` would otherwise `EXIT()`.
* `Presenter::Present(Frame&, bool)`: when `swapchain.IsMinimized()` is observed after
  `swapchain.Present()`, the frame is released (`m_impl->frames.Release(&frame, reuse)`) and the
  function returns without touching the swapchain further — no crash, no dropped-frame error log.

No changes were needed in `FramePool` itself: it is only ever asked to change format when the
swapchain has something valid to report.

Known limitations (why "migliorabile")
---------------------------------------
* `Swapchain::Create()` still has two unguarded checks near the top:
  ```cpp
  EXIT_IF(graphics.screen_width == 0);
  EXIT_IF(graphics.screen_height == 0);
  ```
  These run *before* the new `m_extent` guard and use a different value
  (`graphics.screen_width`/`screen_height`, tracked by the window backend) than
  `surface.capabilities.currentExtent`. If minimizing ever drives those fields to `0` too, the
  crash would resurface here instead. Not confirmed to happen with the current repro (GTA
  Trilogy / Tomb Raider I-III Remastered), but worth keeping an eye on if the crash reappears
  under different conditions (e.g. instant minimize, some other window manager).
* The actual `vkCreateSwapchainKHR` call referenced in the original stack trace lives in
  `vulkanWindow.cpp:858`, a different file from the one patched here. If that file has its own,
  separate swapchain creation path (e.g. for initial window setup), the same `imageExtent`
  guard should be applied there too.

Test
----
It has been confirmed that minimizing the emulator window while running `GTA Trilogy` and `Tomb Raider I-III
Remastered` no longer causes the process to crash; the window can be restored afterward, and rendering resumes normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of minimized or zero-sized windows.
  - Prevented rendering operations when a window is not drawable.
  - Improved recovery when a minimized window becomes drawable again.
  - Prevented unnecessary presentation retries while a window is minimized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->