### PR TITLE
Fix stencil synchronization and missing DOOM menu text

### DIFF
--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -955,7 +955,7 @@ struct TextureCache::DownloadPlan {
 
 TextureCache::TextureTransferPlan
 TextureCache::BuildTextureTransfer(const Image& image, BindingType binding,
-                                    TransferDirection direction) const {
+                                   TransferDirection direction) const {
 	const auto& info             = image.info;
 	const bool  upload           = direction == TransferDirection::Upload;
 	const bool  render_target    = binding == BindingType::RenderTarget;
@@ -1040,7 +1040,7 @@ TextureCache::DownloadPlan TextureCache::BuildDownload(const Image& image) const
 void TextureCache::UploadImage(Image& image, Buffer& source, uint64_t source_offset) {
 	const auto& info    = image.info;
 	const auto  binding = UploadBinding(image);
-	const auto  upload  = [&](std::vector<vk::BufferImageCopy>& copies, TileManager::Result linear) {
+	const auto  upload = [&](std::vector<vk::BufferImageCopy>& copies, TileManager::Result linear) {
 		for (auto& copy: copies) {
 			copy.bufferOffset += linear.offset;
 		}
@@ -1071,8 +1071,8 @@ void TextureCache::UploadImage(Image& image, Buffer& source, uint64_t source_off
 		return;
 	}
 
-	if (info.samples != 1 || image.backing.samples != 1 ||
-	    info.resources.layers == 0 || info.data.size % info.resources.layers != 0 ||
+	if (info.samples != 1 || image.backing.samples != 1 || info.resources.layers == 0 ||
+	    info.data.size % info.resources.layers != 0 ||
 	    Prospero::NumBytesPerElement(info.guest_format) != info.bytes_per_block) {
 		EXIT("TextureCache: invalid depth upload\n");
 	}
@@ -1530,7 +1530,8 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t address
 	} else {
 		uint8_t stencil_clear = 0;
 		if ((aspect == vk::ImageAspectFlagBits::eDepth &&
-		     !DecodePackedDepthClear(image.info.pixel_format, packed_clear, clear.depthStencil.depth)) ||
+		     !DecodePackedDepthClear(image.info.pixel_format, packed_clear,
+		                             clear.depthStencil.depth)) ||
 		    (aspect == vk::ImageAspectFlagBits::eStencil &&
 		     !DecodePackedStencilClear(packed_clear, stencil_clear))) {
 			return false;
@@ -1544,7 +1545,7 @@ bool TextureCache::ClearImageFromBuffer(CommandBuffer& command, uint64_t address
 
 void TextureCache::ClearImage(CommandBuffer& command, ImageId id,
                               const vk::ImageSubresourceRange& range, const vk::ClearValue& clear) {
-	auto& image = m_slot_images[id];
+	auto&      image   = m_slot_images[id];
 	const auto aspects = image.info.IsDepth() ? ImageViewOps::DepthAspectMask(image.backing.format)
 	                                          : vk::ImageAspectFlagBits::eColor;
 	EXIT_IF(range.baseMipLevel >= image.info.resources.levels);
@@ -1721,7 +1722,7 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, uint64_t vaddr, uin
 	}
 
 	std::scoped_lock lock {m_texture_cache.m_lock};
-	auto& image = m_texture_cache.m_slot_images[selected];
+	auto&            image = m_texture_cache.m_slot_images[selected];
 	// The GPU thread owns image retirement; CPU invalidation can dirty this image after lookup.
 	if (!m_texture_cache.SafeToDownload(image)) {
 		return false;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -134,6 +134,11 @@ void NameImageBinding(GraphicContext& graphics, Image& image, vk::ImageView view
 	    view_info.level_count, view_info.base_layer, view_info.layer_count);
 }
 
+[[nodiscard]] bool CanTransferStencil(const ImageInfo& info) {
+	// Raw buffer copies cannot decode Hi-Stencil or initialize multisampled images.
+	return info.samples == 1 && !info.metadata.stencil_compressed;
+}
+
 [[nodiscard]] std::vector<vk::BufferImageCopy> BuildDepthCopies(const ImageInfo& info,
                                                                 uint64_t         slice_stride) {
 	std::vector<vk::BufferImageCopy> copies(info.resources.layers);
@@ -347,6 +352,7 @@ void TextureCache::DeleteImage(ImageId id) {
 }
 
 void TextureCache::FreeImage(ImageId id) {
+	PreserveStencil(id);
 	auto& image = m_slot_images[id];
 	if (image.IsGpuModified()) {
 		image.ClearGpuModified();
@@ -1112,6 +1118,65 @@ void TextureCache::UploadImage(Image& image, Buffer& source, uint64_t source_off
 	upload(copies, linear);
 }
 
+void TextureCache::TransferStencil(Image& image, GuestRange stencil, Buffer& buffer,
+                                   uint64_t offset, TransferDirection direction) {
+	auto info            = image.info;
+	info.data            = stencil;
+	info.bytes_per_block = 1;
+	// PS5 stores stencil separately, with its own one-byte depth-tile pitch.
+	if (info.IsTiled()) {
+		info.pitch = TileGetDepthPitch(info.extent.width, 1, 0);
+	}
+	EXIT_IF(info.resources.levels != 1 || info.resources.layers == 0 ||
+	        stencil.size % info.resources.layers != 0);
+	const auto slice_size = stencil.size / info.resources.layers;
+	EXIT_IF(static_cast<uint64_t>(info.pitch) * info.extent.height > slice_size);
+	auto copies = BuildDepthCopies(info, slice_size);
+	for (auto& copy: copies) {
+		copy.imageSubresource.aspectMask = vk::ImageAspectFlagBits::eStencil;
+	}
+	const bool          upload = direction == TransferDirection::Upload;
+	TileManager::Result linear {buffer.Handle(), offset, stencil.size};
+	if (info.IsTiled()) {
+		const auto tiles = BuildDepthTiles(info);
+		if (!upload) {
+			m_tiler.TileImage(image, copies, buffer.Handle(), offset, stencil.size, stencil.size,
+			                  tiles);
+			return;
+		}
+		linear = m_tiler.Detile(buffer.Handle(), offset, stencil.size, stencil.size, tiles);
+	}
+	for (auto& copy: copies) {
+		copy.bufferOffset += linear.offset;
+	}
+	if (upload) {
+		image.Upload(copies, linear.buffer, linear.offset, linear.size);
+	} else {
+		image.Download(copies, linear.buffer, linear.offset, linear.size);
+	}
+}
+
+void TextureCache::PreserveStencil(ImageId depth_id) {
+	auto& depth = m_slot_images[depth_id];
+	if (depth.depth_id || !depth.info.HasStencil() || !CanTransferStencil(depth.info)) {
+		return;
+	}
+	const auto stencil = depth.info.stencil;
+	for (const auto id: FindImagesInRegion(stencil.address, stencil.size, false)) {
+		auto& record = m_slot_images[id];
+		if (record.depth_id != depth_id || record.info.data != stencil || record.IsCpuDirty() ||
+		    record.IsBufferModified()) {
+			continue;
+		}
+		// Publish stencil writes before retiring the image.
+		auto [buffer, offset] =
+		    m_buffer_cache.ObtainBuffer(stencil.address, stencil.size, true, false);
+		EXIT_IF(buffer == nullptr);
+		TransferStencil(depth, stencil, *buffer, offset, TransferDirection::Download);
+		record.MarkBufferModified();
+	}
+}
+
 void TextureCache::InitializeImage(ImageId id) {
 	auto& image = m_slot_images[id];
 	if (image.info.data.Empty()) {
@@ -1124,7 +1189,13 @@ void TextureCache::InitializeImage(ImageId id) {
 		}
 		return;
 	}
-	if (image.info.samples > 1) {
+	const auto& target = image.depth_id ? m_slot_images[image.depth_id] : image;
+	// Multisampled images cannot be initialized with a buffer-to-image copy.
+	if (target.info.samples > 1) {
+		return;
+	}
+	if (image.depth_id &&
+	    (!CanTransferStencil(target.info) || image.info.data != target.info.stencil)) {
 		return;
 	}
 	const bool upload = image.IsBufferModified() || image.IsCpuDirty();
@@ -1134,7 +1205,12 @@ void TextureCache::InitializeImage(ImageId id) {
 		if (source == nullptr) {
 			EXIT("TextureCache: failed to obtain image upload source\n");
 		}
-		UploadImage(image, *source, source_offset);
+		if (image.depth_id) {
+			TransferStencil(m_slot_images[image.depth_id], image.info.data, *source, source_offset,
+			                TransferDirection::Upload);
+		} else {
+			UploadImage(image, *source, source_offset);
+		}
 		image.ClearBufferModified();
 	}
 	if (image.IsCpuDirty()) {
@@ -1240,7 +1316,23 @@ void TextureCache::AssociateStencil(ImageId depth_id, GuestRange stencil) {
 	}
 	auto& record = m_slot_images[association];
 	TouchImage(record);
-	record.depth_id = depth_id;
+	const bool unsupported_pair = depth.info.stencil != stencil || record.info.data != stencil ||
+	                              (record.depth_id && record.depth_id != depth_id) ||
+	                              record.backing.image != nullptr;
+	record.depth_id             = depth_id;
+	if (unsupported_pair) {
+		// TODO(stencil): preserve GPU-written contents across pairing changes.
+		if (!m_warned_stencil_reassociation) {
+			LOGF_COLOR(Log::Color::BrightYellow,
+			           "TextureCache: stencil reassociation is unsupported; "
+			           "depth=0x%016" PRIx64 ", stencil=0x%016" PRIx64
+			           "; continuing without stencil upload (further warnings suppressed)\n",
+			           depth.info.data.address, stencil.address);
+			m_warned_stencil_reassociation = true;
+		}
+		return;
+	}
+	RefreshImage(association);
 }
 
 ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_format) {
@@ -1567,6 +1659,25 @@ void TextureCache::ClearImage(CommandBuffer& command, ImageId id,
 			EXIT("TextureCache: image clear retained guest ownership\n");
 		}
 	}
+	std::vector<ImageId> stencil_associations;
+	if ((range.aspectMask & vk::ImageAspectFlagBits::eStencil) && image.info.stencil.Valid()) {
+		const bool full_stencil = range.baseMipLevel == 0 &&
+		                          range.levelCount == image.info.resources.levels &&
+		                          range.baseArrayLayer == 0 && range.layerCount == layers;
+		for (const auto association:
+		     FindImagesInRegion(image.info.stencil.address, image.info.stencil.size, false)) {
+			auto& stencil = m_slot_images[association];
+			if (stencil.depth_id != id || stencil.info.data != image.info.stencil) {
+				continue;
+			}
+			TrackImage(association);
+			// Partial clears must retain guest writes outside the cleared subresources.
+			if (!full_stencil) {
+				RefreshImage(association);
+			}
+			stencil_associations.push_back(association);
+		}
+	}
 	command.EndRendering();
 	if (image.info.IsVolume() && !full_image) {
 		EXIT_NOT_IMPLEMENTED(range.aspectMask != vk::ImageAspectFlagBits::eColor ||
@@ -1614,6 +1725,14 @@ void TextureCache::ClearImage(CommandBuffer& command, ImageId id,
 		                                        &clear.depthStencil, 1, &native_range);
 	}
 	CommitGpuWrite(image);
+	for (const auto association: stencil_associations) {
+		auto& stencil = m_slot_images[association];
+		// The native clear supersedes the pending stencil upload on the next binding.
+		stencil.ClearBufferModified();
+		if (stencil.IsCpuDirty()) {
+			stencil.RefreshComplete();
+		}
+	}
 }
 
 void TextureCache::InvalidateMemory(uint64_t address, uint64_t size) {
@@ -1831,7 +1950,7 @@ void TextureCache::InvalidateMemoryFromGPU(uint64_t address, uint64_t size) {
 	std::scoped_lock lock {m_lock};
 	for (const auto id: FindImagesInRegion(address, size, true)) {
 		auto& image = m_slot_images[id];
-		if (image.depth_id || !image.Overlaps(address, size)) {
+		if (!image.Overlaps(address, size)) {
 			continue;
 		}
 		if (image.IsGpuModified()) {
@@ -2026,7 +2145,7 @@ void TextureCache::RunGarbageCollector() {
 				}
 				owner->ClearGpuModified();
 			}
-			DeleteImage(id);
+			FreeImage(id);
 			if (m_total_used_memory < m_critical_gc_memory && aggressive) {
 				deletions >>= 2;
 				aggressive = false;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.cpp
@@ -2129,18 +2129,32 @@ void TextureCache::RunGarbageCollector() {
 			}
 			--deletions;
 			auto owner = m_slot_images.try_get(id);
-			if (owner == nullptr || !owner->registered || owner->depth_id) {
+			if (owner == nullptr || !owner->registered) {
+				continue;
+			}
+			// Rotate retained entries so they cannot monopolize subsequent bounded scans.
+			if (owner->depth_id) {
+				TouchImage(*owner);
 				continue;
 			}
 			if (owner->IsGpuModified()) {
 				const bool safe = SafeToDownload(*owner);
+				// Buffer dirtiness may predate image writes; blocked readback does not prove
+				// these pixels are stale. Keep them until invalidation or safe readback.
+				if (!safe && owner->SafeToDownload()) {
+					TouchImage(*owner);
+					continue;
+				}
 				if (safe && owner->info.IsTiled()) {
+					TouchImage(*owner);
 					continue;
 				}
 				if (safe && !pressured) {
+					TouchImage(*owner);
 					continue;
 				}
 				if (safe && !TryDownloadImage(id)) {
+					TouchImage(*owner);
 					continue;
 				}
 				owner->ClearGpuModified();

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -137,6 +137,9 @@ private:
 	                                                       TransferDirection direction) const;
 	[[nodiscard]] DownloadPlan        BuildDownload(const Image& image) const;
 	void UploadImage(Image& image, Buffer& source, uint64_t source_offset);
+	void TransferStencil(Image& image, GuestRange stencil, Buffer& buffer, uint64_t offset,
+	                     TransferDirection direction);
+	void PreserveStencil(ImageId depth);
 	void DownloadImageData(Image& image, Buffer& destination, uint64_t destination_offset,
 	                       uint64_t destination_size, DownloadPlan plan);
 	void DownloadDepth(Image& image, Buffer& destination, uint64_t destination_offset);
@@ -171,10 +174,11 @@ private:
 	uint64_t                                          m_total_used_memory  = 0;
 	uint64_t                                          m_trigger_gc_memory  = 0;
 	uint64_t                                          m_pressure_gc_memory = 1536ull * 1024 * 1024;
-	uint64_t         m_critical_gc_memory     = 3ull * 1024 * 1024 * 1024;
-	uint64_t         m_gc_tick                = 0;
-	mutable uint32_t m_image_query_epoch      = 0;
-	bool             m_readback_linear_images = false;
+	uint64_t         m_critical_gc_memory           = 3ull * 1024 * 1024 * 1024;
+	uint64_t         m_gc_tick                      = 0;
+	mutable uint32_t m_image_query_epoch            = 0;
+	bool             m_readback_linear_images       = false;
+	bool             m_warned_stencil_reassociation = false;
 
 	friend struct TextureCacheTestAccess;
 	friend class BufferCache;

--- a/src/graphics/host_gpu/renderer/cache/textureCache.h
+++ b/src/graphics/host_gpu/renderer/cache/textureCache.h
@@ -133,9 +133,9 @@ private:
 	void                        RefreshImage(ImageId id);
 	void                        PrepareDccClear(ImageId id, const ImageDesc& desc);
 	void                        InitializeImage(ImageId id);
-	[[nodiscard]] TextureTransferPlan
-	BuildTextureTransfer(const Image& image, BindingType binding, TransferDirection direction) const;
-	[[nodiscard]] DownloadPlan BuildDownload(const Image& image) const;
+	[[nodiscard]] TextureTransferPlan BuildTextureTransfer(const Image& image, BindingType binding,
+	                                                       TransferDirection direction) const;
+	[[nodiscard]] DownloadPlan        BuildDownload(const Image& image) const;
 	void UploadImage(Image& image, Buffer& source, uint64_t source_offset);
 	void DownloadImageData(Image& image, Buffer& destination, uint64_t destination_offset,
 	                       uint64_t destination_size, DownloadPlan plan);

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -223,10 +223,11 @@ struct TextureCacheTestAccess {
 
   static void ConfigureGarbageCollection(TextureCache &cache,
                                          std::span<const ImageId> oldest,
-                                         uint64_t tick, uint64_t pressure) {
+                                         uint64_t tick, uint64_t pressure,
+                                         uint64_t critical = UINT64_MAX) {
     cache.m_trigger_gc_memory = 0;
     cache.m_pressure_gc_memory = pressure;
-    cache.m_critical_gc_memory = UINT64_MAX;
+    cache.m_critical_gc_memory = critical;
     cache.m_gc_tick = tick;
     std::vector<ImageId> live;
     cache.m_lru_cache = {};
@@ -7569,6 +7570,48 @@ public:
       Require(name, "depth/stencil GC traversal budget", gc_depth_budget,
               "recursive association deletion stopped LRU traversal or "
               "exceeded the ten-entry deletion budget");
+
+      // Retained images must not monopolize the bounded GC scan, even under
+      // critical pressure. The last entry is clean and can be reclaimed.
+      for (const uint64_t critical : {UINT64_MAX, uint64_t{0}}) {
+        constexpr uint64_t offset = 0x360000;
+        constexpr uint64_t stride = 0x1000;
+        std::array<ImageId, 41> oldest{};
+        for (size_t index = 0; index < oldest.size(); index++) {
+          const auto address = base + offset + index * stride;
+          auto desc = MakeLinearDesc(
+              address, 4, vk::Format::eR32Uint, Prospero::BufferFormat::k32UInt,
+              Prospero::ImageType::kColor2D, {1, 1, 1}, 1, 4, 1);
+          if (index + 1 < oldest.size()) {
+            auto [buffer, buffer_offset] =
+                resources.GetBufferCache().ObtainBuffer(address, 4, true);
+            buffer->Fill(buffer_offset, 4, 0x11111111u);
+          }
+          oldest[index] = texture_cache.FindImage(desc);
+          if (index + 1 < oldest.size()) {
+            Require(name, "blocked GC image clear",
+                    texture_cache.ClearImageFromBuffer(
+                        command, address, 4, 0x33333333u),
+                    "failed to prepare a rendered image over older dirty buffer bytes");
+          }
+        }
+        TextureCacheTestAccess::ConfigureGarbageCollection(
+            texture_cache, oldest, 161, 0, critical);
+        for (uint32_t cycle = 0; cycle < 3; cycle++) {
+          texture_cache.RunGarbageCollector();
+        }
+        Require(name, "GC progresses past retained images",
+                !texture_cache.FindImageFromRange(
+                    base + offset + 40 * stride, 4, false),
+                "forty retained images prevented collection of a later clean image");
+        for (size_t index = 0; index < 40; index++) {
+          Require(name, "GC retains ambiguous image contents",
+                  texture_cache.FindImageFromRange(
+                      base + offset + index * stride, 4, false) == oldest[index],
+                  "GC gained progress by discarding potentially newer image contents");
+        }
+        texture_cache.UnmapMemory(base + offset, oldest.size() * stride);
+      }
 
       constexpr uint64_t large_offset = 0x400000;
       constexpr uint32_t large_width = 4096;

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -5674,6 +5674,92 @@ public:
       }
       DestroyBuffer(&stencil_readback);
 
+      // A native stencil clear must supersede the earlier guest buffer write,
+      // including when a partial clear must first preserve the untouched layer.
+      {
+        auto desc = MakeLinearDesc(
+            base + 0x3c0000, 32, vk::Format::eD32SfloatS8Uint,
+            Prospero::BufferFormat::k32Float, Prospero::ImageType::kColor2D,
+            {4, 1, 1}, 2, 4, 1);
+        desc.type = BindingType::DepthTarget;
+        desc.info.stencil = {base + 0x3c2000, 8};
+        desc.view_info.aspect = vk::ImageAspectFlagBits::eDepth |
+                                vk::ImageAspectFlagBits::eStencil;
+        desc.view_info.usage = vk::ImageUsageFlagBits::eDepthStencilAttachment;
+        std::memset(memory + 0x3c0000, 0, 32);
+        std::memset(memory + 0x3c2000, 0x11, 8);
+        const auto id = texture_cache.FindImage(desc);
+        (void)texture_cache.FindDepthTarget(id, desc);
+        for (const bool cpu_write : {false, true}) {
+          for (const bool partial : {false, true}) {
+            if (cpu_write) {
+              resources.GetBufferCache().ReadMemory(desc.info.stencil.address, 8);
+              std::memset(memory + 0x3c2000, 0x22, 8);
+            } else {
+              (void)resources.GetBufferCache().ObtainBuffer(
+                  desc.info.stencil.address, 8, true);
+              resources.GetBufferCache().FillBuffer(
+                  desc.info.stencil.address, 8, 0x22222222u, false);
+            }
+            if (partial) {
+              vk::ClearValue clear{};
+              clear.depthStencil.stencil = 0x33;
+              TextureCacheTestAccess::ClearImage(
+                  texture_cache, command, id,
+                  {vk::ImageAspectFlagBits::eStencil, 0, 1, 1, 1}, clear);
+            } else {
+              Require(name, "optimized stencil clear accepted",
+                      texture_cache.ClearImageFromBuffer(
+                          command, desc.info.stencil.address, 8, 0x33333333u),
+                      "optimized stencil buffer fill was rejected");
+            }
+            (void)texture_cache.FindDepthTarget(id, desc);
+            auto readback = CreateHostBuffer(
+                name, 8, vk::BufferUsageFlagBits::eTransferDst, {});
+            vk::BufferImageCopy copy{};
+            copy.imageSubresource = {vk::ImageAspectFlagBits::eStencil, 0, 0, 2};
+            copy.imageExtent = {4, 1, 1};
+            texture_cache.GetImage(id).Download(
+                std::span{&copy, 1}, readback.buffer, 0, 8);
+            HostReadBarrier(readback.buffer, 8, vk::PipelineStageFlagBits::eTransfer,
+                            vk::AccessFlagBits::eTransferWrite);
+            scheduler.Finish();
+            Require(name, "stencil clear survives depth rebind",
+                    ReadBuffer(name, readback, 2) ==
+                        std::vector<u32>{partial ? 0x22222222u : 0x33333333u,
+                                         0x33333333u},
+                    "stencil refresh undid the clear or lost the untouched layer");
+            DestroyBuffer(&readback);
+          }
+        }
+        // Pressure retirement must preserve stencil as well as the depth plane.
+        TextureCacheTestAccess::ConfigureGarbageCollection(
+            texture_cache, std::array{id}, 81, 0);
+        texture_cache.RunGarbageCollector();
+        Require(name, "stencil pressure retirement",
+                !texture_cache.FindImageFromRange(desc.info.data.address, 32, false),
+                "the linear depth/stencil image was not retired under pressure");
+        scheduler.Finish();
+        scheduler.DrainPriorityOperations();
+        const auto recreated = texture_cache.FindImage(desc);
+        (void)texture_cache.FindDepthTarget(recreated, desc);
+        auto readback = CreateHostBuffer(
+            name, 8, vk::BufferUsageFlagBits::eTransferDst, {});
+        vk::BufferImageCopy copy{};
+        copy.imageSubresource = {vk::ImageAspectFlagBits::eStencil, 0, 0, 2};
+        copy.imageExtent = {4, 1, 1};
+        texture_cache.GetImage(recreated).Download(
+            std::span{&copy, 1}, readback.buffer, 0, 8);
+        HostReadBarrier(readback.buffer, 8, vk::PipelineStageFlagBits::eTransfer,
+                        vk::AccessFlagBits::eTransferWrite);
+        scheduler.Finish();
+        Require(name, "stencil contents survive pressure retirement",
+                ReadBuffer(name, readback, 2) ==
+                    std::vector<u32>{0x22222222u, 0x33333333u},
+                "recreated depth/stencil image uploaded stale stencil backing");
+        DestroyBuffer(&readback);
+      }
+
       constexpr uint64_t partial_image_offset = 0xa000;
       constexpr uint64_t partial_buffer_offset = 0xa010;
       constexpr uint64_t partial_clean_offset = 0xa020;
@@ -8798,6 +8884,7 @@ public:
 
     {
       RenderContext context(m_runtime_context);
+      context.InitializeGpu(nullptr);
       auto &scheduler = context.GetCommandScheduler();
       HW::Context registers{};
       HW::UserConfig user_config{};
@@ -13140,9 +13227,26 @@ private:
     device_features.shaderInt64 = true;
     device_features.fillModeNonSolid = true;
     device_info.pEnabledFeatures = &device_features;
-    constexpr const char *device_extensions[] = {
+    u32 extension_count = 0;
+    RequireVk("VulkanHarness", "dispatch",
+              m_physical_device.enumerateDeviceExtensionProperties(
+                  nullptr, &extension_count, nullptr),
+              "vkEnumerateDeviceExtensionProperties");
+    std::vector<vk::ExtensionProperties> available_extensions(extension_count);
+    RequireVk("VulkanHarness", "dispatch",
+              m_physical_device.enumerateDeviceExtensionProperties(
+                  nullptr, &extension_count, available_extensions.data()),
+              "vkEnumerateDeviceExtensionProperties");
+    const bool khr_derivatives = std::ranges::any_of(
+        available_extensions, [](const auto &extension) {
+          return std::strcmp(extension.extensionName,
+                             VK_KHR_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME) == 0;
+        });
+    // The NV predecessor uses the same feature structure on older Vulkan drivers.
+    const char *device_extensions[] = {
         VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME,
-        VK_KHR_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME,
+        khr_derivatives ? VK_KHR_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME
+                        : VK_NV_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME,
         VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME,
         VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME,
         VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME,


### PR DESCRIPTION
Related issue: [#290](https://github.com/KytyPS5/KytyPS5/issues/290).

DOOM + DOOM II displays white backgrounds around glyphs and loses menu letters. Stencil buffer contents were not uploaded into Vulkan images, and garbage collection could discard rendered glyph atlases when older buffer writes blocked readback.

This change:

- Uploads stencil contents and refreshes them after guest writes.
- Prevents pending uploads from undoing optimized stencil clears.
- Preserves stencil contents when images are replaced or garbage-collected.
- Retains potentially current atlas images while allowing GC to reach other reclaimable images.

Changed depth/stencil pairings remain unsupported: log once and continue, accepting possible rendering artifacts. Retained images may occupy GPU memory longer.

Validated on Linux/NVIDIA with DOOM startup and collection menus, the existing GPU cache suite, and new regressions for clear/rebind, stencil retirement, and GC progress. Each regression failed before its fix and passes afterward. Windows/AMD and long gameplay remain unverified.

### Screenshots

DOOM + DOOM II startup screen on Linux/NVIDIA, without debugger overrides.

| Before | After |
| --- | --- |
| ![Before: white glyph backgrounds and missing options](https://raw.githubusercontent.com/OldKrab/KytyPS5/88c32d04d7cea9d8b891ec92caa31c72c0b2b0ad/startup-before.png) | ![After: readable text and restored options](https://raw.githubusercontent.com/OldKrab/KytyPS5/88c32d04d7cea9d8b891ec92caa31c72c0b2b0ad/startup-after.png) |
