### PR TITLE
loader: refresh imports after dynamic module loads

### DIFF
--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -1288,7 +1288,7 @@ void RuntimeLinker::RelocateProgram(Program* program) {
 	EXIT_IF(program == nullptr);
 	EXIT_IF(std::find(m_programs.begin(), m_programs.end(), program) == m_programs.end());
 
-	Relocate(program);
+	RelocateAll();
 	if (!GamePatch::ApplyPending(program)) {
 		EXIT("Failed to apply pending game cheat\n");
 	}


### PR DESCRIPTION
Castlevania Dominus Collection crashes after unloading and reloading `dra03.prx` because the main executable retains an invalid address for an imported object.

`UnloadProgram()` already calls `RelocateAll()`. Once the module is removed, this replaces its object's address in the main executable's GOT with an invalid-object placeholder. Loading the module again currently relocates only the newly loaded module, leaving that GOT entry unchanged.

I propose calling `RelocateAll()` from `RelocateProgram()` as well, so existing imports receive the loaded module's addresses before it starts.

Validation: Linux build passed. Order of Ecclesia passed the original crash point and ran for roughly five minutes without another crash. Windows and audio remain untested.

Fixes #307.
