### PR TITLE
renderer: do not materialize a non-finite packed colour clear

### DIFF
--- a/src/graphics/host_gpu/renderer/image/imageInfo.h
+++ b/src/graphics/host_gpu/renderer/image/imageInfo.h
@@ -438,7 +438,17 @@ IsSupportedDisplayRenderTargetTileMode(Prospero::TileMode tile_mode) noexcept {
 		// A single-plane float target carries its clear as raw float bits, the same encoding the
 		// depth decoder below uses. Without this the clear is discarded and the target keeps stale
 		// contents.
-		case vk::Format::eR32Sfloat: next.float32[0] = std::bit_cast<float>(packed); break;
+		case vk::Format::eR32Sfloat: {
+			// A packed clear word is guest data and can hold any bit pattern, including an
+			// infinity or a NaN. Materializing one into a clear value hands it to every
+			// subsequent read of the target; leave the clear untracked instead.
+			const auto value = std::bit_cast<float>(packed);
+			if (!std::isfinite(value)) {
+				return false;
+			}
+			next.float32[0] = value;
+			break;
+		}
 		case vk::Format::eR32Uint: next.uint32[0] = packed; break;
 		case vk::Format::eR32Sint: next.int32[0] = static_cast<int32_t>(packed); break;
 		case vk::Format::eR8G8B8A8Srgb:


### PR DESCRIPTION
**Problem.** `DecodePackedColorClear` bit-casts the render target's packed clear word to a float for `R32_SFLOAT`. That word is guest data and can hold any bit pattern, including an infinity or a NaN. A non-finite clear value is not confined to the clear: it becomes the contents of the target, so every subsequent sample or blend reads it, and a single infinity propagates through anything that touches the surface.

**Change.** Reject non-finite values in that decode. The clear is then left untracked, which is exactly what already happens for any other encoding the decoder does not support, so the target takes the normal path instead of a fast clear.

**Effect.** A garbage or non-finite packed clear word no longer becomes the target's contents. No performance change; performance was not measured. Finite clear values are unaffected, so this only removes a case that was previously materialized.

**Verification.** Builds clean; `ShaderRecompilerComputeTests` passes. No dedicated regression: the decoder's other unsupported encodings have none either, and reaching this case needs a title that writes a non-finite clear word.

**Limitations.** This rejects the value at decode; it does not investigate why a title would program a non-finite clear word, and it does not change the other formats' decoding.

**References**

No external specification. Correctness argument only: the packed clear word is guest-controlled, and `std::bit_cast<float>` of an arbitrary 32-bit pattern can yield an infinity or NaN, which the surrounding code then treats as a valid clear colour. The adjacent normalized-format path in the same file already rejects values outside its representable range.
