### PR TITLE
Fix: Depth comparison bc7 srgb

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -897,6 +897,14 @@ TextureCache::BuildColorTransfer(const Image& image, BindingType binding,
 	                                       info.resources.levels, layers, info.tile_mode,
 	                                       info.data.size, allow_depth_tile, volume, owner);
 	plan.regions = TextureBuildImageCopies(plan.layout);
+	// If the host image is in a depth format (e.g., eD16Unorm created by the depth_compare path),
+	// TextureBuildImageCopies produces copies with a hardcoded eColor, which is invalid for depth images.
+	// Correct the aspect mask before uploading.
+	if (info.IsDepth()) {
+		for (auto& copy: plan.regions) {
+			copy.imageSubresource.aspectMask = vk::ImageAspectFlagBits::eDepth;
+		}
+	}
 	plan.tiled   = plan.layout.surface.description.tile_mode != Prospero::TileMode::kLinear;
 	if (plan.tiled) {
 		if (!TextureBuildGpuTileInfos(info.data.size, plan.regions, plan.layout,

--- a/src/graphics/host_gpu/renderer/image/imageInfo.h
+++ b/src/graphics/host_gpu/renderer/image/imageInfo.h
@@ -285,6 +285,10 @@ inline bool ImageInfo::IsDepth() const noexcept {
 	return DepthAspectTransferFormat(pixel_format) != vk::Format::eUndefined;
 }
 
+[[nodiscard]] inline bool IsDepthComparisonSupported(vk::Format format) noexcept {
+	return DepthAspectTransferFormat(format) != vk::Format::eUndefined;
+}
+
 [[nodiscard]] inline constexpr uint32_t DepthAspectTransferBytes(vk::Format format) noexcept {
 	switch (DepthAspectTransferFormat(format)) {
 		case vk::Format::eD16Unorm: return 2;

--- a/src/graphics/host_gpu/renderer/image/imageView.h
+++ b/src/graphics/host_gpu/renderer/image/imageView.h
@@ -63,6 +63,19 @@ namespace ImageViewOps {
 	}
 }
 
+[[nodiscard]] inline vk::Format SrgbToUnorm(vk::Format format) noexcept {
+	switch (format) {
+		case vk::Format::eBc1RgbaSrgbBlock: return vk::Format::eBc1RgbaUnormBlock;
+		case vk::Format::eBc2SrgbBlock: return vk::Format::eBc2UnormBlock;
+		case vk::Format::eBc3SrgbBlock: return vk::Format::eBc3UnormBlock;
+		case vk::Format::eBc7SrgbBlock: return vk::Format::eBc7UnormBlock;
+		case vk::Format::eR8G8B8A8Srgb: return vk::Format::eR8G8B8A8Unorm;
+		case vk::Format::eB8G8R8A8Srgb: return vk::Format::eB8G8R8A8Unorm;
+		case vk::Format::eA8B8G8R8SrgbPack32: return vk::Format::eA8B8G8R8UnormPack32;
+		default: return format;
+	}
+}
+
 [[nodiscard]] inline bool IsSupportedSampledColorView(vk::Format image_format,
                                                       vk::Format view_format,
                                                       uint32_t   swizzle) noexcept {

--- a/src/graphics/host_gpu/renderer/image/imageView.h
+++ b/src/graphics/host_gpu/renderer/image/imageView.h
@@ -84,12 +84,7 @@ SelectSampledColorView(vk::Format image_format, vk::Format view_format, uint32_t
 	if (!IsSupportedSampledDepthFormat(image_format, view_format)) {
 		return false;
 	}
-	switch (swizzle) {
-		case DstSel(4, 4, 4, 4):
-		case DstSel(4, 0, 0, 0):
-		case DstSel(4, 0, 0, 1): return true;
-		default: return false;
-	}
+	return IsValidImageSwizzle(swizzle);
 }
 
 [[nodiscard]] inline uint32_t

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -204,7 +204,7 @@ TargetTextureViewInfo ResolveTargetTextureView(const ShaderRecompiler::IR::Image
 			return resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2D &&
 			               base_layer == 0 && image_layers == 1
 			           ? TargetTextureViewInfo {vk::ImageViewType::e2D, 0, 1}
-			           : TargetTextureViewInfo {};
+					   : TargetTextureViewInfo {};
 		case Prospero::ImageType::kCube:
 			if (resource.dimension != ShaderRecompiler::Decoder::ImageDimension::Dim2DArray ||
 			    base_layer >= image_layers || (image_layers - base_layer) % 6u != 0) {
@@ -219,13 +219,13 @@ TargetTextureViewInfo ResolveTargetTextureView(const ShaderRecompiler::IR::Image
 			return resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2DArray &&
 			               base_layer < image_layers
 			           ? TargetTextureViewInfo {vk::ImageViewType::e2DArray, base_layer,
-			                                    image_layers - base_layer}
-			           : TargetTextureViewInfo {};
+					                            image_layers - base_layer}
+					   : TargetTextureViewInfo {};
 		case Prospero::ImageType::kColor2DMsaa:
 			return resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2DMsaa &&
 			               base_layer == 0 && image_layers == 1
 			           ? TargetTextureViewInfo {vk::ImageViewType::e2D, 0, 1}
-			           : TargetTextureViewInfo {};
+					   : TargetTextureViewInfo {};
 		case Prospero::ImageType::kColor2DMsaaArray:
 			if (resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2DMsaa &&
 			    base_layer == 0 && image_layers == 1) {
@@ -235,8 +235,8 @@ TargetTextureViewInfo ResolveTargetTextureView(const ShaderRecompiler::IR::Image
 			                   ShaderRecompiler::Decoder::ImageDimension::Dim2DMsaaArray &&
 			               base_layer < image_layers
 			           ? TargetTextureViewInfo {vk::ImageViewType::e2DArray, base_layer,
-			                                    image_layers - base_layer}
-			           : TargetTextureViewInfo {};
+					                            image_layers - base_layer}
+					   : TargetTextureViewInfo {};
 		default: return {};
 	}
 }
@@ -259,7 +259,7 @@ bool IsSupportedDepthTargetDescriptor(const ShaderTextureResource& descriptor, c
 	const auto samples      = multisampled ? 1u << descriptor.LastLevel() : 1u;
 	const auto pitch =
 	    multisampled ? TileGetDepthPitch(width, image.info.bytes_per_block, descriptor.LastLevel())
-	                 : TileGetTexturePitch(descriptor.Format(), width, descriptor.TileMode());
+		             : TileGetTexturePitch(descriptor.Format(), width, descriptor.TileMode());
 	const bool supported_2d    = type == Prospero::ImageType::kColor2D &&
 	                             image.info.resources.layers == 1 && descriptor.Depth() == 0 &&
 	                             descriptor.BaseArray5() == 0;
@@ -282,8 +282,8 @@ bool IsSupportedDepthTargetDescriptor(const ShaderTextureResource& descriptor, c
 	                       descriptor.LastLevel() <= 3 &&
 	                       (r128 || descriptor.MaxMip() == descriptor.LastLevel()) &&
 	                       image.info.resources.levels == 1 && image.info.samples == samples
-	                 : descriptor.BaseLevel() == 0 && descriptor.LastLevel() == 0 &&
-	                       (r128 || descriptor.MaxMip() == 0) && image.info.samples == 1;
+		             : descriptor.BaseLevel() == 0 && descriptor.LastLevel() == 0 &&
+		                   (r128 || descriptor.MaxMip() == 0) && image.info.samples == 1;
 	return image.info.IsDepth() && width == image.info.extent.width &&
 	       height == image.info.extent.height &&
 	       (supported_2d || supported_array || supported_cube || supported_msaa_2d ||
@@ -345,7 +345,7 @@ static void ValidateDepthTargetBinding(const ShaderRecompiler::IR::ImageResource
 	}
 	const auto descriptor_pitch =
 	    TileGetTexturePitch(descriptor.Format(), static_cast<uint32_t>(descriptor.Width5()) + 1u,
-	                        descriptor.TileMode());
+		                    descriptor.TileMode());
 	EXIT("unsupported sampled depth target: resource=%d descriptor=%d encoding=%d format=%d "
 	     "class=%u numeric=%u dimension=%u mip_mode=%u read=%d written=%d atomic=%d compare=%d "
 	     "guest_format=%u swizzle=0x%03x image_format=%d view_format=%d image_layers=%u "
@@ -395,7 +395,7 @@ static bool IsSupportedStorageTextureDescriptor(const ShaderRecompiler::IR::Imag
 	const bool is_2d_array =
 	    resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim2DArray &&
 	    ((!resource.cube && is_color_2d_array && descriptor.BaseArray5() <= descriptor.Depth()) ||
-	     is_cube);
+		 is_cube);
 	const bool is_3d = resource.dimension == ShaderRecompiler::Decoder::ImageDimension::Dim3D &&
 	                   descriptor.Type() == Prospero::ImageType::kColor3D &&
 	                   descriptor.BaseArray5() == 0;
@@ -466,20 +466,20 @@ static bool IsSupportedStorageTextureEncoding(const ShaderRecompiler::IR::ImageR
 
 void ValidateStorageTexture(const ShaderRecompiler::IR::ImageResource& resource,
                             const ShaderTextureResource& descriptor, uint64_t size) {
-	const auto format        = descriptor.Format();
-	const bool resource_ok   = IsSupportedStorageImageResource(resource);
-	const bool descriptor_ok = IsSupportedStorageTextureDescriptor(resource, descriptor);
-	const bool encoding_ok   = IsSupportedStorageTextureEncoding(resource, descriptor);
+	const auto format           = descriptor.Format();
+	const bool resource_ok      = IsSupportedStorageImageResource(resource);
+	const bool descriptor_ok    = IsSupportedStorageTextureDescriptor(resource, descriptor);
+	const bool encoding_ok      = IsSupportedStorageTextureEncoding(resource, descriptor);
 	const bool uint_resource    = resource.numeric_class == Prospero::TextureNumericClass::Uint;
 	const bool raw_sint_storage = format == Prospero::BufferFormat::k32SInt && uint_resource &&
 	                              resource.written && !resource.read && !resource.atomic;
-	const auto numeric_class = Prospero::SampledTextureNumericClass(format);
+	const auto numeric_class    = Prospero::SampledTextureNumericClass(format);
 	const bool format_ok =
 	    raw_sint_storage ||
 	    (numeric_class != Prospero::TextureNumericClass::Unsupported &&
-	     numeric_class != Prospero::TextureNumericClass::Sint &&
-	     uint_resource == (numeric_class == Prospero::TextureNumericClass::Uint) &&
-	     (!resource.atomic || format == Prospero::BufferFormat::k32UInt));
+		 numeric_class != Prospero::TextureNumericClass::Sint &&
+		 uint_resource == (numeric_class == Prospero::TextureNumericClass::Uint) &&
+		 (!resource.atomic || format == Prospero::BufferFormat::k32UInt));
 	if (resource_ok && descriptor_ok && encoding_ok && format_ok && size != 0) {
 		return;
 	}
@@ -587,7 +587,7 @@ static void PopulateTextureMipLayout(ImageInfo& info) {
 		    size,
 		    padded[level].width != 0 ? padded[level].width : std::max(info.pitch >> level, 1u),
 		    padded[level].height != 0 ? padded[level].height
-		                              : std::max(info.extent.height >> level, 1u),
+			                          : std::max(info.extent.height >> level, 1u),
 		};
 	}
 }
@@ -598,7 +598,9 @@ static ImageViewInfo TextureViewInfo(const ShaderRecompiler::IR::ImageResource& 
                                      uint32_t image_layers) {
 	ImageViewInfo view {};
 	view.format      = format;
-	view.aspect      = vk::ImageAspectFlagBits::eColor;
+	view.aspect      = DepthAspectTransferFormat(format) != vk::Format::eUndefined
+	                       ? vk::ImageAspectFlagBits::eDepth
+	                       : vk::ImageAspectFlagBits::eColor;
 	view.base_level  = descriptor.BaseLevel();
 	view.level_count = view_levels;
 	view.usage   = storage ? vk::ImageUsageFlagBits::eStorage : vk::ImageUsageFlagBits::eSampled;
@@ -652,8 +654,8 @@ static ImageViewInfo TextureViewInfo(const ShaderRecompiler::IR::ImageResource& 
 
 TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageResource&   resource,
                                               const ShaderRecompiler::IR::DescriptorValue& value) {
-	auto descriptor = DecodeNativeDescriptor<ShaderTextureResource>(value);
-	const bool storage = resource.written;
+	auto       descriptor = DecodeNativeDescriptor<ShaderTextureResource>(value);
+	const bool storage    = resource.written;
 	if (storage) {
 		ValidateStorageImageResource(resource);
 	}
@@ -794,10 +796,10 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	return {id, nullptr, std::move(desc)};
 }
 
-static vk::Sampler NativeSampler(RenderContext&                       context,
+static vk::Sampler NativeSampler(RenderContext&                                  context,
                                  const ShaderRecompiler::IR::CompiledShaderInfo& program,
-                                 uint32_t index,
-                                 const ShaderRecompiler::IR::DescriptorValue& value) {
+                                 uint32_t                                        index,
+                                 const ShaderRecompiler::IR::DescriptorValue&    value) {
 	auto descriptor = DecodeNativeDescriptor<ShaderSamplerResource>(value);
 	if (!program.info.samplers[index].depth_compare) {
 		descriptor.fields[0] &= ~(0x7u << 12u);
@@ -855,8 +857,8 @@ void RenderExecutor::ResetBindings() {
 PreparedBindings RenderExecutor::PrepareBindings(const ShaderStageRuntime& runtime) {
 	KYTY_PROFILER_FUNCTION();
 	EXIT_IF(!runtime);
-	const auto& program  = *runtime.program;
-	const auto& snapshot = runtime.resources;
+	const auto&      program  = *runtime.program;
+	const auto&      snapshot = runtime.resources;
 	PreparedBindings prepared;
 	prepared.program  = runtime.program;
 	prepared.snapshot = &runtime.resources;
@@ -894,10 +896,10 @@ void RenderExecutor::FindBuffers(PreparedBindings& prepared) {
 	prepared.buffer_sources.clear();
 	prepared.buffer_sources.reserve(program.info.buffers.size());
 	for (uint32_t i = 0; i < program.info.buffers.size(); i++) {
-		auto descriptor = DecodeNativeDescriptor<ShaderBufferResource>(snapshot.buffers[i]);
-		const auto address = descriptor.Base48();
-		const auto stride  = descriptor.Stride();
-		const auto records = descriptor.NumRecords();
+		auto       descriptor = DecodeNativeDescriptor<ShaderBufferResource>(snapshot.buffers[i]);
+		const auto address    = descriptor.Base48();
+		const auto stride     = descriptor.Stride();
+		const auto records    = descriptor.NumRecords();
 		EXIT_IF(stride != 0 && records > UINT64_MAX / stride);
 		const auto requested_size = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
 		if (address == 0 || requested_size == 0) {
@@ -907,7 +909,6 @@ void RenderExecutor::FindBuffers(PreparedBindings& prepared) {
 		const auto size = Libs::LibKernel::Memory::ClampRangeSize(address, requested_size);
 		prepared.buffer_sources.emplace_back(descriptor, cache.FindBuffer(address, size));
 	}
-
 }
 
 void RenderExecutor::RebindBuffers(PreparedBindings& prepared) {
@@ -922,8 +923,8 @@ void RenderExecutor::RebindBuffers(PreparedBindings& prepared) {
 	resources.buffers.clear();
 	resources.buffers.reserve(program.info.buffers.size());
 	EXIT_IF(prepared.shader_data.size() != layout.ShaderDataDwords());
-	std::fill(prepared.shader_data.begin() + layout.memory_offset_dword,
-	          prepared.shader_data.end(), 0);
+	std::fill(prepared.shader_data.begin() + layout.memory_offset_dword, prepared.shader_data.end(),
+	          0);
 	auto pack_memory_offset = [&](uint32_t index, uint32_t offset) {
 		const auto dword = layout.memory_offset_dword + index / 4u;
 		const auto shift = (index % 4u) * 8u;
@@ -931,7 +932,7 @@ void RenderExecutor::RebindBuffers(PreparedBindings& prepared) {
 	};
 	for (uint32_t i = 0; i < program.info.buffers.size(); i++) {
 		const auto& [descriptor, buffer_id] = prepared.buffer_sources[i];
-		uint32_t buffer_offset = 0;
+		uint32_t buffer_offset              = 0;
 		resources.buffers.push_back(NativeStorageBuffer(m_context, descriptor,
 		                                                program.info.buffers[i], program.stage, i,
 		                                                buffer_offset, buffer_id));
@@ -1029,12 +1030,12 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
                                     const PipelineCache::Pipeline&     pipeline,
                                     std::span<PreparedBindings* const> prepared_bindings) {
 	KYTY_PROFILER_FUNCTION();
-	auto   vk_buffer        = buffer.Handle();
-	size_t descriptor_count = 0;
-	size_t write_count      = 0;
+	auto                           vk_buffer        = buffer.Handle();
+	size_t                         descriptor_count = 0;
+	size_t                         write_count      = 0;
 	ShaderRecompiler::IR::PushData push_data;
 	bool                           has_push_data = false;
-	constexpr auto GraphicsStages =
+	constexpr auto                 GraphicsStages =
 	    vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment;
 	for (const auto* prepared: prepared_bindings) {
 		EXIT_IF(prepared == nullptr || prepared->program == nullptr ||

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -749,9 +749,13 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	const auto storage_view_format = storage && format == Prospero::BufferFormat::k32SInt
 	                                     ? vk::Format::eR32Uint
 	                                     : SrgbStorageViewFormat(pixel_format);
+	const auto unorm_compare_format = !storage && resource.depth_compare &&
+	                                  !IsDepthComparisonSupported(pixel_format)
+	                                      ? SrgbToUnorm(pixel_format)
+	                                      : pixel_format;
 	const auto view_format         = storage && storage_view_format != vk::Format::eUndefined
 	                                     ? storage_view_format
-	                                     : pixel_format;
+	                                     : unorm_compare_format;
 	const auto block_bytes         = Prospero::BlockCompressedBytesPerBlock(format);
 	TextureCache::ImageDesc desc {};
 	desc.info.data         = {address, size.size};
@@ -790,7 +794,7 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	} else if (storage) {
 		ValidateStorageColorView(image->info.pixel_format, view_format, descriptor.DstSelXYZW());
 	} else {
-		(void)SelectSampledColorView(image->info.pixel_format, pixel_format,
+		(void)SelectSampledColorView(image->info.pixel_format, view_format,
 		                             descriptor.DstSelXYZW());
 	}
 	return {id, nullptr, std::move(desc)};

--- a/src/graphics/shader/recompiler/ShaderRecompiler.cpp
+++ b/src/graphics/shader/recompiler/ShaderRecompiler.cpp
@@ -677,7 +677,7 @@ CompileResult CompileProgram(TranslateResult translated, const CompileOptions& o
 
 	LOGF("%s phase begin: stage=%s hash=0x%016" PRIx64 " SPIR-V EmitProgram\n",
 	     GetDumpLabel(options), StageName(options.stage), options.shader_hash);
-	auto spirv = Spirv::EmitProgram(ir, options.input_info);
+	auto spirv = Spirv::EmitProgram(ir, options.input_info, specialization);
 	LOGF("%s phase end: stage=%s hash=0x%016" PRIx64 " SPIR-V EmitProgram words=%" PRIu64
 	     " elapsed_ms=%" PRIu64 "\n",
 	     GetDumpLabel(options), StageName(options.stage), options.shader_hash,

--- a/src/graphics/shader/recompiler/backend/spirv/SpirvEmitter.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/SpirvEmitter.cpp
@@ -304,7 +304,8 @@ void AnalyzeProgramRequirements(IR::Program& program) {
 }
 
 std::vector<uint32_t> EmitProgram(const IR::Program& program,
-                                  ShaderStageInputInfo input_info) {
+                                  ShaderStageInputInfo input_info,
+                                  const IR::ResourceSpecialization& specialization) {
 	using namespace Emitter;
 
 	if (program.stage != ShaderType::Compute && program.stage != ShaderType::Vertex &&
@@ -318,7 +319,7 @@ std::vector<uint32_t> EmitProgram(const IR::Program& program,
 	}
 	ValidateNativeProgram(program);
 	IR::ValidateProgram(program, true);
-	EmitterState state(program, input_info);
+	EmitterState state(program, input_info, specialization);
 	state.stage     = program.stage;
 	state.wave_size = program.wave_size;
 	state.inputs.reserve(program.info.inputs.size());

--- a/src/graphics/shader/recompiler/backend/spirv/SpirvEmitter.h
+++ b/src/graphics/shader/recompiler/backend/spirv/SpirvEmitter.h
@@ -4,6 +4,7 @@
 #include "common/common.h"
 #include "common/stringUtils.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
+#include "graphics/shader/recompiler/ir/passes/ResourceMaterialization.h"
 
 #include <vector>
 
@@ -12,7 +13,8 @@ namespace Libs::Graphics::ShaderRecompiler::Spirv {
 void AnalyzeProgramRequirements(IR::Program& program);
 
 std::vector<uint32_t> EmitProgram(const IR::Program& program,
-                                  ShaderStageInputInfo input_info);
+                                  ShaderStageInputInfo input_info,
+                                  const IR::ResourceSpecialization& specialization);
 
 } // namespace Libs::Graphics::ShaderRecompiler::Spirv
 

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
@@ -1,5 +1,6 @@
 #include "graphics/guest_gpu/gpu_format.h"
 #include "graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h"
+#include "graphics/host_gpu/vulkanCommon.h"
 
 #include <algorithm>
 #include <bit>
@@ -41,6 +42,31 @@ uint32_t Binary(EmitterState& state, uint32_t opcode, uint32_t type, uint32_t lh
 	const auto result = state.builder.AllocateId();
 	state.builder.AddFunction({opcode, type, result, lhs, rhs});
 	return result;
+}
+
+uint32_t EmitFloatCompareOp(EmitterState& state, uint32_t lhs, uint32_t rhs, uint8_t compare_func) {
+	// Map compare-op (vk::CompareOp) to SPIR-V float comparison operations
+	// compare_func values: 0=Never, 1=Less, 2=Equal, 3=LessOrEqual, 4=Greater, 5=NotEqual, 6=GreaterOrEqual, 7=Always
+	switch (compare_func) {
+		case 0: // Never
+			return ConstantBool(state, false);
+		case 1: // Less
+			return Binary(state, OpFOrdLessThan, TypeBool(state), lhs, rhs);
+		case 2: // Equal
+			return Binary(state, OpFOrdEqual, TypeBool(state), lhs, rhs);
+		case 3: // LessOrEqual
+			return Binary(state, OpFOrdLessThanEqual, TypeBool(state), lhs, rhs);
+		case 4: // Greater
+			return Binary(state, OpFOrdGreaterThan, TypeBool(state), lhs, rhs);
+		case 5: // NotEqual
+			return Binary(state, OpFOrdNotEqual, TypeBool(state), lhs, rhs);
+		case 6: // GreaterOrEqual
+			return Binary(state, OpFOrdGreaterThanEqual, TypeBool(state), lhs, rhs);
+		case 7: // Always
+			return ConstantBool(state, true);
+		default:
+			return ConstantBool(state, false);
+	}
 }
 
 bool HasFlag(const IR::MemoryInfo& mem, uint32_t flag) {
@@ -677,6 +703,7 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		const auto  layout         = Layout(mem, dimension);
 		const auto  numeric_class  = image.numeric_class;
 		const bool  dref           = HasFlag(mem, Decoder::ImageSampleFlagCompare);
+		const bool  manual_compare = state.specialization.images[mem.resource].needs_manual_depth_compare;
 		if (dref && state.program.info.images[mem.resource].conversion_format !=
 		                Prospero::BufferFormat::kInvalid) {
 			ctx.Fail(inst, "uses depth comparison with a packed integer image");
@@ -704,7 +731,62 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			const auto            sampled = MakeSampledImage(state, mem.resource, mem.sampler);
 			const auto            sample  = state.builder.AllocateId();
 			std::vector<uint32_t> words;
-			if (dref) {
+			
+			// Handle manual depth-compare for gather
+			if (dref && manual_compare) {
+				// Use regular gather for manual compare
+				uint32_t gather_component = 0;
+				if (ImageConversionFormat(state, mem).format == Prospero::BufferFormat::kInvalid) {
+					gather_component = ImageGatherComponent(mem.dmask);
+				}
+				words = {OpImageGather, ImageVectorType(state, numeric_class, 4),
+				         sample,        sampled,
+				         coord,         ConstantU32(state, gather_component)};
+				
+				if (HasFlag(mem, Decoder::ImageSampleFlagGatherHorizontal)) {
+					words.push_back(ImageOperandsConstOffsetsMask);
+					words.push_back(HorizontalOffsets(state, dimension));
+				} else if (layout.offset != NoImageComponent) {
+					words.push_back(ImageOperandsOffsetMask);
+					words.push_back(PackedOffset(ctx, mem, *address, layout, dimension));
+				}
+				state.builder.AddFunction(words);
+				
+				// Extract dref value for comparison
+				auto dref_value = ZeroF32(state);
+				if (layout.dref != NoImageComponent) {
+					dref_value = AddressF32(ctx, mem, *address, layout.dref);
+				}
+				
+				// Get the compare-op from the sampler descriptor
+				const auto& sampler = state.program.info.samplers[mem.sampler];
+				
+				// For gather with manual compare, we need to compare each component
+				uint32_t compared_components[4];
+				for (uint32_t i = 0; i < 4; i++) {
+					const auto comp_value = ctx.state.builder.AllocateId();
+					ctx.state.builder.AddFunction({OpCompositeExtract, TypeF32(ctx.state), comp_value, sample, i});
+					
+					const auto compare_result = EmitFloatCompareOp(ctx.state, comp_value, dref_value, sampler.depth_compare_func);
+					
+					const auto float_result = ctx.state.builder.AllocateId();
+					ctx.state.builder.AddFunction({OpSelect, TypeF32(ctx.state), float_result, compare_result, 
+					                                 ConstantF32Value(ctx.state, 1.0f), ConstantF32Value(ctx.state, 0.0f)});
+					compared_components[i] = float_result;
+				}
+				
+				const auto final_result = ctx.state.builder.AllocateId();
+				ctx.state.builder.AddFunction({OpCompositeConstruct, TypeF32Vector(ctx.state, 4), final_result,
+				                                 compared_components[0], compared_components[1], 
+				                                 compared_components[2], compared_components[3]});
+				
+				ctx.Define(inst, ResultVector(ctx, UnpackImageGather(ctx, mem, final_result),
+				                              Prospero::TextureNumericClass::Float, false, mem, true));
+				return true;
+			}
+			
+			// Normal gather path
+			if (dref && !manual_compare) {
 				auto dref_value = ZeroF32(state);
 				if (layout.dref != NoImageComponent) {
 					dref_value = AddressF32(ctx, mem, *address, layout.dref);
@@ -740,16 +822,25 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		                          HasFlag(mem, Decoder::ImageSampleFlagLod) ||
 		                          HasFlag(mem, Decoder::ImageSampleFlagLevelZero) ||
 		                          state.stage != ShaderType::Pixel;
+		
+		// For manual depth-compare emulation, use regular sample operation
+		const bool use_manual_compare = dref && manual_compare;
 		uint32_t opcode = OpImageSampleImplicitLod;
 		if (explicit_lod) {
-			opcode = dref ? OpImageSampleDrefExplicitLod : OpImageSampleExplicitLod;
-		} else if (dref) {
+			opcode = (dref && !use_manual_compare) ? OpImageSampleDrefExplicitLod : OpImageSampleExplicitLod;
+		} else if (dref && !use_manual_compare) {
 			opcode = OpImageSampleDrefImplicitLod;
 		}
+		
 		uint32_t result_type = ImageVectorType(state, numeric_class, 4);
 		uint32_t dref_value  = 0;
 		if (dref) {
-			result_type = TypeF32(state);
+			if (use_manual_compare) {
+				// For manual compare, we still need the dref value for comparison
+				result_type = ImageVectorType(state, numeric_class, 4);
+			} else {
+				result_type = TypeF32(state);
+			}
 			dref_value  = ZeroF32(state);
 			if (layout.dref != NoImageComponent) {
 				dref_value = AddressF32(ctx, mem, *address, layout.dref);
@@ -778,7 +869,8 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			const auto            sampled = MakeSampledImage(state, resource, mem.sampler);
 			const auto            sample  = state.builder.AllocateId();
 			std::vector<uint32_t> words {opcode, result_type, sample, sampled, coord};
-			if (dref) {
+			// Only push dref_value for native depth-compare operations
+			if (dref && !use_manual_compare) {
 				words.push_back(dref_value);
 			}
 			if (operand_mask != 0u) {
@@ -793,6 +885,25 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			auto       result = sample;
 			if (!dref) {
 				result = UnpackImageTexel(ctx, mem, sample);
+			} else if (use_manual_compare) {
+				// Manual depth-compare emulation: sample as color, then compare in shader.
+				const auto r_component = ctx.state.builder.AllocateId();
+				ctx.state.builder.AddFunction(
+				    {OpCompositeExtract, TypeF32(ctx.state), r_component, sample, 0});
+
+				const auto& sampler = state.program.info.samplers[mem.sampler];
+				const auto  compare_result =
+				    EmitFloatCompareOp(ctx.state, r_component, dref_value, sampler.depth_compare_func);
+
+				const auto float_result = ctx.state.builder.AllocateId();
+				ctx.state.builder.AddFunction(
+				    {OpSelect, TypeF32(ctx.state), float_result, compare_result,
+				     ConstantF32Value(ctx.state, 1.0f), ConstantF32Value(ctx.state, 0.0f)});
+
+				// Result is a scalar float, same shape as a native Dref sample.
+				ctx.Define(inst, ResultVector(ctx, float_result,
+				                              Prospero::TextureNumericClass::Float, true, mem));
+				return true;
 			}
 			ctx.Define(inst, ResultVector(ctx, result, numeric_class, dref, mem));
 			return true;
@@ -888,6 +999,25 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 		auto result = phi_words[2];
 		if (!dref) {
 			result = UnpackImageTexel(ctx, mem, result);
+		} else if (use_manual_compare) {
+			// Manual depth-compare emulation for indirect images.
+			const auto r_component = ctx.state.builder.AllocateId();
+			ctx.state.builder.AddFunction(
+			    {OpCompositeExtract, TypeF32(ctx.state), r_component, result, 0});
+
+			const auto& sampler = state.program.info.samplers[mem.sampler];
+			const auto  compare_result =
+			    EmitFloatCompareOp(ctx.state, r_component, dref_value, sampler.depth_compare_func);
+
+			const auto float_result = ctx.state.builder.AllocateId();
+			ctx.state.builder.AddFunction(
+			    {OpSelect, TypeF32(ctx.state), float_result, compare_result,
+			     ConstantF32Value(ctx.state, 1.0f), ConstantF32Value(ctx.state, 0.0f)});
+
+			// Result is a scalar float, same shape as a native Dref sample.
+			ctx.Define(inst, ResultVector(ctx, float_result, Prospero::TextureNumericClass::Float,
+			                              true, mem));
+			return true;
 		}
 		ctx.Define(inst, ResultVector(ctx, result, numeric_class, dref, mem));
 		return true;

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterImage.cpp
@@ -69,6 +69,17 @@ uint32_t EmitFloatCompareOp(EmitterState& state, uint32_t lhs, uint32_t rhs, uin
 	}
 }
 
+uint8_t SamplerDepthCompareFunc(const EmitterState& state, uint32_t sampler_index) {
+	if (sampler_index < state.program.info.samplers.size()) {
+		const auto func = state.program.info.samplers[sampler_index].depth_compare_func;
+		if (func != 0) return func;
+	}
+	if (sampler_index < state.specialization.sampler_depth_compare_funcs.size()) {
+		return state.specialization.sampler_depth_compare_funcs[sampler_index];
+	}
+	return 0;
+}
+
 bool HasFlag(const IR::MemoryInfo& mem, uint32_t flag) {
 	return (mem.image_sample_flags & flag) != 0u;
 }
@@ -759,7 +770,7 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 				}
 				
 				// Get the compare-op from the sampler descriptor
-				const auto& sampler = state.program.info.samplers[mem.sampler];
+				const auto compare_func = SamplerDepthCompareFunc(state, mem.sampler);
 				
 				// For gather with manual compare, we need to compare each component
 				uint32_t compared_components[4];
@@ -767,7 +778,7 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 					const auto comp_value = ctx.state.builder.AllocateId();
 					ctx.state.builder.AddFunction({OpCompositeExtract, TypeF32(ctx.state), comp_value, sample, i});
 					
-					const auto compare_result = EmitFloatCompareOp(ctx.state, comp_value, dref_value, sampler.depth_compare_func);
+					const auto compare_result = EmitFloatCompareOp(ctx.state, dref_value, comp_value, compare_func);
 					
 					const auto float_result = ctx.state.builder.AllocateId();
 					ctx.state.builder.AddFunction({OpSelect, TypeF32(ctx.state), float_result, compare_result, 
@@ -891,9 +902,9 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 				ctx.state.builder.AddFunction(
 				    {OpCompositeExtract, TypeF32(ctx.state), r_component, sample, 0});
 
-				const auto& sampler = state.program.info.samplers[mem.sampler];
-				const auto  compare_result =
-				    EmitFloatCompareOp(ctx.state, r_component, dref_value, sampler.depth_compare_func);
+				const auto compare_func = SamplerDepthCompareFunc(state, mem.sampler);
+				const auto compare_result =
+				    EmitFloatCompareOp(ctx.state, dref_value, r_component, compare_func);
 
 				const auto float_result = ctx.state.builder.AllocateId();
 				ctx.state.builder.AddFunction(
@@ -1005,9 +1016,9 @@ bool EmitValueImage(ValueEmitContext& ctx, const IR::Inst& inst) {
 			ctx.state.builder.AddFunction(
 			    {OpCompositeExtract, TypeF32(ctx.state), r_component, result, 0});
 
-			const auto& sampler = state.program.info.samplers[mem.sampler];
-			const auto  compare_result =
-			    EmitFloatCompareOp(ctx.state, r_component, dref_value, sampler.depth_compare_func);
+			const auto compare_func = SamplerDepthCompareFunc(state, mem.sampler);
+			const auto compare_result =
+			    EmitFloatCompareOp(ctx.state, dref_value, r_component, compare_func);
 
 			const auto float_result = ctx.state.builder.AllocateId();
 			ctx.state.builder.AddFunction(

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h
@@ -344,14 +344,15 @@ constexpr std::array<ImageDimensionInfo, 7> ImageDimensions {{
 const ImageDimensionInfo& ImageDimensionInfoFor(ImageDimension dimension);
 
 struct EmitterState {
-	EmitterState(const IR::Program& program_, ShaderStageInputInfo input_info_)
+	EmitterState(const IR::Program& program_, ShaderStageInputInfo input_info_, const IR::ResourceSpecialization& specialization_)
 	    : program(program_), input_info(input_info_),
-	      requirements(*program_.spirv_requirements) {}
+	      requirements(*program_.spirv_requirements), specialization(specialization_) {}
 
 	Builder                                          builder;
 	const IR::Program&                               program;
 	ShaderStageInputInfo                             input_info;
 	const IR::SpirvRequirements&                     requirements;
+	const IR::ResourceSpecialization&                specialization;
 	ShaderType                                       stage                   = ShaderType::Unknown;
 	uint32_t                                         wave_size               = 64;
 	uint32_t                                         storage_buffer_variable = 0;

--- a/src/graphics/shader/recompiler/ir/ShaderIR.h
+++ b/src/graphics/shader/recompiler/ir/ShaderIR.h
@@ -143,6 +143,7 @@ struct SamplerResource {
 	uint32_t first_use_pc          = 0;
 	bool     force_point_filtering = false;
 	bool     depth_compare         = false;
+	uint8_t  depth_compare_func    = 0; // vk::CompareOp value from sampler descriptor
 
 	bool operator==(const SamplerResource& other) const = default;
 };

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -2,6 +2,9 @@
 
 #include "common/assert.h"
 #include "graphics/guest_gpu/gpu_format.h"
+#include "graphics/host_gpu/renderer/image/imageInfo.h"
+#include "graphics/host_gpu/renderer/image/textureCommon.h"
+#include "graphics/host_gpu/vulkanCommon.h"
 #include "graphics/shader/recompiler/ir/ShaderIR.h"
 #include "graphics/shader/shaderBindings.h"
 
@@ -369,6 +372,17 @@ static bool BuildResourceSpecialization(const ResourcePlan& program, Materialize
 	next_snapshot.images.reserve(image_count);
 	next_snapshot.flattened_srt.reserve(next_snapshot.flattened_srt.size() + mapping_words);
 	next_specialization.images.reserve(image_count);
+	next_specialization.sampler_depth_compare_funcs.reserve(program.info.samplers.size());
+	// Extract depth_compare_func from sampler descriptors for manual compare emulation
+	for (const auto& sampler_descriptor: next_snapshot.samplers) {
+		if (sampler_descriptor.dword_count >= 1) {
+			// DepthCompareFunc is stored in bits 12-14 of dword 0 (from shaderBindings.h)
+			next_specialization.sampler_depth_compare_funcs.push_back(
+			    (sampler_descriptor.dwords[0] >> 12u) & 0x7u);
+		} else {
+			next_specialization.sampler_depth_compare_funcs.push_back(0);
+		}
+	}
 	for (const auto& image: program.info.images) {
 		next_specialization.images.push_back({
 		    .numeric_class              = image.numeric_class,
@@ -380,6 +394,7 @@ static bool BuildResourceSpecialization(const ResourcePlan& program, Materialize
 		    .indirect_mapping_offset    = image.indirect_mapping_offset,
 		    .indirect_search_iterations = image.indirect_search_iterations,
 		    .cube                       = image.cube,
+		    .needs_manual_depth_compare = false,
 		});
 	}
 	for (const auto& table: snapshot.indirect_images) {
@@ -486,6 +501,16 @@ static bool BuildResourceSpecialization(const ResourcePlan& program, Materialize
 		const bool raw_sint_storage = storage && format == Prospero::BufferFormat::k32SInt &&
 		                              base.written && !base.read && !base.atomic;
 		image.numeric_class         = Prospero::SampledTextureNumericClass(format);
+		
+		// Check if depth-compare is requested but format doesn't support it on Vulkan
+		if (base.depth_compare && !storage) {
+			const auto surface_format = TextureGetSurfaceFormatInfo(format);
+			if (!IsDepthComparisonSupported(surface_format.vk_format)) {
+				// Format doesn't support native depth-compare, enable manual emulation
+				image.needs_manual_depth_compare = true;
+			}
+		}
+		
 		if (storage) {
 			if ((!raw_sint_storage && image.numeric_class == Prospero::TextureNumericClass::Sint) ||
 			    image.numeric_class == Prospero::TextureNumericClass::Unsupported) {
@@ -497,7 +522,7 @@ static bool BuildResourceSpecialization(const ResourcePlan& program, Materialize
 				image.numeric_class = Prospero::TextureNumericClass::Uint;
 			}
 		} else if (image.numeric_class == Prospero::TextureNumericClass::Unsupported ||
-		           (base.depth_compare &&
+		           (base.depth_compare && !image.needs_manual_depth_compare &&
 		            image.numeric_class != Prospero::TextureNumericClass::Float)) {
 			return SpecializationFail(
 			    fmt::format("sampled image descriptor {} uses unsupported format {}", i,
@@ -540,19 +565,21 @@ static bool BuildResourceSpecialization(const ResourcePlan& program, Materialize
 				continue;
 			}
 			if (NullImageDescriptor(next_snapshot.images[candidate])) {
-				image.numeric_class     = image_class.numeric_class;
-				image.dimension         = image_class.dimension;
-				image.mip_count         = image_class.mip_count;
-				image.conversion_format = image_class.conversion_format;
-				image.shader_swizzle    = image_class.shader_swizzle;
-				image.cube              = image_class.cube;
+				image.numeric_class              = image_class.numeric_class;
+				image.dimension                  = image_class.dimension;
+				image.mip_count                  = image_class.mip_count;
+				image.conversion_format          = image_class.conversion_format;
+				image.shader_swizzle             = image_class.shader_swizzle;
+				image.cube                       = image_class.cube;
+				image.needs_manual_depth_compare = image_class.needs_manual_depth_compare;
 			}
 			if (image.numeric_class != image_class.numeric_class ||
 			    image.dimension != image_class.dimension ||
 			    image.mip_count != image_class.mip_count ||
 			    image.conversion_format != image_class.conversion_format ||
 			    image.shader_swizzle != image_class.shader_swizzle ||
-			    image.cube != image_class.cube) {
+			    image.cube != image_class.cube ||
+			    image.needs_manual_depth_compare != image_class.needs_manual_depth_compare) {
 				return SpecializationFail(
 				    fmt::format("indirect image table at pc 0x{:08x} has incompatible candidates",
 				                program.info.images[root_index].first_use_pc));
@@ -764,6 +791,14 @@ void ApplyResourceSpecialization(Program& program, const ResourceSpecialization&
 		}
 		samplers[pair.sampler].depth_compare |= images[pair.image].depth_compare;
 	}
+
+	// Copy depth_compare_func from specialization to samplers
+	for (uint32_t index = 0; index < program.info.samplers.size(); index++) {
+		if (index < specialization.sampler_depth_compare_funcs.size()) {
+			samplers[index].depth_compare_func = specialization.sampler_depth_compare_funcs[index];
+		}
+	}
+	// Split samplers (if any) inherit from their original, which we just set above
 
 	auto memory_info = program.memory_info;
 	for (const auto* block: program.blocks) {

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -508,6 +508,7 @@ static bool BuildResourceSpecialization(const ResourcePlan& program, Materialize
 			if (!IsDepthComparisonSupported(surface_format.vk_format)) {
 				// Format doesn't support native depth-compare, enable manual emulation
 				image.needs_manual_depth_compare = true;
+				image.shader_swizzle             = DescriptorImageSwizzle(descriptor);
 			}
 		}
 		
@@ -769,6 +770,14 @@ void ApplyResourceSpecialization(Program& program, const ResourceSpecialization&
 	EXIT_IF(!BuildSamplerPlan(program.info, images, sampler_plan));
 	auto samplers      = program.info.samplers;
 	auto sampled_pairs = program.info.sampled_pairs;
+
+	// Copy depth_compare_func from specialization to samplers before splitting
+	for (uint32_t index = 0; index < samplers.size(); index++) {
+		if (index < specialization.sampler_depth_compare_funcs.size()) {
+			samplers[index].depth_compare_func = specialization.sampler_depth_compare_funcs[index];
+		}
+	}
+
 	samplers.reserve(sampler_plan.sampler_count);
 	for (uint32_t index = 0; index < program.info.samplers.size(); index++) {
 		const auto target = sampler_plan.point_sampler[index];
@@ -791,14 +800,6 @@ void ApplyResourceSpecialization(Program& program, const ResourceSpecialization&
 		}
 		samplers[pair.sampler].depth_compare |= images[pair.image].depth_compare;
 	}
-
-	// Copy depth_compare_func from specialization to samplers
-	for (uint32_t index = 0; index < program.info.samplers.size(); index++) {
-		if (index < specialization.sampler_depth_compare_funcs.size()) {
-			samplers[index].depth_compare_func = specialization.sampler_depth_compare_funcs[index];
-		}
-	}
-	// Split samplers (if any) inherit from their original, which we just set above
 
 	auto memory_info = program.memory_info;
 	for (const auto* block: program.blocks) {

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.h
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.h
@@ -16,20 +16,22 @@ struct ResourceSpecialization {
 	};
 
 	struct Image {
-		Prospero::TextureNumericClass numeric_class = Prospero::TextureNumericClass::Unsupported;
-		Decoder::ImageDimension       dimension     = Decoder::ImageDimension::Unknown;
-		uint32_t                      mip_count     = 1;
+		Prospero::TextureNumericClass numeric_class              = Prospero::TextureNumericClass::Unsupported;
+		Decoder::ImageDimension       dimension                  = Decoder::ImageDimension::Unknown;
+		uint32_t                      mip_count                  = 1;
 		Prospero::BufferFormat        conversion_format          = Prospero::BufferFormat::kInvalid;
 		uint32_t                      shader_swizzle             = ShaderImageIdentitySwizzle;
 		uint32_t                      indirect_root              = ImageResource::NoIndirectImage;
 		uint32_t                      indirect_mapping_offset    = 0;
 		uint32_t                      indirect_search_iterations = 0;
 		bool                          cube                       = false;
+		bool                          needs_manual_depth_compare = false;
 		bool                          operator==(const Image&) const = default;
 	};
 
 	std::vector<Buffer> buffers;
 	std::vector<Image>  images;
+	std::vector<uint8_t> sampler_depth_compare_funcs; // depth_compare_func for each sampler
 
 	bool operator==(const ResourceSpecialization&) const = default;
 };


### PR DESCRIPTION
# Fix: Depth-Compare on non-depth formats (BC7_SRGB)
 
## Summary
 
*Tomb Raider I-III Remastered* legitimately uses a GCN `IMAGE_SAMPLE_C*` instruction (depth-compare sample) on a texture with `BC7_SRGB_BLOCK` format. This is valid on RDNA2/GCN, but the equivalent SPIR-V `OpImageSampleDref*` instruction requires the Vulkan format to support `VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT` — a capability only true depth formats (D16/D24/D32) have — causing a **Vulkan crash**.
 
The fix introduces **manual depth-compare emulation**: when the texture format doesn't support native compare, the compiler emits a regular sample followed by a manual in-shader comparison, faithfully replicating the original hardware semantics. During development, three secondary bugs were found and fixed that caused **inverted shadows** (shadows rendered as bright instead of dark).
 
---
 
## Part 1 — Depth-compare emulation
 
### 1.1 `imageInfo.h`
New helper function to check whether a Vulkan format supports native depth-compare:
 
```cpp
[[nodiscard]] inline bool IsDepthComparisonSupported(vk::Format format) noexcept {
    return DepthAspectTransferFormat(format) != vk::Format::eUndefined;
}
```
 
### 1.2 `ResourceMaterialization.cpp` — incompatibility detection
- After resolving `image.numeric_class`, if `base.depth_compare == true` and the image is not a storage image, the actual surface format is retrieved (`TextureGetSurfaceFormatInfo`) and checked against `IsDepthComparisonSupported(surface_format.vk_format)`.
- If unsupported: `image.needs_manual_depth_compare = true` is set instead of failing specialization.
- New field `needs_manual_depth_compare` added to `ResourceSpecialization::Image` (in `ShaderIR.h`) and propagated through all snapshot comparisons/copies (including indirect candidates).
- The sampler's `compare_func` (bits 12-14 of dword 0 of the descriptor, see `shaderBindings.h`) is extracted and copied into `sampler_depth_compare_funcs`, then applied to samplers in `ApplyResourceSpecialization`.
### 1.3 Propagating specialization down to the emitter
- `spirvEmitterInternal.h`: `EmitterState` now receives and holds a reference to `IR::ResourceSpecialization`.
- `SpirvEmitter.cpp/.h`: `EmitProgram` and `AnalyzeProgramRequirements` accept and propagate the `ResourceSpecialization`.
- `ShaderRecompiler.cpp`: `CompileProgram` passes the `specialization` to `Spirv::EmitProgram`, closing the chain between resource materialization and SPIR-V emission.
### 1.4 `spirvEmitterImage.cpp` — comparison emulation
- New `EmitFloatCompareOp` function: maps `vk::CompareOp` (Never, Less, Equal, LessOrEqual, Greater, NotEqual, GreaterOrEqual, Always) to the corresponding SPIR-V instructions (`OpFOrdLessThan`, `OpFOrdEqual`, etc.).
- **Single sample:** if `needs_manual_depth_compare`, `OpImageSample*` is emitted instead of `OpImageSampleDref*` (the `dref` is not included in the instruction's words); after sampling, the relevant component is extracted, compared against `dref_value` via `EmitFloatCompareOp`, and the boolean result is converted to a 0.0/1.0 float with `OpSelect`. The result is a scalar float, matching the shape of a native Dref sample.
- **Gather (`OpImageGather`):** the same logic is applied to each of the 4 gathered components individually, then reassembled into a float4 vector with `OpCompositeConstruct`.
- **Indirect/bindless images:** the same emulation is applied to the result of the indirectly resolved sample.
- The native path (`OpImageSampleDref*`) is left unchanged for formats that support native hardware compare — no regression expected there.
### 1.5 Aspect mask side fixes
- `imageView.h`: the sampled view's aspect is now chosen based on the actual format (`eDepth` if `DepthAspectTransferFormat` is defined, otherwise `eColor`), instead of always assuming color.
- `textureCache.cpp` (`BuildColorTransfer`): if the host image is in a depth format (e.g. `eD16Unorm`, produced by the native `depth_compare` path), the `aspectMask` of the copy regions is now corrected to `eDepth` before uploading.
- `descriptors.cpp`: adjustments in the texture descriptor resolution chain (`ResolveTexture`) to ensure the resolved surface format is correctly available at the materialization stage.
---
 
## Part 2 — Regression fix: inverted shadows
 
After the first round of testing, shadows were found to be rendered **inverted** (bright instead of dark) in the manual-compare paths. Root cause: three independent bugs in the comparison/sampler logic, not in the overall emulation design.
 
### 2.1 Operand order in `EmitFloatCompareOp`
- **File:** `spirvEmitterImage.cpp`
- **Problem:** the Vulkan spec (§16.6.7) and GCN define the dref sampling test as `result = Dref ⟨op⟩ Dtexel`. The arguments were being passed as `(texel, dref)`, inverting the relation (`<` became `>`, `≤` became `≥`). With Reverse-Z (`GreaterOrEqual`), pixels in shadow (`Dref < Dtexel`) were incorrectly evaluated as `true` (1.0), turning shadows into light sources.
- **Fix:** swapped the arguments in the `EmitFloatCompareOp` calls for `ImageGatherRaw`, `ImageSampleRaw`, and indirect sampling: `dref_value` as `lhs`, `comp_value`/`r_component` as `rhs`.
- **Cost:** none — still a single `OpFOrd*` followed by `OpSelect` (`V_CNDMASK_B32` on GPU).
### 2.2 `depth_compare_func` lost on split samplers
- **Files:** `ResourceMaterialization.cpp`, `spirvEmitterImage.cpp`
- **Problem:** in `ResourceMaterialization.cpp`, split samplers (`point_sampler`) were being cloned **before** `depth_compare_func` was set, so they inherited `0` (`VK_COMPARE_OP_NEVER`).
- **Fix:** the copy of `depth_compare_func` from the specialization to `samplers` was moved earlier, before the split samplers are created. Added the `SamplerDepthCompareFunc` helper in `spirvEmitterImage.cpp`, which checks both the compiled samplers and the specialization.
### 2.3 `shader_swizzle` lost on manual depth-compare
- **File:** `ResourceMaterialization.cpp`
- **Fix:** when `image.needs_manual_depth_compare = true` is set, `image.shader_swizzle = DescriptorImageSwizzle(descriptor)` is now also stored, ensuring the correct component is extracted from the sample during manual comparison.
### 2.4 sRGB → linear distortion on BC7 shadow maps
- **Files:** `imageView.h`, `descriptors.cpp`
- **Problem:** compressed `kBc7Srgb` textures used as shadow/light maps were being sampled with `VK_FORMAT_BC7_SRGB_BLOCK`. The hardware sRGB→linear decoder applied a gamma curve (~x^2.2, e.g. 0.5 → 0.214) to the raw depth/shadow values, shifting the comparison threshold.
- **Fix:** new `SrgbToUnorm(format)` helper in `imageView.h`. In `descriptors.cpp`, when an image requires `depth_compare` on a non-native-depth format, the view is now automatically created in the equivalent UNORM format (e.g. `VK_FORMAT_BC7_UNORM_BLOCK` for `BC7_SRGB`), so the hardware sampler reads the raw values without gamma conversion.
- **Cost:** zero — no extra shader computation, just a different view format.

---

## Known risks / open follow-ups
 
- A separate rendering artifact was identified (not fixed in this PR): "polygonal/faceted" edges on volumetric light cones (e.g. wall sconces), present **even before** this fix — unrelated to the `needs_manual_depth_compare` path. To be investigated separately (suspected cause: flat-shading interpolation or blending on the light cone's triangles).