### PR TITLE
renderer: reduce FPS overhead in GPU scheduling and resource caching

### DIFF
--- a/src/graphics/guest_gpu/command_processor/commandProcessor.h
+++ b/src/graphics/guest_gpu/command_processor/commandProcessor.h
@@ -2,6 +2,7 @@
 #define GRAPHICS_GUEST_GPU_COMMAND_PROCESSOR_COMMAND_PROCESSOR_H
 
 #include "common/assert.h"
+#include "graphics/guest_gpu/command_processor/releaseMemBatch.h"
 #include "graphics/guest_gpu/hardwareContext.h"
 #include "graphics/host_gpu/renderer/render.h"
 #include "graphics/host_gpu/renderer/renderContext.h"
@@ -61,6 +62,11 @@ public:
 
 	void            BufferInit();
 	void            BufferFlush();
+	void            FlushPendingReleaseMem();
+	bool DeferReleaseMemFlush(std::span<const uint32_t> current,
+	                          std::span<const uint32_t> next) {
+		return m_release_mem_batch.Defer(current, next);
+	}
 	void            BufferFlushAndWait();
 	void            BufferWait();
 	HW::Context&    GetCtx() { return m_ctx; }
@@ -173,6 +179,7 @@ private:
 
 	FlipInfo  m_flip;
 	const int m_interrupt_event_id;
+	ReleaseMemBatch m_release_mem_batch;
 	uint64_t  m_submit_id                   = 0;
 	uint64_t  m_synthetic_occlusion_counter = 0;
 	bool      m_predicate_skip              = false;

--- a/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
+++ b/src/graphics/guest_gpu/command_processor/pm4Handlers.cpp
@@ -2314,7 +2314,11 @@ KYTY_CP_OP_PARSER(CpOpReleaseMem) {
 		cp.WriteAtEndOfPipe32(cache_policy, event_write_dest, eop_event_type, cache_action,
 		                      event_index, event_source, dst_gpu_addr, static_cast<uint32_t>(value),
 		                      interrupt_selector, interrupt_context_id);
-		cp.BufferFlush();
+		const std::array<uint32_t, 8> current {cmd_id, buffer[0], buffer[1], buffer[2],
+		                                      buffer[3], buffer[4], buffer[5], buffer[6]};
+		if (dw < 16 || !cp.DeferReleaseMemFlush(current, {buffer + 7, dw - 8})) {
+			cp.BufferFlush();
+		}
 
 		return 7;
 	}

--- a/src/graphics/guest_gpu/command_processor/releaseMemBatch.h
+++ b/src/graphics/guest_gpu/command_processor/releaseMemBatch.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+namespace Libs::Graphics {
+
+// Only adjacent, non-predicated, plain 32-bit CPU labels may share a submission.
+class ReleaseMemBatch {
+public:
+	static constexpr uint32_t MaxPackets = 8;
+
+	static bool Eligible(std::span<const uint32_t> packet) noexcept {
+		if (packet.size() < 8 || packet[0] != 0xc0061060u || packet[1] != 0x528u ||
+		    packet[2] != (1u << 29u)) {
+			return false;
+		}
+		const uint64_t address = uint64_t {packet[3]} | (uint64_t {packet[4]} << 32u);
+		return address != 0 && (address & 3u) == 0;
+	}
+
+	bool Defer(std::span<const uint32_t> current, std::span<const uint32_t> next) noexcept {
+		if (m_pending + 1 >= MaxPackets || !Eligible(current) || !Eligible(next)) {
+			return false;
+		}
+		++m_pending;
+		return true;
+	}
+
+	[[nodiscard]] bool Pending() const noexcept { return m_pending != 0; }
+	void Reset() noexcept { m_pending = 0; }
+
+private:
+	uint32_t m_pending = 0;
+};
+
+} // namespace Libs::Graphics

