### PR TITLE
kernel: release descriptors when rejecting read-only truncation

### DIFF
--- a/src/kernel/fileSystem.cpp
+++ b/src/kernel/fileSystem.cpp
@@ -458,6 +458,7 @@ int KYTY_SYSV_ABI KernelOpen(const char* path, int flags, uint16_t mode) {
 	file->real_name = g_mount_points->ResolvePath(file->name);
 
 	if (trunc && rw_mode == Common::File::Mode::Read) {
+		g_files->DeleteDescriptor(descriptor);
 		return KERNEL_ERROR_EACCES;
 	}
 


### PR DESCRIPTION
Release the descriptor allocated by `KernelOpen` before returning `KERNEL_ERROR_EACCES` for read-only truncation. Repeated rejected opens otherwise retain guest descriptor slots and their allocations until filesystem shutdown.

The patch contains only the missing `DeleteDescriptor` call. No test files or test-target changes are included.

Validation: checked descriptor allocation/cleanup and the neighboring failure paths; `git diff --check` passes. No build or runtime tests were run for this revision.
