### PR TITLE
kernel: retry a fault on memory our own map says is committed

### DIFF
--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -51,6 +51,10 @@ int32_t GetGpuIndex() {
 	return g_config->gpu_index;
 }
 
+bool RetryTransientMapFaults() {
+	return g_config->retry_transient_map_faults;
+}
+
 bool FullscreenEnabled() {
 	return g_config->fullscreen_enabled;
 }

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -68,6 +68,9 @@ struct ConfigOptions {
 	bool                   renderdoc_enabled           = false;
 	bool                   readback_linear_images      = false;
 	bool                   playgo_hack_enabled         = false;
+	// Retry a fault on guest memory this emulator's own map reports as committed, rather than
+	// aborting. Bounded per address, so a genuinely bad address still fails.
+	bool                   retry_transient_map_faults  = true;
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	bool red_zone_protection_enabled = false;
 #endif
@@ -82,6 +85,7 @@ const std::string& GetUserName();
 int32_t  GetUserId();
 PresentMode GetPresentMode();
 int32_t GetGpuIndex();
+bool     RetryTransientMapFaults();
 bool     FullscreenEnabled();
 uint32_t GetVblankFrequency();
 uint32_t GetConsoleLanguage();

--- a/src/loader/runtimeLinker.cpp
+++ b/src/loader/runtimeLinker.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <thread>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -799,6 +800,29 @@ static bool KytyExceptionHandler(const Common::HostException::ExceptionInfo& exc
 		}
 		if (Libs::LibKernel::Memory::HandleGpuFault(access, info->access_violation_vaddr)) {
 			return true;
+		}
+		// Remapping guest direct memory is not atomic: MapBacking/UnmapBacking go through Windows
+		// placeholders, so the pages are briefly absent. A guest thread touching them in that window
+		// faults on memory that is committed both before and after - observed as two VirtualQuery
+		// calls one line apart disagreeing about the same range. Retry the instruction instead of
+		// aborting, bounded so a genuinely bad address still fails loudly.
+		if (Config::RetryTransientMapFaults()) {
+			Libs::LibKernel::Memory::VirtualQueryInfo guest {};
+			if (Libs::LibKernel::Memory::KernelVirtualQuery(
+			        reinterpret_cast<const void*>(info->access_violation_vaddr), 0, &guest,
+			        sizeof(guest)) == 0 &&
+			    guest.is_committed != 0) {
+				thread_local uint64_t last_vaddr = 0;
+				thread_local uint32_t retries    = 0;
+				if (info->access_violation_vaddr != last_vaddr) {
+					last_vaddr = info->access_violation_vaddr;
+					retries    = 0;
+				}
+				if (++retries <= 4096) {
+					std::this_thread::yield();
+					return true;
+				}
+			}
 		}
 	}
 	EXIT("Unhandled host exception: type=%u code=%u pc=0x%016" PRIx64

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,7 @@ static void PrintUsage() {
 	::printf(
 	    "  --readback-linear-images <true|false> Read back writable linear images on submit.\n");
 	::printf("  --playgo-hack                       Use the supplied PlayGo stub fallback.\n");
+	::printf("  --no-retry-transient-map-faults      Abort instead of retrying a transient map fault.\n");
 #if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
 	::printf("  --redzone                            Protect the guest SysV red zone.\n");
 #endif
@@ -164,6 +165,11 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 
 		if (arg == "--playgo-hack") {
 			options.config.playgo_hack_enabled = true;
+			continue;
+		}
+
+		if (arg == "--no-retry-transient-map-faults") {
+			options.config.retry_transient_map_faults = false;
 			continue;
 		}
 


### PR DESCRIPTION
**Problem.** Remapping guest direct memory is not atomic. `MapBacking` and `UnmapBacking` go through Windows placeholders, so the pages are briefly absent, and a guest thread touching them in that window takes an access violation on memory that is committed both before and after the remap. This was observed directly: two `VirtualQuery` calls one line apart disagreed about the same range, reporting `MEM_RESERVE` and then `MEM_COMMIT`. The exception handler treated it as a fatal access violation and aborted.

**Change.** When the fault address is reported as committed by this emulator's own guest map, retry the faulting instruction instead of aborting. The retry is bounded to 4096 attempts per address, so an address that is genuinely bad still fails rather than spinning, and it sits behind `--no-retry-transient-map-faults` for anyone who would rather see the abort.

**Effect.** GTA V previously crashed reproducibly while streaming during the first mission; with this it completed that mission with zero faults. No performance change; performance was not measured.

**Limitations, and why this is a draft.**
- **This mitigates the race, it does not remove it.** The remap is still non-atomic; the fix converts a crash into a retry. A reviewer may reasonably prefer making `MapBacking`/`UnmapBacking` atomic, or serialising guest access against the remap, and treat this as a stopgap.
- A retry on a committed-looking address can in principle mask a genuine access violation whose page happens to be committed. The per-address bound limits how long that can go unnoticed but does not rule it out.
- Verified on Windows only. The placeholder mechanism this works around is Windows-specific, but the retry path is not conditionally compiled.
- No automated regression: reproducing it needs the specific streaming workload that triggered it, and the window is timing-dependent.

**Verification.** Builds clean. Exercised by the GTA V run described above; the diagnosis rests on the contradictory `VirtualQuery` pair, which is direct evidence of the window rather than an inference from the crash alone.

**References**

Microsoft Windows API, `VirtualAlloc2` / `MapViewOfFile3` placeholder semantics: splitting or replacing a placeholder mapping unmaps the region before the new view is mapped, leaving the address range temporarily inaccessible to other threads.
