### PR TITLE
libc: treat negative dynamic printf precision as omitted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,13 @@ add_executable(resource_tracking_tests EXCLUDE_FROM_ALL
 target_link_libraries(resource_tracking_tests fmt::fmt)
 target_include_directories(resource_tracking_tests PRIVATE ${inc_headers})
 
+add_executable(guest_printf_tests EXCLUDE_FROM_ALL
+	"${KYTY_TESTS_DIR}/GuestPrintfTests.cpp"
+	"${KYTY_SOURCE_DIR}/libs/guestPrintf.cpp"
+)
+target_link_libraries(guest_printf_tests common)
+target_include_directories(guest_printf_tests PRIVATE ${inc_headers})
+
 add_executable(audio_out2_port_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/AudioOut2PortTests.cpp"
 	"${KYTY_SOURCE_DIR}/libs/libAudio2.cpp"
@@ -533,6 +540,7 @@ if(BUILD_TESTING)
 	add_test(NAME emulator_present_mode_invalid
 	         COMMAND $<TARGET_FILE:kyty_emulator> --help --present-mode Invalid)
 	set_tests_properties(emulator_present_mode_invalid PROPERTIES WILL_FAIL TRUE)
+	add_test(NAME guest_printf COMMAND $<TARGET_FILE:guest_printf_tests>)
 	add_test(NAME ime_dialog COMMAND $<TARGET_FILE:ime_dialog_tests>)
 	add_test(NAME shader_cfg COMMAND $<TARGET_FILE:shader_cfg_tests>)
 	add_test(NAME scalar_provenance COMMAND $<TARGET_FILE:scalar_provenance_tests>)
@@ -589,6 +597,7 @@ if(BUILD_TESTING)
 	endif()
 
 	add_custom_target(kyty_tests DEPENDS
+		guest_printf_tests
 		ime_dialog_tests
 		shader_cfg_tests
 		scalar_provenance_tests

--- a/src/libs/guestPrintf.cpp
+++ b/src/libs/guestPrintf.cpp
@@ -527,7 +527,12 @@ static int kyty_printf_internal(bool sn, char* sn_s, size_t sn_n, const char* fo
 			} else if (*format == '*') {
 				// const int prec = (int)va_arg(va, int);
 				const int prec = VaArg_int(va_list);
-				precision      = prec > 0 ? static_cast<unsigned int>(prec) : 0U;
+				if (prec < 0) {
+					// A negative dynamic precision is treated as omitted.
+					flags &= ~FLAGS_PRECISION;
+				} else {
+					precision = static_cast<unsigned int>(prec);
+				}
 				format++;
 			}
 		}

--- a/tests/GuestPrintfTests.cpp
+++ b/tests/GuestPrintfTests.cpp
@@ -1,0 +1,190 @@
+#include "libs/guestPrintf.h"
+#include "libs/vaContext.h"
+
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <clocale>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <type_traits>
+
+namespace {
+
+void Check(bool condition, const char* message) {
+	if (!condition) {
+		std::fprintf(stderr, "GuestPrintfTests: %s\n", message);
+		std::abort();
+	}
+}
+
+// Model the guest SysV register-save area, independently of the host va_list.
+// snprintf's three fixed arguments occupy GP slots 0..2. Integer/pointer args
+// use the remaining GP slots; doubles use the low eight bytes of separate
+// 16-byte FP slots. Once a class is exhausted its arguments go on the stack,
+// in argument order. Only these scalar argument types are needed by this test.
+struct GuestArguments {
+	alignas(16) Libs::VaContext context {};
+	alignas(16) std::array<uint64_t, 64> stack {};
+	size_t gp_count = 0;
+	size_t fp_count = 0;
+	size_t stack_count = 0;
+
+	GuestArguments() {
+		context.va_list.reg_save_area = &context.reg_save_area;
+		context.va_list.gp_offset = offsetof(Libs::VaRegSave, gp);
+		context.va_list.fp_offset = offsetof(Libs::VaRegSave, fp);
+		context.va_list.overflow_arg_area = stack.data();
+	}
+
+	template <typename T>
+	void Add(T value) {
+		static_assert(std::is_integral_v<T> || std::is_pointer_v<T> ||
+		              std::is_same_v<T, double>);
+		static_assert(sizeof(T) <= sizeof(uint64_t));
+		void* slot = nullptr;
+		if constexpr (std::is_same_v<T, double>) {
+			if (fp_count < 8) {
+				slot = &context.reg_save_area.fp[fp_count];
+			}
+			++fp_count;
+		} else {
+			if (gp_count < 6) {
+				slot = &context.reg_save_area.gp[gp_count];
+			}
+			++gp_count;
+		}
+		if (slot == nullptr) {
+			Check(stack_count < stack.size(), "argument fixture stack overflow");
+			slot = &stack[stack_count++];
+		}
+		std::memcpy(slot, &value, sizeof(value));
+	}
+
+	void CheckConsumed() const {
+		Check(context.va_list.gp_offset == std::min(gp_count, size_t {6}) * 8,
+		      "wrong GP argument consumption");
+		Check(context.va_list.fp_offset == offsetof(Libs::VaRegSave, fp) +
+		                                      std::min(fp_count, size_t {8}) * 16,
+		      "wrong FP argument consumption");
+		Check(context.va_list.overflow_arg_area == stack.data() + stack_count,
+		      "wrong overflow argument consumption");
+	}
+};
+
+size_t g_cases = 0;
+size_t g_failures = 0;
+
+template <typename... Args>
+void Compare(const char* format, Args... args) {
+	// Keep enough room for every result: truncation and n == 0 have separate
+	// known limitations and are not part of the precision-parser regression.
+	std::array<char, 512> expected;
+	std::array<char, 512> actual;
+	expected.fill('~');
+	actual.fill('~');
+	const int expected_length = std::snprintf(expected.data(), expected.size(), format, args...);
+	Check(expected_length >= 0 && static_cast<size_t>(expected_length) < expected.size(),
+	      "host snprintf failed or fixture buffer too small");
+
+	GuestArguments guest;
+	guest.Add(actual.data());
+	guest.Add(actual.size());
+	guest.Add(format);
+	(guest.Add(args), ...);
+	const int actual_length = Libs::GetGuestSnprintfCtxFunc()(&guest.context);
+	guest.CheckConsumed();
+
+	++g_cases;
+	// Compare the terminator and untouched tail as well as the output and
+	// returned byte count. Do not rely on assert(), which Release disables.
+	if (actual_length != expected_length || actual != expected) {
+		++g_failures;
+		std::fprintf(stderr,
+		             "case %zu format=\"%s\": expected length=%d \"%s\", "
+		             "got length=%d \"%.*s\"\n",
+		             g_cases, format, expected_length, expected.data(), actual_length,
+		             static_cast<int>(actual.size()), actual.data());
+	}
+}
+
+void CheckPrecisionMatrix() {
+	// INT_MIN ensures a negative precision is ignored, not negated or cast to
+	// an enormous unsigned precision. Zero and positive values are controls.
+	for (int precision: {-1, -7, INT_MIN, 0, 1, 3, 6}) {
+		std::printf("precision=%d\n", precision);
+		for (const char* format: {"%.*d", "%08.*d", "%+08.*d", "%8.*i"}) {
+			for (int value: {0, 42, -42}) {
+				Compare(format, precision, value);
+			}
+		}
+		for (const char* format: {"%.*u", "%08.*u", "%.*x", "%08.*X", "%.*o"}) {
+			for (unsigned int value: {0U, 42U}) {
+				Compare(format, precision, value);
+			}
+		}
+		for (const char* format: {"%.*lld", "%012.*lld"}) {
+			for (long long value: {0LL, 123456789LL, -123456789LL}) {
+				Compare(format, precision, value);
+			}
+		}
+		Compare("%.*hhd|%.*hd", precision, 0, precision, 0);
+		for (const char* format: {"%.*s", "[%8.*s]", "[%-8.*s]"}) {
+			for (const char* value: {"", "abcdef"}) {
+				Compare(format, precision, value);
+			}
+		}
+		for (const char* format: {"%.*f", "%.*F", "%012.*f", "%-12.*f"}) {
+			for (double value: {0.0, 1.25, -1.25, 12.375}) {
+				Compare(format, precision, value);
+			}
+		}
+		for (const char* format: {"%.*e", "%.*E", "%014.*e"}) {
+			Compare(format, precision, 1.25);
+			Compare(format, precision, -1.25);
+		}
+		// Width and precision are GP arguments even for a floating conversion.
+		Compare("[%0*.*d]", 8, precision, 0);
+		Compare("[%*.*s]", -8, precision, "abcdef");
+		Compare("[%0*.*f]", 12, precision, 1.25);
+	}
+}
+
+void CheckArgumentPlacement() {
+	for (int precision: {-1, 0, 3}) {
+		// Precision in the last GP register, then precision on the stack.
+		// The following conversion verifies that .* always consumes its int.
+		Compare("%d:%d:%.*d:%d", 11, 22, precision, 0, 77);
+		Compare("%d:%d:%d:%.*s:%d", 11, 22, 33, precision, "abcdef", 77);
+		// GP exhaustion must not cause a double to be read from the stack
+		// while there are FP registers left.
+		Compare("%d:%d:%d:%0*.*f:%d", 11, 22, 33, 12, precision, 1.25, 77);
+		// Exhaust both classes. The ninth double follows a stack precision;
+		// the next integer follows that double in the same overflow area.
+		Compare("%.*f|%.*f|%.*f|%.*f|%.*f|%.*f|%.*f|%.*f|%.*f|%d",
+		        precision, 1.25, precision, 2.25, precision, 3.25,
+		        precision, 4.25, precision, 5.25, precision, 6.25,
+		        precision, 7.25, precision, 8.25, precision, 9.25, 77);
+	}
+	// Precision state is per conversion, not sticky across a format string.
+	Compare("%.*s|%.*s|%.*s|%s", 2, "abcdef", -1, "abcdef", 0, "abcdef", "tail");
+	Compare("%.*f|%.*f|%.*f|%f", 2, 1.25, -1, 1.25, 0, 1.25, 1.25);
+	Compare("%08.*d|%08.*d|%08.*d|%08d", 3, 42, -1, 42, 0, 0, 42);
+}
+
+} // namespace
+
+int main() {
+	Check(std::setlocale(LC_ALL, "C") != nullptr, "could not select C locale");
+	std::setvbuf(stdout, nullptr, _IONBF, 0);
+	Compare("");
+	Compare("literal %%");
+	Compare("%d|%s|%f", 0, "", 0.0);
+	Compare("%.d|%.s|%.f", 0, "abcdef", 1.25);
+	Compare("%.0d|%.0s|%.0f", 0, "abcdef", 1.25);
+	CheckPrecisionMatrix();
+	CheckArgumentPlacement();
+	std::printf("GuestPrintfTests: %zu cases, %zu failures\n", g_cases, g_failures);
+	return g_failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Treat negative precision arguments supplied through `.*` as omitted in guest printf. Clear `FLAGS_PRECISION` for negative values; preserve explicit zero and positive precision. No snprintf truncation changes.

The [printf contract](https://pubs.opengroup.org/onlinepubs/9699919799/functions/printf.html) states: “A negative precision is taken as if the precision were omitted.” Previously the parser clamped the value to zero while retaining the explicit-precision flag. This suppressed zero integers, emptied strings, disabled integer zero-padding and selected zero rather than default floating precision.

## Regression coverage

Add `guest_printf_tests`, registered as CTest `guest_printf` and included in `kyty_tests`. Tests call `GetGuestSnprintfCtxFunc` with a real `VaContext`, comparing output, returned lengths, termination and untouched buffer tails against host `snprintf` in the C locale.

440 comparisons cover negative precision (including `INT_MIN`), explicit zero/positive precision, zero integers, empty strings/format, integer and f/F/e/E conversions, widths, sign/zero-padding, per-conversion state reset, GP register boundaries and interleaved GP/FP stack overflow. Argument consumption is checked separately.

## Validation

Same test source against the entire actual production `guestPrintf.cpp`:

- Upstream `6aa6e390ee2930d7eeba7351c38bd342b783d933`: 440 cases, **151 failures**, executable exit 1 / CTest exit 8.
- Parser patch only: 440 cases, **0 failures**, executable and CTest exit 0.
- Zero/positive precision controls pass on both.

These were focused CMake/Ninja/CTest unit runs on Linux x86-64 using Zig 0.13 / Clang 18 and libc++. No formatter or argument-accessor copies were used. The verification driver supplies fail-fast link fixtures only for unused logging/fatal hooks and uses real fmt headers; the checked-in target links `common`. Objects were compiled in Release mode; a link-only `-O0` option reused the bootstrapped Zig runtime.

The normal project configure was attempted but blocked by Zig rejecting `-Wl,-v` during compiler ABI detection. Consequently the root-project target itself has not been built locally. With the normal project configured, run:

```sh
cmake --build build --target guest_printf_tests -j1
ctest --test-dir build -R '^guest_printf$' --output-on-failure
```

No full emulator/game compatibility, Windows/macOS validation, truncation/zero-size-buffer behavior or comprehensive floating-point conformance is claimed.

Developed and verified with AI assistance.
