### PR TITLE
renderer: finalize bindings after every range-changing operation

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -496,6 +496,21 @@ std::pair<Buffer*, uint64_t> BufferCache::ObtainBuffer(uint64_t vaddr, uint64_t 
 	return {buffer, buffer->Offset(vaddr)};
 }
 
+std::pair<Buffer*, uint64_t> BufferCache::FindPublishedOwner(uint64_t vaddr, uint64_t size) {
+	if (!GuestRange {vaddr, size}.Valid()) {
+		return {nullptr, 0};
+	}
+	const auto* owner = m_page_table.Find(vaddr >> PageTable::kPageBits);
+	if (owner == nullptr || !*owner) {
+		return {nullptr, 0};
+	}
+	auto& buffer = m_slot_buffers[*owner];
+	if (buffer.is_deleted || !buffer.IsInBounds(vaddr, size)) {
+		return {nullptr, 0};
+	}
+	return {&buffer, buffer.Offset(vaddr)};
+}
+
 std::pair<Buffer*, uint64_t> BufferCache::ObtainBufferForImage(uint64_t vaddr, uint64_t size) {
 	if (!GuestRange {vaddr, size}.Valid()) {
 		EXIT("BufferCache: invalid image source\n");

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.h
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.h
@@ -55,6 +55,20 @@ public:
 		}
 		EXIT("BufferCache: invalid utility-buffer usage\n");
 	}
+	// Resolves the buffer that currently owns a guest range, or {nullptr, 0} when none does.
+	// Performs a page-table lookup and nothing else: no allocation, no join, no synchronize, no
+	// upload, no dirty-state change, no LRU touch. Those belong to ObtainBuffer and must not be
+	// repeated when a binding is republished.
+	[[nodiscard]] std::pair<Buffer*, uint64_t> FindPublishedOwner(uint64_t vaddr, uint64_t size);
+
+	// True when the buffer is the stream ring rather than a cached, guest-range-owned buffer.
+	// ObtainBuffer's stream fast path returns a throwaway ring allocation holding a private copy
+	// of the guest bytes; such a binding is owned by no guest range, must never be re-resolved by
+	// address, and keeps its allocation, offset and lifetime as issued.
+	[[nodiscard]] bool IsStreamAllocation(const Buffer* buffer) const noexcept {
+		return buffer == &m_stream_buffer;
+	}
+
 	[[nodiscard]] const Buffer* GetGdsBuffer() const noexcept { return &m_gds_buffer; }
 	[[nodiscard]] Buffer* GetBdaPageTableBuffer() noexcept { return &m_bda_pagetable_buffer; }
 	[[nodiscard]] Buffer* GetFaultBuffer() noexcept { return m_fault_manager.GetFaultBuffer(); }

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.cpp
@@ -129,12 +129,14 @@ static bool IsMultisampledTexture(Prospero::ImageType type) {
 }
 
 static vk::DescriptorBufferInfo
