### PR TITLE
docs: fix pre-commit setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,14 @@ starting a large change.
 
 Set up the clang-format hook after cloning:
 
-```powershell
-python -m pip install pre-commit
+Install `pre-commit` using the method appropriate for your platform:
+
+- **Arch Linux / CachyOS:** `sudo pacman -S pre-commit`
+- **Other Linux / macOS / Windows:** `python -m pip install pre-commit`
+
+Then install the Git hook:
+
+```bash
 python -m pre_commit install --install-hooks
 ```
 


### PR DESCRIPTION
The README currently recommends installing pre-commit with Python pip.

On Arch Linux and Arch-based distributions using an externally managed Python environment, this command fails with an `externally-managed-environment` error.

This updates the README to:

* use the distribution package manager for Arch (`sudo pacman -S pre-commit`)
* use the `pre-commit` command directly for installing the Git hook
* label the command block as Bash instead of PowerShell
