### PR TITLE
Fix primitive restart fatal error, memory watcher overflow, and vertex fetch

### DIFF
--- a/src/graphics/host_gpu/pageManager.cpp
+++ b/src/graphics/host_gpu/pageManager.cpp
@@ -128,8 +128,8 @@ uint64_t PageEnd(uint64_t vaddr, uint64_t size) {
 
 struct PageManager::Impl {
 	struct PageState {
-		uint8_t write_watchers  : 7 = 0;
-		uint8_t access_watchers : 1 = 0;
+		uint16_t write_watchers  : 15 = 0;
+		uint16_t access_watchers : 1  = 0;
 
 		[[nodiscard]] uint32_t Perms() const noexcept {
 			if (access_watchers != 0) {
@@ -160,7 +160,7 @@ struct PageManager::Impl {
 				}
 			} else {
 				if constexpr (delta == 1) {
-					if (write_watchers == 0x7f) {
+					if (write_watchers == 0x7fff) {
 						Fatal("write-watcher overflow at 0x%016" PRIx64, address);
 					}
 					return ++write_watchers;
@@ -175,7 +175,7 @@ struct PageManager::Impl {
 			}
 		}
 	};
-	static_assert(sizeof(PageState) == 1);
+	static_assert(sizeof(PageState) == 2);
 
 	struct Region {
 		std::atomic_flag                    lock = ATOMIC_FLAG_INIT;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -819,7 +819,6 @@ TextureCache::OverlapResult TextureCache::ResolveOverlap(const ImageInfo& reques
 	const auto current_tick = m_scheduler.CurrentTick();
 	const bool safe_to_delete =
 	    current_tick - std::min(current_tick, cached.tick_accessed_last) > NumFramesBeforeRemoval;
-
 	if (requested.data.address == cached.info.data.address) {
 		const uint32_t requested_block = requested.bytes_per_block * requested.samples;
 		const uint32_t cached_block    = cached.info.bytes_per_block * cached.info.samples;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -749,7 +749,10 @@ ImageId TextureCache::ResolveDepthOverlap(const ImageInfo& requested, BindingTyp
 			recreate |= requested.IsDepth() && !cached.info.IsDepth();
 			recreate |= raw_d16_texture;
 			break;
-		case BindingType::Storage: recreate |= cached.info.IsDepth(); break;
+		case BindingType::Storage:
+			recreate |= cached.info.IsDepth() || cached.depth_id ||
+			            !(cached.backing.usage & vk::ImageUsageFlagBits::eStorage);
+			break;
 		case BindingType::RenderTarget: recreate |= cached.info.IsDepth(); break;
 		case BindingType::DepthTarget:
 			recreate |= !cached.info.IsDepth();
@@ -955,7 +958,7 @@ struct TextureCache::DownloadPlan {
 
 TextureCache::TextureTransferPlan
 TextureCache::BuildTextureTransfer(const Image& image, BindingType binding,
-                                    TransferDirection direction) const {
+                                   TransferDirection direction) const {
 	const auto& info             = image.info;
 	const bool  upload           = direction == TransferDirection::Upload;
 	const bool  render_target    = binding == BindingType::RenderTarget;
@@ -1040,7 +1043,7 @@ TextureCache::DownloadPlan TextureCache::BuildDownload(const Image& image) const
 void TextureCache::UploadImage(Image& image, Buffer& source, uint64_t source_offset) {
 	const auto& info    = image.info;
 	const auto  binding = UploadBinding(image);
-	const auto  upload  = [&](std::vector<vk::BufferImageCopy>& copies, TileManager::Result linear) {
+	const auto  upload = [&](std::vector<vk::BufferImageCopy>& copies, TileManager::Result linear) {
 		for (auto& copy: copies) {
 			copy.bufferOffset += linear.offset;
 		}
@@ -1071,8 +1074,8 @@ void TextureCache::UploadImage(Image& image, Buffer& source, uint64_t source_off
 		return;
 	}
 
-	if (info.samples != 1 || image.backing.samples != 1 ||
-	    info.resources.layers == 0 || info.data.size % info.resources.layers != 0 ||
+	if (info.samples != 1 || image.backing.samples != 1 || info.resources.layers == 0 ||
+	    info.data.size % info.resources.layers != 0 ||
 	    Prospero::NumBytesPerElement(info.guest_format) != info.bytes_per_block) {
 		EXIT("TextureCache: invalid depth upload\n");
 	}
@@ -1262,6 +1265,11 @@ ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_format) {
 
 		for (const auto id: candidates) {
 			const auto& image = m_slot_images[id];
+			if (desc.type == BindingType::Storage &&
+			    (image.info.IsDepth() || image.depth_id ||
+			     !(image.backing.usage & vk::ImageUsageFlagBits::eStorage))) {
+				continue;
+			}
 			if (SameBacking(image.info, desc.info, exact_format)) {
 				result = id;
 			}
@@ -1288,6 +1296,11 @@ ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_format) {
 			if (exact_format && resolved.info.pixel_format != desc.info.pixel_format) {
 				result = {};
 			} else if (resolved.info.resources < desc.info.resources) {
+				FreeImage(result);
+				result = {};
+			} else if (desc.type == BindingType::Storage &&
+			           (resolved.info.IsDepth() || resolved.depth_id ||
+			            !(resolved.backing.usage & vk::ImageUsageFlagBits::eStorage))) {
 				FreeImage(result);
 				result = {};
 			}
@@ -1530,7 +1543,8 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t address
 	} else {
 		uint8_t stencil_clear = 0;
 		if ((aspect == vk::ImageAspectFlagBits::eDepth &&
-		     !DecodePackedDepthClear(image.info.pixel_format, packed_clear, clear.depthStencil.depth)) ||
+		     !DecodePackedDepthClear(image.info.pixel_format, packed_clear,
+		                             clear.depthStencil.depth)) ||
 		    (aspect == vk::ImageAspectFlagBits::eStencil &&
 		     !DecodePackedStencilClear(packed_clear, stencil_clear))) {
 			return false;
@@ -1544,7 +1558,7 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t address
 
 void TextureCache::ClearImage(CommandBuffer& command, ImageId id,
                               const vk::ImageSubresourceRange& range, const vk::ClearValue& clear) {
-	auto& image = m_slot_images[id];
+	auto&      image   = m_slot_images[id];
 	const auto aspects = image.info.IsDepth() ? ImageViewOps::DepthAspectMask(image.backing.format)
 	                                          : vk::ImageAspectFlagBits::eColor;
 	EXIT_IF(range.baseMipLevel >= image.info.resources.levels);
@@ -1721,7 +1735,7 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, uint64_t vaddr, uin
 	}
 
 	std::scoped_lock lock {m_texture_cache.m_lock};
-	auto& image = m_texture_cache.m_slot_images[selected];
+	auto&            image = m_texture_cache.m_slot_images[selected];
 	// The GPU thread owns image retirement; CPU invalidation can dirty this image after lookup.
 	if (!m_texture_cache.SafeToDownload(image)) {
 		return false;

--- a/src/graphics/host_gpu/renderer/image/imageView.h
+++ b/src/graphics/host_gpu/renderer/image/imageView.h
@@ -92,6 +92,18 @@ SelectSampledColorView(vk::Format image_format, vk::Format view_format, uint32_t
 	}
 }
 
+[[nodiscard]] inline bool IsValidImageSwizzle(uint32_t swizzle) noexcept;
+
+[[nodiscard]] inline bool IsSupportedSampledStencilView(vk::Format image_format,
+                                                        vk::Format view_format,
+                                                        uint32_t   swizzle) noexcept {
+	if (DepthAspectTransferFormat(image_format) == vk::Format::eUndefined ||
+	    view_format != vk::Format::eR8Uint || !IsValidImageSwizzle(swizzle)) {
+		return false;
+	}
+	return true;
+}
+
 [[nodiscard]] inline bool
 IsSupportedSampledDepthResource(const ShaderRecompiler::IR::ImageResource& resource) noexcept {
 	if (resource.resource_class != ShaderRecompiler::IR::ImageResourceClass::Sampled) {

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -251,8 +251,7 @@ static void ValidateSampledDepthBinding(const ShaderRecompiler::IR::ImageResourc
 	     "descriptor_type=%u base_array=%u depth=%u descriptor_pitch=%u target_pitch=%u "
 	     "addr=0x%016" PRIx64 " size=0x%016" PRIx64
 	     " dwords=%08x,%08x,%08x,%08x,%08x,%08x,%08x,%08x\n",
-	     resource_ok, encoding_ok, view_ok,
-	     static_cast<uint32_t>(resource.resource_class),
+	     resource_ok, encoding_ok, view_ok, static_cast<uint32_t>(resource.resource_class),
 	     static_cast<uint32_t>(resource.numeric_class), static_cast<uint32_t>(resource.dimension),
 	     static_cast<uint32_t>(resource.mip_mode), resource.read, resource.written, resource.atomic,
 	     resource.depth_compare, static_cast<uint32_t>(descriptor.Format()),
@@ -363,14 +362,14 @@ static bool IsSupportedStorageTextureEncoding(const ShaderRecompiler::IR::ImageR
 
 void ValidateStorageTexture(const ShaderRecompiler::IR::ImageResource& resource,
                             const ShaderTextureResource& descriptor, uint64_t size) {
-	const auto format        = descriptor.Format();
-	const bool resource_ok   = IsSupportedStorageImageResource(resource);
-	const bool descriptor_ok = IsSupportedStorageTextureDescriptor(resource, descriptor);
-	const bool encoding_ok   = IsSupportedStorageTextureEncoding(resource, descriptor);
+	const auto format           = descriptor.Format();
+	const bool resource_ok      = IsSupportedStorageImageResource(resource);
+	const bool descriptor_ok    = IsSupportedStorageTextureDescriptor(resource, descriptor);
+	const bool encoding_ok      = IsSupportedStorageTextureEncoding(resource, descriptor);
 	const bool uint_resource    = resource.numeric_class == Prospero::TextureNumericClass::Uint;
 	const bool raw_sint_storage = format == Prospero::BufferFormat::k32SInt && uint_resource &&
 	                              resource.written && !resource.read && !resource.atomic;
-	const auto numeric_class = Prospero::SampledTextureNumericClass(format);
+	const auto numeric_class    = Prospero::SampledTextureNumericClass(format);
 	const bool format_ok =
 	    raw_sint_storage ||
 	    (numeric_class != Prospero::TextureNumericClass::Unsupported &&
@@ -549,8 +548,8 @@ static ImageViewInfo TextureViewInfo(const ShaderRecompiler::IR::ImageResource& 
 
 TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageResource&   resource,
                                               const ShaderRecompiler::IR::DescriptorValue& value) {
-	auto descriptor = DecodeNativeDescriptor<ShaderTextureResource>(value);
-	const bool storage = resource.written;
+	auto       descriptor = DecodeNativeDescriptor<ShaderTextureResource>(value);
+	const bool storage    = resource.written;
 	if (storage) {
 		ValidateStorageImageResource(resource);
 	}
@@ -687,10 +686,11 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	auto       id                  = texture_cache.FindImage(desc, shader_conversion);
 	auto*      image               = &texture_cache.GetImage(id);
 	const bool stencil_association = static_cast<bool>(image->depth_id);
-	if (stencil_association) {
+	if (stencil_association && !storage) {
 		id    = image->depth_id;
 		image = &texture_cache.GetImage(id);
-	} else if (image->info.IsDepth()) {
+	}
+	if (image->info.IsDepth()) {
 		if (storage) {
 			EXIT("depth target cannot be bound as a storage image\n");
 		}
@@ -704,10 +704,10 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	return {id, nullptr, std::move(desc)};
 }
 
-static vk::Sampler NativeSampler(RenderContext&                       context,
+static vk::Sampler NativeSampler(RenderContext&                                  context,
                                  const ShaderRecompiler::IR::CompiledShaderInfo& program,
-                                 uint32_t index,
-                                 const ShaderRecompiler::IR::DescriptorValue& value) {
+                                 uint32_t                                        index,
+                                 const ShaderRecompiler::IR::DescriptorValue&    value) {
 	auto descriptor = DecodeNativeDescriptor<ShaderSamplerResource>(value);
 	if (!program.info.samplers[index].depth_compare) {
 		descriptor.fields[0] &= ~(0x7u << 12u);
@@ -766,8 +766,8 @@ void RenderExecutor::ResetBindings() {
 PreparedBindings RenderExecutor::PrepareBindings(const ShaderStageRuntime& runtime) {
 	KYTY_PROFILER_FUNCTION();
 	EXIT_IF(!runtime);
-	const auto& program  = *runtime.program;
-	const auto& snapshot = runtime.resources;
+	const auto&      program  = *runtime.program;
+	const auto&      snapshot = runtime.resources;
 	PreparedBindings prepared;
 	prepared.program  = runtime.program;
 	prepared.snapshot = &runtime.resources;
@@ -803,10 +803,10 @@ void RenderExecutor::FindBuffers(PreparedBindings& prepared) {
 	prepared.buffer_sources.clear();
 	prepared.buffer_sources.reserve(program.info.buffers.size());
 	for (uint32_t i = 0; i < program.info.buffers.size(); i++) {
-		auto descriptor = DecodeNativeDescriptor<ShaderBufferResource>(snapshot.buffers[i]);
-		const auto address = descriptor.Base48();
-		const auto stride  = descriptor.Stride();
-		const auto records = descriptor.NumRecords();
+		auto       descriptor = DecodeNativeDescriptor<ShaderBufferResource>(snapshot.buffers[i]);
+		const auto address    = descriptor.Base48();
+		const auto stride     = descriptor.Stride();
+		const auto records    = descriptor.NumRecords();
 		// The descriptor has a 14-bit stride and 32-bit record count, so the product fits u64.
 		const auto requested_size = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
 		if (address == 0 || requested_size == 0) {
@@ -821,16 +821,16 @@ void RenderExecutor::FindBuffers(PreparedBindings& prepared) {
 void RenderExecutor::RebindBuffers(PreparedBindings& prepared) {
 	KYTY_PROFILER_FUNCTION();
 	EXIT_IF(prepared.program == nullptr || prepared.snapshot == nullptr);
-	const auto& program   = *prepared.program;
-	const auto& snapshot  = *prepared.snapshot;
-	const auto& layout    = program.bindings;
+	const auto& program  = *prepared.program;
+	const auto& snapshot = *prepared.snapshot;
+	const auto& layout   = program.bindings;
 	EXIT_IF(prepared.buffer_sources.size() != program.info.buffers.size());
 
 	prepared.buffers.clear();
 	prepared.buffers.reserve(program.info.buffers.size());
 	EXIT_IF(prepared.shader_data.size() != layout.ShaderDataDwords());
-	std::fill(prepared.shader_data.begin() + layout.memory_offset_dword,
-	          prepared.shader_data.end(), 0);
+	std::fill(prepared.shader_data.begin() + layout.memory_offset_dword, prepared.shader_data.end(),
+	          0);
 	auto pack_memory_offset = [&](uint32_t index, uint32_t offset) {
 		const auto dword = layout.memory_offset_dword + index / 4u;
 		const auto shift = (index % 4u) * 8u;
@@ -935,11 +935,11 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
                                     const PipelineCache::Pipeline&     pipeline,
                                     std::span<PreparedBindings* const> prepared_bindings) {
 	KYTY_PROFILER_FUNCTION();
-	auto   vk_buffer        = buffer.Handle();
-	size_t descriptor_count = 0;
-	size_t write_count      = 0;
+	auto                           vk_buffer        = buffer.Handle();
+	size_t                         descriptor_count = 0;
+	size_t                         write_count      = 0;
 	ShaderRecompiler::IR::PushData push_data;
-	bool                           has_push_data = false;
+	bool                           has_push_data  = false;
 	constexpr auto                 GraphicsStages = vk::ShaderStageFlagBits::eVertex |
 	                                                vk::ShaderStageFlagBits::eMeshEXT |
 	                                                vk::ShaderStageFlagBits::eFragment;

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -134,7 +134,9 @@ NativeStorageBuffer(RenderContext& context, const PreparedBindings::BufferSource
                     uint32_t slot, uint32_t& buffer_offset) {
 	buffer_offset = 0;
 
-	const auto& [address, size, id] = source;
+	const auto address = source.address;
+	const auto size    = source.size;
+	const auto id      = source.id;
 	if (address == 0 || size == 0) {
 		return {context.GetBufferCache().GetBuffer(NULL_BUFFER_ID).Handle(), 0, 16};
 	}
@@ -238,7 +240,10 @@ static void ValidateSampledDepthBinding(const ShaderRecompiler::IR::ImageResourc
 	const bool resource_ok = IsSupportedSampledDepthResource(resource);
 	const bool encoding_ok = IsSupportedDepthTextureEncoding(descriptor, resource.r128);
 	const bool view_ok =
-	    IsSupportedSampledDepthView(image.info.pixel_format, view_format, descriptor.DstSelXYZW());
+	    IsSupportedSampledDepthView(image.info.pixel_format, view_format, descriptor.DstSelXYZW()) ||
+	    (image.info.HasStencil() &&
+	     IsSupportedSampledStencilView(image.info.pixel_format, view_format,
+	                                   descriptor.DstSelXYZW()));
 	if (resource_ok && encoding_ok && view_ok) {
 		return;
 	}
@@ -686,7 +691,17 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	auto       id                  = texture_cache.FindImage(desc, shader_conversion);
 	auto*      image               = &texture_cache.GetImage(id);
 	const bool stencil_association = static_cast<bool>(image->depth_id);
-	if (stencil_association && !storage) {
+	const auto* associated_image = stencil_association
+	                                   ? &texture_cache.GetImage(image->depth_id)
+	                                   : nullptr;
+	const bool depth_view = stencil_association && !storage &&
+	                        (IsSupportedSampledDepthFormat(associated_image->info.pixel_format,
+	                                                       pixel_format) ||
+                         (associated_image->info.HasStencil() &&
+                          IsSupportedSampledStencilView(associated_image->info.pixel_format,
+	                                                        pixel_format,
+	                                                        descriptor.DstSelXYZW())));
+	if (depth_view) {
 		id    = image->depth_id;
 		image = &texture_cache.GetImage(id);
 	}
@@ -809,11 +824,11 @@ void RenderExecutor::FindBuffers(PreparedBindings& prepared) {
 		const auto records    = descriptor.NumRecords();
 		// The descriptor has a 14-bit stride and 32-bit record count, so the product fits u64.
 		const auto requested_size = stride != 0 ? static_cast<uint64_t>(stride) * records : records;
-		if (address == 0 || requested_size == 0) {
+		const auto size = Libs::LibKernel::Memory::TryClampRangeSize(address, requested_size);
+		if (size == 0) {
 			prepared.buffer_sources.push_back({});
 			continue;
 		}
-		const auto size = Libs::LibKernel::Memory::ClampRangeSize(address, requested_size);
 		prepared.buffer_sources.push_back({address, size, cache.FindBuffer(address, size)});
 	}
 }

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -239,11 +239,11 @@ static void ValidateSampledDepthBinding(const ShaderRecompiler::IR::ImageResourc
                                         vk::Format view_format, uint64_t size) {
 	const bool resource_ok = IsSupportedSampledDepthResource(resource);
 	const bool encoding_ok = IsSupportedDepthTextureEncoding(descriptor, resource.r128);
-	const bool view_ok =
-	    IsSupportedSampledDepthView(image.info.pixel_format, view_format, descriptor.DstSelXYZW()) ||
-	    (image.info.HasStencil() &&
-	     IsSupportedSampledStencilView(image.info.pixel_format, view_format,
-	                                   descriptor.DstSelXYZW()));
+	const bool view_ok     = IsSupportedSampledDepthView(image.info.pixel_format, view_format,
+	                                                     descriptor.DstSelXYZW()) ||
+	                         (image.info.HasStencil() &&
+	                          IsSupportedSampledStencilView(image.info.pixel_format, view_format,
+	                                                        descriptor.DstSelXYZW()));
 	if (resource_ok && encoding_ok && view_ok) {
 		return;
 	}
@@ -688,19 +688,17 @@ TextureBinding RenderExecutor::ResolveTexture(const ShaderRecompiler::IR::ImageR
 	                                 view_levels, desc.info.resources.layers);
 	desc.type = storage ? TextureCache::BindingType::Storage : TextureCache::BindingType::Texture;
 
-	auto       id                  = texture_cache.FindImage(desc, shader_conversion);
-	auto*      image               = &texture_cache.GetImage(id);
-	const bool stencil_association = static_cast<bool>(image->depth_id);
-	const auto* associated_image = stencil_association
-	                                   ? &texture_cache.GetImage(image->depth_id)
-	                                   : nullptr;
-	const bool depth_view = stencil_association && !storage &&
-	                        (IsSupportedSampledDepthFormat(associated_image->info.pixel_format,
-	                                                       pixel_format) ||
-                         (associated_image->info.HasStencil() &&
-                          IsSupportedSampledStencilView(associated_image->info.pixel_format,
-	                                                        pixel_format,
-	                                                        descriptor.DstSelXYZW())));
+	auto        id                  = texture_cache.FindImage(desc, shader_conversion);
+	auto*       image               = &texture_cache.GetImage(id);
+	const bool  stencil_association = static_cast<bool>(image->depth_id);
+	const auto* associated_image =
+	    stencil_association ? &texture_cache.GetImage(image->depth_id) : nullptr;
+	const bool depth_view =
+	    stencil_association && !storage &&
+	    (IsSupportedSampledDepthFormat(associated_image->info.pixel_format, pixel_format) ||
+	     (associated_image->info.HasStencil() &&
+	      IsSupportedSampledStencilView(associated_image->info.pixel_format, pixel_format,
+	                                    descriptor.DstSelXYZW())));
 	if (depth_view) {
 		id    = image->depth_id;
 		image = &texture_cache.GetImage(id);

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -536,7 +536,11 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 	if (depth.image_id) {
 		const auto owner = cache.m_slot_images.try_get(depth.image_id);
 		if (owner == nullptr || !owner->registered || owner->binding.needs_rebind) {
-			EXIT("depth target changed after render-state discovery\n");
+			if (owner != nullptr) {
+				owner->binding = {};
+			}
+			depth.image_id = cache.FindImage(depth.desc);
+			BindRenderTarget(depth.image_id);
 		}
 		const auto  image_view = cache.FindDepthTarget(depth.image_id, depth.desc);
 		const auto& metadata   = depth.desc.info.metadata;

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -863,23 +863,31 @@ static bool GetDrawTopology(const HW::UserConfig& ucfg, bool auto_draw,
 	return true;
 }
 
-static bool ResolvePrimitiveRestart(const CommandBuffer& buffer, vk::PrimitiveTopology topology,
-                                    uint32_t index_type_and_size) {
+struct PrimitiveRestartInfo {
+	bool     enable       = false;
+	bool     remap_needed = false;
+	uint32_t reset_index  = 0;
+};
+
+static PrimitiveRestartInfo ResolvePrimitiveRestart(const CommandBuffer& buffer,
+                                                    vk::PrimitiveTopology topology,
+                                                    uint32_t index_type_and_size) {
+	PrimitiveRestartInfo info {};
 	const auto control = buffer.GetUserConfig().GetPrimitiveResetControl();
 	EXIT_NOT_IMPLEMENTED((control & ~0x3u) != 0);
 	if ((control & 0x1u) == 0) {
-		return false;
+		return info;
 	}
 	switch (buffer.GetUserConfig().GetPrimType()) {
 		case Prospero::PrimitiveType::kLineStrip:
 		case Prospero::PrimitiveType::kTriFan:
 		case Prospero::PrimitiveType::kTriStrip: break;
-		default: return false;
+		default: return info;
 	}
 	if (topology != vk::PrimitiveTopology::eLineStrip &&
 	    topology != vk::PrimitiveTopology::eTriangleStrip &&
 	    topology != vk::PrimitiveTopology::eTriangleFan) {
-		return false;
+		return info;
 	}
 
 	uint32_t index_mask = 0;
@@ -890,12 +898,18 @@ static bool ResolvePrimitiveRestart(const CommandBuffer& buffer, vk::PrimitiveTo
 		default: EXIT("unknown index_type_and_size: %u\n", index_type_and_size);
 	}
 
-	const auto reset_index = buffer.GetRegisters().GetPrimitiveResetIndex();
-	if ((control & 0x2u) != 0 && (reset_index & ~index_mask) != 0) {
-		return false;
+	info.enable = true;
+	if ((control & 0x2u) == 0) {
+		info.reset_index  = index_mask;
+		info.remap_needed = false;
+		return info;
 	}
-	EXIT_NOT_IMPLEMENTED((reset_index & index_mask) != index_mask);
-	return true;
+
+	const auto     raw_reset_index = buffer.GetRegisters().GetPrimitiveResetIndex();
+	const uint32_t target_reset    = raw_reset_index & index_mask;
+	info.reset_index               = target_reset;
+	info.remap_needed              = (target_reset != index_mask);
+	return info;
 }
 
 bool RenderExecutor::PrepareDrawRenderState(uint64_t submit_id, CommandBuffer& buffer,
@@ -1273,7 +1287,7 @@ void RenderExecutor::DrawIndex(uint64_t submit_id, CommandBuffer& buffer,
 	vk::IndexType index_type           = vk::IndexType::eUint16;
 	uint64_t      index_size           = 0;
 	bool          expand_index8_to_u16 = false;
-	const bool    primitive_restart =
+	const auto restart_info =
 	    ResolvePrimitiveRestart(buffer, topology, args.index_type_and_size);
 
 	switch (static_cast<Prospero::IndexType>(args.index_type_and_size)) {
@@ -1294,24 +1308,47 @@ void RenderExecutor::DrawIndex(uint64_t submit_id, CommandBuffer& buffer,
 		default: EXIT("unknown index_type_and_size: %u\n", args.index_type_and_size);
 	}
 
-	const DrawCallInfo    draw {"DrawIndex", CommandBufferDebugOp::DrawIndex, args.index_count,
-	                            args.instance_count, args.first_instance};
-	std::vector<uint16_t> expanded_indices;
+	const DrawCallInfo   draw {"DrawIndex", CommandBufferDebugOp::DrawIndex, args.index_count,
+	                           args.instance_count, args.first_instance};
+	std::vector<uint8_t> host_index_buffer;
 	if (expand_index8_to_u16) {
 		EXIT_NOT_IMPLEMENTED(args.index_addr == nullptr);
 		const auto* src = static_cast<const uint8_t*>(args.index_addr);
-		expanded_indices.resize(args.index_count);
+		host_index_buffer.resize(args.index_count * sizeof(uint16_t));
+		auto*      dst       = reinterpret_cast<uint16_t*>(host_index_buffer.data());
+		const auto reset_val = static_cast<uint8_t>(restart_info.reset_index);
 		for (uint32_t i = 0; i < args.index_count; i++) {
-			expanded_indices[i] = primitive_restart && src[i] == 0xffu ? 0xffffu : src[i];
+			dst[i] = (restart_info.enable && src[i] == reset_val) ? 0xffffu
+			                                                      : static_cast<uint16_t>(src[i]);
+		}
+	} else if (restart_info.enable && restart_info.remap_needed) {
+		EXIT_NOT_IMPLEMENTED(args.index_addr == nullptr);
+		if (static_cast<Prospero::IndexType>(args.index_type_and_size) ==
+		    Prospero::IndexType::kIndex16) {
+			const auto* src = static_cast<const uint16_t*>(args.index_addr);
+			host_index_buffer.resize(args.index_count * sizeof(uint16_t));
+			auto*      dst       = reinterpret_cast<uint16_t*>(host_index_buffer.data());
+			const auto reset_val = static_cast<uint16_t>(restart_info.reset_index);
+			for (uint32_t i = 0; i < args.index_count; i++) {
+				dst[i] = (src[i] == reset_val) ? 0xffffu : src[i];
+			}
+		} else if (static_cast<Prospero::IndexType>(args.index_type_and_size) ==
+		           Prospero::IndexType::kIndex32) {
+			const auto* src = static_cast<const uint32_t*>(args.index_addr);
+			host_index_buffer.resize(args.index_count * sizeof(uint32_t));
+			auto*      dst       = reinterpret_cast<uint32_t*>(host_index_buffer.data());
+			const auto reset_val = restart_info.reset_index;
+			for (uint32_t i = 0; i < args.index_count; i++) {
+				dst[i] = (src[i] == reset_val) ? 0xffffffffu : src[i];
+			}
 		}
 	}
 
 	DrawIndexBufferSource index_source {};
 	index_source.address = reinterpret_cast<uint64_t>(args.index_addr);
 	index_source.host_data =
-	    expanded_indices.empty() ? nullptr : static_cast<const void*>(expanded_indices.data());
-	index_source.size =
-	    expanded_indices.empty() ? index_size : expanded_indices.size() * sizeof(uint16_t);
+	    host_index_buffer.empty() ? nullptr : static_cast<const void*>(host_index_buffer.data());
+	index_source.size = host_index_buffer.empty() ? index_size : host_index_buffer.size();
 	index_source.type = index_type;
 	index_source.guest_element_size = static_cast<uint32_t>(index_size / args.index_count);
 
@@ -1340,7 +1377,7 @@ void RenderExecutor::DrawIndex(uint64_t submit_id, CommandBuffer& buffer,
 	    indirect ? args.first_instance : ResolveInstanceOffset(state.vs_input_info);
 
 	ExecutePreparedDraw(submit_id, buffer, draw, state, topology, emit, index_source,
-	                    primitive_restart, true, true, false);
+	                    restart_info.enable, true, true, false);
 	ResetBindings();
 }
 

--- a/src/graphics/host_gpu/renderer/renderDraw.cpp
+++ b/src/graphics/host_gpu/renderer/renderDraw.cpp
@@ -84,9 +84,9 @@ uint32_t ResolveInstanceOffset(const ShaderVertexInputInfo& vs_input_info) {
 	return 0;
 }
 
-static std::atomic<uint32_t> g_draw_state_log_count   = 0;
-static std::atomic<uint32_t> g_draw_input_log_count   = 0;
-static std::atomic<uint32_t> g_mrt_state_log_count    = 0;
+static std::atomic<uint32_t> g_draw_state_log_count = 0;
+static std::atomic<uint32_t> g_draw_input_log_count = 0;
+static std::atomic<uint32_t> g_mrt_state_log_count  = 0;
 
 static std::atomic<uint32_t> g_framebuffer_skip_log_count = 0;
 
@@ -222,9 +222,9 @@ static void LogDrawTargetState(const char* draw_name, const RenderColorInfo& col
 	    log_id, buffer.GetContext().GetGpu().GetFrameNum(), draw_name, RenderColorTypeName(color),
 	    color.desc.info.data.address, extent.width, extent.height,
 	    static_cast<uint32_t>(ucfg.GetPrimType()), index_count, flags, ctx.GetRenderTargetMask(),
-	    cc.mode, cc.op,
-	    bc.enable ? "true" : "false", bc.color_srcblend, bc.color_destblend, bc.color_comb_fcn,
-	    static_cast<int>(ps_resources.images.size()), static_cast<int>(sampled_images),
+	    cc.mode, cc.op, bc.enable ? "true" : "false", bc.color_srcblend, bc.color_destblend,
+	    bc.color_comb_fcn, static_cast<int>(ps_resources.images.size()),
+	    static_cast<int>(sampled_images),
 	    static_cast<int>(ps_resources.images.size() - sampled_images),
 	    ps_input_info.ps_pixel_kill_enable ? "true" : "false", ps_input_info.target_output_mode[0],
 	    dc.z_enable ? "true" : "false", dc.z_write_enable ? "true" : "false", dc.zfunc,
@@ -457,12 +457,12 @@ static bool PixelShaderHasDepthOrCoverageSideEffects(const HW::ShaderRegisters& 
 }
 
 struct DrawRenderState {
-	RenderDepthInfo       depth_info;
-	RenderColorInfo       color_info[RENDER_COLOR_ATTACHMENTS_MAX] = {};
-	uint32_t              color_count                              = 0;
-	bool                  ps_active                                = true;
-	ShaderVertexInputInfo vs_input_info;
-	ShaderPixelInputInfo  ps_input_info;
+	RenderDepthInfo                 depth_info;
+	RenderColorInfo                 color_info[RENDER_COLOR_ATTACHMENTS_MAX] = {};
+	uint32_t                        color_count                              = 0;
+	bool                            ps_active                                = true;
+	ShaderVertexInputInfo           vs_input_info;
+	ShaderPixelInputInfo            ps_input_info;
 	PipelineCache::GraphicsPrograms programs;
 };
 
@@ -572,7 +572,8 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 			EXIT("mixed color/depth sample counts are unsupported: %u and %u\n", attachment_samples,
 			     depth.desc.info.samples);
 		}
-		const bool feedback = depth.depth_write_enable && pixel &&
+		const bool feedback =
+		    depth.depth_write_enable && pixel &&
 		    std::ranges::any_of(pixel->images, [&](const TextureBinding& binding) {
 			    if (binding.image_id != depth.image_id ||
 			        binding.desc.type != TextureCache::BindingType::Texture) {
@@ -582,7 +583,7 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 			        std::ranges::find(image.views, binding.image_view, &CachedImageView::view);
 			    EXIT_IF(native == image.views.end());
 			    const auto& sampled = native->info;
-			    const auto& target = depth.desc.view_info;
+			    const auto& target  = depth.desc.view_info;
 			    return (sampled.aspect & vk::ImageAspectFlagBits::eDepth) &&
 			           ImageRangeOverlaps(sampled.base_level, sampled.level_count,
 			                              target.base_level, target.level_count) &&
@@ -595,8 +596,8 @@ RenderState RenderExecutor::AcquireRenderTargets(CommandBuffer& buffer, RenderCo
 		const auto layout = feedback ? vk::ImageLayout::eAttachmentFeedbackLoopOptimalEXT
 		                             : depth_attachment_layout(depth);
 		// The attachment store writes even when guest depth/stencil tests do not.
-		const auto access = vk::AccessFlagBits2::eDepthStencilAttachmentRead |
-		                    vk::AccessFlagBits2::eDepthStencilAttachmentWrite;
+		const auto access               = vk::AccessFlagBits2::eDepthStencilAttachmentRead |
+		                                  vk::AccessFlagBits2::eDepthStencilAttachmentWrite;
 		image.binding.attachment_layout = layout;
 		image.binding.attachment_access = access;
 		const auto& view                = depth.desc.view_info;
@@ -666,17 +667,17 @@ static bool ConsumeMetadataColorOperation(const CommandBuffer& buffer) {
 }
 
 struct DrawEmitInfo {
-	bool     indexed       = false;
-	int32_t  vertex_offset = 0;
-	uint32_t first_vertex  = 0;
+	bool     indexed        = false;
+	int32_t  vertex_offset  = 0;
+	uint32_t first_vertex   = 0;
 	uint32_t first_instance = 0;
 };
 
 struct DrawIndexBufferSource {
-	uint64_t      address   = 0;
-	const void*   host_data = nullptr;
-	uint64_t      size      = 0;
-	vk::IndexType type      = vk::IndexType::eUint16;
+	uint64_t      address            = 0;
+	const void*   host_data          = nullptr;
+	uint64_t      size               = 0;
+	vk::IndexType type               = vk::IndexType::eUint16;
 	uint32_t      guest_element_size = 0;
 };
 
@@ -687,7 +688,7 @@ struct PreparedIndexBuffer {
 };
 
 static uint64_t VertexBufferDescriptorSize(const ShaderVertexInputBuffer& buffer,
-                                           const ShaderVertexInputInfo& info) {
+                                           const ShaderVertexInputInfo&   info) {
 	if (buffer.stride != 0 || buffer.num_records == 0) {
 		return static_cast<uint64_t>(buffer.stride) * buffer.num_records;
 	}
@@ -697,10 +698,11 @@ static uint64_t VertexBufferDescriptorSize(const ShaderVertexInputBuffer& buffer
 		const auto& resource = info.resources[buffer.attr_indices[i]];
 		// RDNA2 OOB_SELECT=2 only checks NumRecords != 0. A constant attribute still
 		// fetches its entire format; NumRecords is not a byte count in this mode.
-		const uint64_t extent = resource.OutOfBounds() == 2
-		                            ? static_cast<uint64_t>(buffer.attr_offsets[i]) +
-		                                  ShaderRecompiler::Format::GetFormatInfo(resource.Format()).byte_size
-		                            : buffer.num_records;
+		const uint64_t extent =
+		    resource.OutOfBounds() == 2
+		        ? static_cast<uint64_t>(buffer.attr_offsets[i]) +
+		              ShaderRecompiler::Format::GetFormatInfo(resource.Format()).byte_size
+		        : buffer.num_records;
 		size = std::max(size, extent);
 	}
 	return size;
@@ -873,11 +875,11 @@ struct PrimitiveRestartInfo {
 	uint32_t reset_index  = 0;
 };
 
-static PrimitiveRestartInfo ResolvePrimitiveRestart(const CommandBuffer& buffer,
+static PrimitiveRestartInfo ResolvePrimitiveRestart(const CommandBuffer&  buffer,
                                                     vk::PrimitiveTopology topology,
-                                                    uint32_t index_type_and_size) {
+                                                    uint32_t              index_type_and_size) {
 	PrimitiveRestartInfo info {};
-	const auto control = buffer.GetUserConfig().GetPrimitiveResetControl();
+	const auto           control = buffer.GetUserConfig().GetPrimitiveResetControl();
 	EXIT_NOT_IMPLEMENTED((control & ~0x3u) != 0);
 	if ((control & 0x1u) == 0) {
 		return info;
@@ -943,7 +945,7 @@ bool RenderExecutor::PrepareDrawRenderState(uint64_t submit_id, CommandBuffer& b
 	}
 	ResolveRenderDepthTarget(submit_id, buffer, state.depth_info);
 
-	state.ps_active       = DrawHasActivePixelShader(buffer);
+	state.ps_active = DrawHasActivePixelShader(buffer);
 	if (state.color_count == 0 && !state.depth_info.image_id && !state.ps_active) {
 		LogFramebufferSkip(draw.name, state.color_info[0], state.depth_info, buffer,
 		                   draw.index_count, 0);
@@ -1094,7 +1096,7 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
                                          const DrawIndexBufferSource& index_source,
                                          bool primitive_restart_enable, bool log_pipeline_phase,
                                          bool set_bind_debug, bool set_auto_debug) {
-	auto& ucfg = buffer.GetUserConfig();
+	auto&      ucfg        = buffer.GetUserConfig();
 	const bool mesh_active = state.vs_input_info.stage.program->stage == ShaderType::Mesh;
 	uint32_t   mesh_groups = 0;
 	if (mesh_active) {
@@ -1121,9 +1123,9 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
 	if (mesh_active && emit.indexed) {
 		// Register the original guest indices for shader reads; PrepareGraphicsBindings
 		// synchronizes registered BDA ranges before any draw commands are committed.
-		(void)m_context.GetBufferCache().FindBuffer(
-		    index_source.address, static_cast<uint64_t>(draw.index_count) *
-		                              index_source.guest_element_size);
+		(void)m_context.GetBufferCache().FindBuffer(index_source.address,
+		                                            static_cast<uint64_t>(draw.index_count) *
+		                                                index_source.guest_element_size);
 	}
 	LogDrawPhase(draw.name, "PrepareBindings");
 	auto bindings = PrepareGraphicsBindings(state.vs_input_info.stage, state.ps_input_info.stage,
@@ -1135,17 +1137,16 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
 		vertex_bindings = AcquireVertexBuffers(buffer, state.vs_input_info);
 		index_binding   = PrepareIndexBuffer(buffer, index_source);
 	}
-	const auto rendering =
-	    AcquireRenderTargets(buffer, state.color_info, state.color_count, state.depth_info,
-	                         bindings.pixel);
+	const auto rendering = AcquireRenderTargets(buffer, state.color_info, state.color_count,
+	                                            state.depth_info, bindings.pixel);
 
 	if (log_pipeline_phase) {
 		LogDrawPhase(draw.name, "CreatePipeline");
 	}
 	auto& pipeline = m_context.GetPipelineCache().CreateGraphicsPipeline(
-	    std::span {state.color_info, state.color_count}, state.depth_info, state.vs_input_info, buffer,
-	    state.ps_active ? &state.ps_input_info : nullptr, topology, primitive_restart_enable,
-	    state.programs.vertex, state.programs.pixel);
+	    std::span {state.color_info, state.color_count}, state.depth_info, state.vs_input_info,
+	    buffer, state.ps_active ? &state.ps_input_info : nullptr, topology,
+	    primitive_restart_enable, state.programs.vertex, state.programs.pixel);
 
 	// Resource preparation above may synchronously finish and restart the scheduler. From this
 	// point onward, every operation targets the current command buffer and cannot touch guest
@@ -1173,12 +1174,13 @@ void RenderExecutor::ExecutePreparedDraw(uint64_t submit_id, CommandBuffer& buff
 	CommitBindings(buffer, vk::PipelineBindPoint::eGraphics, pipeline,
 	               std::span {descriptor_stages.data(), descriptor_stage_count});
 	if (mesh_active) {
-		const uint32_t draw_data[] {
-		    draw.index_count,
-		    emit.indexed ? static_cast<uint32_t>(emit.vertex_offset) : emit.first_vertex,
-		    emit.first_instance, index_source.guest_element_size,
-		    static_cast<uint32_t>(index_source.address),
-		    static_cast<uint32_t>(index_source.address >> 32u)};
+		const uint32_t draw_data[] {draw.index_count,
+		                            emit.indexed ? static_cast<uint32_t>(emit.vertex_offset)
+		                                         : emit.first_vertex,
+		                            emit.first_instance,
+		                            index_source.guest_element_size,
+		                            static_cast<uint32_t>(index_source.address),
+		                            static_cast<uint32_t>(index_source.address >> 32u)};
 		static_assert(std::size(draw_data) == ShaderRecompiler::IR::PushData::MeshDrawDwordCount);
 		vk_buffer.pushConstants(pipeline.pipeline_layout,
 		                        vk::ShaderStageFlagBits::eMeshEXT |
@@ -1291,8 +1293,7 @@ void RenderExecutor::DrawIndex(uint64_t submit_id, CommandBuffer& buffer,
 	vk::IndexType index_type           = vk::IndexType::eUint16;
 	uint64_t      index_size           = 0;
 	bool          expand_index8_to_u16 = false;
-	const auto restart_info =
-	    ResolvePrimitiveRestart(buffer, topology, args.index_type_and_size);
+	const auto restart_info = ResolvePrimitiveRestart(buffer, topology, args.index_type_and_size);
 
 	switch (static_cast<Prospero::IndexType>(args.index_type_and_size)) {
 		case Prospero::IndexType::kIndex16:

--- a/src/graphics/shader/recompiler/BufferFormat.h
+++ b/src/graphics/shader/recompiler/BufferFormat.h
@@ -36,8 +36,11 @@ struct FormattedSource {
 constexpr FormattedSource ResolveFormattedSource(const BufferFormatInfo& info, uint32_t selector) {
 	if (selector == 0u) return {};
 	if (selector == 1u) return {FormattedSourceKind::One, 0};
-	if (selector < 4u || selector > 7u || info.component_count == 0u) {
-		return {FormattedSourceKind::Invalid, 0};
+	if (selector == 2u || selector == 3u || info.component_count == 0u) {
+		return {};
+	}
+	if (selector < 4u || selector > 7u) {
+		return {};
 	}
 	// Formatted decoding expands source channels before applying the swizzle.
 	return {FormattedSourceKind::Memory, (selector - 4u) % info.component_count};

--- a/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
+++ b/src/graphics/shader/recompiler/backend/spirv/spirvEmitterMemory.cpp
@@ -1,6 +1,5 @@
-#include "graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h"
-
 #include "graphics/host_gpu/renderer/cache/bufferCache.h"
+#include "graphics/shader/recompiler/backend/spirv/spirvEmitterInternal.h"
 
 #include <algorithm>
 
@@ -115,20 +114,19 @@ uint32_t AddU64Low(EmitterState& state, uint32_t low, uint32_t high, uint32_t ad
 
 uint32_t ScratchByteAddress(ValueEmitContext& ctx, const IR::MemoryInfo& mem, uint32_t low,
                             uint32_t high) {
-	auto& state     = ctx.state;
-	auto  immediate = static_cast<int32_t>(mem.offset);
+	auto&      state          = ctx.state;
+	auto       immediate      = static_cast<int32_t>(mem.offset);
 	const auto immediate_low  = ConstantU32(state, static_cast<uint32_t>(immediate));
 	const auto immediate_high = ConstantU32(state, immediate < 0 ? UINT32_MAX : 0u);
-	low                      = AddU64Low(state, low, high, immediate_low, immediate_high, high);
-	const auto valid =
-	    Binary(state, OpIEqual, TypeBool(state), high, ConstantU32(state, 0));
+	low                       = AddU64Low(state, low, high, immediate_low, immediate_high, high);
+	const auto valid = Binary(state, OpIEqual, TypeBool(state), high, ConstantU32(state, 0));
 	return Select(state, TypeU32(state), valid, low, ConstantU32(state, UINT32_MAX));
 }
 
 uint32_t ConstantDeviceAddress(EmitterState& state, uint64_t value) {
-	return state.builder.Constant(OpConstant, TypeDeviceAddress(state),
-	                              {static_cast<uint32_t>(value),
-	                               static_cast<uint32_t>(value >> 32u)});
+	return state.builder.Constant(
+	    OpConstant, TypeDeviceAddress(state),
+	    {static_cast<uint32_t>(value), static_cast<uint32_t>(value >> 32u)});
 }
 
 uint32_t DeviceAddressFromWords(EmitterState& state, uint32_t low, uint32_t high) {
@@ -156,8 +154,8 @@ uint32_t GuestAddress(ValueEmitContext& ctx, const IR::Inst& inst, const IR::Mem
 			return ConstantDeviceAddress(state, 0);
 		}
 		const auto base = DeviceAddressFromWords(state, ctx.Arg(*handle, 0), ctx.Arg(*handle, 1));
-		address = Binary(state, OpIAdd, TypeDeviceAddress(state), base,
-		                 Unary(state, OpUConvert, TypeDeviceAddress(state), low));
+		address         = Binary(state, OpIAdd, TypeDeviceAddress(state), base,
+		                         Unary(state, OpUConvert, TypeDeviceAddress(state), low));
 	}
 	auto immediate = static_cast<int32_t>(mem.offset);
 	if (mem.kind == IR::ResourceKind::ScalarAddress) {
@@ -166,8 +164,8 @@ uint32_t GuestAddress(ValueEmitContext& ctx, const IR::Inst& inst, const IR::Mem
 	return immediate == 0
 	           ? address
 	           : Binary(state, OpIAdd, TypeDeviceAddress(state), address,
-	                    ConstantDeviceAddress(state,
-	                                          static_cast<uint64_t>(static_cast<int64_t>(immediate))));
+	                    ConstantDeviceAddress(
+	                        state, static_cast<uint64_t>(static_cast<int64_t>(immediate))));
 }
 
 uint32_t FaultElementPointer(EmitterState& state, uint32_t index) {
@@ -178,11 +176,11 @@ uint32_t FaultElementPointer(EmitterState& state, uint32_t index) {
 }
 
 void RecordBdaFault(EmitterState& state, uint32_t page) {
-	const auto word = Binary(state, OpShiftRightLogical, TypeU32(state), page,
-	                         ConstantU32(state, 5));
-	const auto bit = Binary(
-	    state, OpShiftLeftLogical, TypeU32(state), ConstantU32(state, 1),
-	    Binary(state, OpBitwiseAnd, TypeU32(state), page, ConstantU32(state, 31)));
+	const auto word =
+	    Binary(state, OpShiftRightLogical, TypeU32(state), page, ConstantU32(state, 5));
+	const auto bit =
+	    Binary(state, OpShiftLeftLogical, TypeU32(state), ConstantU32(state, 1),
+	           Binary(state, OpBitwiseAnd, TypeU32(state), page, ConstantU32(state, 31)));
 	const auto pointer = FaultElementPointer(state, word);
 	const auto value   = state.builder.AllocateId();
 	state.builder.AddFunction({OpLoad, TypeU32(state), value, pointer});
@@ -199,14 +197,13 @@ uint32_t GetBdaPointer(ValueEmitContext& ctx, uint32_t address) {
 }
 
 uint32_t LoadBdaDword(ValueEmitContext& ctx, uint32_t address) {
-	auto&      state   = ctx.state;
-	const auto bda     = GetBdaPointer(ctx, address);
-	const auto present = Binary(state, OpINotEqual, TypeBool(state), bda,
-	                            ConstantDeviceAddress(state, 0));
+	auto&      state = ctx.state;
+	const auto bda   = GetBdaPointer(ctx, address);
+	const auto present =
+	    Binary(state, OpINotEqual, TypeBool(state), bda, ConstantDeviceAddress(state, 0));
 	return EmitValueOrZeroIfCondition(state, present, [&]() {
 		const auto pointer = state.builder.AllocateId();
-		state.builder.AddFunction(
-		    {OpConvertUToPtr, TypePhysicalU32Pointer(state), pointer, bda});
+		state.builder.AddFunction({OpConvertUToPtr, TypePhysicalU32Pointer(state), pointer, bda});
 		const auto value = state.builder.AllocateId();
 		state.builder.AddFunction(
 		    {OpLoad, TypeU32(state), value, pointer, MemoryAccessAlignedMask, sizeof(uint32_t)});
@@ -215,7 +212,7 @@ uint32_t LoadBdaDword(ValueEmitContext& ctx, uint32_t address) {
 }
 
 uint32_t LoadBda(ValueEmitContext& ctx, const IR::Inst& inst, const IR::MemoryInfo& mem,
-	             uint32_t bits) {
+                 uint32_t bits) {
 	auto&      state   = ctx.state;
 	const auto address = GuestAddress(ctx, inst, mem);
 	const auto active  = ctx.Arg(inst, inst.NumArgs() - 1);
@@ -223,35 +220,32 @@ uint32_t LoadBda(ValueEmitContext& ctx, const IR::Inst& inst, const IR::MemoryIn
 		const auto aligned = Binary(state, OpBitwiseAnd, TypeDeviceAddress(state), address,
 		                            ConstantDeviceAddress(state, ~uint64_t {3}));
 		const auto first   = LoadBdaDword(ctx, aligned);
-		const auto byte = Binary(state, OpBitwiseAnd, TypeU32(state),
-		                         Unary(state, OpUConvert, TypeU32(state), address),
-		                         ConstantU32(state, 3));
-		const auto crosses = bits == 8u
-		                          ? ConstantBool(state, false)
-		                          : Binary(state, bits == 16u ? OpUGreaterThan : OpINotEqual,
-		                                   TypeBool(state), byte,
-		                                   ConstantU32(state, bits == 16u ? 2u : 0u));
-		const auto second = EmitValueOrZeroIfCondition(state, crosses, [&]() {
-			return LoadBdaDword(
-			    ctx, Binary(state, OpIAdd, TypeDeviceAddress(state), aligned,
-			                ConstantDeviceAddress(state, sizeof(uint32_t))));
-		});
-		const auto shift = Binary(state, OpShiftLeftLogical, TypeU32(state), byte,
-		                          ConstantU32(state, 3));
-		const auto upper_shift = Binary(
-		    state, OpShiftLeftLogical, TypeU32(state),
+		const auto byte =
 		    Binary(state, OpBitwiseAnd, TypeU32(state),
-		           Binary(state, OpISub, TypeU32(state), ConstantU32(state, 4), byte),
-		           ConstantU32(state, 3)),
-		    ConstantU32(state, 3));
-		const auto merged = Binary(
-		    state, OpBitwiseOr, TypeU32(state),
-		    Binary(state, OpShiftRightLogical, TypeU32(state), first, shift),
-		    Binary(state, OpShiftLeftLogical, TypeU32(state), second, upper_shift));
-		return bits == 32u
-		           ? merged
-		           : Binary(state, OpBitwiseAnd, TypeU32(state), merged,
-		                    ConstantU32(state, bits == 8u ? 0xffu : 0xffffu));
+		           Unary(state, OpUConvert, TypeU32(state), address), ConstantU32(state, 3));
+		const auto crosses =
+		    bits == 8u ? ConstantBool(state, false)
+		               : Binary(state, bits == 16u ? OpUGreaterThan : OpINotEqual, TypeBool(state),
+		                        byte, ConstantU32(state, bits == 16u ? 2u : 0u));
+		const auto second = EmitValueOrZeroIfCondition(state, crosses, [&]() {
+			return LoadBdaDword(ctx, Binary(state, OpIAdd, TypeDeviceAddress(state), aligned,
+			                                ConstantDeviceAddress(state, sizeof(uint32_t))));
+		});
+		const auto shift =
+		    Binary(state, OpShiftLeftLogical, TypeU32(state), byte, ConstantU32(state, 3));
+		const auto upper_shift =
+		    Binary(state, OpShiftLeftLogical, TypeU32(state),
+		           Binary(state, OpBitwiseAnd, TypeU32(state),
+		                  Binary(state, OpISub, TypeU32(state), ConstantU32(state, 4), byte),
+		                  ConstantU32(state, 3)),
+		           ConstantU32(state, 3));
+		const auto merged =
+		    Binary(state, OpBitwiseOr, TypeU32(state),
+		           Binary(state, OpShiftRightLogical, TypeU32(state), first, shift),
+		           Binary(state, OpShiftLeftLogical, TypeU32(state), second, upper_shift));
+		return bits == 32u ? merged
+		                   : Binary(state, OpBitwiseAnd, TypeU32(state), merged,
+		                            ConstantU32(state, bits == 8u ? 0xffu : 0xffffu));
 	});
 }
 
@@ -399,10 +393,12 @@ FormattedSource ResolveFormattedSource(ValueEmitContext& ctx, const IR::MemoryIn
 	}
 	const auto selector = GetDstSel(ctx.state.program.info.buffers[mem.resource].descriptor_swizzle,
 	                                output_component);
-	const auto source = Format::ResolveFormattedSource(info, selector);
+	auto       source   = Format::ResolveFormattedSource(info, selector);
 	if (source.kind == FormattedSourceKind::Invalid) {
-		ExitDescriptorBindingFailure(ctx.state, IR::DescriptorBindingKind::Buffers, mem.resource,
-		                             "buffer descriptor has reserved dst_sel");
+		LOGF_COLOR(Log::Color::BrightYellow,
+		           "buffer descriptor has reserved dst_sel %u for resource %u component %u\n",
+		           selector, mem.resource, output_component);
+		source = {FormattedSourceKind::Zero, 0};
 	}
 	return source;
 }
@@ -607,14 +603,14 @@ uint32_t EmitAtomicOperation(ValueEmitContext& ctx, const IR::Inst& inst, uint32
 		const auto desired    = ctx.Arg(inst, inst.NumArgs() - 3);
 		const auto comparator = ctx.Arg(inst, inst.NumArgs() - 2);
 		ctx.state.builder.AddFunction(
-		    {OpAtomicCompareExchange, TypeU32(ctx.state), old, pointer, ConstantU32(ctx.state, scope),
-		     ConstantU32(ctx.state, MemorySemanticsNone),
+		    {OpAtomicCompareExchange, TypeU32(ctx.state), old, pointer,
+		     ConstantU32(ctx.state, scope), ConstantU32(ctx.state, MemorySemanticsNone),
 		     ConstantU32(ctx.state, MemorySemanticsNone), desired, comparator});
 	} else {
 		const auto value = ctx.Arg(inst, inst.NumArgs() - 2);
-		ctx.state.builder.AddFunction(
-		    {SpirvAtomicOpcode(inst.GetOpcode()), TypeU32(ctx.state), old, pointer,
-		     ConstantU32(ctx.state, scope), ConstantU32(ctx.state, MemorySemanticsNone), value});
+		ctx.state.builder.AddFunction({SpirvAtomicOpcode(inst.GetOpcode()), TypeU32(ctx.state), old,
+		                               pointer, ConstantU32(ctx.state, scope),
+		                               ConstantU32(ctx.state, MemorySemanticsNone), value});
 	}
 	return old;
 }
@@ -665,10 +661,10 @@ uint32_t EmitBufferAtomic64(ValueEmitContext& ctx, const IR::Inst& inst,
 			        const auto old   = state.builder.AllocateId();
 			        state.builder.AddFunction(
 			            {SpirvAtomicOpcode(inst.GetOpcode()), TypeScalarU64(state), old,
-			             EmitStorageBufferElementPointer(
-			                 state, resource, index, TypeStorageBufferU64ElementPointer(state)),
-			             ConstantU32(state, ScopeDevice),
-			             ConstantU32(state, MemorySemanticsNone), value});
+			             EmitStorageBufferElementPointer(state, resource, index,
+			                                             TypeStorageBufferU64ElementPointer(state)),
+			             ConstantU32(state, ScopeDevice), ConstantU32(state, MemorySemanticsNone),
+			             value});
 			        EmitDeviceAtomicMemoryBarrier(state);
 			        return Unary(state, OpBitcast, TypeU64(state), old);
 		        });
@@ -722,11 +718,11 @@ uint32_t SharedFloatAtomic(ValueEmitContext& ctx, const IR::Inst& inst, const IR
 }
 
 uint32_t AppendConsume(ValueEmitContext& ctx, const IR::Inst& inst, bool append) {
-	auto&      state = ctx.state;
+	auto& state = ctx.state;
 	if (ctx.half == 1) {
 		return ctx.other_half->Def(IR::Value(const_cast<IR::Inst*>(&inst)));
 	}
-	const auto m0    = ctx.Arg(inst, 0);
+	const auto m0 = ctx.Arg(inst, 0);
 	const auto base =
 	    Binary(state, OpShiftRightLogical, TypeU32(state), m0, ConstantU32(state, 16));
 	const auto size = Binary(state, OpBitwiseAnd, TypeU32(state), m0, ConstantU32(state, 0xffffu));
@@ -739,8 +735,8 @@ uint32_t AppendConsume(ValueEmitContext& ctx, const IR::Inst& inst, bool append)
 	const auto index  = EmitMemoryElementIndex(state, access, raw_index);
 	const auto exec   = ctx.Arg(inst, 1);
 	const auto ballot = ctx.Ballot(inst.Arg(1));
-	const auto low  = state.builder.AllocateId();
-	const auto high = state.builder.AllocateId();
+	const auto low    = state.builder.AllocateId();
+	const auto high   = state.builder.AllocateId();
 	state.builder.AddFunction({OpCompositeExtract, TypeU32(state), low, ballot, 0});
 	state.builder.AddFunction({OpCompositeExtract, TypeU32(state), high, ballot, 1});
 	const auto count =
@@ -1015,10 +1011,9 @@ void DefineGetBdaPointer(EmitterState& state) {
 	state.builder.AddFunction({OpFunctionParameter, type, address});
 	EmitLabel(state, entry_label);
 
-	const auto page64 = Binary(
-	    state, OpShiftRightLogical, type, address,
-	    ConstantDeviceAddress(state, BufferCache::CACHING_PAGEBITS));
-	const auto page = Unary(state, OpUConvert, TypeU32(state), page64);
+	const auto page64        = Binary(state, OpShiftRightLogical, type, address,
+	                                  ConstantDeviceAddress(state, BufferCache::CACHING_PAGEBITS));
+	const auto page          = Unary(state, OpUConvert, TypeU32(state), page64);
 	const auto entry_pointer = state.builder.AllocateId();
 	state.builder.AddFunction({OpAccessChain, TypeDeviceAddressStoragePointer(state), entry_pointer,
 	                           state.bda_pagetable_variable, ConstantU32(state, 0), page});
@@ -1030,17 +1025,15 @@ void DefineGetBdaPointer(EmitterState& state) {
 	const auto available_label = state.builder.AllocateId();
 	const auto merge_label     = state.builder.AllocateId();
 	state.builder.AddFunction({OpSelectionMerge, merge_label, SelectionControlNone});
-	state.builder.AddFunction(
-	    {OpBranchConditional, missing, fault_label, available_label});
+	state.builder.AddFunction({OpBranchConditional, missing, fault_label, available_label});
 
 	EmitLabel(state, fault_label);
 	RecordBdaFault(state, page);
 	state.builder.AddFunction({OpBranch, merge_label});
 
 	EmitLabel(state, available_label);
-	const auto offset = Binary(
-	    state, OpBitwiseAnd, type, address,
-	    ConstantDeviceAddress(state, BufferCache::CACHING_PAGESIZE - 1));
+	const auto offset    = Binary(state, OpBitwiseAnd, type, address,
+	                              ConstantDeviceAddress(state, BufferCache::CACHING_PAGESIZE - 1));
 	const auto available = Binary(state, OpIAdd, type, base, offset);
 	state.builder.AddFunction({OpBranch, merge_label});
 
@@ -1117,10 +1110,10 @@ bool EmitValueMemory(ValueEmitContext& ctx, const IR::Inst& inst) {
 		ctx.Define(inst, LoadBda(ctx, inst, ctx.Memory(inst), address_info.data_bits));
 		return true;
 	}
-	const bool load_buffer  = op == IR::ValueOpcode::LoadBufferU8 ||
-	                          op == IR::ValueOpcode::LoadBufferU16 ||
-	                          op == IR::ValueOpcode::LoadBufferU32;
-	const bool load_shared  = IR::SharedAccessOf(op) == IR::SharedAccess::Read;
+	const bool load_buffer = op == IR::ValueOpcode::LoadBufferU8 ||
+	                         op == IR::ValueOpcode::LoadBufferU16 ||
+	                         op == IR::ValueOpcode::LoadBufferU32;
+	const bool load_shared = IR::SharedAccessOf(op) == IR::SharedAccess::Read;
 	if (load_address || load_buffer || load_shared) {
 		const auto mem   = ctx.Memory(inst);
 		uint32_t   value = 0;
@@ -1188,11 +1181,10 @@ bool EmitValueMemory(ValueEmitContext& ctx, const IR::Inst& inst) {
 			target = EmitDsSwizzleTargetLane(state, EmitSubgroupLocalInvocationId(state),
 			                                 inst.Arg(1).IsImmediate() ? inst.Arg(1).U32() : 0);
 		} else {
-			const auto index = Binary(
-			    state, OpBitwiseAnd, TypeU32(state),
-			    Binary(state, OpShiftRightLogical, TypeU32(state), ctx.Arg(inst, 1),
-			           ConstantU32(state, 2)),
-			    ConstantU32(state, 31));
+			const auto index = Binary(state, OpBitwiseAnd, TypeU32(state),
+			                          Binary(state, OpShiftRightLogical, TypeU32(state),
+			                                 ctx.Arg(inst, 1), ConstantU32(state, 2)),
+			                          ConstantU32(state, 31));
 			const auto base =
 			    Binary(state, OpBitwiseAnd, TypeU32(state), EmitSubgroupLocalInvocationId(state),
 			           ConstantU32(state, ~31u));

--- a/src/graphics/shader/recompiler/frontend/translate/Attribute.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Attribute.cpp
@@ -48,22 +48,24 @@ IR::ExportFlags Translator::AddExportInfo(const Decoder::Instruction& inst) {
 }
 
 void Translator::TranslateEmbeddedFetch(const Decoder::Instruction& inst, uint32_t attribute,
-                                        uint32_t component_count,
+                                        uint32_t                    component_count,
                                         const ShaderBufferResource& resource) {
 	const auto format = Format::GetFormatInfo(resource.Format());
 	for (uint32_t component = 0; component < component_count; component++) {
 		auto source = Format::FormattedSource {Format::FormattedSourceKind::Memory, component};
 		if (inst.formatted && !inst.typed) {
-			source = Format::ResolveFormattedSource(
-			    format, GetDstSel(resource.DstSelXYZW(), component));
+			source =
+			    Format::ResolveFormattedSource(format, GetDstSel(resource.DstSelXYZW(), component));
 			if (source.kind == Format::FormattedSourceKind::Invalid) {
-				EXIT("invalid formatted vertex input %u at pc 0x%08x", attribute, inst.pc);
+				LOGF_COLOR(Log::Color::BrightYellow,
+				           "invalid formatted vertex input %u at pc 0x%08x\n", attribute, inst.pc);
+				source = {Format::FormattedSourceKind::Zero, 0};
 			}
 		}
 		IR::Value value;
 		if (source.kind == Format::FormattedSourceKind::Memory) {
-			value = ir.Emit(IR::ValueOpcode::GetAttribute,
-			                {IR::Value(attribute), IR::Value(source.component)});
+			value          = ir.Emit(IR::ValueOpcode::GetAttribute,
+			                         {IR::Value(attribute), IR::Value(source.component)});
 			auto& required = program.info.vertex_fetch_components[attribute];
 			required = static_cast<uint8_t>(std::max<uint32_t>(required, source.component + 1u));
 		} else {

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -895,6 +895,10 @@ uint64_t ClampRangeSize(uint64_t vaddr, uint64_t size) {
 	return clamped_size;
 }
 
+uint64_t TryClampRangeSize(uint64_t vaddr, uint64_t size) noexcept {
+	return g_virtual_ranges != nullptr ? g_virtual_ranges->ClampRangeSize(vaddr, size) : 0;
+}
+
 void WriteBacking(uint64_t vaddr, const void* data, uint64_t size) noexcept {
 	if (!TryWriteBacking(vaddr, data, size)) {
 		EXIT("Memory: required direct-backing write failed, addr=0x%016" PRIx64

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -112,6 +112,7 @@ bool                   TryReadBacking(uint64_t vaddr, void* data, uint64_t size)
 bool                   TryReadGpuCleanBacking(uint64_t vaddr, void* data, uint64_t size);
 bool                   TryReadPrtBacking(uint64_t vaddr, void* data, uint64_t size);
 [[nodiscard]] uint64_t ClampRangeSize(uint64_t vaddr, uint64_t size);
+[[nodiscard]] uint64_t TryClampRangeSize(uint64_t vaddr, uint64_t size) noexcept;
 void                   WriteBacking(uint64_t vaddr, const void* data, uint64_t size) noexcept;
 void                   InvalidateMemory(uint64_t vaddr, uint64_t size);
 void                   InstallGpuResources(Graphics::GpuResourceManager* resources) noexcept;

--- a/tests/PageManagerTests.cpp
+++ b/tests/PageManagerTests.cpp
@@ -509,7 +509,7 @@ void TestReadWriteWatcherInteractions() {
   } else if (std::strcmp(name, "write-overflow") == 0) {
     auto *memory = Allocate(page_size);
     const auto address = reinterpret_cast<uint64_t>(memory);
-    for (uint32_t count = 0; count < 128; count++) {
+    for (uint32_t count = 0; count <= 0x7fff; count++) {
       manager.UpdatePageWatchers<true>(address, page_size);
     }
   }


### PR DESCRIPTION
# Fix: Primitive Restart fatal error, memory watcher overflow, texture/storage validation, and vertex-fetch resilience
 
## Overview
 
This PR resolves a fatal error triggered by hardware Primitive Restart with a custom reset index, and extends the fix with related robustness work across the memory manager, the texture cache, descriptor/view creation, and the SPIR-V emitter's vertex-fetch path. Together these changes remove several blocking `EXIT`/`EXIT_NOT_IMPLEMENTED` paths that were being hit by real titles, replacing them with correct handling or safe fallbacks, without touching guest memory integrity.
 
## Problem
 
Rendering hit a fatal error whenever the hardware requested a Primitive Restart with a custom reset index (i.e. different from the maximum value expected for the index format in use). The `EXIT_NOT_IMPLEMENTED` macro blocked execution as soon as `reset_index & index_mask != index_mask`, so this valid, hardware-supported case was never handled — it just crashed.
 
Related, previously unhandled edge cases surfaced during investigation and testing:
 
- Write-watcher counters in `PageManager` could overflow on heavily saturated memory pages.
- Buffer descriptor clamping had no safe, exception-free path for out-of-bounds ranges.
- Sampled views could not be created for stencil resources, and Storage Image binding did not reject invalid targets (Depth targets, or resources without the `eStorage` flag).
- Reserved/invalid channel selectors in vertex attribute fetch caused a hard `EXIT(...)`.
## Solution
 
### 1. Primitive Restart handling (`renderDraw.cpp`)
 
- Introduced a `PrimitiveRestartInfo` structure with three fields: `enable`, `remap_needed`, `reset_index`.
- Correctly parse the `GE_MULTI_PRIM_IB_RESET_EN` control register:
  - Bit 0 (`RESET_EN`): if `0`, primitive restart is disabled (`enable = false`).
  - Bit 1 (`RESET_INDX_EN`):
    - if `0` → the hardware uses the default reset index (`index_mask`: `0xFF` for 8-bit, `0xFFFF` for 16-bit, `0xFFFFFFFF` for 32-bit); the `VGT_MULTI_PRIM_IB_RESET_INDX` register is ignored and `remap_needed = false`.
    - if `1` → `raw_reset_index` is read from `GetPrimitiveResetIndex()` and masked with `index_mask`. If it matches `index_mask`, `remap_needed = false`; otherwise `remap_needed = true`.
- Removed the blocking macro:
```cpp
EXIT_NOT_IMPLEMENTED((reset_index & index_mask) != index_mask);
```
 
- In `DrawIndex`, guest memory (`args.index_addr`) is never modified directly. When `remap_needed` is true:
  - a temporary host-side buffer (`host_index_buffer`) is allocated;
  - the custom reset index is converted to `index_mask` inside this buffer;
  - the buffer is assigned to `index_source.host_data`.
- In `PrepareIndexBuffer`, `host_data` is automatically uploaded to the GPU stream utility buffer (`UtilityBuffer(MemoryUsage::Stream)`).
This means both the default reset-index case and the custom remap case are now handled correctly, with guest memory and cache buffer state left completely intact.
 
### 2. Memory manager robustness (`PageManager`, `memory.cpp`)
 
- Widened the `write_watchers` bitfield from 7 bits (`0x7f`) to 15 bits (`0x7fff`) to prevent counter overflow on memory pages that see heavy write-watcher traffic.
- Added `TryClampRangeSize`, a safe, exception-free clamping routine used to validate buffer descriptor ranges instead of relying on out-of-bounds access or thrown exceptions.
### 3. Texture resolution and Stencil/Depth views (`TextureCache`, `imageView.h`, `descriptors.cpp`)
 
- Added `IsSupportedSampledStencilView` in `imageView.h`, allowing sampled views to be created on stencil resources (`vk::Format::eR8Uint`).
- Added checks in `TextureCache::FindImage` and `ResolveTexture` to reject Depth targets, or any resource missing the `eStorage` flag, when bound as a Storage Image.
### 4. SPIR-V emitter and vertex fetch (`spirvEmitterMemory.cpp`, `BufferFormat.h`, `Attribute.cpp`)
 
- Unified handling of invalid/reserved channel selectors (`selector == 2u || selector == 3u`) in `ResolveFormattedSource`.
- Replaced the blocking `EXIT(...)` call with a logged warning (`LOGF_COLOR`) when an invalid formatting selector is encountered during vertex attribute translation, falling back to a value of zero instead of crashing.
## Impact
 
| Component | Type of change | Result / benefit |
|---|---|---|
| `renderDraw.cpp` | Bug fix / robustness | Fixes the crash in *Tomb Raider VI Remastered* and similar titles by eliminating the blocking exit on custom reset indices, while keeping guest memory fully intact. |
| `PageManager.h` | Stability | Increases write-watcher capacity (2⁷ → 2¹⁵), eliminating "write-watcher overflow" failures. |
| `descriptors.cpp` / `imageView.h` | Vulkan correctness | Improves compatibility with depth/stencil texture binding and enforces stricter validation of Storage Image usage. |
| `Attribute.cpp` / `spirvEmitterMemory.cpp` | Recompiler resilience | Improves tolerance for vertex shaders that use reserved swizzles in buffer descriptors. |
 
## Files changed
 
- `renderDraw.cpp`
- `PageManager.h` / `memory.cpp`
- `descriptors.cpp`
- `imageView.h`
- `TextureCache` (relevant source files)
- `spirvEmitterMemory.cpp`
- `BufferFormat.h`
- `Attribute.cpp`
## Testing
 
The Primitive Restart fix was tested on *Tomb Raider VI Remastered*, which originally triggered the fatal error, as well as across a range of other titles (Like GTA San Andreas, GTA Vice City), with no observed drop in rendering quality or performance. The accompanying memory, texture-validation, and vertex-fetch changes were exercised as part of the same regression pass.
 
## AI
 
Written with the help of artificial intelligence. Every change was reviewed, implemented, and tested locally by me.