-NativeStorageBuffer(RenderContext& context, const PreparedBindings::BufferSource& source,
+NativeStorageBuffer(RenderContext& context, PreparedBindings::BufferSource& source,
                     const ShaderRecompiler::IR::BufferResource& resource, ShaderType stage,
                     uint32_t slot, uint32_t& buffer_offset) {
 	buffer_offset = 0;
 
-	const auto& [address, size, id] = source;
+	const auto address = source.address;
+	const auto size    = source.size;
+	const auto id      = source.id;
 	if (address == 0 || size == 0) {
 		return {context.GetBufferCache().GetBuffer(NULL_BUFFER_ID).Handle(), 0, 16};
 	}
@@ -151,7 +153,10 @@ NativeStorageBuffer(RenderContext& context, const PreparedBindings::BufferSource
 	if (adjustment % sizeof(uint32_t) != 0 || adjustment >= 256 || size > max_range - adjustment) {
 		EXIT("storage buffer offset adjustment is unsupported\n");
 	}
-	buffer_offset = static_cast<uint32_t>(adjustment);
+	buffer_offset       = static_cast<uint32_t>(adjustment);
+	source.stream       = context.GetBufferCache().IsStreamAllocation(buffer);
+	source.resolved     = true;
+	source.adjustment   = buffer_offset;
 	const vk::DescriptorBufferInfo result {buffer->Handle(), aligned_offset, size + adjustment};
 	if (resource.formatted && resource.written) {
 		context.GetTextureCache().InvalidateMemoryFromGPU(address, size);
@@ -812,6 +817,8 @@ void RenderExecutor::FindBuffers(PreparedBindings& prepared) {
 void RenderExecutor::RebindBuffers(PreparedBindings& prepared) {
 	KYTY_PROFILER_FUNCTION();
 	EXIT_IF(prepared.runtime == nullptr || !*prepared.runtime);
+	// Rebinding rebuilds the descriptors, so any earlier publication is stale from here.
+	prepared.published = false;
 	const auto& program   = *prepared.runtime->program;
 	const auto& snapshot  = prepared.runtime->resources;
 	const auto& layout    = program.bindings;
@@ -834,19 +841,115 @@ void RenderExecutor::RebindBuffers(PreparedBindings& prepared) {
 		                                               buffer_offset));
 		pack_memory_offset(i, buffer_offset);
 	}
+	// The flattened_srt and shader_data uploads used to happen here. shader_data carries the
+	// packed memory offsets, so it has to be uploaded from the settled state - see PublishBuffers.
+}
+
+// Re-resolves every cache-backed binding from its guest range and republishes the descriptor, the
+// packed offset and the uploads from one settled snapshot.
+//
+// Runs after all range-changing work for the draw or dispatch. RebindImages reaches CreateBuffer
+// through ResolveTexture -> FindImage -> InitializeImage -> ObtainBufferForImage, so a buffer a
+// stage already captured can be retired after that stage was rebound.
+//
+// Performs no obtain-side work: no allocation, no join, no synchronize, no upload into a buffer,
+// no dirty-state change, no LRU touch. Those happened once, in order, during RebindBuffers.
+void RenderExecutor::PublishBuffers(PreparedBindings& prepared) {
+	KYTY_PROFILER_FUNCTION();
+	EXIT_IF(prepared.runtime == nullptr || !*prepared.runtime);
+	const auto& program  = *prepared.runtime->program;
+	const auto& snapshot = prepared.runtime->resources;
+	const auto& layout   = program.bindings;
+	prepared.published   = true;
+
+	if (prepared.buffer_sources.size() == prepared.buffers.size()) {
+		auto& cache = m_context.GetBufferCache();
+		std::fill(prepared.shader_data.begin() + layout.memory_offset_dword,
+		          prepared.shader_data.end(), 0);
+		for (uint32_t i = 0; i < prepared.buffer_sources.size(); i++) {
+			const auto& source = prepared.buffer_sources[i];
+			if (!source.resolved) {
+				continue;
+			}
+			const auto pack = [&](uint32_t adjustment) {
+				const auto dword = layout.memory_offset_dword + i / 4u;
+				const auto shift = (i % 4u) * 8u;
+				prepared.shader_data[dword] |= adjustment << shift;
+			};
+			if (source.stream) {
+				// As issued: the ring allocation holds this binding's private copy of the guest
+				// bytes, and no guest range owns it.
+				pack(source.adjustment);
+				continue;
+			}
+			const auto owner = cache.FindPublishedOwner(source.address, source.size);
+			if (owner.first == nullptr) {
+				// Allocating here would be a range-changing operation after everything was
+				// supposed to have settled, and publishing an unconfirmed view would hide it.
+				EXIT("binding publication found no owner for guest range 0x%016" PRIx64
+				     " size 0x%" PRIx64 "\n",
+				     source.address, source.size);
+			}
+			const auto  alignment      = m_context.GetGraphics().StorageMinAlignment();
+			const auto  aligned_offset = owner.second - owner.second % alignment;
+			const auto  adjustment     = static_cast<uint32_t>(owner.second - aligned_offset);
+			auto&       view           = prepared.buffers[i];
+			view.buffer                = owner.first->Handle();
+			view.offset                = aligned_offset;
+			view.range                 = source.size + adjustment;
+			pack(adjustment);
+		}
+	}
 	if (ShaderRecompiler::IR::FindBinding(
 	        layout, ShaderRecompiler::IR::DescriptorBindingKind::FlattenedSrt) != nullptr) {
 		prepared.flattened_srt = NativeUpload(m_context, snapshot.flattened_srt);
 	}
 	if (ShaderRecompiler::IR::FindBinding(
-	        program.bindings, ShaderRecompiler::IR::DescriptorBindingKind::ShaderData) != nullptr) {
+	        layout, ShaderRecompiler::IR::DescriptorBindingKind::ShaderData) != nullptr) {
 		prepared.shader_data_buffer = NativeUpload(m_context, prepared.shader_data);
+	}
+}
+
+// Rebind and publish every stage of a draw or dispatch.
+//
+// THREE PASSES OVER THE WHOLE SPAN, never stage at a time: finalizing one stage completely before
+// starting the next is the bug this exists to prevent, because the second stage's rebinding can
+// retire a buffer the first stage already published.
+//
+//   1. rebind buffers, every stage
+//   2. rebind images,  every stage   (these can reach CreateBuffer)
+//   3. publish,        every stage   (nothing after this changes ranges)
+//
+// One call, so a caller cannot rebind without publishing.
+void RenderExecutor::FinalizeBindings(std::span<PreparedBindings* const> stages) {
+	KYTY_PROFILER_FUNCTION();
+	for (auto* stage: stages) {
+		if (stage != nullptr) {
+			stage->published = false;
+		}
+	}
+	for (auto* stage: stages) {
+		if (stage != nullptr) {
+			RebindBuffers(*stage);
+		}
+	}
+	for (auto* stage: stages) {
+		if (stage != nullptr) {
+			RebindImages(*stage);
+		}
+	}
+	for (auto* stage: stages) {
+		if (stage != nullptr) {
+			PublishBuffers(*stage);
+		}
 	}
 }
 
 void RenderExecutor::RebindImages(PreparedBindings& prepared) {
 	KYTY_PROFILER_FUNCTION();
 	EXIT_IF(prepared.runtime == nullptr || !*prepared.runtime);
+	// Image resolution can retire a buffer an earlier publish resolved.
+	prepared.published = false;
 	const auto& program  = *prepared.runtime->program;
 	const auto& snapshot = prepared.runtime->resources;
 	auto&       images   = prepared.images;
@@ -910,17 +1013,13 @@ RenderExecutor::PrepareGraphicsBindings(const ShaderStageRuntime& vertex,
 	    (bindings.pixel && bindings.pixel->runtime->program->info.uses_dma)) {
 		m_context.GetGpuResources().PrepareBda();
 	}
-	RebindBuffers(bindings.vertex);
-	if (bindings.pixel) {
-		RebindBuffers(*bindings.pixel);
-	}
-	RebindImages(bindings.vertex);
-	if (bindings.pixel) {
-		RebindImages(*bindings.pixel);
-	}
+	PreparedBindings* stages[2] = {&bindings.vertex, bindings.pixel ? &*bindings.pixel : nullptr};
+	FinalizeBindings(std::span<PreparedBindings* const> {stages, bindings.pixel ? 2u : 1u});
 	return bindings;
 }
 
+// Publication owns the shader_data and flattened_srt uploads, so a stage reaching commit
+// unpublished has unbound descriptors. Fail here, naming the cause.
 void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
                                     vk::PipelineBindPoint              pipeline_bind_point,
                                     const PipelineCache::Pipeline&     pipeline,
@@ -938,7 +1037,8 @@ void RenderExecutor::CommitBindings(CommandBuffer&                     buffer,
 	                                       ? vk::ShaderStageFlagBits::eFragment
 	                                       : vk::ShaderStageFlags {};
 	for (const auto* prepared: prepared_bindings) {
-		EXIT_IF(prepared == nullptr || prepared->runtime == nullptr || !*prepared->runtime);
+		EXIT_IF(prepared == nullptr || prepared->runtime == nullptr || !*prepared->runtime ||
+		        !prepared->published);
 		const auto& program = *prepared->runtime->program;
 		write_count += program.bindings.descriptors.size();
 		for (const auto& binding: program.bindings.descriptors) {

--- a/src/graphics/host_gpu/renderer/pipeline/descriptors.h
+++ b/src/graphics/host_gpu/renderer/pipeline/descriptors.h
@@ -31,6 +31,15 @@ struct PreparedBindings {
 		uint64_t address = 0;
 		uint64_t size    = 0;
 		BufferId id;
+		// Set when ObtainBuffer served this binding from the stream ring. Such a binding is
+		// republished as issued; re-resolving it by address would hand back a cached buffer and
+		// discard the ring allocation holding its data.
+		bool stream = false;
+		// False for a null binding, which has nothing to republish.
+		bool resolved = false;
+		// Byte adjustment folded into the packed memory offsets in shader_data. Kept beside the
+		// range so publication rewrites both together and they cannot disagree.
+		uint32_t adjustment = 0;
 	};
 
 	// The draw owns the immutable compiled-program/runtime-snapshot association through commit.
@@ -39,6 +48,11 @@ struct PreparedBindings {
 	// become stale and need resolving again when bindings are rebound.
 	std::vector<BufferSource>             buffer_sources;
 	std::vector<vk::DescriptorBufferInfo> buffers;
+	// Set by PublishBuffers, asserted by CommitBindings. The shader_data and flattened_srt
+	// uploads happen during publication, so a stage that reaches commit unpublished has unbound
+	// descriptors. Cleared by anything that can retire a buffer, so a reused PreparedBindings
+	// cannot carry a stale true past the assertion.
+	bool                                  published = false;
 	std::vector<TextureBinding>           images;
 	std::vector<vk::Sampler>              samplers;
 	vk::DescriptorBufferInfo              gds {nullptr, 0, VK_WHOLE_SIZE};

--- a/src/graphics/host_gpu/renderer/render.h
+++ b/src/graphics/host_gpu/renderer/render.h
@@ -160,6 +160,10 @@ public:
 	[[nodiscard]] PreparedBindings PrepareBindings(const ShaderStageRuntime& runtime);
 	void                           FindBuffers(PreparedBindings& bindings);
 	void                           RebindBuffers(PreparedBindings& bindings);
+	void                           PublishBuffers(PreparedBindings& bindings);
+	// Rebind and publish every stage: three passes over the whole span, never stage at a time.
+	// Both the graphics and compute paths go through this.
+	void                           FinalizeBindings(std::span<PreparedBindings* const> stages);
 	void                           RebindImages(PreparedBindings& bindings);
 	void CommitBindings(CommandBuffer& buffer, vk::PipelineBindPoint pipeline_bind_point,
 	                    const PipelineCache::Pipeline&     pipeline,

--- a/src/graphics/host_gpu/renderer/renderCompute.cpp
+++ b/src/graphics/host_gpu/renderer/renderCompute.cpp
@@ -380,8 +380,8 @@ void RenderExecutor::DispatchDirect(uint64_t submit_id, CommandBuffer& buffer,
 	if (program.info.uses_dma) {
 		m_context.GetGpuResources().PrepareBda();
 	}
-	RebindBuffers(bindings);
-	RebindImages(bindings);
+	PreparedBindings* stages[1] = {&bindings};
+	FinalizeBindings(std::span<PreparedBindings* const> {stages, 1u});
 
 	auto              vk_buffer        = buffer.Handle();
 	PreparedBindings* descriptor_stage = &bindings;


### PR DESCRIPTION
**Problem.** A binding captured during draw preparation can be left pointing at a buffer that a later operation in the same draw retired. `NativeStorageBuffer` captures a `VkBuffer` handle, an offset and a packed byte adjustment; any later `ObtainBuffer` can reach `CreateBuffer`, which replaces the buffers covering a range with one wider buffer and retires the originals. Retirement is deferred past GPU completion, so the captured handle stays usable but stops being current: a later upload lands in the replacement, and a write through the stale alias lands in storage nothing else reads. `RebindBuffers(pixel)` can retire what `RebindBuffers(vertex)` captured, and `RebindImages` reaches `CreateBuffer` through `ResolveTexture -> FindImage -> InitializeImage -> ObtainBufferForImage`, so it can retire buffers both stages captured. The `shader_data` upload carries the packed memory offsets and ran before any of the image work, so the offsets and the handles could disagree.

**Change.** Split obtaining from publishing. Obtaining keeps its position and all of its side effects — synchronize, upload, dirty-state change, LRU touch — unchanged and unrepeated, and records how each binding was served. `PublishBuffers` then re-resolves every cache-backed binding from its **guest range** (a `BufferId` is exactly what retirement invalidates) through a new non-allocating `BufferCache::FindPublishedOwner`, and rewrites the descriptor, the packed offset and the `shader_data`/`flattened_srt` uploads from one settled snapshot. `FinalizeBindings` runs three passes over the whole stage span — rebind buffers, rebind images, publish — so no stage is finalized against a state a later stage changes; both the graphics and compute paths call it, so rebinding without publishing is not expressible. Stream-backed bindings are republished as issued: `ObtainBuffer`'s stream fast path returns a ring allocation holding a private copy that no guest range owns, so re-resolving one by address would discard it. A `published` flag is cleared by anything that can retire a buffer and asserted in `CommitBindings`.

**Effect.** No measured performance change; performance was not measured for this and no improvement is claimed. Publication adds a page-table lookup per cache-backed binding and moves two uploads later in the same draw. This closes a silent-corruption path: bindings that read bytes that were never uploaded to the buffer they point at, and writes that land in a retired buffer.

**Verification.** Builds clean on this base. The equivalent change in a downstream tree is covered by a device-backed regression that proves the defect by GPU readback — the captured handle reads the pre-update byte while the live owner reads the updated one, with a control check first so the stale result cannot be attributed to missing upload tracking — and additionally checks that a stream-backed binding keeps its allocation, offset and contents, that publication fails loudly rather than allocating when a range has no owner, and that rebinding clears publication. That tree also ran two full GTA V city drives with the change, exit code 0, no errors and no publication failures; the driver reported no visual problems.

**Limitations.** Marked draft for these:
- The regression above has **not** been ported to this base. Bringing the device harness up here crashes inside `ObtainBuffer` during test setup, unresolved, so this PR carries no automated regression. The fix itself is a re-implementation against this tree's structure, not the downstream patch.
- Not exercised anywhere: an image-triggered replacement specifically (retirement is driven by a spanning `ObtainBuffer` in the downstream test), writable aliases (`is_written` bindings), and `CommitBindings` itself — the `published` assertion is verified by reading, not by running.
- Reviewers may prefer the headless device setup used by `ShaderRecompilerComputeTests` over the SDL-window approach the downstream harness uses, if a regression is added here.

**References**

No external specification. Correctness argument only: `NativeStorageBuffer` captures `buffer->Handle()` into `prepared.buffers`, and `CreateBuffer` retires the buffers it replaces while `BindGraphicsResources` continues to rebind further stages and images afterwards.
