### PR TITLE
Fix save search timestamps so GTA V restores saved settings

### DIFF
--- a/src/libs/libSaveData.cpp
+++ b/src/libs/libSaveData.cpp
@@ -247,6 +247,18 @@ static std::string get_title_id() {
 	return title_id;
 }
 
+static int64_t get_save_data_mtime(const std::filesystem::path& directory) {
+	// Approximate the save's modification time using the newest file timestamp,
+	// including files in subdirectories. In-place writes do not update the parent
+	// directory's timestamp, so its timestamp alone would miss those changes.
+	// Some games require a nonzero modification time to load an existing save.
+	int64_t mtime = 0;
+	for (const auto& file: Common::File::FindFiles(directory)) {
+		mtime = std::max(mtime, static_cast<int64_t>(file.last_write_time.ToUnix()));
+	}
+	return mtime;
+}
+
 static void queue_save_data_event(uint32_t type, int32_t user_id,
                                   const SceSaveDataTitleId* title_id,
                                   const SceSaveDataDirName* dir_name, int32_t error_code = OK) {
@@ -409,6 +421,8 @@ int KYTY_SYSV_ABI SaveDataDirNameSearch(const SaveDataDirNameSearchCond* cond,
 		              dir_list[i].c_str());
 		if (result->params != nullptr) {
 			result->params[i] = {};
+			result->params[i].mtime =
+			    get_save_data_mtime(std::filesystem::path(root) / dir_list[i]);
 		}
 		if (result->infos != nullptr) {
 			result->infos[i]             = {};


### PR DESCRIPTION
Fix save searches returning a zero modification time, which causes some games to ignore existing saves and reset settings.
Report the newest file timestamp within each save directory, including subdirectories.

Verified in GTA V: graphics settings persist across multiple restarts.