### PR TITLE
renderer: publish linear storage images before CPU access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,6 +556,10 @@ if(BUILD_TESTING)
 		COMMAND $<TARGET_FILE:virtual_memory_allocation_tests> --red-zone-patcher-only)
 	add_test(NAME command_scheduler_timeline
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --scheduler-only)
+	add_test(NAME shader_recompiler_image_cpu_readback
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --image-cpu-readback-only)
+	add_test(NAME buffer_cache_private_upload
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --private-buffer-upload-only)
 	add_test(NAME stream_buffer_ring
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --stream-buffer-only)
 	add_test(NAME gpu_command_lane

--- a/src/graphics/host_gpu/pageManager.cpp
+++ b/src/graphics/host_gpu/pageManager.cpp
@@ -128,8 +128,9 @@ uint64_t PageEnd(uint64_t vaddr, uint64_t size) {
 
 struct PageManager::Impl {
 	struct PageState {
-		uint8_t write_watchers  : 7 = 0;
-		uint8_t access_watchers : 1 = 0;
+		uint8_t write_watchers = 0;
+		// Buffers and disjoint images may independently own bytes on the same host page.
+		uint8_t access_watchers = 0;
 
 		[[nodiscard]] uint32_t Perms() const noexcept {
 			if (access_watchers != 0) {
@@ -146,7 +147,7 @@ struct PageManager::Impl {
 			static_assert(delta >= -1 && delta <= 1);
 			if constexpr (is_read) {
 				if constexpr (delta == 1) {
-					if (access_watchers != 0) {
+					if (access_watchers == UINT8_MAX) {
 						Fatal("read-watcher overflow at 0x%016" PRIx64, address);
 					}
 					return ++access_watchers;
@@ -175,7 +176,7 @@ struct PageManager::Impl {
 			}
 		}
 	};
-	static_assert(sizeof(PageState) == 1);
+	static_assert(sizeof(PageState) == 2);
 
 	struct Region {
 		std::atomic_flag                    lock = ATOMIC_FLAG_INIT;
@@ -331,13 +332,15 @@ uint64_t PageManager::GetPageSize() const {
 	return PAGE_SIZE;
 }
 
-template <bool track>
+template <bool track, bool is_read>
 void PageManager::UpdatePageWatchers(uint64_t vaddr, uint64_t size) {
-	m_impl->UpdatePageWatchers<track, false>(vaddr, size);
+	m_impl->UpdatePageWatchers<track, is_read>(vaddr, size);
 }
 
-template void PageManager::UpdatePageWatchers<true>(uint64_t, uint64_t);
-template void PageManager::UpdatePageWatchers<false>(uint64_t, uint64_t);
+template void PageManager::UpdatePageWatchers<true, false>(uint64_t, uint64_t);
+template void PageManager::UpdatePageWatchers<false, false>(uint64_t, uint64_t);
+template void PageManager::UpdatePageWatchers<true, true>(uint64_t, uint64_t);
+template void PageManager::UpdatePageWatchers<false, true>(uint64_t, uint64_t);
 
 template <bool track, bool is_read>
 void PageManager::UpdatePageWatchersForRegion(uint64_t base_addr, RegionBits& mask) {

--- a/src/graphics/host_gpu/pageManager.h
+++ b/src/graphics/host_gpu/pageManager.h
@@ -20,7 +20,7 @@ public:
 
 	[[nodiscard]] uint64_t GetPageSize() const;
 
-	template <bool track>
+	template <bool track, bool is_read = false>
 	void UpdatePageWatchers(uint64_t vaddr, uint64_t size);
 	template <bool track, bool is_read = false>
 	void UpdatePageWatchersForRegion(uint64_t base_addr, RegionBits& mask);

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -443,7 +443,12 @@ vk::Buffer BufferCache::UploadCopies(Buffer& buffer, std::span<vk::BufferCopy> c
 	if (mapped != nullptr) {
 		for (auto& copy: copies) {
 			const auto address = buffer.CpuAddress() + copy.dstOffset;
-			std::memcpy(mapped + copy.srcOffset, reinterpret_cast<const void*>(address), copy.size);
+			if (!Libs::LibKernel::Memory::TryReadGpuUploadMemory(address, mapped + copy.srcOffset,
+			                                                     copy.size)) {
+				EXIT("BufferCache: unreadable upload source addr=0x%016" PRIx64
+				     " size=0x%016" PRIx64 "\n",
+				     address, uint64_t(copy.size));
+			}
 			copy.srcOffset += base_offset;
 		}
 		m_staging_buffer.Commit();
@@ -454,8 +459,12 @@ vk::Buffer BufferCache::UploadCopies(Buffer& buffer, std::span<vk::BufferCopy> c
 	                                         vk::BufferUsageFlagBits::eTransferSrc, total_size);
 	for (const auto& copy: copies) {
 		const auto address = buffer.CpuAddress() + copy.dstOffset;
-		std::memcpy(temporary->Mapped().data() + copy.srcOffset,
-		            reinterpret_cast<const void*>(address), copy.size);
+		if (!Libs::LibKernel::Memory::TryReadGpuUploadMemory(
+		        address, temporary->Mapped().data() + copy.srcOffset, copy.size)) {
+			EXIT("BufferCache: unreadable temporary upload source addr=0x%016" PRIx64
+			     " size=0x%016" PRIx64 "\n",
+			     address, uint64_t(copy.size));
+		}
 	}
 	temporary->Flush(0, total_size);
 	const auto handle = temporary->Handle();

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -18,6 +18,8 @@ bool GpuResourceManager::HandleFault(PageFaultAccess access, uint64_t fault_vadd
 	if (!IsMapped(fault_vaddr, fault_size)) {
 		return false;
 	}
+	// A partial CPU write must first preserve the other GPU-authored pixels too.
+	SynchronizeCpuImages(fault_vaddr, fault_size);
 	if (access == PageFaultAccess::Write) {
 		m_buffer_cache.InvalidateMemory(fault_vaddr, fault_size);
 		m_texture_cache.InvalidateMemory(fault_vaddr, fault_size);
@@ -31,9 +33,25 @@ bool GpuResourceManager::InvalidateMemory(uint64_t vaddr, uint64_t size) {
 	if (!IsMapped(vaddr, size)) {
 		return false;
 	}
+	SynchronizeCpuImages(vaddr, size);
 	m_buffer_cache.InvalidateMemory(vaddr, size);
 	m_texture_cache.InvalidateMemory(vaddr, size);
 	return true;
+}
+
+void GpuResourceManager::SynchronizeCpuImages(uint64_t vaddr, uint64_t size) {
+	if (!m_texture_cache.HasPendingCpuRead(vaddr, size)) {
+		return;
+	}
+	if (CommandScheduler::InDeferredOperation()) {
+		EXIT("unsupported image readback from an asynchronous GPU completion\n");
+	}
+	const auto read = [this, vaddr, size] { m_texture_cache.ReadMemory(vaddr, size); };
+	if (m_gpu == nullptr) {
+		read();
+	} else {
+		m_gpu->SendCommandSync(read);
+	}
 }
 
 bool GpuResourceManager::IsMapped(uint64_t vaddr, uint64_t size) const noexcept {

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
@@ -34,6 +34,8 @@ public:
 	void               RunGarbageCollector();
 
 private:
+	void SynchronizeCpuImages(uint64_t vaddr, uint64_t size);
+
 	PageManager               m_page_manager;
 	CommandScheduler&         m_scheduler;
 	BufferCache               m_buffer_cache;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -425,6 +425,7 @@ void TextureCache::TrackImageTail(ImageId id) {
 
 void TextureCache::UntrackImage(ImageId id) {
 	auto& image = m_slot_images[id];
+	UntrackCpuRead(image);
 	if (!image.IsTracked()) {
 		return;
 	}
@@ -434,6 +435,14 @@ void TextureCache::UntrackImage(ImageId id) {
 	image.track_addr_end = 0;
 	if (size != 0) {
 		m_page_manager.UpdatePageWatchers<false>(address, size);
+	}
+}
+
+void TextureCache::UntrackCpuRead(Image& image) {
+	if (image.cpu_read_tracked) {
+		image.cpu_read_tracked = false;
+		m_page_manager.UpdatePageWatchers<false, true>(image.info.data.address,
+		                                               image.info.data.size);
 	}
 }
 
@@ -680,7 +689,7 @@ void TextureCache::CopyImage(ImageId destination_id, ImageId source_id) {
 		destination.CopyImageWithBuffer(source, copy_buffer);
 	}
 	if (source.IsGpuModified()) {
-		destination.MarkGpuModified();
+		CommitGpuWrite(destination);
 	}
 	destination.ClearBufferModified();
 }
@@ -696,7 +705,7 @@ void TextureCache::CopyImageMip(ImageId destination_id, ImageId source_id, uint3
 	}
 	destination.CopyMip(source, mip, layer);
 	if (source.IsGpuModified()) {
-		destination.MarkGpuModified();
+		CommitGpuWrite(destination);
 	}
 }
 
@@ -1385,6 +1394,7 @@ vk::ImageView TextureCache::FindTexture(ImageId id, const ImageDesc& desc) {
 	switch (desc.type) {
 		case BindingType::Texture: break;
 		case BindingType::Storage:
+			image.usage.storage = true;
 			if (!image.info.data.Empty()) {
 				if (!image.registered || image.depth_id) {
 					EXIT("TextureCache: cannot acquire an unavailable storage image\n");
@@ -1475,6 +1485,16 @@ void TextureCache::CommitGpuWrite(Image& image) {
 		image.RefreshComplete();
 	}
 	image.MarkGpuModified();
+	// Demand readback is bounded to supported, single-subresource linear storage images.
+	const auto& info = image.info;
+	if (!image.cpu_read_tracked && image.registered && image.usage.storage && !info.IsTiled() &&
+	    !info.IsDepth() && !info.IsBlock() && !info.HasMetadata() && !info.HasStencil() &&
+	    !info.IsVolume() && info.resources == ImageSubresources {1, 1} && info.data.Valid() &&
+	    info.data.size <= m_buffer_cache.GetUtilityBuffer(MemoryUsage::Download).Size() &&
+	    BuildDownload(image).valid) {
+		m_page_manager.UpdatePageWatchers<true, true>(info.data.address, info.data.size);
+		image.cpu_read_tracked = true;
+	}
 }
 
 bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t address, uint64_t size,
@@ -1776,6 +1796,49 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, uint64_t vaddr, uin
 	return true;
 }
 
+bool TextureCache::HasPendingCpuRead(uint64_t address, uint64_t size) {
+	std::scoped_lock lock {m_lock};
+	for (const auto id: FindImagesInRegion(address, size, true)) {
+		if (m_slot_images[id].cpu_read_tracked) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void TextureCache::ReadMemory(uint64_t address, uint64_t size) {
+	std::scoped_lock lock {m_lock};
+	// A fault can be in padding or a neighboring allocation sharing the host page.
+	// Resolve every image read owner of that page, not just byte-overlapping images.
+	for (const auto id: FindImagesInRegion(address, size, true)) {
+		auto& image = m_slot_images[id];
+		if (!image.cpu_read_tracked) {
+			continue;
+		}
+		const auto range = image.info.data;
+		for (const auto alias: FindImagesInRegion(range.address, range.size, false)) {
+			if (alias != id && m_slot_images[alias].IsGpuModified()) {
+				EXIT("TextureCache: ambiguous GPU image ownership during CPU readback\n");
+			}
+		}
+		if (!TryDownloadImage(id)) {
+			EXIT("TextureCache: CPU readback cannot resolve a protected image at 0x%016" PRIx64
+			     "\n",
+			     range.address);
+		}
+		const auto tick = m_scheduler.CurrentTick();
+		m_scheduler.Finish();
+		// GPU completion alone does not publish the deferred WriteBacking operation.
+		m_scheduler.WaitPriorityOperations(tick);
+		image.ClearGpuModified();
+		m_download_images.erase(id);
+		// Invalidate stale buffer mirrors after publishing the exact image range. The buffer
+		// tracker preserves disjoint GPU-owned bytes even when they share a host page.
+		m_buffer_cache.InvalidateMemory(range.address, range.size);
+		UntrackCpuRead(image);
+	}
+}
+
 bool TextureCache::TryDownloadImage(ImageId id) {
 	auto& image = m_slot_images[id];
 	if (image.depth_id) {
@@ -1832,6 +1895,7 @@ void TextureCache::InvalidateMemoryFromGPU(uint64_t address, uint64_t size) {
 		if (image.IsGpuModified()) {
 			image.ClearGpuModified();
 		}
+		UntrackCpuRead(image);
 		image.MarkBufferModified();
 	}
 }

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -59,6 +59,9 @@ public:
 	[[nodiscard]] bool ClearImageFromBuffer(CommandBuffer& command, uint64_t address, uint64_t size,
 	                                        uint32_t packed_clear);
 	void               InvalidateMemory(uint64_t address, uint64_t size);
+	[[nodiscard]] bool HasPendingCpuRead(uint64_t address, uint64_t size);
+	// GPU command lane only; publish image bytes before releasing CPU read protection.
+	void                     ReadMemory(uint64_t address, uint64_t size);
 	void               InvalidateMemoryFromGPU(uint64_t address, uint64_t size);
 	[[nodiscard]] bool IsRegionGpuModified(uint64_t address, uint64_t size);
 
@@ -113,6 +116,7 @@ private:
 	void                      TrackImageHead(ImageId id);
 	void                      TrackImageTail(ImageId id);
 	void                      UntrackImage(ImageId id);
+	void                             UntrackCpuRead(Image& image);
 	void                      UntrackImageHead(ImageId id);
 	void                      UntrackImageTail(ImageId id);
 	void                      MarkAsMaybeDirty(ImageId id, Image& image);

--- a/src/graphics/host_gpu/renderer/image/image.h
+++ b/src/graphics/host_gpu/renderer/image/image.h
@@ -143,6 +143,7 @@ public:
 	ImageUsage       usage;
 	ImageBinding     binding;
 	bool             registered     = false;
+	bool                         cpu_read_tracked = false;
 	mutable uint32_t query_epoch    = 0;
 	uint64_t         track_addr     = 0;
 	uint64_t         track_addr_end = 0;

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -44,7 +44,13 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
+#include <sys/uio.h>
 #include <unistd.h>
+#endif
+
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
 #endif
 
 namespace Libs::LibKernel::Memory {
@@ -963,6 +969,60 @@ bool TryReadPrtBacking(uint64_t vaddr, void* data, uint64_t size) {
 		return false;
 	}
 	return g_guest_address_space->TryReadSparseBacking(vaddr, data, size);
+}
+
+bool TryReadGpuUploadMemory(uint64_t vaddr, void* data, uint64_t size) {
+	if (data == nullptr || vaddr == 0 || size == 0 || UINT64_MAX - vaddr < size) {
+		return false;
+	}
+	// Keep the non-faulting alias path for GPU-protected direct and sparse memory.
+	if (TryReadBacking(vaddr, data, size) || TryReadPrtBacking(vaddr, data, size)) {
+		return true;
+	}
+	std::vector<VirtualRanges::Range> ranges;
+	if (g_virtual_ranges == nullptr || !g_virtual_ranges->QuerySpan(vaddr, size, &ranges)) {
+		return false;
+	}
+	for (const auto& range: ranges) {
+		auto* destination = static_cast<uint8_t*>(data) + (range.start - vaddr);
+		if (TryReadBacking(range.start, destination, range.size) ||
+		    TryReadPrtBacking(range.start, destination, range.size)) {
+			continue;
+		}
+		// Executable data, runtime allocations and stacks are committed guest memory,
+		// not direct-memory aliases. Never reinterpret reserved/unmapped holes as zeros.
+		if (!IsPrivateCommittedRangeType(range.type)) {
+			return false;
+		}
+		// A plain memcpy here could re-enter the GPU fault handler with cache locks held.
+		// Ask the OS to copy readable pages; NOACCESS/guard/unmapped pages must fail.
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+		SIZE_T copied = 0;
+		if (!ReadProcessMemory(GetCurrentProcess(), reinterpret_cast<const void*>(range.start),
+		                       destination, static_cast<SIZE_T>(range.size), &copied) ||
+		    copied != range.size) {
+			return false;
+		}
+#elif defined(__APPLE__)
+		mach_vm_size_t copied = 0;
+		if (mach_vm_read_overwrite(mach_task_self(), range.start, range.size,
+		                           reinterpret_cast<mach_vm_address_t>(destination),
+		                           &copied) != KERN_SUCCESS ||
+		    copied != range.size) {
+			return false;
+		}
+#elif KYTY_PLATFORM == KYTY_PLATFORM_LINUX
+		iovec local {destination, static_cast<size_t>(range.size)};
+		iovec remote {reinterpret_cast<void*>(range.start), static_cast<size_t>(range.size)};
+		if (process_vm_readv(getpid(), &local, 1, &remote, 1, 0) !=
+		    static_cast<ssize_t>(range.size)) {
+			return false;
+		}
+#else
+		return false;
+#endif
+	}
+	return true;
 }
 
 static bool SelfTestSub64SharedPlaceholderAlias() {

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -111,6 +111,9 @@ bool                   TryWriteBacking(uint64_t vaddr, const void* data, uint64_
 bool                   TryReadBacking(uint64_t vaddr, void* data, uint64_t size);
 bool                   TryReadGpuCleanBacking(uint64_t vaddr, void* data, uint64_t size);
 bool                   TryReadPrtBacking(uint64_t vaddr, void* data, uint64_t size);
+// GPU upload callback only: reads CPU-authored bytes without entering GPU fault handlers.
+// Not a general coherent CPU read; partial destination contents must be discarded on failure.
+bool                   TryReadGpuUploadMemory(uint64_t vaddr, void* data, uint64_t size);
 [[nodiscard]] uint64_t ClampRangeSize(uint64_t vaddr, uint64_t size);
 void                   WriteBacking(uint64_t vaddr, const void* data, uint64_t size) noexcept;
 void                   InvalidateMemory(uint64_t vaddr, uint64_t size);

--- a/tests/PageManagerTests.cpp
+++ b/tests/PageManagerTests.cpp
@@ -226,6 +226,30 @@ void TestCrossRegionRange() {
   Check(VirtualFree(memory, 0, MEM_RELEASE) != 0, "VirtualFree failed");
 }
 
+void TestSharedReadWatchers() {
+  PageManager manager;
+  const auto page = manager.GetPageSize();
+  auto *memory = Allocate(page * 2);
+  const auto base = reinterpret_cast<uint64_t>(memory);
+  manager.UpdatePageWatchers<true>(base, page * 2);
+  manager.UpdatePageWatchers<true, true>(base + 16, page);
+  manager.UpdatePageWatchers<true, true>(base + 64, 16);
+  Check(Protection(memory) == PAGE_NOACCESS &&
+            Protection(memory + page) == PAGE_NOACCESS,
+        "unaligned image range did not protect both pages");
+  manager.UpdatePageWatchers<false, true>(base + 16, page);
+  Check(Protection(memory) == PAGE_NOACCESS &&
+            Protection(memory + page) == PAGE_READONLY,
+        "one image released a shared read owner or a write watcher");
+  manager.UpdatePageWatchers<false, true>(base + 64, 16);
+  Check(Protection(memory) == PAGE_READONLY,
+        "last image read owner lost the remaining write watcher");
+  manager.UpdatePageWatchers<false>(base, page * 2);
+  Check(IsWritable(memory) && IsWritable(memory + page),
+        "shared read/write owners leaked protection");
+  Check(VirtualFree(memory, 0, MEM_RELEASE) != 0, "VirtualFree failed");
+}
+
 void TestBatchedWatcherRanges() {
   PageManager manager;
   const auto page_size = manager.GetPageSize();
@@ -504,8 +528,9 @@ void TestReadWriteWatcherInteractions() {
     const auto region_base = address & ~(TRACKER_REGION_SIZE - 1);
     const auto page = static_cast<size_t>((address - region_base) / page_size);
     mask.Set(page);
-    manager.UpdatePageWatchersForRegion<true, true>(region_base, mask);
-    manager.UpdatePageWatchersForRegion<true, true>(region_base, mask);
+    for (uint32_t count = 0; count < 256; ++count) {
+      manager.UpdatePageWatchersForRegion<true, true>(region_base, mask);
+    }
   } else if (std::strcmp(name, "write-overflow") == 0) {
     auto *memory = Allocate(page_size);
     const auto address = reinterpret_cast<uint64_t>(memory);
@@ -581,6 +606,7 @@ int main(int argc, char **argv) {
   }
   TestWatchAndUnwatch();
   TestSharedWatcherCounts();
+  TestSharedReadWatchers();
   TestCrossRegionRange();
   TestBatchedWatcherRanges();
   TestRegionMaskWatcherRanges();

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -149,6 +149,16 @@ static_assert(BlitHelper::ColorToMsDepthLayout ==
               vk::ImageLayout::eDepthStencilAttachmentOptimal);
 
 struct BufferCacheTestAccess {
+  static uint64_t StagingCapacity(BufferCache &cache) {
+    return cache.m_staging_buffer.Size();
+  }
+
+  static vk::Buffer UploadCopies(BufferCache &cache, Buffer &buffer,
+                                 std::span<vk::BufferCopy> copies,
+                                 uint64_t size) {
+    return cache.UploadCopies(buffer, copies, size);
+  }
+
   static_assert(std::same_as<decltype(BufferCache::m_slot_buffers),
                              Common::SlotVector<Buffer>>);
 
@@ -3426,6 +3436,286 @@ public:
                                   vk::ImageCreateFlagBits::e2DArrayCompatible),
             "2D slice views of a compatible 3D backing were rejected");
     std::printf("[host]    %-32s ok\n", name);
+  }
+
+  void CheckPrivateBufferUpload() {
+    constexpr const char *name = "PrivateBufferUpload";
+    constexpr uint64_t base = 0x207000000ull;
+    constexpr uint64_t bytes = 0x4000;
+    EnsureRuntimeContext();
+    Require(name, "code allocation",
+            LibKernel::Memory::AllocateProgramMemory(
+                base, bytes, Common::VirtualMemory::Mode::ReadWrite,
+                "upload-code") == base,
+            "code allocation failed");
+    Require(name, "runtime allocation",
+            LibKernel::Memory::AllocateRuntimeMemory(
+                base + bytes, bytes, Common::VirtualMemory::Mode::ReadWrite,
+                "upload-runtime", true) == base + bytes,
+            "adjacent runtime allocation failed");
+    int64_t direct_offset = -1;
+    Require(name, "direct allocation",
+            LibKernel::Memory::KernelAllocateDirectMemory(
+                0, LibKernel::Memory::KernelGetDirectMemorySize(), bytes, bytes,
+                0, &direct_offset) == 0,
+            "direct allocation failed");
+    void *direct = reinterpret_cast<void *>(base + bytes * 2);
+    Require(name, "direct mapping",
+            LibKernel::Memory::KernelMapDirectMemory(
+                &direct, bytes, 0x3, 0x10, direct_offset, bytes) == 0 &&
+                direct == reinterpret_cast<void *>(base + bytes * 2),
+            "adjacent direct map failed");
+    std::vector<uint32_t> expected(bytes * 3 / 4);
+    for (size_t i = 0; i < expected.size(); ++i)
+      expected[i] = 0xabc00000u + uint32_t(i);
+    std::memcpy(reinterpret_cast<void *>(base), expected.data(), bytes * 3);
+    LibKernel::Memory::SetProgramMemoryProtection(
+        base, bytes, Common::VirtualMemory::Mode::Read);
+    uint32_t probe = 0;
+    Require(name, "no backing alias",
+            !LibKernel::Memory::TryReadBacking(base, &probe, 4) &&
+                !LibKernel::Memory::TryReadPrtBacking(base, &probe, 4),
+            "test accidentally uses direct or PRT backing");
+    std::vector<uint32_t> observed(expected.size());
+    Require(name, "protect direct",
+            LibKernel::Memory::ProtectGuestHostMemory(
+                base + bytes * 2, bytes, Common::VirtualMemory::Mode::NoAccess),
+            "direct protection failed");
+    Require(name, "mixed private/protected alias",
+            LibKernel::Memory::TryReadGpuUploadMemory(base, observed.data(),
+                                                      bytes * 3) &&
+                observed == expected,
+            "mixed private/direct reads faulted or changed bytes");
+    Require(
+        name, "restore direct",
+        LibKernel::Memory::ProtectGuestHostMemory(
+            base + bytes * 2, bytes, Common::VirtualMemory::Mode::ReadWrite),
+        "direct restore failed");
+    Require(name, "protect private",
+            LibKernel::Memory::ProtectGuestHostMemory(
+                base + bytes, bytes, Common::VirtualMemory::Mode::NoAccess),
+            "private protection failed");
+    Require(name, "no recursive private fault",
+            !LibKernel::Memory::TryReadGpuUploadMemory(base + bytes, &probe, 4),
+            "protected private memory was read");
+    Require(name, "restore private",
+            LibKernel::Memory::ProtectGuestHostMemory(
+                base + bytes, bytes, Common::VirtualMemory::Mode::ReadWrite),
+            "private restore failed");
+    Require(
+        name, "unmapped rejected",
+        !LibKernel::Memory::TryReadGpuUploadMemory(base + bytes * 3, &probe, 4),
+        "unmapped memory was accepted");
+    {
+      RenderContext context(m_runtime_context);
+      context.InitializeGpu(nullptr);
+      auto &scheduler = context.GetCommandScheduler();
+      HW::Context registers{};
+      HW::UserConfig user_config{};
+      HW::Shader shaders{};
+      scheduler.Begin(registers, user_config, shaders);
+      auto &resources = context.GetGpuResources();
+      resources.MapMemory(base, bytes * 3);
+      auto &cache = resources.GetBufferCache();
+      const auto read = [&](vk::Buffer source, uint64_t offset,
+                            uint64_t count) {
+        auto output = CreateHostBuffer(name, count * 4,
+                                       vk::BufferUsageFlagBits::eTransferDst,
+                                       std::vector<uint32_t>(count));
+        vk::BufferCopy copy{offset, 0, count * 4};
+        scheduler.Current().Handle().copyBuffer(source, output.buffer, 1,
+                                                &copy);
+        vk::BufferMemoryBarrier barrier{};
+        barrier.srcAccessMask = vk::AccessFlagBits::eTransferWrite;
+        barrier.dstAccessMask = vk::AccessFlagBits::eHostRead;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.buffer = output.buffer;
+        barrier.size = count * 4;
+        scheduler.Current().Handle().pipelineBarrier(
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eHost, {}, 0, nullptr, 1, &barrier, 0,
+            nullptr);
+        scheduler.Finish();
+        auto result = ReadBuffer(name, output, count);
+        DestroyBuffer(&output);
+        return result;
+      };
+      // Exceeds the small-uniform fast path and crosses two private allocation
+      // kinds.
+      auto [buffer, offset] = cache.ObtainBuffer(base, bytes * 3, false, false);
+      Require(name, "staging upload",
+              read(buffer->Handle(), offset, expected.size()) == expected,
+              "private code/runtime bytes were not uploaded exactly");
+      // Oversize reservation forces the real temporary-buffer branch;
+      // only64bytes are copied.
+      std::array<vk::BufferCopy, 1> copies{
+          {{0, buffer->Offset(base + 32), 64}}};
+      auto temporary = BufferCacheTestAccess::UploadCopies(
+          cache, *buffer, copies,
+          BufferCacheTestAccess::StagingCapacity(cache) + 4);
+      Require(name, "temporary upload",
+              read(temporary, copies[0].srcOffset, 16) ==
+                  std::vector<uint32_t>(expected.begin() + 8,
+                                        expected.begin() + 24),
+              "temporary upload lost private memory bytes");
+      resources.UnmapMemory(base, bytes * 3);
+      scheduler.Finish();
+      context.ShutdownGpu();
+    }
+    Require(name, "free code", LibKernel::Memory::FreeGuestMemory(base, bytes),
+            "code free failed");
+    Require(name, "free runtime",
+            LibKernel::Memory::FreeGuestMemory(base + bytes, bytes),
+            "runtime free failed");
+    Require(name, "unmap direct",
+            LibKernel::Memory::KernelMunmap(base + bytes * 2, bytes) == 0,
+            "direct unmap failed");
+    Require(
+        name, "release direct",
+        LibKernel::Memory::KernelReleaseDirectMemory(direct_offset, bytes) == 0,
+        "direct release failed");
+    std::printf("[vulkan]  %-32s ok\n", name);
+  }
+
+  void CheckLinearImageCpuReadback() {
+    constexpr const char *name = "LinearImageCpuReadback";
+    constexpr uint64_t base = 0x206000000ull;
+    constexpr uint64_t bytes = 0x20000;
+    constexpr uint64_t pixels = base + 0x100;
+    EnsureRuntimeContext();
+    int64_t direct_offset = -1;
+    Require(name, "allocate",
+            LibKernel::Memory::KernelAllocateDirectMemory(
+                0, LibKernel::Memory::KernelGetDirectMemorySize(), bytes, bytes,
+                0, &direct_offset) == 0,
+            "direct allocation failed");
+    void *mapped = reinterpret_cast<void *>(base);
+    Require(name, "map",
+            LibKernel::Memory::KernelMapDirectMemory(
+                &mapped, bytes, 0x3, 0x10, direct_offset, bytes) == 0 &&
+                mapped == reinterpret_cast<void *>(base),
+            "fixed mapping failed");
+    std::memset(mapped, 0x5a, bytes);
+    {
+      RenderContext context(m_runtime_context);
+      context.InitializeGpu(nullptr);
+      auto &scheduler = context.GetCommandScheduler();
+      HW::Context registers{};
+      HW::UserConfig user_config{};
+      HW::Shader shaders{};
+      scheduler.Begin(registers, user_config, shaders);
+      auto &resources = context.GetGpuResources();
+      resources.MapMemory(base, bytes);
+      auto &cache = resources.GetTextureCache();
+      TextureCacheTestAccess::SetLinearReadback(cache, false);
+      const auto create = [&](uint64_t address, uint32_t width, uint32_t height,
+                              uint64_t size) {
+        TextureCache::ImageDesc desc{};
+        desc.type = TextureCache::BindingType::Storage;
+        desc.info.data = {address, size};
+        desc.info.pixel_format = vk::Format::eR32G32B32A32Sfloat;
+        desc.info.guest_format = Prospero::BufferFormat::k32_32_32_32Float;
+        desc.info.extent = {width, height, 1};
+        desc.info.pitch = width;
+        desc.info.bytes_per_block = 16;
+        desc.info.mip_layout[0] = {0, size, width, height};
+        desc.view_info.format = desc.info.pixel_format;
+        desc.view_info.usage = vk::ImageUsageFlagBits::eStorage;
+        const auto id = cache.FindImage(desc);
+        (void)cache.FindTexture(id, desc);
+        return id;
+      };
+      const auto large = create(pixels, 64, 64, 65536);
+      const auto small_image = create(base + 0x40, 1, 1, 32);
+      const std::array<float, 4> color{1, .179931640625f, .18994140625f,
+                                       .219970703125f};
+      const auto clear = [&](ImageId id, const std::array<float, 4> &value) {
+        auto &image = cache.GetImage(id);
+        image.Transit(vk::ImageLayout::eTransferDstOptimal,
+                      vk::AccessFlagBits2::eTransferWrite, {},
+                      scheduler.Current().Handle());
+        const vk::ClearColorValue native(value);
+        const vk::ImageSubresourceRange range{vk::ImageAspectFlagBits::eColor,
+                                              0, 1, 0, 1};
+        scheduler.Current().Handle().clearColorImage(
+            image.backing.image, vk::ImageLayout::eTransferDstOptimal, &native,
+            1, &range);
+        cache.MarkGpuWritten(id);
+      };
+      clear(large, color);
+      clear(small_image, color);
+      auto [neighbor, neighbor_offset] =
+          resources.GetBufferCache().ObtainBuffer(base + 0x80, 4, true, true);
+      neighbor->Fill(neighbor_offset, 4, 0x12345678);
+      Require(name, "demand only",
+              cache.HasPendingCpuRead(base, 1) &&
+                  !TextureCacheTestAccess::PendingDownload(cache, large),
+              "read tracking requires the global eager readback option");
+      std::array<float, 4> before{};
+      LibKernel::Memory::TryReadBacking(pixels, before.data(), sizeof(before));
+      Require(name, "unpublished before fault", before != color,
+              "test did not retain stale CPU bytes before the fault");
+      // Fault outside either image, but on their shared head page.
+      Require(name, "read fault",
+              resources.HandleFault(PageFaultAccess::Read, base),
+              "shared-page read fault was not handled");
+      std::vector<std::array<float, 4>> values(4096);
+      LibKernel::Memory::TryReadBacking(pixels, values.data(), 65536);
+      std::array<float, 4> small_value{};
+      LibKernel::Memory::TryReadBacking(base + 0x40, small_value.data(),
+                                        sizeof(small_value));
+      Require(name, "completed publication",
+              small_value == color &&
+                  std::all_of(values.begin(), values.end(),
+                              [&](const auto &v) { return v == color; }) &&
+                  !cache.HasPendingCpuRead(pixels, 65536),
+              "CPU resumed before all finite GPU colors were published");
+      std::array<uint8_t, 16> padding{};
+      LibKernel::Memory::TryReadBacking(base + 0x50, padding.data(),
+                                        padding.size());
+      Require(name, "padding",
+              std::all_of(padding.begin(), padding.end(),
+                          [](uint8_t b) { return b == 0x5a; }) &&
+                  *reinterpret_cast<volatile uint8_t *>(base) == 0x5a &&
+                  *reinterpret_cast<volatile uint32_t *>(base + 0x80) ==
+                      0x12345678,
+              "readback overwrote padding or kept a shared page inaccessible");
+      // Re-arm on a later GPU write, then perform a partial CPU write.
+      const std::array<float, 4> next{1, .25f, .5f, .75f};
+      clear(large, next);
+      Require(name, "write fault",
+              resources.HandleFault(PageFaultAccess::Write, pixels + 4),
+              "partial CPU write fault was not handled");
+      *reinterpret_cast<volatile float *>(pixels + 4) = .125f;
+      std::array<float, 4> modified{};
+      LibKernel::Memory::TryReadBacking(pixels, modified.data(),
+                                        sizeof(modified));
+      Require(name, "partial write preservation",
+              modified == std::array<float, 4>{1, .125f, .5f, .75f},
+              "partial CPU write lost the other GPU-produced channels");
+      // Reacquiring uploads that CPU write and arms read tracking exactly once.
+      const auto again = create(pixels, 64, 64, 65536);
+      Require(name, "same owner", again == large,
+              "reacquisition replaced the owner");
+      Require(name, "repeat read",
+              resources.HandleFault(PageFaultAccess::Read, pixels),
+              "reacquired storage read failed");
+      LibKernel::Memory::TryReadBacking(pixels, before.data(), sizeof(before));
+      Require(name, "CPU upload preserved", before == modified,
+              "reacquisition restored stale buffer mirror contents");
+      clear(small_image, next);
+      resources.UnmapMemory(base, bytes);
+      scheduler.Finish();
+      context.ShutdownGpu();
+    }
+    Require(name, "unmap", LibKernel::Memory::KernelMunmap(base, bytes) == 0,
+            "unmap failed");
+    Require(
+        name, "release",
+        LibKernel::Memory::KernelReleaseDirectMemory(direct_offset, bytes) == 0,
+        "release failed");
+    std::printf("[vulkan]  %-32s ok\n", name);
   }
 
   void CheckBufferCacheDirtyGarbageCollection() {
@@ -28266,6 +28556,16 @@ int main(int argc, char **argv) {
   if (argc == 2 && std::strcmp(argv[1], "--host-image-allocation-only") == 0) {
     VulkanHarness vulkan;
     vulkan.CheckHostImageAllocation();
+    return 0;
+  }
+  if (argc == 2 && std::strcmp(argv[1], "--image-cpu-readback-only") == 0) {
+    VulkanHarness vulkan;
+    vulkan.CheckLinearImageCpuReadback();
+    return 0;
+  }
+  if (argc == 2 && std::strcmp(argv[1], "--private-buffer-upload-only") == 0) {
+    VulkanHarness vulkan;
+    vulkan.CheckPrivateBufferUpload();
     return 0;
   }
   if (argc == 2 && std::strcmp(argv[1], "--occlusion-dump-only") == 0) {


### PR DESCRIPTION
**Problem.** A linear image the GPU has written is not visible to the guest CPU until its contents are downloaded to the backing. The page-fault path published GPU-modified *buffers* but not linear storage images, so a title that writes a linear storage image on the GPU and then reads it on the CPU observed whatever the backing happened to hold — stale bytes, or never-written ones.

**Change.** Track linear storage images the GPU has modified, and publish them to their backing before the CPU is allowed to observe the page, through the same fault path that already publishes buffers. The page manager learns to ask the resource manager for an image publication, and the texture cache performs the download.

**Effect.** CPU reads of a GPU-written linear storage image return the written contents. No performance change was measured, and none is claimed; the publication happens on the faulting path, so it costs a download only when the CPU actually touches such an image.

**Verification.** Device-backed coverage included and passing:
- `LinearImageCpuReadback` — writes a linear image on the GPU, then reads it back on the CPU through the guest path and compares.
- `PrivateBufferUpload` — covers the buffer path that the same publication mechanism uses.
- `HostImageAllocation` and the existing `PageManagerTests` still pass.
Full `ShaderRecompilerComputeTests` and `PageManagerTests` suites pass.

**Limitations.**
- Covers linear storage images. Tiled images are not published by this path, since the CPU cannot interpret their layout directly.
- The tests exercise a written-then-read sequence on one image; they do not cover concurrent GPU writes racing a CPU read, which remains ordered by the fault only.

**References**

No external specification. Correctness argument only: a GPU write to a linear image lands in device memory, and the guest's view of that memory is the backing, so the CPU's first observation of the page must be preceded by a download — the same invariant the buffer path already maintains.