--- a/src/graphics/guest_gpu/graphicsRun.cpp
+++ b/src/graphics/guest_gpu/graphicsRun.cpp
@@ -126,7 +126,7 @@ void GuestGpu::SendCommand(Common::UniqueFunction<void>&& command) {
 	m_work_available.Signal();
 }
 
-void GuestGpu::ProcessCommands() {
+void GuestGpu::ProcessCommands(CommandProcessor* processor) {
 	EXIT_IF(!IsGpuThread());
 	while (m_pending_commands.load(std::memory_order_acquire) != 0) {
 		Common::UniqueFunction<void> command;
@@ -136,6 +136,9 @@ void GuestGpu::ProcessCommands() {
 			command = std::move(m_commands.front());
 			m_commands.pop_front();
 			EXIT_IF(m_pending_commands.fetch_sub(1, std::memory_order_acq_rel) == 0);
+		}
+		if (processor != nullptr) {
+			processor->FlushPendingReleaseMem();
 		}
 		command();
 	}
@@ -265,7 +268,14 @@ void CommandProcessor::BufferInit() {
 }
 
 void CommandProcessor::BufferFlush() {
+	m_release_mem_batch.Reset();
 	GetScheduler().Flush();
+}
+
+void CommandProcessor::FlushPendingReleaseMem() {
+	if (m_release_mem_batch.Pending()) {
+		BufferFlush();
+	}
 }
 
 void CommandProcessor::BufferFlushAndWait() {
@@ -673,6 +683,7 @@ Pm4ProcessResult CommandProcessor::Process(Pm4Execution&             execution,
 	} execution_scope(*this, execution);
 
 	ProcessPm4(execution, 0);
+	FlushPendingReleaseMem();
 	return execution.m_buffer_stack.empty() ? Pm4ProcessResult::Complete
 	                                        : Pm4ProcessResult::Blocked;
 }
@@ -696,7 +707,7 @@ void CommandProcessor::SuspendPm4() {
 void CommandProcessor::ProcessPm4(Pm4Execution& execution, size_t stop_depth) {
 	while (execution.m_buffer_stack.size() > stop_depth) {
 		if (g_gpu_state != nullptr) {
-			g_gpu_state->ProcessCommands();
+			g_gpu_state->ProcessCommands(this);
 		}
 		const auto buffer_index = execution.m_buffer_stack.size() - 1;
 		auto&      cursor       = execution.m_buffer_stack[buffer_index];
@@ -718,6 +729,10 @@ void CommandProcessor::ProcessPm4(Pm4Execution& execution, size_t stop_depth) {
 		const auto        remaining_dw  = total_dw - cursor.offset_dw;
 		const auto        packet_header = packet[0];
 		const auto        opcode        = (packet_header >> 8u) & 0xffu;
+		if (m_release_mem_batch.Pending() &&
+		    !ReleaseMemBatch::Eligible({packet, remaining_dw})) {
+			FlushPendingReleaseMem();
+		}
 		EXIT_NOT_IMPLEMENTED(remaining_dw > total_dw);
 
 		if (packet_header == 0x80000000u) {

--- a/src/graphics/guest_gpu/graphicsRun.h
+++ b/src/graphics/guest_gpu/graphicsRun.h
@@ -67,7 +67,7 @@ private:
 
 	void              Enqueue(Submission submission);
 	void              WaitForIdle();
-	void              ProcessCommands();
+	void              ProcessCommands(CommandProcessor* processor = nullptr);
 	bool              Process(Submission& submission);
 	static void       ThreadRun(void* data);
 	CommandProcessor& GetProcessor(uint32_t queue_id);

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -19,6 +19,7 @@
 #include <array>
 #include <bit>
 #include <cinttypes>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <mutex>
@@ -174,15 +175,24 @@ TextureCache::TextureCache(GraphicContext& graphics, CommandScheduler& scheduler
       m_buffer_cache(buffer_cache),
       m_readback_linear_images(Config::ReadbackLinearImagesEnabled()) {
 	if (m_graphics.CanReportMemoryUsage()) {
-		constexpr int64_t GiB = 1024ll * 1024 * 1024;
-		const auto        budget =
-		    static_cast<int64_t>(std::min<uint64_t>(m_graphics.GetTotalMemoryBudget(), INT64_MAX));
-		const auto threshold = std::min<int64_t>(budget, 8 * GiB);
-		m_pressure_gc_memory = static_cast<uint64_t>(
-		    std::max<int64_t>(std::min(budget - 6 * threshold / 10, budget - GiB), GiB + GiB / 2));
-		m_critical_gc_memory = static_cast<uint64_t>(
-		    std::max<int64_t>(std::min(budget - 2 * threshold / 10, budget - GiB / 2), 3 * GiB));
-		m_trigger_gc_memory = static_cast<uint64_t>(std::max<int64_t>((budget - threshold) / 2, 0));
+		ConfigureGarbageCollectionBudget(m_graphics.GetTotalMemoryBudget());
+	}
+}
+
+void TextureCache::ConfigureGarbageCollectionBudget(uint64_t available_budget) {
+	constexpr int64_t GiB = 1024ll * 1024 * 1024;
+	const auto budget = static_cast<int64_t>(std::min<uint64_t>(available_budget, INT64_MAX));
+	const auto threshold = std::min<int64_t>(budget, 8 * GiB);
+	m_pressure_gc_memory = static_cast<uint64_t>(
+	    std::max<int64_t>(std::min(budget - 6 * threshold / 10, budget - GiB), GiB + GiB / 2));
+	m_critical_gc_memory = static_cast<uint64_t>(
+	    std::max<int64_t>(std::min(budget - 2 * threshold / 10, budget - GiB / 2), 3 * GiB));
+	// Keep reusable images resident until memory is actually under pressure.
+	m_trigger_gc_memory = m_pressure_gc_memory;
+	if (const auto* legacy = std::getenv("KYTY_TEXTURE_CACHE_EARLY_GC");
+	    legacy != nullptr && std::strcmp(legacy, "1") == 0) {
+		m_trigger_gc_memory =
+		    static_cast<uint64_t>(std::max<int64_t>((budget - threshold) / 2, 0));
 	}
 }
 

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -101,6 +101,7 @@ private:
 
 	using ImageIds       = InlinePageOwnerList<ImageId, 16>;
 	using ImagePageTable = MultiLevelPageTable<ImageIds, 20, 40, 10>;
+	void ConfigureGarbageCollectionBudget(uint64_t available_budget);
 
 	[[nodiscard]] ImageId     InsertImage(const ImageInfo& info);
 	[[nodiscard]] ImageId     GetNullImage(const ImageDesc& desc);

--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
@@ -102,6 +102,12 @@ bool ReadShaderGuestMemory(void*, uint64_t address, uint32_t* value) {
 	       Libs::LibKernel::Memory::TryReadGpuCleanBacking(address, value, sizeof(*value));
 }
 
+bool ReadShaderGuestMemoryBlock(void*, uint64_t address, uint32_t* words, uint32_t word_count) {
+	return words != nullptr && word_count != 0 &&
+	       Libs::LibKernel::Memory::TryReadGpuCleanBacking(
+	           address, words, uint64_t {word_count} * sizeof(uint32_t));
+}
+
 void DumpShaderSpirv(const char* stage_name, uint64_t shader_hash,
                      const std::vector<uint32_t>& spirv) {
 	if (!Config::GraphicsDebugDumpEnabled()) {
@@ -297,6 +303,7 @@ struct PipelineCache::ProgramCache {
 		    .user_data                  = params.user_data,
 		    .shader_base                = params.Base(),
 		    .read_specialization_memory = ReadShaderGuestMemory,
+		    .read_specialization_block  = ReadShaderGuestMemoryBlock,
 		};
 		if (entry != programs.end()) {
 			EXIT_IF(!ShaderRecompiler::IR::MaterializeResources(

--- a/src/graphics/host_gpu/renderer/pipeline/shaderResourceBarrier.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaderResourceBarrier.cpp
@@ -88,8 +88,14 @@ bool HasShaderBufferWrites(const ShaderStageRuntime& runtime) {
 	return has_writes;
 }
 
-void ShaderAccessBarrier(vk::CommandBuffer vk_buffer, vk::PipelineStageFlags source_stages) {
+void ShaderAccessBarrier(vk::CommandBuffer vk_buffer, vk::PipelineStageFlags source_stages,
+                         bool writes_memory) {
 	EXIT_IF(vk_buffer == nullptr || !source_stages);
+	if (!writes_memory) {
+		vk_buffer.pipelineBarrier(source_stages, vk::PipelineStageFlagBits::eAllCommands,
+		                          vk::DependencyFlags {}, 0, nullptr, 0, nullptr, 0, nullptr);
+		return;
+	}
 	const auto barrier = MakeShaderAccessDependency();
 	vk_buffer.pipelineBarrier(source_stages, vk::PipelineStageFlagBits::eAllCommands,
 	                          vk::DependencyFlags {}, 1, &barrier, 0, nullptr, 0, nullptr);

--- a/src/graphics/host_gpu/renderer/pipeline/shaderResourceBarrier.h
+++ b/src/graphics/host_gpu/renderer/pipeline/shaderResourceBarrier.h
@@ -14,7 +14,8 @@ VulkanMemoryBarrier     MakeShaderWriteHazardDependency();
 VulkanMemoryBarrier     MakeShaderWriteDependency();
 vk::BufferMemoryBarrier MakeGdsDependency(vk::Buffer buffer);
 bool HasShaderBufferWrites(const ShaderStageRuntime& runtime);
-void ShaderAccessBarrier(vk::CommandBuffer vk_buffer, vk::PipelineStageFlags source_stages);
+void ShaderAccessBarrier(vk::CommandBuffer vk_buffer, vk::PipelineStageFlags source_stages,
+                         bool writes_memory = true);
 void ShaderWriteHazardBarrier(vk::CommandBuffer      vk_buffer,
                               vk::PipelineStageFlags destination_stages);
 void ShaderWriteBarrier(vk::CommandBuffer vk_buffer, vk::PipelineStageFlags source_stages);

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -404,8 +404,14 @@ void RenderExecutor::DispatchDirect(uint64_t submit_id, CommandBuffer& buffer,
 	vk_buffer.bindPipeline(vk::PipelineBindPoint::eCompute, pipeline.pipeline);
 	vk_buffer.dispatch(thread_group_x, thread_group_y, thread_group_z);
 
-	// The removed host fence also ordered read-only dispatches before later writers.
-	ShaderAccessBarrier(vk_buffer, vk::PipelineStageFlagBits::eComputeShader);
+	// Read-only dispatches need ordering, but no memory visibility operation.
+	const bool writes_memory =
+	    has_storage_writes || program.info.uses_dma || bindings.gds.buffer != nullptr ||
+	    std::any_of(program.info.buffers.begin(), program.info.buffers.end(),
+	                [](const auto& resource) { return resource.written || resource.atomic; }) ||
+	    std::any_of(program.info.images.begin(), program.info.images.end(),
+	                [](const auto& resource) { return resource.written || resource.atomic; });
+	ShaderAccessBarrier(vk_buffer, vk::PipelineStageFlagBits::eComputeShader, writes_memory);
 	ResetBindings();
 }
 

--- a/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ResourceMaterialization.cpp
@@ -184,6 +184,14 @@ bool ReadSpecializationWord(const SrtRuntime& runtime, uint64_t address, uint32_
 	       runtime.read_specialization_memory(runtime.userdata, address, &word);
 }
 
+bool TryReadSpecializationBlock(const SrtRuntime& runtime, uint64_t address, uint32_t* words,
+                                uint32_t count) {
+	return runtime.read_specialization_memory != nullptr &&
+	       runtime.read_specialization_block != nullptr && count != 0 && address <= AddressMask &&
+	       uint64_t {count} * sizeof(uint32_t) - 1 <= AddressMask - address &&
+	       runtime.read_specialization_block(runtime.userdata, address, words, count);
+}
+
 bool ReadScalarBufferWord(const ShaderBufferResource& descriptor, uint32_t dynamic_offset,
                           uint32_t immediate_offset, const SrtRuntime& runtime, uint32_t& word) {
 	const auto byte_offset = static_cast<uint64_t>(dynamic_offset) + immediate_offset;
@@ -256,7 +264,17 @@ bool MaterializeIndirectImage(const DescriptorSource::IndirectImage& indirect,
 		DescriptorValue candidate;
 		candidate.dword_count  = 8u;
 		const auto heap_offset = key << 5u;
-		for (uint32_t dword = 0; dword < candidate.dword_count; dword++) {
+		const auto heap_size = ScalarBufferSize(heap);
+		const auto heap_base = heap.Base48() & ~uint64_t {3};
+		const bool full_entry = heap_offset <= heap_size &&
+		                        heap_size - heap_offset >=
+		                            candidate.dword_count * sizeof(uint32_t) &&
+		                        heap_offset <= AddressMask - heap_base;
+		const bool block_read =
+		    full_entry && TryReadSpecializationBlock(runtime, heap_base + heap_offset,
+		                                             candidate.dwords.data(),
+		                                             candidate.dword_count);
+		for (uint32_t dword = 0; !block_read && dword < candidate.dword_count; dword++) {
 			if (!ReadScalarBufferWord(heap, heap_offset, dword * sizeof(uint32_t), runtime,
 			                          candidate.dwords[dword])) {
 				return false;

--- a/src/graphics/shader/recompiler/ir/passes/SrtWalker.h
+++ b/src/graphics/shader/recompiler/ir/passes/SrtWalker.h
@@ -10,6 +10,8 @@ namespace Libs::Graphics::ShaderRecompiler::IR {
 class Value;
 
 using SrtMemoryReader = bool (*)(void* userdata, uint64_t address, uint32_t* value);
+using SrtMemoryBlockReader =
+    bool (*)(void* userdata, uint64_t address, uint32_t* words, uint32_t word_count);
 
 struct SrtRuntime {
 	std::span<const uint32_t> user_data;
@@ -17,6 +19,7 @@ struct SrtRuntime {
 	SrtMemoryReader           read_memory                = nullptr;
 	void*                     userdata                   = nullptr;
 	SrtMemoryReader           read_specialization_memory = nullptr;
+	SrtMemoryBlockReader      read_specialization_block  = nullptr;
 };
 
 enum class RuntimeValueType { Any, Integer };


### PR DESCRIPTION
Frequent GPU submissions, early texture eviction and repeated descriptor reads add avoidable frame-time overhead. This change reduces that work while preserving ordering and conservative handling of shader writes.

- Batch up to eight adjacent eligible 32-bit RELEASE_MEM CPU labels; flush at ineligible packets, queued commands and processing boundaries.
- Keep reusable textures resident until memory pressure; KYTY_TEXTURE_CACHE_EARLY_GC=1 restores the earlier GC trigger.
- Use execution-only barriers for read-only compute dispatches, retaining memory barriers for possible writes, atomics, DMA and GDS.
- Read eligible indirect-image descriptors in blocks, retaining bounds checks and the per-word fallback.

Adapted to upstream main (6aa6e39); excludes the unrelated local merge of #500. Contribution by @Techx3.

Validation on this branch (Windows, Clang 22.1.8, Release):
- Built kyty_emulator, resource_materialization_tests and shader_recompiler_compute_tests successfully.
- Eight focused CTest cases passed: resource_materialization, command_scheduler_timeline, gpu_command_lane, pm4_context_state, texture_cache_image_views, texture_cache_storage_sampled, compute_meta_clear_classification and buffer_cache_dirty_gc.
- git diff --check passed.

The full GPU suite and in-game FPS benchmarks have not been run on this isolated branch; no numerical FPS improvement is claimed.
