### PR TITLE
graphics: support deferred DCC clears beyond 32 slices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,6 +577,8 @@ if(BUILD_TESTING)
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --depth-readback-only)
 	add_test(NAME compute_meta_clear_classification
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --compute-meta-clear-only)
+	add_test(NAME texture_cache_dcc_slice_range
+		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --dcc-slice-range-only)
 	add_test(NAME buffer_cache_dirty_gc
 		COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --buffer-cache-gc-only)
 

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -5,6 +5,7 @@
 #include "common/logging/log.h"
 #include "common/profiler.h"
 #include "graphics/guest_gpu/gpu_format.h"
+#include "graphics/guest_gpu/pm4.h"
 #include "graphics/guest_gpu/tile.h"
 #include "graphics/host_gpu/graphicContext.h"
 #include "graphics/host_gpu/renderer/cache/bufferCache.h"
@@ -31,6 +32,19 @@ namespace Libs::Graphics {
 namespace {
 
 constexpr uint64_t NumFramesBeforeRemoval = 32;
+
+// A full metadata fill covers every slice the guest can address. CB_COLOR_VIEW and DB_DEPTH_VIEW
+// both encode slice indices in 13 bits, so derive the capacity from the register field rather than
+// from any host integer width.
+constexpr uint64_t MetaSliceCapacity = static_cast<uint64_t>(Pm4::CB_COLOR0_VIEW_SLICE_MAX_MASK) + 1;
+// Pending ranges are bounded by the capacity and are narrowed to the 32-bit baseArrayLayer and
+// layerCount fields of vk::ImageSubresourceRange when a run is materialized.
+static_assert(MetaSliceCapacity <= std::numeric_limits<uint32_t>::max());
+
+// HTile pending state is still consumed one slice at a time at the depth binding, which checks only
+// the view's base layer. Arming the same 32 slices it armed before keeps depth behaviour unchanged;
+// widening it belongs with the separate multi-layer depth fix, not with this colour-DCC change.
+constexpr uint64_t LegacyNonDccSliceCapacity = 32;
 
 [[nodiscard]] bool DecodeDccClear(const TextureCache::ImageDesc& desc, vk::Format format,
                                   uint32_t fill, vk::ClearColorValue& clear) {
@@ -1152,7 +1166,7 @@ void TextureCache::PrepareDccClear(ImageId id, const ImageDesc& desc) {
 	} else if (metadata.type != MetaDataInfo::Type::Dcc) {
 		EXIT("TextureCache: image reuses non-DCC metadata\n");
 	}
-	if (metadata.clear_mask == 0 || image.info.resources.levels != 1 ||
+	if (!metadata.AnyPending() || image.info.resources.levels != 1 ||
 	    desc.info.metadata.range.size == 0 || metadata.fill_size < desc.info.metadata.range.size) {
 		return;
 	}
@@ -1165,26 +1179,31 @@ void TextureCache::PrepareDccClear(ImageId id, const ImageDesc& desc) {
 	const auto  first          = volume_texture ? 0u : view.base_layer;
 	const auto  count = volume_texture ? std::max(image.info.extent.depth >> view.base_level, 1u)
 	                                   : view.layer_count;
-	if (first >= 32 || count > 32 - first) {
+	// Check count against the capacity before subtracting, so an out-of-range view cannot wrap the
+	// bound and reach ForEachIntersection with a range the pending state can never describe.
+	if (count == 0 || count > MetaSliceCapacity || first > MetaSliceCapacity - count) {
 		return;
 	}
+	// Collect the pending runs before touching anything: ClearImage and the state update below both
+	// mutate structures that the traversal would otherwise be walking.
+	std::vector<RangeSet::Range> pending;
+	metadata.pending_clear.ForEachIntersection(
+	    first, count, [&pending](RangeSet::Range range) { pending.push_back(range); });
 	// The metadata fill covers the complete allocation. Consume each layer only after its
 	// native image contents exist; already materialized layers may have been rendered since.
-	for (uint32_t layer = first; layer < first + count;) {
-		if ((metadata.clear_mask & (1u << layer)) == 0) {
-			layer++;
-			continue;
-		}
-		const auto start = layer;
-		uint32_t   mask  = 0;
-		do {
-			mask |= 1u << layer++;
-		} while (layer < first + count && (metadata.clear_mask & (1u << layer)) != 0);
+	const auto metadata_address = desc.info.metadata.range.address;
+	for (const auto& range: pending) {
 		ClearImage(m_scheduler.Current(), id,
-		           {vk::ImageAspectFlagBits::eColor, view.base_level, view.level_count, start,
-		            layer - start},
+		           {vk::ImageAspectFlagBits::eColor, view.base_level, view.level_count,
+		            static_cast<uint32_t>(range.address), static_cast<uint32_t>(range.size)},
 		           clear);
-		metadata.clear_mask &= ~mask;
+		// ClearImage can retire images, and retiring an image that shares this metadata allocation
+		// erases the entry, so re-resolve it instead of holding a reference across the clear.
+		const auto current = m_surface_metas.find(metadata_address);
+		if (current == m_surface_metas.end() || current->second.type != MetaDataInfo::Type::Dcc) {
+			return;
+		}
+		current->second.pending_clear.Subtract(range.address, range.size);
 	}
 }
 
@@ -1436,15 +1455,17 @@ vk::ImageView TextureCache::FindDepthTarget(ImageId id, const ImageDesc& desc) {
 	RefreshImage(id);
 	if (desc.info.HasMetadata()) {
 		image.info.metadata = desc.info.metadata;
-		auto [metadata, inserted] =
-		    m_surface_metas.try_emplace(desc.info.metadata.range.address,
-		                                MetaDataInfo {.type       = MetaDataInfo::Type::HTile,
-		                                              .clear_mask = image.info.htile_clear_mask});
-		if (!inserted && metadata->second.type != MetaDataInfo::Type::HTile) {
-			// PS5 allocations can reuse DCC storage as HTile while the old color image is cached.
-			// The depth binding defines the new type; incompatible fill state cannot carry over.
-			metadata->second = {.type       = MetaDataInfo::Type::HTile,
-			                    .clear_mask = image.info.htile_clear_mask};
+		// htile_clear_mask only ever carries "everything pending" or "nothing pending" at this
+		// handoff, so it maps onto the range set as a whole-state flag.
+		auto [metadata, inserted] = m_surface_metas.try_emplace(
+		    desc.info.metadata.range.address, MetaDataInfo {.type = MetaDataInfo::Type::HTile});
+		// PS5 allocations can reuse DCC storage as HTile while the old color image is cached.
+		// The depth binding defines the new type; incompatible fill state cannot carry over.
+		if (inserted || metadata->second.type != MetaDataInfo::Type::HTile) {
+			metadata->second = MetaDataInfo {.type = MetaDataInfo::Type::HTile};
+			if (image.info.htile_clear_mask != 0) {
+				metadata->second.ArmSlices(LegacyNonDccSliceCapacity);
+			}
 		}
 	}
 	CommitGpuWrite(image);
@@ -1885,13 +1906,13 @@ bool TextureCache::IsMetaCleared(uint64_t address, uint32_t slice, uint32_t* fil
 	std::scoped_lock lock {m_lock};
 	const auto       found = m_surface_metas.find(address);
 	if (found == m_surface_metas.end() || found->second.type == MetaDataInfo::Type::PendingDcc ||
-	    slice >= 32) {
+	    slice >= MetaSliceCapacity) {
 		return false;
 	}
 	if (fill_value != nullptr) {
 		*fill_value = found->second.fill_value;
 	}
-	return (found->second.clear_mask & (1u << slice)) != 0;
+	return found->second.IsPending(slice);
 }
 
 bool TextureCache::ClearMeta(uint64_t address) {
@@ -1903,7 +1924,7 @@ bool TextureCache::ClearMeta(uint64_t address) {
 		// validated fill value, so an arbitrary compute write must not clear it.
 		return false;
 	}
-	found->second.clear_mask = UINT32_MAX;
+	found->second.ArmSlices(LegacyNonDccSliceCapacity);
 	return true;
 }
 
@@ -1913,18 +1934,18 @@ void TextureCache::TrackDccFill(uint64_t address, uint64_t size, uint32_t fill_v
 	}
 	// DCC fills use a repeated byte code. Require all four bytes of the detected dword to agree,
 	// and mark only recognized deferred-clear encodings as logically clear.
-	const auto dcc_clear_mask = [fill_value] {
+	const bool dcc_clears_all = [fill_value] {
 		const auto code = static_cast<uint8_t>(fill_value);
 		if (fill_value != static_cast<uint32_t>(code) * 0x01010101u) {
-			return 0u;
+			return false;
 		}
 		switch (code) {
 			case 0x00:
 			case 0x20:
 			case 0x40:
 			case 0x80:
-			case 0xc0: return UINT32_MAX;
-			default: return 0u;
+			case 0xc0: return true;
+			default: return false;
 		}
 	}();
 	std::scoped_lock lock {m_lock};
@@ -1933,7 +1954,12 @@ void TextureCache::TrackDccFill(uint64_t address, uint64_t size, uint32_t fill_v
 	const auto found = m_surface_metas.try_emplace(address).first;
 	if (found->second.type == MetaDataInfo::Type::PendingDcc ||
 	    found->second.type == MetaDataInfo::Type::Dcc) {
-		found->second.clear_mask = dcc_clear_mask;
+		// A fill covers the whole allocation, so every addressable slice becomes pending again.
+		if (dcc_clears_all) {
+			found->second.ArmSlices(MetaSliceCapacity);
+		} else {
+			found->second.DisarmSlices();
+		}
 		found->second.fill_value = fill_value;
 		found->second.fill_size  = size;
 	}
@@ -1943,13 +1969,13 @@ bool TextureCache::TouchMeta(uint64_t address, uint32_t slice, bool is_clear) {
 	std::scoped_lock lock {m_lock};
 	const auto       found = m_surface_metas.find(address);
 	if (found == m_surface_metas.end() || found->second.type == MetaDataInfo::Type::PendingDcc ||
-	    slice >= 32) {
+	    slice >= MetaSliceCapacity) {
 		return false;
 	}
 	if (is_clear) {
-		found->second.clear_mask |= 1u << slice;
+		found->second.pending_clear.Add(slice, 1);
 	} else {
-		found->second.clear_mask &= ~(1u << slice);
+		found->second.pending_clear.Subtract(slice, 1);
 	}
 	return true;
 }

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -6,6 +6,7 @@
 #include "common/lruCache.h"
 #include "common/slotVector.h"
 #include "graphics/host_gpu/pageManager.h"
+#include "graphics/host_gpu/rangeSet.h"
 #include "graphics/host_gpu/regionManager.h"
 #include "graphics/host_gpu/renderer/cache/multiLevelPageTable.h"
 #include "graphics/host_gpu/renderer/image/blitHelper.h"
@@ -87,10 +88,26 @@ private:
 		// registered beside HTile and DCC without introducing parallel tracking paths.
 		enum class Type : uint8_t { PendingDcc, CMask, FMask, HTile, Dcc };
 
+		// Slices still awaiting materialization, as absolute slice indices in half-open ranges.
+		// A range set rather than a bitmask: the guest encodes 13-bit slice indices, so volumetric
+		// render targets legitimately exceed any fixed-width mask, and consumption is naturally
+		// expressed as "remove the contiguous runs that were just cleared".
 		Type     type       = Type::PendingDcc;
-		uint32_t clear_mask = 0;
+		RangeSet pending_clear;
 		uint32_t fill_value = 0xffffffffu;
 		uint64_t fill_size  = 0;
+
+		void ArmSlices(uint64_t capacity) {
+			pending_clear.Clear();
+			if (capacity != 0) {
+				pending_clear.Add(0, capacity);
+			}
+		}
+		void DisarmSlices() { pending_clear.Clear(); }
+		[[nodiscard]] bool AnyPending() const { return !pending_clear.Empty(); }
+		[[nodiscard]] bool IsPending(uint32_t slice) const {
+			return pending_clear.Contains(slice, 1);
+		}
 	};
 
 	struct OverlapResult {

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -372,10 +372,25 @@ struct TextureCacheTestAccess {
     std::lock_guard lock(cache.m_lock);
     auto &metadata = cache.m_surface_metas[address];
     metadata.type = TextureCache::MetaDataInfo::Type::HTile;
-    metadata.clear_mask = 0;
+    metadata.DisarmSlices();
   }
 
   static TileManager &Tiler(TextureCache &cache) { return cache.m_tiler; }
+
+  // Stands in for "the guest rendered into these slices since the clear was
+  // materialised", so a later bind must not clear them again.
+  static void PaintSlices(TextureCache &cache, CommandBuffer &command, ImageId id,
+                          uint32_t base_slice, uint32_t slice_count,
+                          const std::array<float, 4> &color) {
+    std::lock_guard lock(cache.m_lock);
+    auto &image = cache.m_slot_images[id];
+    vk::ClearValue clear{};
+    clear.color.float32 = color;
+    cache.ClearImage(command, id,
+                     {vk::ImageAspectFlagBits::eColor, 0,
+                      image.info.resources.levels, base_slice, slice_count},
+                     clear);
+  }
 };
 
 struct RenderExecutorTestAccess {
@@ -8313,6 +8328,247 @@ public:
     auto result = ReadBuffer(name, probe, bytes / 4);
     DestroyBuffer(&probe);
     return result;
+  }
+
+  // Drives one DCC-backed volume colour target through the production bind path
+  // (ResolveRenderColorTarget -> FindRenderTarget -> PrepareDccClear -> ClearImage)
+  // and hands the live context to the case body.
+  template <typename Body>
+  void RunDccVolumeCase(const char *name, uintptr_t base, uint32_t width_minus1,
+                        uint32_t height_minus1, uint32_t depth_minus1,
+                        Body &&body) {
+    constexpr uint64_t color_size = 0x1000000;
+    constexpr uint64_t metadata_size = 0x100000;
+    constexpr uint64_t allocation_size = color_size + metadata_size;
+    constexpr uint64_t allocation_alignment = 0x10000;
+    const uint64_t dcc_address = base + color_size;
+
+    int64_t direct_offset = -1;
+    Require(name, "direct allocation",
+            Libs::LibKernel::Memory::KernelAllocateDirectMemory(
+                0, Libs::LibKernel::Memory::KernelGetDirectMemorySize(),
+                allocation_size, allocation_alignment, 0, &direct_offset) == 0,
+            "DCC slice-range direct-memory allocation failed");
+    void *mapped = reinterpret_cast<void *>(base);
+    Require(name, "direct mapping",
+            Libs::LibKernel::Memory::KernelMapDirectMemory(
+                &mapped, allocation_size, 0x3, 0x10, direct_offset,
+                allocation_alignment) == 0 &&
+                mapped == reinterpret_cast<void *>(base),
+            "DCC slice-range direct mapping failed");
+    std::memset(mapped, 0, allocation_size);
+
+    {
+      RenderContext context(m_runtime_context);
+      auto &scheduler = context.GetCommandScheduler();
+      HW::Context registers{};
+      HW::UserConfig user_config{};
+      HW::Shader shaders{};
+      registers.SetColorBase(0, {.addr = base});
+      registers.SetColorInfo(
+          0, {.dcc_compression_enable = true,
+              .format = Prospero::ChannelLayout::k16_16_16_16,
+              .channel_type = Prospero::ChannelType::kFloat,
+              .channel_order = Prospero::ChannelOrder::kStandard});
+      registers.SetColorAttrib2(0, {.height = height_minus1, .width = width_minus1});
+      registers.SetColorAttrib3(0,
+                                {.depth = depth_minus1,
+                                 .tile_mode = Prospero::TileMode::kRenderTarget,
+                                 .dimension = 2,
+                                 .metadata_pipe_aligned = true});
+      registers.SetColorDccAddr(0, {.addr = dcc_address});
+      registers.SetColorClearWord0(0, {.word0 = 0});
+      registers.SetColorClearWord1(0, {.word1 = 0});
+      registers.SetRenderTargetMask(0x0f);
+      scheduler.Begin(registers, user_config, shaders);
+
+      auto &resources = context.GetGpuResources();
+      resources.MapMemory(base, allocation_size);
+      body(context, registers, dcc_address, metadata_size);
+      RenderExecutorTestAccess::ResetBindings(context.GetRenderExecutor());
+      resources.UnmapMemory(base, allocation_size);
+      scheduler.Finish();
+    }
+
+    Require(name, "unmap direct backing",
+            Libs::LibKernel::Memory::KernelMunmap(base, allocation_size) == 0,
+            "DCC slice-range direct mapping release failed");
+    Require(name, "release direct backing",
+            Libs::LibKernel::Memory::KernelReleaseDirectMemory(
+                direct_offset, allocation_size) == 0,
+            "DCC slice-range direct-memory allocation release failed");
+  }
+
+  // Deferred DCC colour clears must cover every slice the guest can address. Kena's volumetric
+  // light-injection target is a 140x79x64 RGBA16F volume; its per-frame DCC fast clear was dropped
+  // whenever the slice range did not fit a 32-bit mask, so stale radiance survived into the next
+  // frame's additive light injection.
+  void CheckDccClearSliceRanges() {
+    constexpr const char *name = "DccClearSliceRanges";
+    // (0,0,0,1), decoded from DCC clear code 0x40 on an RGBA16F kStandard target.
+    const std::vector<u32> cleared{0x00000000u, 0x3c000000u};
+    // Distinctive non-zero contents so zero-initialised memory cannot pass for a clear.
+    constexpr std::array<float, 4> paint{0.5f, 0.25f, 0.75f, 0.125f};
+    const std::vector<u32> painted{0x34003800u, 0x30003a00u};
+    constexpr std::array<float, 4> repaint{0.25f, 0.5f, 0.125f, 0.75f};
+    const std::vector<u32> repainted{0x38003400u, 0x3a003000u};
+    EnsureRuntimeContext();
+
+    const auto arm_and_bind = [&](RenderContext &context, HW::Context &registers,
+                                  uint64_t dcc_address, uint32_t first,
+                                  uint32_t last) {
+      auto &executor = context.GetRenderExecutor();
+      auto &texture_cache = context.GetGpuResources().GetTextureCache();
+      RenderExecutorTestAccess::ResetBindings(executor);
+      registers.SetColorView(
+          0, {.base_array_slice_index = first, .last_array_slice_index = last});
+      RenderColorInfo color{};
+      RenderExecutorTestAccess::ResolveRenderColorTarget(
+          executor, context.GetCommandScheduler().Current(), color, 0);
+      Require(name, "resolved slices",
+              color.image_id &&
+                  color.desc.info.metadata.kind == ImageMetadataKind::Dcc &&
+                  color.desc.info.metadata.range.address == dcc_address &&
+                  color.desc.view_info.base_layer == first &&
+                  color.desc.view_info.layer_count == last - first + 1,
+              "the volume colour target did not resolve the requested slice range");
+      // The DCC allocation sits immediately after the colour image, so metadata must not overlap
+      // image storage if a tiling or layout change ever grows the resolved size.
+      Require(name, "colour storage fits its reservation",
+              color.desc.info.data.size <= dcc_address - color.desc.info.data.address,
+              "the resolved colour image is larger than the space reserved before its metadata");
+      const auto attachment =
+          texture_cache.FindRenderTarget(color.image_id, color.desc);
+      Require(name, "bind slices", attachment != nullptr,
+              "the volume colour target did not produce an attachment view");
+      return color.image_id;
+    };
+
+    // T1 - the Kena shape: a full 64-slice view must clear every slice, including above 31.
+    RunDccVolumeCase(name, 0x0000000210000000ull, 139, 78, 63,
+                     [&](RenderContext &context, HW::Context &registers,
+                         uint64_t dcc_address, uint64_t fill_size) {
+      auto &texture_cache = context.GetGpuResources().GetTextureCache();
+      const auto id = arm_and_bind(context, registers, dcc_address, 0, 63);
+      TextureCacheTestAccess::PaintSlices(
+          texture_cache, context.GetCommandScheduler().Current(), id, 0, 64, paint);
+      texture_cache.TrackDccFill(dcc_address, fill_size, 0x40404040u);
+      Require(name, "T1 armed",
+              texture_cache.IsMetaCleared(dcc_address, 0) &&
+                  texture_cache.IsMetaCleared(dcc_address, 31) &&
+                  texture_cache.IsMetaCleared(dcc_address, 32) &&
+                  texture_cache.IsMetaCleared(dcc_address, 63),
+              "a full DCC fill did not arm every slice of a 64-slice target");
+      arm_and_bind(context, registers, dcc_address, 0, 63);
+      Require(name, "T1 consumed",
+              !texture_cache.IsMetaCleared(dcc_address, 0) &&
+                  !texture_cache.IsMetaCleared(dcc_address, 31) &&
+                  !texture_cache.IsMetaCleared(dcc_address, 32) &&
+                  !texture_cache.IsMetaCleared(dcc_address, 63),
+              "materialising a 64-slice view left pending clear state behind");
+      Require(name, "T1 texels",
+              ReadCachedTexel(name, context, id, {0, 0, 0}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 31}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 32}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 63}) == cleared,
+              "a 64-slice DCC clear did not reach every slice");
+    });
+
+    // T2 - a view entirely above slice 31 must clear exactly itself.
+    RunDccVolumeCase(name, 0x0000000212000000ull, 139, 78, 63,
+                     [&](RenderContext &context, HW::Context &registers,
+                         uint64_t dcc_address, uint64_t fill_size) {
+      auto &texture_cache = context.GetGpuResources().GetTextureCache();
+      const auto id = arm_and_bind(context, registers, dcc_address, 0, 63);
+      TextureCacheTestAccess::PaintSlices(
+          texture_cache, context.GetCommandScheduler().Current(), id, 0, 64, paint);
+      texture_cache.TrackDccFill(dcc_address, fill_size, 0x40404040u);
+      Require(name, "T2 armed", texture_cache.IsMetaCleared(dcc_address, 40),
+              "a full DCC fill did not arm a slice above 31");
+      arm_and_bind(context, registers, dcc_address, 40, 55);
+      Require(name, "T2 consumed range only",
+              !texture_cache.IsMetaCleared(dcc_address, 40) &&
+                  !texture_cache.IsMetaCleared(dcc_address, 55) &&
+                  texture_cache.IsMetaCleared(dcc_address, 39) &&
+                  texture_cache.IsMetaCleared(dcc_address, 56) &&
+                  texture_cache.IsMetaCleared(dcc_address, 0) &&
+                  texture_cache.IsMetaCleared(dcc_address, 63),
+              "a base_layer>=32 view consumed the wrong pending slices");
+      Require(name, "T2 texels",
+              ReadCachedTexel(name, context, id, {0, 0, 40}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 55}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 39}) == painted &&
+                  ReadCachedTexel(name, context, id, {0, 0, 56}) == painted,
+              "a base_layer>=32 view cleared slices outside itself");
+    });
+
+    // T3 - slices already materialised may have been rendered into, so a wider view that crosses
+    // slice 32 must clear only the part still pending.
+    RunDccVolumeCase(name, 0x0000000214000000ull, 139, 78, 63,
+                     [&](RenderContext &context, HW::Context &registers,
+                         uint64_t dcc_address, uint64_t fill_size) {
+      auto &texture_cache = context.GetGpuResources().GetTextureCache();
+      const auto id = arm_and_bind(context, registers, dcc_address, 0, 63);
+      TextureCacheTestAccess::PaintSlices(
+          texture_cache, context.GetCommandScheduler().Current(), id, 0, 64, paint);
+      texture_cache.TrackDccFill(dcc_address, fill_size, 0x40404040u);
+      arm_and_bind(context, registers, dcc_address, 20, 25);
+      Require(name, "T3 first range consumed",
+              !texture_cache.IsMetaCleared(dcc_address, 20) &&
+                  !texture_cache.IsMetaCleared(dcc_address, 25) &&
+                  texture_cache.IsMetaCleared(dcc_address, 26),
+              "the first partial materialisation consumed the wrong slices");
+      // Stand in for the guest rendering into the slices it just had cleared.
+      TextureCacheTestAccess::PaintSlices(
+          texture_cache, context.GetCommandScheduler().Current(), id, 20, 6, repaint);
+      arm_and_bind(context, registers, dcc_address, 20, 45);
+      Require(name, "T3 widened range consumed",
+              !texture_cache.IsMetaCleared(dcc_address, 26) &&
+                  !texture_cache.IsMetaCleared(dcc_address, 45) &&
+                  texture_cache.IsMetaCleared(dcc_address, 46),
+              "widening the view did not consume the remaining pending slices");
+      Require(name, "T3 texels",
+              ReadCachedTexel(name, context, id, {0, 0, 20}) == repainted &&
+                  ReadCachedTexel(name, context, id, {0, 0, 25}) == repainted &&
+                  ReadCachedTexel(name, context, id, {0, 0, 26}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 45}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 19}) == painted &&
+                  ReadCachedTexel(name, context, id, {0, 0, 46}) == painted,
+              "an overlapping view re-cleared slices that had been rendered into");
+    });
+
+    // T4 - more than 64 slices, so a wider fixed-width mask is not a general fix either.
+    RunDccVolumeCase(name, 0x0000000216000000ull, 7, 7, 127,
+                     [&](RenderContext &context, HW::Context &registers,
+                         uint64_t dcc_address, uint64_t fill_size) {
+      auto &texture_cache = context.GetGpuResources().GetTextureCache();
+      const auto id = arm_and_bind(context, registers, dcc_address, 0, 127);
+      TextureCacheTestAccess::PaintSlices(
+          texture_cache, context.GetCommandScheduler().Current(), id, 0, 128, paint);
+      texture_cache.TrackDccFill(dcc_address, fill_size, 0x40404040u);
+      Require(name, "T4 armed",
+              texture_cache.IsMetaCleared(dcc_address, 64) &&
+                  texture_cache.IsMetaCleared(dcc_address, 127),
+              "a full DCC fill did not arm slices above 63");
+      arm_and_bind(context, registers, dcc_address, 20, 100);
+      Require(name, "T4 consumed range only",
+              !texture_cache.IsMetaCleared(dcc_address, 20) &&
+                  !texture_cache.IsMetaCleared(dcc_address, 64) &&
+                  !texture_cache.IsMetaCleared(dcc_address, 100) &&
+                  texture_cache.IsMetaCleared(dcc_address, 19) &&
+                  texture_cache.IsMetaCleared(dcc_address, 101),
+              "a view spanning more than 64 slices consumed the wrong range");
+      Require(name, "T4 texels",
+              ReadCachedTexel(name, context, id, {0, 0, 20}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 63}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 64}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 100}) == cleared &&
+                  ReadCachedTexel(name, context, id, {0, 0, 19}) == painted &&
+                  ReadCachedTexel(name, context, id, {0, 0, 101}) == painted,
+              "a view spanning more than 64 slices was not fully cleared");
+    });
+
+    std::printf("[gpu]     %-32s ok\n", name);
   }
 
   void CheckRenderExecutorDccFixedClearFloat() {
@@ -29079,10 +29335,16 @@ int main(int argc, char **argv) {
     vulkan.CheckUnifiedTextureCacheFlow();
     return 0;
   }
+  if (argc == 2 && std::strcmp(argv[1], "--dcc-slice-range-only") == 0) {
+    VulkanHarness vulkan;
+    vulkan.CheckDccClearSliceRanges();
+    return 0;
+  }
   if (argc == 2 && std::strcmp(argv[1], "--compute-meta-clear-only") == 0) {
     CheckDynamicRenderingState();
     VulkanHarness vulkan;
     vulkan.CheckComputeMetaClearClassification();
+    vulkan.CheckDccClearSliceRanges();
     vulkan.CheckRenderExecutorColorVolumeDiscovery();
     vulkan.CheckRenderExecutorDccFixedClearFloat();
     vulkan.CheckSampledDccClear();


### PR DESCRIPTION
## Problem

`MetaDataInfo::clear_mask` tracked pending DCC clear slices in a `uint32_t`, so only
slices 0-31 could be represented. `PrepareDccClear` bailed out on any view whose slice
range fell outside that window, and `IsMetaCleared`/`TouchMeta` reported slice 32 and
above as not pending. A recognised guest DCC clear on a layered target with more than
32 slices was armed and then never materialised, leaving the image with its previous
contents.

## Change

Track pending slices with the existing `RangeSet` across the slice range the guest can
address. Widening the integer would only move the limit — `CB_COLOR_VIEW` encodes 13-bit
slice indices.

`PrepareDccClear` now materialises the intersection of the bound view with the slices
still pending, one contiguous run at a time. Partial consumption is unchanged: slices
already cleared are not cleared again, since they may have been rendered into since, and
a repeated metadata fill re-arms the whole range. The metadata entry is re-found after
each `ClearImage`, because retiring an image can erase it.

HTile still arms the same 32 slices as before; widening that belongs with a separate
multi-layer depth change.

## Validation

New `texture_cache_dcc_slice_range` covers a 64-slice target, a view starting above slice
31, overlapping partial consumption, and a target past 64 slices so widening the mask
alone does not pass. The cases run through `ResolveRenderColorTarget`/`FindRenderTarget`
and check host texels and pending state before and after.

Focused DCC, HTile, depth and cache groups pass. Full CTest 37/38; `kernel_file_system`
fails identically on pristine upstream.

Kena: Bridge of Spirits exposed this with a 64-slice RGBA16F volumetric lighting target
that is fast-cleared each frame before additive light injection. Before, the clear never
landed and radiance accumulated across frames into progressively over-bright blue/white
lighting. After, lighting stays stable.

## AI assistance

AI assistance was used during investigation, implementation and testing. I reviewed the
resulting change and validation before submitting it.