### PR TITLE
net: drop MSG_WAITALL when combined with MSG_PEEK on Windows

### DIFF
--- a/src/libs/network.cpp
+++ b/src/libs/network.cpp
@@ -1011,9 +1011,15 @@ static int ConvertMessageFlags(int flags) {
 	if ((flags & guest_msg_dontroute) != 0) {
 		host_flags |= MSG_DONTROUTE;
 	}
-	if ((flags & guest_msg_waitall) != 0) {
+		if ((flags & guest_msg_waitall) != 0) {
 		host_flags |= MSG_WAITALL;
 	}
+#if defined(_WIN32)
+	// Winsock's recv() rejects MSG_PEEK combined with MSG_WAITALL.
+	if ((host_flags & (MSG_PEEK | MSG_WAITALL)) == (MSG_PEEK | MSG_WAITALL)) {
+		host_flags &= ~MSG_WAITALL;
+	}
+#endif
 #if !defined(_WIN32)
 	if ((flags & guest_msg_dontwait) != 0) {
 		host_flags |= MSG_DONTWAIT;


### PR DESCRIPTION
Fixes #505.

Winsock's recv() doesn't support MSG_PEEK and MSG_WAITALL together —
POSIX allows it, Windows doesn't. These got merged into one shared
code path in 46850f9, which broke kernel_file_system on Windows
(the new CheckSocketWakeup check specifically).

Fix drops WAITALL on Windows when PEEK is also set, same as the
existing DONTWAIT/NOSIGNAL carve-out a few lines above it in
ConvertMessageFlags. Worth noting this means Windows won't actually
block for the full length when peeking data that hasn't fully
arrived yet across multiple segments — fine for this test and the
common case, but not a complete WAITALL emulation. Open to doing the
fuller loop-based version instead if that's preferred.

Ran the full test suite locally on Windows/clang-cl before and after:
kernel_file_system was the only failure before (matching #505
exactly), zero failures after.

Used AI to help track down the root cause and draft the diff; reviewed
the change and ran the tests myself before opening this.