### PR TITLE
graphics: find BDA upload work from CPU-dirty hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ add_executable(memory_tracker_tests EXCLUDE_FROM_ALL
 )
 target_link_libraries(memory_tracker_tests fmt::fmt common)
 target_include_directories(memory_tracker_tests PRIVATE ${inc_headers})
+target_compile_definitions(memory_tracker_tests PRIVATE KYTY_BDA_TEST_HOOKS=1)
 
 add_executable(shader_vertex_metadata_tests EXCLUDE_FROM_ALL
 	"${KYTY_TESTS_DIR}/ShaderVertexMetadataTests.cpp"
@@ -488,6 +489,7 @@ target_link_libraries(image_page_table_tests common fmt::fmt)
 target_include_directories(image_page_table_tests PRIVATE ${inc_headers})
 
 add_kyty_full_emulator_test(shader_recompiler_compute_tests "${KYTY_TESTS_DIR}/ShaderRecompilerComputeTests.cpp")
+target_compile_definitions(shader_recompiler_compute_tests PRIVATE KYTY_BDA_TEST_HOOKS=1)
 
 set(gpu_test_generated_dir "${PROJECT_BINARY_DIR}/gpu_test_shaders")
 set(gpu_test_ms_depth_source
@@ -533,6 +535,11 @@ if(BUILD_TESTING)
 	add_test(NAME emulator_present_mode_invalid
 	         COMMAND $<TARGET_FILE:kyty_emulator> --help --present-mode Invalid)
 	set_tests_properties(emulator_present_mode_invalid PROPERTIES WILL_FAIL TRUE)
+	add_test(NAME emulator_bda_sync_cli
+	         COMMAND $<TARGET_FILE:kyty_emulator> --help --bda-sync Legacy)
+	add_test(NAME emulator_bda_sync_invalid
+	         COMMAND $<TARGET_FILE:kyty_emulator> --help --bda-sync Invalid)
+	set_tests_properties(emulator_bda_sync_invalid PROPERTIES WILL_FAIL TRUE)
 	add_test(NAME ime_dialog COMMAND $<TARGET_FILE:ime_dialog_tests>)
 	add_test(NAME shader_cfg COMMAND $<TARGET_FILE:shader_cfg_tests>)
 	add_test(NAME scalar_provenance COMMAND $<TARGET_FILE:scalar_provenance_tests>)
@@ -588,6 +595,8 @@ if(BUILD_TESTING)
 			COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --htile-clear-only)
 		add_test(NAME buffer_cache_ranges
 			COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --buffer-cache-range-only)
+		add_test(NAME buffer_cache_bda_selective
+			COMMAND $<TARGET_FILE:shader_recompiler_compute_tests> --bda-selective-only)
 	endif()
 
 	add_custom_target(kyty_tests DEPENDS

--- a/src/common/emulatorConfig.cpp
+++ b/src/common/emulatorConfig.cpp
@@ -47,6 +47,10 @@ PresentMode GetPresentMode() {
 	return g_config->present_mode;
 }
 
+BdaSyncMode GetBdaSyncMode() {
+	return g_config->bda_sync_mode;
+}
+
 int32_t GetGpuIndex() {
 	return g_config->gpu_index;
 }

--- a/src/common/emulatorConfig.h
+++ b/src/common/emulatorConfig.h
@@ -29,6 +29,11 @@ enum class OutputDirection { Silent, Console, File };
 
 enum class PresentMode { Fifo, Mailbox, Immediate };
 
+// How PrepareBda finds CPU-dirty buffers. Selective visits only owners of dirty pages in hinted
+// regions; Legacy walks every mapped owner; SelectiveChecked adds a full invariant check after
+// every selective pass and aborts on a violation.
+enum class BdaSyncMode { Selective, Legacy, SelectiveChecked };
+
 using Keymap = std::vector<std::string>;
 
 constexpr uint32_t DEFAULT_CONSOLE_LANGUAGE = 1;
@@ -48,6 +53,7 @@ struct ConfigOptions {
 	std::string            user_name                   = "Kyty";
 	int32_t                user_id                     = DEFAULT_USER_ID;
 	PresentMode            present_mode                = PresentMode::Fifo;
+	BdaSyncMode            bda_sync_mode               = BdaSyncMode::Selective;
 	int32_t                gpu_index                   = -1;
 	bool                   fullscreen_enabled          = false;
 	uint32_t               vblank_frequency            = 60;
@@ -81,6 +87,7 @@ uint32_t GetScreenHeight();
 const std::string& GetUserName();
 int32_t  GetUserId();
 PresentMode GetPresentMode();
+BdaSyncMode GetBdaSyncMode();
 int32_t GetGpuIndex();
 bool     FullscreenEnabled();
 uint32_t GetVblankFrequency();

--- a/src/graphics/host_gpu/bdaTestHooks.h
+++ b/src/graphics/host_gpu/bdaTestHooks.h
@@ -1,0 +1,40 @@
+#ifndef EMULATOR_SRC_GRAPHICS_HOST_GPU_BDATESTHOOKS_H_
+#define EMULATOR_SRC_GRAPHICS_HOST_GPU_BDATESTHOOKS_H_
+
+#include <cstdint>
+
+#if defined(KYTY_BDA_TEST_HOOKS)
+#include <atomic>
+#endif
+
+// Interleaving points for the selective BDA synchronisation tests. They compile to nothing
+// unless KYTY_BDA_TEST_HOOKS is defined, which only test targets do.
+namespace Libs::Graphics::BdaTestHooks {
+
+enum class Point : uint32_t {
+	AfterHintExchange,     // value: hint word; the pass now owns that word's regions
+	NullRegionManager,     // value: region; a consumed region has no RegionManager yet
+	AfterDirtySnapshot,    // value: region; CPU-dirty snapshot taken, owners not yet visited
+	RegionHintPublished,   // value: region; P2 published the hint, not yet the manager pointer
+	BeforeUploadCopy,      // value: buffer address; protection re-armed, staging copy not made
+	AfterUploadCopy,       // value: buffer address; staging copy made
+	ForceSelectiveFailure, // value: guest address; returning true simulates an owner-index failure
+};
+
+#if defined(KYTY_BDA_TEST_HOOKS)
+using Callback = bool (*)(Point point, uint64_t value);
+inline std::atomic<Callback> g_callback {nullptr};
+
+inline bool Fire(Point point, uint64_t value) {
+	const auto callback = g_callback.load(std::memory_order_acquire);
+	return callback != nullptr && callback(point, value);
+}
+#else
+constexpr bool Fire(Point /*point*/, uint64_t /*value*/) noexcept {
+	return false;
+}
+#endif
+
+} // namespace Libs::Graphics::BdaTestHooks
+
+#endif // EMULATOR_SRC_GRAPHICS_HOST_GPU_BDATESTHOOKS_H_

--- a/src/graphics/host_gpu/memoryTracker.cpp
+++ b/src/graphics/host_gpu/memoryTracker.cpp
@@ -1,6 +1,7 @@
 #include "graphics/host_gpu/memoryTracker.h"
 
 #include "common/assert.h"
+#include "graphics/host_gpu/bdaTestHooks.h"
 
 namespace Libs::Graphics {
 
@@ -10,6 +11,10 @@ MemoryTracker::MemoryTracker(PageManager& page_manager): m_page_manager(page_man
 	m_regions = std::make_unique<std::atomic<RegionManager*>[]>(REGION_COUNT);
 	for (size_t i = 0; i < REGION_COUNT; i++) {
 		m_regions[i].store(nullptr, std::memory_order_relaxed);
+	}
+	m_bda_hints = std::make_unique<std::atomic<uint64_t>[]>(BDA_HINT_WORDS);
+	for (size_t i = 0; i < BDA_HINT_WORDS; i++) {
+		m_bda_hints[i].store(0, std::memory_order_relaxed);
 	}
 }
 
@@ -61,11 +66,64 @@ RegionManager* MemoryTracker::GetOrCreateRegion(uint64_t index) {
 	if (auto* manager = m_regions[index].load(std::memory_order_acquire); manager != nullptr) {
 		return manager;
 	}
-	auto  manager = std::make_unique<RegionManager>(m_page_manager, index * TRACKER_REGION_SIZE);
+	auto  manager = std::make_unique<RegionManager>(m_page_manager, index * TRACKER_REGION_SIZE,
+	                                                m_bda_hints[index / 64]);
 	auto* ptr     = manager.get();
 	m_region_storage.push_back(std::move(manager));
+	// P2: a new region starts entirely CPU-dirty. Initialise, publish the hint, then publish
+	// the pointer. A consumer that sees the hint while the pointer is still null synchronises
+	// the region's mapped part through the legacy walk at once; that walk's Iterate<true>
+	// waits on m_region_mutex here and receives this manager.
+	ptr->PublishBdaHint();
+	(void)BdaTestHooks::Fire(BdaTestHooks::Point::RegionHintPublished, index);
 	m_regions[index].store(ptr, std::memory_order_release);
 	return ptr;
+}
+
+void MemoryTracker::PublishBdaHints(uint64_t vaddr, uint64_t size) noexcept {
+	if (size == 0 || vaddr >= TRACKER_ADDRESS_SIZE) {
+		return;
+	}
+	const auto end   = size > TRACKER_ADDRESS_SIZE - vaddr ? TRACKER_ADDRESS_SIZE : vaddr + size;
+	const auto first = vaddr / TRACKER_REGION_SIZE;
+	const auto last  = (end - 1) / TRACKER_REGION_SIZE;
+	for (auto region = first; region <= last; ++region) {
+		m_bda_hints[region / 64].fetch_or(uint64_t {1} << (region % 64), std::memory_order_release);
+	}
+}
+
+uint64_t MemoryTracker::ConsumeBdaHintWord(size_t word) noexcept {
+	auto& hint = m_bda_hints[word];
+	// A publication that happens-before this pass is visible to this relaxed load by
+	// coherence, so the precheck cannot skip anything the current consumer must see. A
+	// concurrent publication it misses stays pending for the next pass.
+	if (hint.load(std::memory_order_relaxed) == 0) {
+		return 0;
+	}
+	return hint.exchange(0, std::memory_order_acquire);
+}
+
+void MemoryTracker::RestoreBdaHints(size_t word, uint64_t bits) noexcept {
+	if (bits != 0) {
+		m_bda_hints[word].fetch_or(bits, std::memory_order_release);
+	}
+}
+
+void MemoryTracker::DiscardBdaHints() noexcept {
+	for (size_t word = 0; word < BDA_HINT_WORDS; word++) {
+		(void)ConsumeBdaHintWord(word);
+	}
+}
+
+bool MemoryTracker::IsBdaHintPending(uint64_t region) const noexcept {
+	return region < REGION_COUNT &&
+	       ((m_bda_hints[region / 64].load(std::memory_order_acquire) >> (region % 64)) & 1u) != 0;
+}
+
+RegionBits MemoryTracker::SnapshotCpuDirty(RegionManager& manager) {
+	CheckNotInUploadCallback();
+	std::scoped_lock lock(manager.lock);
+	return manager.CpuDirtyBits();
 }
 
 bool MemoryTracker::IsRegionCpuModified(uint64_t vaddr, uint64_t size) {

--- a/src/graphics/host_gpu/memoryTracker.h
+++ b/src/graphics/host_gpu/memoryTracker.h
@@ -16,6 +16,10 @@
 
 namespace Libs::Graphics {
 
+// Hint publication runs inside the guest write-fault path: it must be one lock-free atomic RMW,
+// never a hidden mutex.
+static_assert(std::atomic<uint64_t>::is_always_lock_free);
+
 class MemoryTracker final {
 public:
 	explicit MemoryTracker(PageManager& page_manager);
@@ -29,6 +33,78 @@ public:
 	void               MarkRegionAsGpuModified(uint64_t vaddr, uint64_t size);
 	void               UnmarkRegionAsGpuModified(uint64_t vaddr, uint64_t size);
 	void               UntrackMemory(uint64_t vaddr, uint64_t size);
+
+	// --- Selective BDA discovery ------------------------------------------------------------
+	// One hint bit per 4 MiB region meaning "this region MAY hold CPU-dirty data that
+	// PrepareBda must examine". It is a conservative index over RegionManager's CPU-dirty
+	// bitmap, which remains the only truth: a false positive costs one empty snapshot, a false
+	// negative is a coherency bug.
+	//
+	// Contract, at every completed publication boundary: if a CPU-dirty page lies inside a
+	// mapped registered buffer and legacy PrepareBda would have to synchronise it before the
+	// current BDA consumer, then its region's hint is pending, or responsibility for that
+	// region has been consumed by the PrepareBda pass executing right now (it exchanged the
+	// hint and has not finished the region). Completion: a write ordered before a BDA consumer
+	// is examined and synchronised before that consumer proceeds; leaving it pending "for next
+	// time" is not enough. Genuinely racing writes keep the legacy semantics.
+	//
+	// Publications:
+	//   P1  RegionManager::ChangeState<Cpu, true>: under the region lock, every execution
+	//   P2  GetOrCreateRegion: the hint before the manager pointer (a new region is all-dirty)
+	//   P3  BufferCache registration: every region of the actual registered span
+	//   P4  GpuResourceManager::MapMemory: under the exclusive mapped-range lock
+	// Consumption exchanges each word once per pass and never clears a completed region again.
+	static constexpr size_t BDA_HINT_WORDS = TRACKER_ADDRESS_SIZE / TRACKER_REGION_SIZE / 64;
+
+	// P3/P4: flag every region intersecting the half-open range [vaddr, vaddr + size).
+	void PublishBdaHints(uint64_t vaddr, uint64_t size) noexcept;
+	// Takes ownership of one word's pending regions for the running pass.
+	[[nodiscard]] uint64_t ConsumeBdaHintWord(size_t word) noexcept;
+	// Makes regions a pass owned but did not complete pending again (fail-closed paths).
+	void RestoreBdaHints(size_t word, uint64_t bits) noexcept;
+	// Legacy walk: drops every pending hint before a full scan answers them.
+	void                         DiscardBdaHints() noexcept;
+	[[nodiscard]] bool           IsBdaHintPending(uint64_t region) const noexcept;
+	[[nodiscard]] RegionManager* FindRegion(uint64_t region) const noexcept {
+		return m_regions[region].load(std::memory_order_acquire);
+	}
+	// Copy of the region's CPU-dirty bitmap taken under its lock. Discovery input only.
+	[[nodiscard]] RegionBits SnapshotCpuDirty(RegionManager& manager);
+
+	// Invariant checker (tests, --bda-sync SelectiveChecked). In every region of the range, a
+	// CPU-dirty page, or a missing manager (all-dirty by construction), requires a pending
+	// hint unless `owned(region)` says the running pass owns the region. The hint is read
+	// under the region lock, which P1 holds while it publishes, so the check cannot race into
+	// a false failure.
+	template <typename Owned>
+	[[nodiscard]] bool BdaHintsCoverCpuDirty(uint64_t vaddr, uint64_t size, Owned&& owned) {
+		CheckNotInUploadCallback();
+		ValidateRange(vaddr, size);
+		uint64_t remaining = size;
+		uint64_t index     = vaddr / TRACKER_REGION_SIZE;
+		uint64_t offset    = vaddr % TRACKER_REGION_SIZE;
+		while (remaining != 0) {
+			const auto bytes = std::min(TRACKER_REGION_SIZE - offset, remaining);
+			if (!owned(index)) {
+				auto* manager = m_regions[index].load(std::memory_order_acquire);
+				if (manager == nullptr) {
+					if (!IsBdaHintPending(index)) {
+						return false;
+					}
+				} else {
+					std::scoped_lock lock(manager->lock);
+					if (manager->IsModified<DirtySource::Cpu>(offset, bytes) &&
+					    !IsBdaHintPending(index)) {
+						return false;
+					}
+				}
+			}
+			remaining -= bytes;
+			offset = 0;
+			index++;
+		}
+		return true;
+	}
 	// Removes protection from a range and flushes GPU-owned data when required.
 	template <typename Flush>
 	void InvalidateRegion(uint64_t vaddr, uint64_t size, Flush&& on_flush) noexcept {
@@ -176,6 +252,7 @@ private:
 	std::vector<std::unique_ptr<RegionManager>>    m_region_storage;
 	std::mutex                                     m_region_mutex;
 	PageManager&                                   m_page_manager;
+	std::unique_ptr<std::atomic<uint64_t>[]>       m_bda_hints;
 };
 
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/regionManager.h
+++ b/src/graphics/host_gpu/regionManager.h
@@ -71,8 +71,11 @@ static_assert(std::atomic_uint32_t::is_always_lock_free);
 
 class RegionManager final {
 public:
-	RegionManager(PageManager& page_manager, uint64_t cpu_addr)
-	    : m_page_manager(page_manager), m_cpu_addr(cpu_addr) {
+	// `bda_hint_word` is required: P1 and P2 publish into it for every region.
+	RegionManager(PageManager& page_manager, uint64_t cpu_addr,
+	              std::atomic<uint64_t>& bda_hint_word)
+	    : m_page_manager(page_manager), m_cpu_addr(cpu_addr), m_bda_hint_word(bda_hint_word),
+	      m_bda_hint_mask(uint64_t {1} << ((cpu_addr / TRACKER_REGION_SIZE) % 64u)) {
 		if (m_cpu_addr % TRACKER_REGION_SIZE != 0) {
 			EXIT("invalid region tracking manager construction\n");
 		}
@@ -84,6 +87,15 @@ public:
 	KYTY_CLASS_NO_COPY(RegionManager);
 
 	[[nodiscard]] uint64_t GetCpuAddr() const { return m_cpu_addr; }
+
+	// Selective BDA discovery: mark this region as possibly holding CPU-dirty pages that
+	// PrepareBda must examine. See MemoryTracker for the contract.
+	void PublishBdaHint() const noexcept {
+		m_bda_hint_word.fetch_or(m_bda_hint_mask, std::memory_order_release);
+	}
+
+	// Caller holds `lock`.
+	[[nodiscard]] const RegionBits& CpuDirtyBits() const noexcept { return m_cpu_dirty; }
 	template <DirtySource source>
 	[[nodiscard]] bool IsModified(uint64_t offset, uint64_t size) const {
 		const auto [start, end] = GetPageRange(m_cpu_addr + offset, size);
@@ -109,6 +121,13 @@ public:
 			bits.SetRange(start, end);
 		} else {
 			bits.UnsetRange(start, end);
+		}
+		if constexpr (source == DirtySource::Cpu && enable) {
+			// P1: this is the only setter of CPU-dirty truth after construction. Publish on
+			// every execution (not only clean -> dirty), after the bits changed and while the
+			// caller still holds `lock`, so a locked snapshot or check never sees the new dirty
+			// bits without the hint.
+			PublishBdaHint();
 		}
 		if constexpr (source == DirtySource::Cpu) {
 			UpdateCpuProtection<!enable>();
@@ -204,6 +223,10 @@ private:
 	RegionBits   m_gpu_dirty;
 	RegionBits   m_writable;
 	RegionBits   m_readable;
+
+	// Selective BDA discovery: the hint word this region shares with 63 others, and its bit.
+	std::atomic<uint64_t>& m_bda_hint_word;
+	uint64_t               m_bda_hint_mask;
 };
 
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.cpp
@@ -4,6 +4,7 @@
 #include "common/logging/log.h"
 #include "common/profiler.h"
 #include "graphics/guest_gpu/graphicsRun.h"
+#include "graphics/host_gpu/bdaTestHooks.h"
 #include "graphics/host_gpu/graphicContext.h"
 #include "graphics/host_gpu/renderer/cache/textureCache.h"
 #include "graphics/host_gpu/renderer/commandScheduler.h"
@@ -83,6 +84,9 @@ void BufferCache::ChangeRegister(BufferId id) {
 		}
 		WriteDataBuffer(m_bda_pagetable_buffer, pages.first * sizeof(vk::DeviceAddress),
 		                addresses.data(), addresses.size() * sizeof(vk::DeviceAddress));
+		// P3: the actual registered span, after JoinOverlap merges and stream growth, may cover
+		// CPU-dirty pages that no mapped owner could reach before.
+		m_memory_tracker.PublishBdaHints(buffer.CpuAddress(), buffer.Size());
 	} else {
 		const auto found = m_buffers.find(buffer.CpuAddress());
 		EXIT_IF(found == m_buffers.end() || found->second != id);
@@ -402,7 +406,11 @@ bool BufferCache::SynchronizeBuffer(Buffer& buffer, uint64_t vaddr, uint64_t siz
 		    copies.emplace_back(total_size, buffer.Offset(address), bytes);
 		    total_size += bytes;
 	    },
-	    [&]() noexcept { source = UploadCopies(buffer, copies, total_size); });
+	    [&]() noexcept {
+		    (void)BdaTestHooks::Fire(BdaTestHooks::Point::BeforeUploadCopy, buffer.CpuAddress());
+		    source = UploadCopies(buffer, copies, total_size);
+		    (void)BdaTestHooks::Fire(BdaTestHooks::Point::AfterUploadCopy, buffer.CpuAddress());
+	    });
 	if (source) {
 		auto& command = m_scheduler.Current();
 		command.EndRendering();
@@ -699,6 +707,161 @@ void BufferCache::SynchronizeBuffersInRange(uint64_t vaddr, uint64_t size) {
 			(void)SynchronizeBuffer(buffer, start, finish - start, false, false);
 		}
 	}
+}
+
+namespace {
+
+// Owns the regions of one consumed hint word while a selective pass processes them. Whatever
+// the pass has not completed is made pending again on every exit: an owner-index failure, an
+// early return, or unwinding. Completed regions are never cleared a second time, so a
+// publication that lands after the exchange stays pending.
+class BdaHintClaim final {
+public:
+	BdaHintClaim(MemoryTracker& tracker, size_t word, uint64_t bits) noexcept
+	    : m_tracker(tracker), m_word(word), m_bits(bits) {}
+	~BdaHintClaim() { m_tracker.RestoreBdaHints(m_word, m_bits); }
+	BdaHintClaim(const BdaHintClaim&)            = delete;
+	BdaHintClaim& operator=(const BdaHintClaim&) = delete;
+
+	void SetRemaining(uint64_t bits) noexcept { m_bits = bits; }
+
+private:
+	MemoryTracker& m_tracker;
+	size_t         m_word;
+	uint64_t       m_bits;
+};
+
+} // namespace
+
+void BufferCache::PublishBdaHints(uint64_t vaddr, uint64_t size) noexcept {
+	m_memory_tracker.PublishBdaHints(vaddr, size);
+}
+
+void BufferCache::SynchronizeBdaLegacy(const RangeSet& mapped) {
+	// Normalise first. Every hint published before this point is answered by the full walk
+	// below; a publication after it stays pending for a later selective pass.
+	m_memory_tracker.DiscardBdaHints();
+	mapped.ForEach(
+	    [this](uint64_t start, uint64_t end) { SynchronizeBuffersInRange(start, end - start); });
+}
+
+bool BufferCache::SynchronizeBdaSelective(const RangeSet& mapped) {
+	struct ActivePass {
+		BufferCache& cache;
+		~ActivePass() {
+			cache.m_bda_active_word = BdaNoActiveWord;
+			cache.m_bda_active_bits = 0;
+		}
+	} active_pass {*this};
+
+	for (size_t word = 0; word < MemoryTracker::BDA_HINT_WORDS; word++) {
+		uint64_t bits = m_memory_tracker.ConsumeBdaHintWord(word);
+		if (bits == 0) {
+			continue;
+		}
+		BdaHintClaim claim(m_memory_tracker, word, bits);
+		m_bda_active_word = word;
+		m_bda_active_bits = bits;
+		(void)BdaTestHooks::Fire(BdaTestHooks::Point::AfterHintExchange, word);
+		while (bits != 0) {
+			const uint64_t region = word * 64 + static_cast<uint64_t>(std::countr_zero(bits));
+			if (!SynchronizeBdaRegion(region, mapped)) {
+				return false; // `claim` re-publishes this region and the rest of the word
+			}
+			bits &= bits - 1;
+			claim.SetRemaining(bits);
+			m_bda_active_bits = bits;
+		}
+	}
+	return true;
+}
+
+bool BufferCache::SynchronizeBdaRegion(uint64_t region, const RangeSet& mapped) {
+	const uint64_t region_begin = region * TRACKER_REGION_SIZE;
+	auto*          manager      = m_memory_tracker.FindRegion(region);
+	if (manager == nullptr) {
+		// P2 or P3 hinted a region that is not tracked yet, so every page counts as CPU-dirty.
+		// Synchronise its mapped part now through the legacy walk: the current consumer may
+		// need these bytes, and that walk's Iterate<true> creates (or waits for) the manager.
+		(void)BdaTestHooks::Fire(BdaTestHooks::Point::NullRegionManager, region);
+		mapped.ForEachIntersection(region_begin, TRACKER_REGION_SIZE,
+		                           [this](RangeSet::Range range) {
+			                           SynchronizeBuffersInRange(range.address, range.size);
+		                           });
+		return true;
+	}
+	// Discovery input only; SynchronizeBuffer re-reads the live bits under the region lock.
+	const auto dirty = m_memory_tracker.SnapshotCpuDirty(*manager);
+	(void)BdaTestHooks::Fire(BdaTestHooks::Point::AfterDirtySnapshot, region);
+	if (dirty.None()) {
+		return true;
+	}
+	bool consistent = true;
+	mapped.ForEachIntersection(region_begin, TRACKER_REGION_SIZE, [&](RangeSet::Range range) {
+		if (consistent) {
+			consistent = SynchronizeDirtyOwners(dirty, region_begin, range.address,
+			                                    range.address + range.size);
+		}
+	});
+	return consistent;
+}
+
+bool BufferCache::SynchronizeDirtyOwners(const RegionBits& dirty, uint64_t region_begin,
+                                         uint64_t begin, uint64_t end) {
+	// [begin, end) is one non-empty mapped interval inside the region. Each owner it reaches
+	// gets one complete SynchronizeBuffer over owner, region and this interval. `synced_end` is
+	// local to the interval, so another mapped piece of the same owner is still visited.
+	uint64_t   synced_end = begin;
+	auto       page       = static_cast<size_t>((begin - region_begin) / TRACKER_PAGE_SIZE);
+	const auto page_limit =
+	    static_cast<size_t>((end - region_begin + TRACKER_PAGE_SIZE - 1) / TRACKER_PAGE_SIZE);
+	while (page < page_limit) {
+		const auto [first, last] = dirty.FirstRangeFrom(page);
+		if (first >= page_limit) {
+			break;
+		}
+		const uint64_t run_begin = std::max(region_begin + first * TRACKER_PAGE_SIZE, begin);
+		const uint64_t run_end   = std::min(region_begin + last * TRACKER_PAGE_SIZE, end);
+		for (uint64_t cursor = std::max(run_begin, synced_end); cursor < run_end;) {
+			const auto* owner = m_page_table.Find(cursor >> CACHING_PAGEBITS);
+			if (owner == nullptr || !*owner) {
+				// No registered owner on this caching page: step to the next aligned boundary.
+				cursor = (cursor & ~(CACHING_PAGESIZE - 1)) + CACHING_PAGESIZE;
+				continue;
+			}
+			auto* buffer = m_slot_buffers.try_get(*owner);
+			if (buffer == nullptr || buffer->is_deleted || !buffer->IsInBounds(cursor, 1) ||
+			    BdaTestHooks::Fire(BdaTestHooks::Point::ForceSelectiveFailure, cursor)) {
+				return false; // the page table disagrees with the registered owners
+			}
+			const uint64_t owner_begin = std::max(buffer->CpuAddress(), begin);
+			const uint64_t owner_end   = std::min(buffer->CpuAddress() + buffer->Size(), end);
+			(void)SynchronizeBuffer(*buffer, owner_begin, owner_end - owner_begin, false, false);
+			synced_end = owner_end;
+			cursor     = owner_end;
+		}
+		page = last;
+	}
+	return true;
+}
+
+bool BufferCache::CheckBdaHintInvariant(const RangeSet& mapped) {
+	const auto owned = [this](uint64_t region) {
+		return region / 64 == m_bda_active_word && ((m_bda_active_bits >> (region % 64)) & 1u) != 0;
+	};
+	for (const auto& [address, id]: m_buffers) {
+		(void)address;
+		const auto& buffer  = m_slot_buffers[id];
+		bool        covered = true;
+		mapped.ForEachIntersection(buffer.CpuAddress(), buffer.Size(), [&](RangeSet::Range range) {
+			covered =
+			    covered && m_memory_tracker.BdaHintsCoverCpuDirty(range.address, range.size, owned);
+		});
+		if (!covered) {
+			return false;
+		}
+	}
+	return true;
 }
 
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/cache/bufferCache.h
+++ b/src/graphics/host_gpu/renderer/cache/bufferCache.h
@@ -69,6 +69,15 @@ public:
 	[[nodiscard]] bool IsRegionGpuModified(uint64_t vaddr, uint64_t size);
 	void               ProcessFaultBuffer();
 	void               SynchronizeBuffersInRange(uint64_t vaddr, uint64_t size);
+	// BDA synchronisation for GpuResourceManager::PrepareBda; both walk only `mapped`.
+	// Legacy: normalise (drop) pending hints, then visit every registered owner.
+	void SynchronizeBdaLegacy(const RangeSet& mapped);
+	// Selective: visit only owners of CPU-dirty pages in hinted regions. Returns false on an
+	// owner-index failure, after making every obligation it had not completed pending again.
+	[[nodiscard]] bool SynchronizeBdaSelective(const RangeSet& mapped);
+	void               PublishBdaHints(uint64_t vaddr, uint64_t size) noexcept;
+	// Invariant checker for tests and --bda-sync SelectiveChecked.
+	[[nodiscard]] bool CheckBdaHintInvariant(const RangeSet& mapped);
 	void               RunGarbageCollector();
 
 private:
@@ -108,6 +117,9 @@ private:
 	[[nodiscard]] bool SynchronizeBufferFromImage(Buffer& buffer, uint64_t vaddr, uint64_t size);
 	void DownloadBufferMemory(std::span<const DownloadCopy> copies);
 	void ReadMemoryOnGpu(uint64_t vaddr, uint64_t size, bool is_write);
+	[[nodiscard]] bool SynchronizeBdaRegion(uint64_t region, const RangeSet& mapped);
+	[[nodiscard]] bool SynchronizeDirtyOwners(const RegionBits& dirty, uint64_t region_begin,
+	                                          uint64_t begin, uint64_t end);
 
 	GraphicContext&                                   m_graphics;
 	CommandScheduler&                                 m_scheduler;
@@ -129,6 +141,10 @@ private:
 	uint64_t m_trigger_gc_memory  = 1ull * 1024 * 1024 * 1024;
 	uint64_t m_critical_gc_memory = 2ull * 1024 * 1024 * 1024;
 	uint64_t m_gc_tick            = 0;
+	// Regions owned by the selective pass in progress (for the invariant checker).
+	static constexpr size_t BdaNoActiveWord   = SIZE_MAX;
+	size_t                  m_bda_active_word = BdaNoActiveWord;
+	uint64_t                m_bda_active_bits = 0;
 };
 
 } // namespace Libs::Graphics

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.cpp
@@ -1,6 +1,7 @@
 #include "graphics/host_gpu/renderer/cache/gpuResourceManager.h"
 
 #include "common/assert.h"
+#include "common/logging/log.h"
 #include "graphics/guest_gpu/graphicsRun.h"
 #include "graphics/host_gpu/renderer/commandScheduler.h"
 namespace Libs::Graphics {
@@ -48,6 +49,10 @@ void GpuResourceManager::MapMemory(uint64_t vaddr, uint64_t size) {
 	{
 		std::lock_guard lock(m_mapped_ranges_mutex);
 		m_mapped_ranges.Add(vaddr, size);
+		// P4: the new mapping can expose CPU-dirty pages of registered owners (for example
+		// after an unmap invalidated them). Published under the exclusive lock, so no checker
+		// holding the shared lock can observe the mapping without its hints.
+		m_buffer_cache.PublishBdaHints(vaddr, size);
 	}
 }
 
@@ -77,9 +82,22 @@ void GpuResourceManager::UnmapMemory(uint64_t vaddr, uint64_t size) {
 
 void GpuResourceManager::PrepareBda() {
 	std::shared_lock lock(m_mapped_ranges_mutex);
-	m_mapped_ranges.ForEach([this](uint64_t start, uint64_t end) {
-		m_buffer_cache.SynchronizeBuffersInRange(start, end - start);
-	});
+	if (m_bda_sync_mode == Config::BdaSyncMode::Legacy || m_bda_selective_failed) {
+		m_buffer_cache.SynchronizeBdaLegacy(m_mapped_ranges);
+	} else if (!m_buffer_cache.SynchronizeBdaSelective(m_mapped_ranges)) {
+		// Fail closed. The pass has made every obligation it had not completed pending again;
+		// answer this consumer with the legacy walk and stay on it.
+#if KYTY_BUILD == KYTY_BUILD_DEBUG
+		EXIT("selective BDA sync: the buffer page table disagrees with the registered owners\n");
+#else
+		LOGF("selective BDA sync: owner index inconsistency; switching to the legacy walk\n");
+		m_bda_selective_failed = true;
+		m_buffer_cache.SynchronizeBdaLegacy(m_mapped_ranges);
+#endif
+	} else if (m_bda_sync_mode == Config::BdaSyncMode::SelectiveChecked &&
+	           !m_buffer_cache.CheckBdaHintInvariant(m_mapped_ranges)) {
+		EXIT("selective BDA sync: a CPU-dirty page of a mapped owner has no pending hint\n");
+	}
 	m_fault_process_pending = true;
 }
 

--- a/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
+++ b/src/graphics/host_gpu/renderer/cache/gpuResourceManager.h
@@ -3,6 +3,7 @@
 
 #include "common/abi.h"
 #include "common/common.h"
+#include "common/emulatorConfig.h"
 #include "graphics/host_gpu/pageManager.h"
 #include "graphics/host_gpu/renderer/cache/bufferCache.h"
 #include "graphics/host_gpu/renderer/cache/textureCache.h"
@@ -31,6 +32,11 @@ public:
 	void               MapMemory(uint64_t vaddr, uint64_t size);
 	void               UnmapMemory(uint64_t vaddr, uint64_t size);
 	void               PrepareBda();
+	// BDA synchronisation mode; GPU thread only, safe to switch at any consumer boundary.
+	void SetBdaSyncMode(Config::BdaSyncMode mode) noexcept { m_bda_sync_mode = mode; }
+	[[nodiscard]] Config::BdaSyncMode GetBdaSyncMode() const noexcept { return m_bda_sync_mode; }
+	// True once a selective pass failed closed; PrepareBda then stays on the legacy walk.
+	[[nodiscard]] bool IsBdaSelectiveDisabled() const noexcept { return m_bda_selective_failed; }
 	void               RunGarbageCollector();
 
 private:
@@ -42,6 +48,10 @@ private:
 	RangeSet                  m_mapped_ranges;
 	GuestGpu*                 m_gpu = nullptr;
 	bool                      m_fault_process_pending = false;
+	Config::BdaSyncMode       m_bda_sync_mode         = Config::BdaSyncMode::Selective;
+	bool                      m_bda_selective_failed  = false;
+
+	friend struct GpuResourceManagerTestAccess;
 };
 
 } // namespace Libs::Graphics

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -1189,6 +1189,7 @@ void WindowContext::CreateVulkan() {
 	}
 
 	render_context = std::make_unique<RenderContext>(graphic_ctx);
+	render_context->GetGpuResources().SetBdaSyncMode(Config::GetBdaSyncMode());
 	LibKernel::Memory::InstallGpuResources(&render_context->GetGpuResources());
 	presenter = std::make_unique<Presenter>(*this);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,8 @@ static void PrintUsage() {
 	         Config::DEFAULT_USER_ID);
 	::printf(
 	    "  --present-mode <value>               Fifo, Mailbox, or Immediate. Default: Fifo.\n");
+	::printf("  --bda-sync <value>                   Selective, Legacy, or SelectiveChecked.\n"
+	         "                                       Default: Selective.\n");
 	::printf(
 	    "  --gpu <index>                        Vulkan physical device index. Default: auto.\n");
 	::printf("  --fullscreen                         Run in borderless desktop fullscreen.\n");
@@ -233,6 +235,11 @@ static bool ParseArgs(int argc, char* argv[], RunOptions& options, bool& show_he
 		} else if (arg == "--present-mode") {
 			if (!ParseEnum(value, options.config.present_mode)) {
 				::printf("invalid present mode: %s\n", value.c_str());
+				return false;
+			}
+		} else if (arg == "--bda-sync") {
+			if (!ParseEnum(value, options.config.bda_sync_mode)) {
+				::printf("invalid BDA sync mode: %s\n", value.c_str());
 				return false;
 			}
 		} else if (arg == "--gpu") {

--- a/tests/MemoryTrackerTests.cpp
+++ b/tests/MemoryTrackerTests.cpp
@@ -1,9 +1,11 @@
 #include "common/hostException.h"
 #include "common/virtualMemory.h"
+#include "graphics/host_gpu/bdaTestHooks.h"
 #include "graphics/host_gpu/memoryTracker.h"
 #include "graphics/host_gpu/rangeSet.h"
 
 #include <atomic>
+#include <barrier>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -907,6 +909,137 @@ bool ProtectGuestHostMemory(uint64_t vaddr, uint64_t size,
 
 } // namespace Libs::LibKernel::Memory
 
+namespace {
+
+using Libs::Graphics::TRACKER_REGION_SIZE;
+namespace BdaHooks = Libs::Graphics::BdaTestHooks;
+
+MemoryTracker *g_bda_p2_tracker = nullptr;
+std::atomic<uint64_t> g_bda_p2_region{UINT64_MAX};
+std::atomic<bool> g_bda_p2_seen{false};
+std::atomic<bool> g_bda_p2_hint_first{false};
+
+bool BdaP2Probe(BdaHooks::Point point, uint64_t value) {
+  if (point == BdaHooks::Point::RegionHintPublished &&
+      value == g_bda_p2_region.load()) {
+    g_bda_p2_seen = true;
+    g_bda_p2_hint_first = g_bda_p2_tracker->IsBdaHintPending(value) &&
+                          g_bda_p2_tracker->FindRegion(value) == nullptr;
+  }
+  return false;
+}
+
+// P1 on every CPU-dirty route and every execution, P2 hint-before-pointer, and the
+// exchange / restore / discard / half-open publication contract of the hint words.
+void TestBdaHintPublication() {
+  TrackerHarness harness;
+  auto &tracker = harness.tracker;
+  const auto page = harness.page_manager.GetPageSize();
+  auto *memory = Allocate(harness.page_manager, 4);
+  const auto vaddr = reinterpret_cast<uint64_t>(memory);
+  const auto region = vaddr / TRACKER_REGION_SIZE;
+  const auto word = static_cast<size_t>(region / 64);
+  const auto pending = [&] { return tracker.IsBdaHintPending(region); };
+
+  Check(!pending() && tracker.FindRegion(region) == nullptr,
+        "fresh tracker already has a hint or a manager");
+
+  g_bda_p2_tracker = &tracker;
+  g_bda_p2_region = region;
+  BdaHooks::g_callback = BdaP2Probe;
+  (void)tracker.IsRegionCpuModified(vaddr, 1); // Iterate<true> creates the region
+  BdaHooks::g_callback = nullptr;
+  Check(g_bda_p2_seen && g_bda_p2_hint_first,
+        "P2 published the manager pointer before the region hint");
+  Check(pending() && tracker.FindRegion(region) != nullptr,
+        "region creation did not leave its hint pending");
+
+  const auto bits = tracker.ConsumeBdaHintWord(word);
+  Check(((bits >> (region % 64)) & 1u) != 0 && !pending() &&
+            tracker.ConsumeBdaHintWord(word) == 0,
+        "hint exchange did not transfer the region exactly once");
+
+  tracker.ForEachUploadRange(
+      vaddr, 4 * page, false, [](uint64_t, uint64_t) noexcept {},
+      []() noexcept {});
+  Check(!pending(), "clearing CPU-dirty state published a hint");
+
+  tracker.InvalidateRegion(vaddr, 1, [] {});
+  Check(pending(), "InvalidateRegion did not publish");
+  (void)tracker.ConsumeBdaHintWord(word);
+  tracker.MarkRegionAsCpuModified(vaddr, 1); // already CPU-dirty
+  Check(pending(), "MarkRegionAsCpuModified on a dirty page did not publish");
+  (void)tracker.ConsumeBdaHintWord(word);
+  tracker.MarkRegionAsCpuModified(vaddr, 1);
+  Check(pending(), "a repeated CPU-dirty execution did not publish again");
+  (void)tracker.ConsumeBdaHintWord(word);
+  tracker.UntrackMemory(vaddr, 4 * page);
+  Check(pending(), "UntrackMemory did not publish");
+
+  const auto owned = tracker.ConsumeBdaHintWord(word);
+  tracker.RestoreBdaHints(word, owned);
+  Check(pending(), "RestoreBdaHints lost an owned region");
+  tracker.DiscardBdaHints();
+  Check(!pending(), "DiscardBdaHints left a hint pending");
+
+  tracker.MarkRegionAsCpuModified(vaddr, 1);
+  (void)tracker.ConsumeBdaHintWord(word);
+  tracker.MarkRegionAsCpuModified(vaddr, 1);
+  Check(pending(), "a publication after the exchange was lost");
+  tracker.DiscardBdaHints();
+
+  const uint64_t boundary = (region + 1) * TRACKER_REGION_SIZE;
+  tracker.PublishBdaHints(boundary - 1, 1);
+  Check(tracker.IsBdaHintPending(region) &&
+            !tracker.IsBdaHintPending(region + 1),
+        "the last byte before a region boundary flagged the next region");
+  tracker.DiscardBdaHints();
+  tracker.PublishBdaHints(boundary - 1, 2);
+  Check(tracker.IsBdaHintPending(region) &&
+            tracker.IsBdaHintPending(region + 1),
+        "a range crossing a region boundary missed a region");
+  tracker.DiscardBdaHints();
+  tracker.PublishBdaHints(boundary, 0);
+  Check(!tracker.IsBdaHintPending(region + 1),
+        "an empty range published a hint");
+
+  Release(memory);
+}
+
+// Two publishers hit two regions of one hint word in lock step with the consumer's exchange;
+// no round may lose either bit.
+void TestBdaHintSameWordConcurrentPublishers() {
+  TrackerHarness harness;
+  auto &tracker = harness.tracker;
+  constexpr size_t word = 300;
+  constexpr uint64_t first = word * 64 + 5;
+  constexpr uint64_t second = word * 64 + 41;
+  constexpr int rounds = 20000;
+  std::barrier sync(3);
+  const auto publisher = [&](uint64_t region) {
+    for (int i = 0; i < rounds; i++) {
+      sync.arrive_and_wait();
+      tracker.PublishBdaHints(region * TRACKER_REGION_SIZE, 1);
+      sync.arrive_and_wait();
+    }
+  };
+  std::thread a(publisher, first);
+  std::thread b(publisher, second);
+  constexpr uint64_t expected =
+      (uint64_t{1} << (first % 64)) | (uint64_t{1} << (second % 64));
+  bool lost = false;
+  for (int i = 0; i < rounds; i++) {
+    sync.arrive_and_wait();
+    sync.arrive_and_wait();
+    lost = lost || tracker.ConsumeBdaHintWord(word) != expected;
+  }
+  a.join();
+  b.join();
+  Check(!lost, "concurrent same-word publications lost a bit");
+}
+
+} // namespace
+
 int main(int argc, char **argv) {
   if (argc == 3 && std::strcmp(argv[1], "--death") == 0) {
     RunDeathCase(argv[2]);
@@ -926,6 +1059,8 @@ int main(int argc, char **argv) {
   TestDownloadDoesNotSerializeDisjointRegion();
   TestGpuUnmarkUsesRegionMask();
   TestFullRegionGpuUnmarkBatching();
+  TestBdaHintPublication();
+  TestBdaHintSameWordConcurrentPublishers();
   TestFatalPaths();
 #if KYTY_PLATFORM == KYTY_PLATFORM_LINUX
   TestFaultOnProtectedStack();

--- a/tests/ShaderRecompilerComputeTests.cpp
+++ b/tests/ShaderRecompilerComputeTests.cpp
@@ -13,6 +13,7 @@
 #include "graphics/guest_gpu/hardwareContext.h"
 #include "graphics/guest_gpu/pm4.h"
 #include "graphics/guest_gpu/tile.h"
+#include "graphics/host_gpu/bdaTestHooks.h"
 #include "graphics/host_gpu/hostMemory.h"
 #include "graphics/host_gpu/memoryTracker.h"
 #include "graphics/host_gpu/pageManager.h"
@@ -100,6 +101,11 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+
+#include <barrier>
+#include <functional>
+#include <semaphore>
+#include <thread>
 #undef min
 #undef max
 #endif
@@ -177,6 +183,24 @@ struct BufferCacheTestAccess {
 
   static bool IsBufferAllocated(const BufferCache &cache, BufferId id) {
     return cache.m_slot_buffers.is_allocated(id);
+  }
+
+  static StreamBuffer &StagingBuffer(BufferCache &cache) {
+    return cache.m_staging_buffer;
+  }
+
+  static bool BdaHintPending(const BufferCache &cache, uint64_t address) {
+    return cache.m_memory_tracker.IsBdaHintPending(address /
+                                                   TRACKER_REGION_SIZE);
+  }
+};
+
+struct GpuResourceManagerTestAccess {
+  // The invariant check without taking the mapped-range lock: callers are single-threaded
+  // test code, or a hook running inside PrepareBda, which already holds that lock shared.
+  static bool HintInvariantHolds(GpuResourceManager &resources) {
+    return resources.m_buffer_cache.CheckBdaHintInvariant(
+        resources.m_mapped_ranges);
   }
 };
 
@@ -3432,6 +3456,903 @@ public:
             "2D slice views of a compatible 3D backing were rejected");
     std::printf("[host]    %-32s ok\n", name);
   }
+
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+  // Selective BDA discovery against the legacy full walk. Every case runs from the same guest
+  // state once per mode. At each BDA consumer boundary it reads the bytes a BDA shader would
+  // read - the registered owner's device buffer - and compares them with guest memory. Dirty
+  // bitmaps, upload lists and protection state can all agree while data arrives one consumer
+  // late, so none of them is the oracle. Guest stores are faithful: a store to a page the OS
+  // reports as protected raises the same fault the host exception path does, then retries.
+  // A non-null `only` runs just the cases whose name contains it.
+  void CheckSelectiveBdaSynchronization(const char *only = nullptr) {
+    constexpr const char *name = "SelectiveBdaSynchronization";
+    constexpr uint64_t kRegion = TRACKER_REGION_SIZE;
+    constexpr uint64_t kOwnerPage = BufferCache::CACHING_PAGESIZE;
+    constexpr uint64_t kPage = TRACKER_PAGE_SIZE;
+    constexpr uintptr_t base = 0x0000000240000000ull;
+    constexpr uint64_t area = 6 * kRegion;
+    constexpr uintptr_t alias_base = 0x0000000250000000ull;
+    constexpr uint64_t alias_size = kRegion;
+    constexpr uint64_t alignment = 0x10000;
+    static_assert(base % kRegion == 0 && alias_base % kRegion == 0);
+    // Regions 0..5 of the test area share one hint word.
+    static_assert((base / kRegion) / 64 == (base / kRegion + 5) / 64);
+
+    EnsureRuntimeContext();
+    auto &context = Renderer();
+    CommandScheduler scheduler(context, m_runtime_context);
+    HW::Context registers{};
+    HW::UserConfig user_config{};
+    HW::Shader shaders{};
+    scheduler.Begin(registers, user_config, shaders);
+    context.InitializeGpu(nullptr);
+    auto &gpu = context.GetGpu();
+
+    int64_t direct_offset = -1;
+    Require(name, "direct allocation",
+            Libs::LibKernel::Memory::KernelAllocateDirectMemory(
+                0, Libs::LibKernel::Memory::KernelGetDirectMemorySize(), area,
+                alignment, 0, &direct_offset) == 0,
+            "direct-memory allocation failed");
+    void *mapped = reinterpret_cast<void *>(base);
+    Require(name, "direct mapping",
+            Libs::LibKernel::Memory::KernelMapDirectMemory(
+                &mapped, area, 0x3, 0x10, direct_offset, alignment) == 0 &&
+                mapped == reinterpret_cast<void *>(base),
+            "fixed direct-memory mapping failed");
+    void *alias = reinterpret_cast<void *>(alias_base);
+    Require(name, "alias mapping",
+            Libs::LibKernel::Memory::KernelMapDirectMemory(
+                &alias, alias_size, 0x3, 0x10, direct_offset, alignment) == 0 &&
+                alias == reinterpret_cast<void *>(alias_base),
+            "fixed alias mapping failed");
+
+    struct Run {
+      GpuResourceManager *resources = nullptr;
+      BufferCache *cache = nullptr;
+      std::vector<std::pair<std::string, std::vector<uint8_t>>> seen;
+    };
+    Run *run = nullptr;
+    uint32_t stamp = 1;
+
+    static std::function<bool(BdaTestHooks::Point, uint64_t)> s_hook;
+    BdaTestHooks::g_callback = [](BdaTestHooks::Point point, uint64_t value) {
+      return s_hook ? s_hook(point, value) : false;
+    };
+
+    const auto addr = [](uint64_t offset) {
+      return static_cast<uint64_t>(base) + offset;
+    };
+    const auto mode_name = [&] {
+      return run->resources->GetBdaSyncMode() == Config::BdaSyncMode::Legacy
+                 ? "legacy"
+                 : "selective";
+    };
+    const auto writable = [&](uint64_t address) {
+      MEMORY_BASIC_INFORMATION info{};
+      Require(name, "protection query",
+              VirtualQuery(reinterpret_cast<void *>(address), &info,
+                           sizeof(info)) != 0,
+              "VirtualQuery failed");
+      constexpr DWORD kWritable = PAGE_READWRITE | PAGE_WRITECOPY |
+                                  PAGE_EXECUTE_READWRITE |
+                                  PAGE_EXECUTE_WRITECOPY;
+      return (info.Protect & kWritable) != 0;
+    };
+    const auto guest_write = [&](uint64_t address, const void *data,
+                                 uint64_t size) {
+      const auto *bytes = static_cast<const uint8_t *>(data);
+      for (uint64_t cursor = address; cursor < address + size;) {
+        const uint64_t page_end = (cursor & ~(kPage - 1)) + kPage;
+        const uint64_t chunk = std::min(page_end, address + size) - cursor;
+        if (!writable(cursor)) {
+          Require(name, "guest fault",
+                  run->resources->HandleFault(PageFaultAccess::Write, cursor),
+                  "a store fault on a protected page was not handled");
+          Require(name, "guest fault", writable(cursor),
+                  "the store fault left the page protected");
+        }
+        std::memcpy(reinterpret_cast<void *>(cursor), bytes + (cursor - address),
+                    chunk);
+        cursor += chunk;
+      }
+    };
+    const auto pattern = [](uint32_t seed, uint64_t size) {
+      std::vector<uint8_t> bytes(size);
+      const uint32_t mixed = seed * 2654435761u;
+      for (uint64_t i = 0; i < size; i++) {
+        bytes[i] = static_cast<uint8_t>((mixed >> ((i & 3) * 8)) ^ (i * 131) ^
+                                        (i >> 7) ^ seed);
+      }
+      return bytes;
+    };
+    const auto fill_at = [&](uint64_t address, uint64_t size) {
+      const auto bytes = pattern(stamp++, size);
+      guest_write(address, bytes.data(), size);
+    };
+    const auto fill = [&](uint64_t offset, uint64_t size) {
+      fill_at(addr(offset), size);
+    };
+    const auto map = [&](uint64_t offset, uint64_t size) {
+      run->resources->MapMemory(addr(offset), size);
+    };
+    const auto unmap = [&](uint64_t offset, uint64_t size) {
+      run->resources->UnmapMemory(addr(offset), size);
+    };
+    const auto owner_at = [&](uint64_t address, uint64_t size) {
+      const auto id = run->cache->FindBuffer(address, size);
+      Require(name, "owner registration", static_cast<bool>(id),
+              "FindBuffer did not register an owner");
+      return id;
+    };
+    const auto owner = [&](uint64_t offset, uint64_t size) {
+      return owner_at(addr(offset), size);
+    };
+    const auto hint_pending = [&](uint64_t offset) {
+      return BufferCacheTestAccess::BdaHintPending(*run->cache, addr(offset));
+    };
+    const auto invariant_holds = [&] {
+      return GpuResourceManagerTestAccess::HintInvariantHolds(*run->resources);
+    };
+    const auto consume = [&](const char *consumer) {
+      run->resources->PrepareBda();
+      if (run->resources->GetBdaSyncMode() != Config::BdaSyncMode::Legacy) {
+        Require(name, consumer, invariant_holds(),
+                "after a selective pass a CPU-dirty page of a mapped owner "
+                "has no pending hint");
+      }
+    };
+    // Bytes the registered owners' device buffers hold for [address, address + size), read
+    // without synchronising anything; empty if part of the range has no owner.
+    const auto read_device = [&](uint64_t address, uint64_t size) {
+      struct Piece {
+        vk::Buffer source;
+        uint64_t begin;
+        uint64_t bytes;
+        uint64_t out;
+        uint64_t skew;
+        uint64_t size;
+      };
+      std::vector<Piece> pieces;
+      uint64_t total = 0;
+      for (uint64_t cursor = address; cursor < address + size;) {
+        const auto id = BufferCacheTestAccess::PageOwner(*run->cache, cursor);
+        if (!id) {
+          return std::vector<uint8_t>{};
+        }
+        auto &buffer = run->cache->GetBuffer(id);
+        const uint64_t piece_end =
+            std::min(buffer.CpuAddress() + buffer.Size(), address + size);
+        const uint64_t relative = cursor - buffer.CpuAddress();
+        const uint64_t begin = relative & ~uint64_t{3};
+        const uint64_t end =
+            (piece_end - buffer.CpuAddress() + 3) & ~uint64_t{3};
+        pieces.push_back({buffer.Handle(), begin, end - begin, total,
+                          relative - begin, piece_end - cursor});
+        total += end - begin;
+        cursor = piece_end;
+      }
+      auto readback = CreateHostBuffer(
+          name, total, vk::BufferUsageFlagBits::eTransferDst, {0});
+      for (const auto &piece : pieces) {
+        const vk::BufferCopy copy{piece.begin, piece.out, piece.bytes};
+        scheduler.Current().Handle().copyBuffer(piece.source, readback.buffer, 1,
+                                                &copy);
+      }
+      vk::BufferMemoryBarrier barrier{};
+      barrier.sType = vk::StructureType::eBufferMemoryBarrier;
+      barrier.srcAccessMask = vk::AccessFlagBits::eTransferWrite;
+      barrier.dstAccessMask = vk::AccessFlagBits::eHostRead;
+      barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+      barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+      barrier.buffer = readback.buffer;
+      barrier.size = readback.size;
+      scheduler.Current().Handle().pipelineBarrier(
+          vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eHost,
+          {}, 0, nullptr, 1, &barrier, 0, nullptr);
+      scheduler.Finish();
+      const auto words = ReadBuffer(name, readback, total / 4);
+      DestroyBuffer(&readback);
+      std::vector<uint8_t> bytes;
+      bytes.reserve(size);
+      const auto *raw = reinterpret_cast<const uint8_t *>(words.data());
+      for (const auto &piece : pieces) {
+        bytes.insert(bytes.end(), raw + piece.out + piece.skew,
+                     raw + piece.out + piece.skew + piece.size);
+      }
+      return bytes;
+    };
+    const auto expect_at = [&](uint64_t address, uint64_t size,
+                               const std::string &label) {
+      const auto device = read_device(address, size);
+      std::vector<uint8_t> guest(size);
+      Require(name, label.c_str(),
+              Libs::LibKernel::Memory::TryReadBacking(address, guest.data(),
+                                                      size),
+              "guest backing read failed");
+      Require(name, label.c_str(), !device.empty() && device == guest,
+              std::string(mode_name()) +
+                  ": BDA-visible bytes differ from guest memory at this "
+                  "consumer boundary");
+      run->seen.emplace_back(label, device);
+    };
+    const auto expect = [&](uint64_t offset, uint64_t size,
+                            const std::string &label) {
+      expect_at(addr(offset), size, label);
+    };
+    const auto record_at = [&](uint64_t address, uint64_t size,
+                               const std::string &label) {
+      run->seen.emplace_back(label, read_device(address, size));
+    };
+    const auto on_other_thread = [](auto &&work) {
+      std::thread worker(std::forward<decltype(work)>(work));
+      worker.join();
+    };
+
+    // Runs `body` once per mode from identical guest state. With `compare_modes`, every
+    // observation must also be identical between the modes.
+    const auto run_case = [&](const char *test, bool compare_modes,
+                              auto &&body) {
+      if (only != nullptr && std::strstr(test, only) == nullptr) {
+        return;
+      }
+      std::vector<std::pair<std::string, std::vector<uint8_t>>> observed[2];
+      constexpr Config::BdaSyncMode modes[2] = {Config::BdaSyncMode::Legacy,
+                                                Config::BdaSyncMode::Selective};
+      for (int m = 0; m < 2; m++) {
+        std::vector<uint8_t> zero(area, 0);
+        Libs::LibKernel::Memory::WriteBacking(base, zero.data(), area);
+        stamp = 1;
+        GpuResourceManager resources(m_runtime_context, scheduler);
+        resources.SetGpu(&gpu);
+        resources.SetBdaSyncMode(modes[m]);
+        Run current{&resources, &resources.GetBufferCache(), {}};
+        run = &current;
+        body(modes[m] == Config::BdaSyncMode::Legacy);
+        s_hook = nullptr;
+        observed[m] = std::move(current.seen);
+        resources.UnmapMemory(base, area);
+        resources.UnmapMemory(alias_base, alias_size);
+        scheduler.Finish();
+        resources.SetGpu(nullptr);
+        run = nullptr;
+      }
+      Require(name, test, !compare_modes || observed[0] == observed[1],
+              "legacy and selective made different bytes BDA-visible");
+      std::printf("[host]    %-32s ok\n", test);
+    };
+    const auto region_of = [](uint64_t offset) { return offset / kRegion; };
+
+    run_case("BDA T1 one dirty among 1000", true, [&](bool) {
+      map(0, area);
+      constexpr uint64_t count = 1000;
+      fill(0, count * kOwnerPage);
+      for (uint64_t i = 0; i < count; i++) {
+        owner(i * kOwnerPage, kOwnerPage);
+      }
+      consume("T1 initial");
+      expect(0, count * kOwnerPage, "T1 initial");
+      fill(537 * kOwnerPage + 0x1234, 1);
+      consume("T1 one dirty");
+      expect(0, count * kOwnerPage, "T1 every owner after one dirty byte");
+    });
+
+    run_case("BDA T2 adjacent owners one dirty", true, [&](bool) {
+      map(0, area);
+      fill(0x10000, 0x20000);
+      owner(0x10000, 0x10000);
+      owner(0x20000, 0x10000);
+      consume("T2 initial");
+      expect(0x10000, 0x20000, "T2 initial");
+      fill(0x18000, 64);
+      consume("T2 one dirty");
+      expect(0x10000, 0x20000, "T2 both owners");
+    });
+
+    run_case("BDA T3 two dirty owners", true, [&](bool) {
+      map(0, area);
+      fill(0x40000, 0x10000);
+      fill(2 * kRegion + 0x40000, 0x10000);
+      owner(0x40000, 0x10000);
+      owner(2 * kRegion + 0x40000, 0x10000);
+      consume("T3 initial");
+      fill(0x44000, 32);
+      fill(2 * kRegion + 0x4c000, 32);
+      consume("T3 two dirty");
+      expect(0x40000, 0x10000, "T3 first owner");
+      expect(2 * kRegion + 0x40000, 0x10000, "T3 second owner");
+    });
+
+    run_case("BDA T4 four 4K quarters", true, [&](bool) {
+      map(0, area);
+      fill(0x80000, kOwnerPage);
+      owner(0x80000, kOwnerPage);
+      consume("T4 initial");
+      for (uint64_t q = 0; q < kOwnerPage / kPage; q++) {
+        fill(0x80000 + q * kPage + 0x7, 1);
+        consume("T4 quarter");
+        expect(0x80000, kOwnerPage, "T4 quarter " + std::to_string(q));
+      }
+      for (uint64_t q = 0; q < kOwnerPage / kPage; q++) {
+        fill(0x80000 + q * kPage + 0x100, 1);
+      }
+      consume("T4 all quarters");
+      expect(0x80000, kOwnerPage, "T4 all quarters");
+    });
+
+    run_case("BDA T5 partial mapped first page", true, [&](bool) {
+      map(0, 0x100000);
+      map(0x100800, area - 0x100800);
+      fill(0x100000, 0x8000);
+      owner(0x100000, 0x8000);
+      consume("T5 initial");
+      expect(0x100800, 0x7800, "T5 initial mapped part");
+      record_at(addr(0x100000), 0x800, "T5 unmapped head");
+      fill(0x100900, 16);
+      consume("T5 write");
+      expect(0x100800, 0x7800, "T5 mapped part");
+      record_at(addr(0x100000), 0x800, "T5 unmapped head after");
+    });
+
+    run_case("BDA T6 partial mapped last page", true, [&](bool) {
+      map(0, 0x207800);
+      map(0x208000, area - 0x208000);
+      fill(0x200000, 0x8000);
+      owner(0x200000, 0x8000);
+      consume("T6 initial");
+      expect(0x200000, 0x7800, "T6 initial mapped part");
+      fill(0x207700, 16);
+      consume("T6 write");
+      expect(0x200000, 0x7800, "T6 mapped part");
+      record_at(addr(0x207800), 0x800, "T6 unmapped tail");
+    });
+
+    run_case("BDA T7 owner crossing 4M boundary", true, [&](bool) {
+      map(0, area);
+      fill(kRegion - 0x10000, 0x20000);
+      owner(kRegion - 0x10000, 0x20000);
+      consume("T7 initial");
+      fill(kRegion - 0x8000, 64);
+      consume("T7 left side");
+      expect(kRegion - 0x10000, 0x20000, "T7 whole owner");
+    });
+
+    run_case("BDA T8 dirty range crossing 4M", true, [&](bool) {
+      map(0, area);
+      fill(kRegion - 0x10000, 0x20000);
+      owner(kRegion - 0x10000, 0x20000);
+      consume("T8 initial");
+      fill(kRegion - 0x2000, 0x4000);
+      consume("T8 crossing write");
+      expect(kRegion - 0x10000, 0x20000, "T8 whole owner");
+    });
+
+    run_case("BDA T9 disjoint mapped pieces", true, [&](bool) {
+      map(0, area);
+      fill(0x300000, 0x40000);
+      owner(0x300000, 0x40000);
+      consume("T9 initial");
+      unmap(0x310000, 0x10000);
+      fill(0x304000, 64);
+      fill(0x314000, 64);
+      fill(0x328000, 64);
+      consume("T9 writes");
+      expect(0x300000, 0x10000, "T9 first mapped piece");
+      expect(0x320000, 0x20000, "T9 second mapped piece");
+      record_at(addr(0x310000), 0x10000, "T9 unmapped gap");
+    });
+
+    run_case("BDA T10 write before exchange", true, [&](bool) {
+      map(0, area);
+      fill(kRegion + 0x40000, 0x10000);
+      owner(kRegion + 0x40000, 0x10000);
+      consume("T10 initial");
+      fill(kRegion + 0x46000, 128);
+      consume("T10 ordered write");
+      expect(kRegion + 0x40000, 0x10000, "T10 owner");
+    });
+
+    run_case("BDA T11 write after exchange", false, [&](bool legacy) {
+      map(0, area);
+      const uint64_t first = 3 * kRegion + 0x40000;
+      const uint64_t other = 2 * kRegion + 0x40000; // same hint word, not in this pass
+      fill(first, 0x10000);
+      fill(other, 0x10000);
+      owner(first, 0x10000);
+      owner(other, 0x10000);
+      consume("T11 initial");
+      fill(first + 0x1000, 64); // makes region 3 part of the next pass
+      if (legacy) {
+        fill(first + 0x3000, 64);
+        fill(other + 0x3000, 64);
+        consume("T11 control");
+        expect(first, 0x10000, "T11 owner");
+        expect(other, 0x10000, "T11 other");
+        return;
+      }
+      const uint64_t word = (base / kRegion + region_of(first)) / 64;
+      bool fired = false;
+      s_hook = [&](BdaTestHooks::Point point, uint64_t value) {
+        if (point == BdaTestHooks::Point::AfterHintExchange && value == word &&
+            !fired) {
+          fired = true;
+          on_other_thread([&] {
+            fill(first + 0x3000, 64); // same region, before its snapshot
+            fill(other + 0x3000, 64); // same word, region not owned by the pass
+          });
+          Require(name, "T11 mid-pass", invariant_holds(),
+                  "invariant failed while the pass owned the word");
+        }
+        return false;
+      };
+      consume("T11 pass");
+      s_hook = nullptr;
+      Require(name, "T11", fired, "the exchange hook never fired");
+      expect(first, 0x10000, "T11 owner");
+      Require(name, "T11", hint_pending(other),
+              "a publication after the exchange was lost");
+      consume("T11 next");
+      expect(other, 0x10000, "T11 other");
+    });
+
+    run_case("BDA T12 write after snapshot", false, [&](bool legacy) {
+      map(0, area);
+      const uint64_t a = 4 * kRegion + 0x40000;
+      const uint64_t b = 4 * kRegion + 0x80000;
+      fill(a, kOwnerPage);
+      fill(b, kOwnerPage);
+      owner(a, kOwnerPage);
+      owner(b, kOwnerPage);
+      consume("T12 initial");
+      fill(a + 0x10, 16);
+      if (legacy) {
+        consume("T12 control");
+        expect(a, kOwnerPage, "T12 A");
+        fill(b + 0x10, 16);
+        consume("T12 control next");
+        expect(b, kOwnerPage, "T12 B");
+        return;
+      }
+      const uint64_t region = base / kRegion + region_of(a);
+      bool fired = false;
+      s_hook = [&](BdaTestHooks::Point point, uint64_t value) {
+        if (point == BdaTestHooks::Point::AfterDirtySnapshot &&
+            value == region && !fired) {
+          fired = true;
+          on_other_thread([&] { fill(b + 0x10, 16); });
+        }
+        return false;
+      };
+      consume("T12 pass");
+      s_hook = nullptr;
+      Require(name, "T12", fired, "the snapshot hook never fired");
+      expect(a, kOwnerPage, "T12 A");
+      Require(name, "T12", hint_pending(b),
+              "a racing publication after the snapshot was lost");
+      consume("T12 next");
+      expect(b, kOwnerPage, "T12 B");
+    });
+
+    run_case("BDA T13 same-word concurrent", true, [&](bool) {
+      map(0, area);
+      const uint64_t a = kRegion + 0x100000;
+      const uint64_t b = 2 * kRegion + 0x100000;
+      fill(a, 0x10000);
+      fill(b, 0x10000);
+      owner(a, 0x10000);
+      owner(b, 0x10000);
+      consume("T13 initial");
+      const auto first = pattern(0x1111, 256);
+      const auto second = pattern(0x2222, 256);
+      std::barrier start(2);
+      std::thread one([&] {
+        start.arrive_and_wait();
+        guest_write(addr(a + 0x2000), first.data(), first.size());
+      });
+      std::thread two([&] {
+        start.arrive_and_wait();
+        guest_write(addr(b + 0x2000), second.data(), second.size());
+      });
+      one.join();
+      two.join();
+      consume("T13 concurrent");
+      expect(a, 0x10000, "T13 A");
+      expect(b, 0x10000, "T13 B");
+    });
+
+    run_case("BDA T14 republish after exchange", false, [&](bool legacy) {
+      map(0, area);
+      const uint64_t o = 5 * kRegion + 0x40000;
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      consume("T14 initial");
+      fill(o + 0x1000, 64);
+      if (legacy) {
+        fill(o + 0x5000, 64);
+        consume("T14 control");
+        expect(o, 0x10000, "T14 owner");
+        return;
+      }
+      const uint64_t word = (base / kRegion + region_of(o)) / 64;
+      bool fired = false;
+      s_hook = [&](BdaTestHooks::Point point, uint64_t value) {
+        if (point == BdaTestHooks::Point::AfterHintExchange && value == word &&
+            !fired) {
+          fired = true;
+          on_other_thread([&] { fill(o + 0x5000, 64); });
+        }
+        return false;
+      };
+      consume("T14 pass");
+      s_hook = nullptr;
+      Require(name, "T14", fired, "the exchange hook never fired");
+      Require(name, "T14", hint_pending(o),
+              "the pass cleared a region republished after its exchange");
+      expect(o, 0x10000, "T14 owner");
+      consume("T14 next");
+      expect(o, 0x10000, "T14 owner next");
+    });
+
+    run_case("BDA T15 store around re-arm", true, [&](bool) {
+      map(0, area);
+      const uint64_t o = kRegion + 0x500000;
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      consume("T15 initial");
+      for (const auto point : {BdaTestHooks::Point::BeforeUploadCopy,
+                               BdaTestHooks::Point::AfterUploadCopy}) {
+        fill(o + 0x100, 32);
+        bool fired = false;
+        s_hook = [&](BdaTestHooks::Point p, uint64_t value) {
+          if (p == point && value == addr(o) && !fired) {
+            fired = true;
+            // The page was just re-protected; this store faults and retries.
+            on_other_thread([&] { fill(o + 0x180, 32); });
+          }
+          return false;
+        };
+        consume("T15 racing pass");
+        s_hook = nullptr;
+        Require(name, "T15", fired, "the upload hook never fired");
+        Require(name, "T15", hint_pending(o),
+                "a store after protection re-arm left no pending hint");
+        consume("T15 next");
+        expect(o, 0x10000, "T15 owner after racing store");
+      }
+    });
+
+    run_case("BDA T16 null manager P2 window", false, [&](bool legacy) {
+      map(0, area);
+      const uint64_t o = 5 * kRegion + 0x200000;
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      if (legacy) {
+        consume("T16 control");
+        expect(o, 0x10000, "T16 owner");
+        return;
+      }
+      const uint64_t region = base / kRegion + region_of(o);
+      std::binary_semaphore paused{0}, release{0}, finished{0};
+      bool null_seen = false;
+      s_hook = [&](BdaTestHooks::Point point, uint64_t value) {
+        if (point == BdaTestHooks::Point::RegionHintPublished && value == region) {
+          paused.release();
+          release.acquire();
+        } else if (point == BdaTestHooks::Point::NullRegionManager &&
+                   value == region && !null_seen) {
+          null_seen = true;
+          release.release();
+          finished.acquire();
+        }
+        return false;
+      };
+      std::thread creator([&] {
+        (void)run->cache->IsRegionCpuModified(addr(o), 1);
+        finished.release();
+      });
+      paused.acquire();
+      consume("T16 pass");
+      creator.join();
+      s_hook = nullptr;
+      Require(name, "T16", null_seen,
+              "the consumer never met the hint-before-pointer window");
+      expect(o, 0x10000, "T16 owner at the same consumer");
+    });
+
+    run_case("BDA T17 owner after publication", true, [&](bool) {
+      map(0, area);
+      const uint64_t a = 2 * kRegion + 0x100000;
+      const uint64_t t = 2 * kRegion + 0x200000;
+      fill(a, kOwnerPage);
+      owner(a, kOwnerPage);
+      consume("T17 initial");
+      fill(t, 0x8000);
+      Require(name, "T17",
+              run->resources->InvalidateMemory(addr(t), 0x8000),
+              "explicit invalidation of a mapped range failed");
+      consume("T17 no owner yet");
+      owner(t, 0x8000);
+      consume("T17 owner registered");
+      expect(t, 0x8000, "T17 new owner");
+    });
+
+    run_case("BDA T18 stream-grown real span", true, [&](bool) {
+      map(0, area);
+      const uint64_t far_owner = 4 * kRegion + 0x300000;
+      fill(far_owner, kOwnerPage);
+      owner(far_owner, kOwnerPage);
+      consume("T18 region 4 tracked");
+      const uint64_t leap_target = 4 * kRegion;
+      fill(leap_target, 0x80000); // orphan pages: dirty, writable, hint consumed
+      consume("T18 orphans");
+      const uint64_t start = 4 * kRegion - 0x80000;
+      fill(start, 24 * kOwnerPage + kOwnerPage);
+      for (uint64_t k = 0; k < 24; k++) {
+        owner(start + (k + 1) * kOwnerPage - 8, 16);
+      }
+      const auto grown = BufferCacheTestAccess::PageOwner(*run->cache, addr(start));
+      Require(name, "T18",
+              grown && BufferCacheTestAccess::PageOwner(
+                           *run->cache, addr(leap_target + 0x40000)) == grown,
+              "stream growth did not extend the owner into the next region");
+      consume("T18 grown");
+      expect(leap_target, 0x80000, "T18 leap-covered pages");
+      expect(start, 24 * kOwnerPage, "T18 requested span");
+    });
+
+    run_case("BDA T19 retire and recreate", true, [&](bool) {
+      map(0, area);
+      const uint64_t o = kRegion + 0x200000;
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      consume("T19 initial");
+      expect(o, 0x10000, "T19 before retirement");
+      BufferCacheTestAccess::SetGarbageCollectionThresholds(*run->cache, 0, 0);
+      for (int i = 0; i < 400 &&
+                      BufferCacheTestAccess::PageOwner(*run->cache, addr(o));
+           i++) {
+        run->cache->RunGarbageCollector();
+      }
+      Require(name, "T19", !BufferCacheTestAccess::PageOwner(*run->cache, addr(o)),
+              "garbage collection did not retire the owner");
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      consume("T19 recreated");
+      expect(o, 0x10000, "T19 recreated owner");
+    });
+
+    run_case("BDA T20 map unmap remap", true, [&](bool) {
+      map(0, area);
+      const uint64_t o = 2 * kRegion + 0x300000;
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      consume("T20 initial");
+      unmap(o, 0x10000);
+      consume("T20 unmapped");
+      fill(o, 0x10000);
+      map(o, 0x10000);
+      consume("T20 remapped");
+      expect(o, 0x10000, "T20 remapped contents");
+    });
+
+    run_case("BDA T21 orphans then owner", true, [&](bool) {
+      map(0, area);
+      const uint64_t a = 3 * kRegion + 0x100000;
+      const uint64_t t = 3 * kRegion + 0x180000;
+      fill(a, kOwnerPage);
+      owner(a, kOwnerPage);
+      consume("T21 initial");
+      fill(t, 0x10000);
+      consume("T21 orphans");
+      owner(t, 0x10000);
+      consume("T21 owner registered");
+      expect(t, 0x10000, "T21 new owner");
+    });
+
+    run_case("BDA T22 GPU to CPU then store", true, [&](bool) {
+      map(0, area);
+      const uint64_t o = kRegion + 0x300000;
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      consume("T22 initial");
+      (void)run->cache->ObtainBuffer(addr(o + 0x100), 16, true, false);
+      run->cache->FillBuffer(addr(o + 0x100), 16, 0xa5a5a5a5u, false);
+      fill(o + 0x100, 16); // faults on the GPU-owned page, flushes, then stores
+      consume("T22 store");
+      expect(o, 0x10000, "T22 owner");
+    });
+
+    run_case("BDA T23 fault-driven owner", true, [&](bool) {
+      map(0, area);
+      const uint64_t t = 5 * kRegion + 0x100000;
+      fill(t, 0x10000);
+      scheduler.DeferOperation(
+          [&] { (void)run->cache->FindBuffer(addr(t), 0x10000); });
+      scheduler.Finish();
+      Require(name, "T23", static_cast<bool>(BufferCacheTestAccess::PageOwner(
+                               *run->cache, addr(t))),
+              "the deferred operation did not register an owner");
+      consume("T23 deferred owner");
+      expect(t, 0x10000, "T23 owner");
+    });
+
+    run_case("BDA T24 alias differential", true, [&](bool) {
+      map(0, area);
+      run->resources->MapMemory(alias_base, alias_size);
+      const uint64_t o = 0x100000;
+      fill(o, 0x10000); // through the primary VA
+      owner_at(alias_base + o, 0x10000);
+      consume("T24 initial");
+      record_at(alias_base + o, 0x10000, "T24 alias owner initial");
+      fill(o + 0x2000, 64); // primary VA: no owner, no fault
+      consume("T24 primary write");
+      record_at(alias_base + o, 0x10000, "T24 alias owner after primary write");
+      fill_at(alias_base + o + 0x4000, 64); // alias VA: owner page faults
+      consume("T24 alias write");
+      record_at(alias_base + o, 0x10000, "T24 alias owner after alias write");
+    });
+
+    // Shared consumption semantics only: consecutive PrepareBda consumers against one global
+    // hint state. This does not drive the real graphics and compute call sites; both of them
+    // reach the same PrepareBda.
+    run_case("BDA T25 consecutive consumers", true, [&](bool) {
+      map(0, area);
+      const uint64_t o = 3 * kRegion + 0x200000;
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      consume("T25 initial");
+      fill(o + 0x1000, 64);
+      consume("T25 consumer 1");
+      expect(o, 0x10000, "T25 consumer 1");
+      fill(o + 0x9000, 64);
+      consume("T25 consumer 2");
+      expect(o, 0x10000, "T25 consumer 2");
+      fill(o + 0x1000, 64);
+      consume("T25 consumer 3");
+      expect(o, 0x10000, "T25 consumer 3");
+    });
+
+    run_case("BDA T26 mode switching", true, [&](bool) {
+      map(0, area);
+      const uint64_t o = kRegion + 0x400000;
+      fill(o, 0x10000);
+      owner(o, 0x10000);
+      consume("T26 initial");
+      fill(o + 0x100, 16);
+      run->resources->SetBdaSyncMode(Config::BdaSyncMode::Legacy);
+      consume("T26 legacy");
+      expect(o, 0x10000, "T26 legacy");
+      fill(o + 0x5100, 16);
+      run->resources->SetBdaSyncMode(Config::BdaSyncMode::Selective);
+      consume("T26 selective");
+      expect(o, 0x10000, "T26 selective");
+      fill(o + 0x9100, 16);
+      run->resources->SetBdaSyncMode(Config::BdaSyncMode::Legacy);
+      fill(o + 0xd100, 16);
+      consume("T26 legacy again");
+      expect(o, 0x10000, "T26 legacy again");
+      run->resources->SetBdaSyncMode(Config::BdaSyncMode::Selective);
+      fill(o + 0x2100, 16);
+      consume("T26 selective again");
+      expect(o, 0x10000, "T26 selective again");
+    });
+
+#if KYTY_BUILD != KYTY_BUILD_DEBUG
+    run_case("BDA T27 selective fails closed", true, [&](bool legacy) {
+      map(0, area);
+      const uint64_t a = 2 * kRegion + 0x80000;
+      const uint64_t b = 3 * kRegion + 0x80000;
+      fill(a, 0x10000);
+      fill(b, 0x10000);
+      owner(a, 0x10000);
+      owner(b, 0x10000);
+      consume("T27 initial");
+      fill(a + 0x100, 16);
+      fill(b + 0x100, 16);
+      bool fired = false;
+      s_hook = [&](BdaTestHooks::Point point, uint64_t) {
+        if (point == BdaTestHooks::Point::ForceSelectiveFailure && !fired) {
+          fired = true;
+          return true;
+        }
+        return false;
+      };
+      run->resources->PrepareBda(); // no invariant check: the pass is meant to fail
+      s_hook = nullptr;
+      Require(name, "T27", legacy || (fired && run->resources->IsBdaSelectiveDisabled()),
+              "an owner-index failure did not fail closed to the legacy walk");
+      expect(a, 0x10000, "T27 A at the failing consumer");
+      expect(b, 0x10000, "T27 B at the failing consumer");
+      fill(a + 0x200, 16);
+      consume("T27 after failure");
+      expect(a, 0x10000, "T27 A afterwards");
+    });
+#endif
+
+    run_case("BDA T28 multi-region near wrap", true, [&](bool) {
+      map(0, area);
+      const uint64_t o = kRegion - 0x100000;
+      const uint64_t size = kRegion + 0x200000; // regions 0, 1 and 2
+      fill(o, size);
+      owner(o, size);
+      consume("T28 initial");
+      auto &staging = BufferCacheTestAccess::StagingBuffer(*run->cache);
+      // Leave 6 KiB before the end: the next 4 KiB page uploads cannot all fit, so they wrap.
+      auto [tail, tail_offset] = staging.Map(staging.Size() - 0x1800, 4);
+      Require(name, "T28", tail != nullptr,
+              "failed to position the staging ring near its wrap");
+      (void)tail_offset;
+      staging.Commit();
+      fill(o + 0x1000, 64);
+      fill(kRegion + 0x1000, 64);
+      fill(2 * kRegion + 0x1000, 64);
+      consume("T28 wrap");
+      expect(o, size, "T28 owner across the wrap");
+    });
+
+    // X1: a mapped interval that begins partway through an ownerless 16 KiB caching page, with
+    // the dirty run continuing into the owned page after it. The discovery cursor starts
+    // unaligned on the orphan page and must step to the next caching-page boundary, not past it.
+    run_case("BDA X1 unaligned orphan start", true, [&](bool) {
+      map(0, area);
+      const uint64_t orphan = kRegion + 0x300000; // caching page without an owner
+      const uint64_t o = orphan + kOwnerPage;     // the owned caching page after it
+      fill(o, kOwnerPage);
+      owner(o, kOwnerPage);
+      consume("X1 initial"); // creates region 1: every page dirty except the owner's
+      unmap(orphan, kPage);  // the next mapped interval starts 4 KiB into the orphan page
+      fill(o + 0x10, 64);    // dirty run: orphan + 4 KiB up to the owner's first page
+      consume("X1 unaligned start");
+      expect(o, kOwnerPage, "X1 owner after an unaligned orphan start");
+    });
+
+    // X8: a hinted region with no RegionManager yet, whose owner has an unmapped hole. The pass
+    // must synchronise both mapped pieces through the legacy walk at this consumer, and must
+    // not synchronise the hole.
+    run_case("BDA X8 null region owner hole", true, [&](bool legacy) {
+      map(0, area);
+      const uint64_t o = 3 * kRegion + 0x100000;
+      const uint64_t hole = o + 0x10000;
+      fill(o, 0x40000);
+      owner(o, 0x40000);
+      unmap(hole, 0x10000);
+      // A pattern no other case uploads, written while the hole is unmapped.
+      const auto rewritten = pattern(0x58380001u, 0x10000);
+      guest_write(addr(hole), rewritten.data(), rewritten.size());
+      const uint64_t region = base / kRegion + region_of(o);
+      bool null_seen = false;
+      s_hook = [&](BdaTestHooks::Point point, uint64_t value) {
+        null_seen = null_seen ||
+                    (point == BdaTestHooks::Point::NullRegionManager && value == region);
+        return false;
+      };
+      consume("X8 pass");
+      s_hook = nullptr;
+      Require(name, "X8", legacy || null_seen,
+              "the selective pass never met the region without a manager");
+      expect(o, 0x10000, "X8 mapped piece before the hole");
+      expect(hole + 0x10000, 0x20000, "X8 mapped piece after the hole");
+      Require(name, "X8", read_device(addr(hole), 0x10000) != rewritten,
+              std::string(mode_name()) + ": the unmapped hole was synchronised");
+    });
+
+    BdaTestHooks::g_callback = nullptr;
+    scheduler.Finish();
+    context.ShutdownGpu();
+    Require(name, "unmap alias",
+            Libs::LibKernel::Memory::KernelMunmap(alias_base, alias_size) == 0,
+            "alias mapping release failed");
+    Require(name, "unmap direct backing",
+            Libs::LibKernel::Memory::KernelMunmap(base, area) == 0,
+            "direct mapping release failed");
+    Require(name, "release direct backing",
+            Libs::LibKernel::Memory::KernelReleaseDirectMemory(direct_offset,
+                                                               area) == 0,
+            "direct-memory allocation release failed");
+    std::printf("[host]    %-32s ok\n", name);
+  }
+#endif
 
   void CheckBufferCacheDirtyGarbageCollection() {
     constexpr const char *name = "BufferCacheDirtyGarbageCollection";
@@ -29464,6 +30385,14 @@ int main(int argc, char **argv) {
     vulkan.CheckUnifiedTextureCacheFlow();
     return 0;
   }
+#if KYTY_PLATFORM == KYTY_PLATFORM_WINDOWS
+  if ((argc == 2 || argc == 3) &&
+      std::strcmp(argv[1], "--bda-selective-only") == 0) {
+    VulkanHarness vulkan;
+    vulkan.CheckSelectiveBdaSynchronization(argc == 3 ? argv[2] : nullptr);
+    return 0;
+  }
+#endif
   if (argc == 2 && std::strcmp(argv[1], "--buffer-cache-gc-only") == 0) {
     VulkanHarness vulkan;
     vulkan.CheckBufferCacheDirtyGarbageCollection();


### PR DESCRIPTION
## Problem

`PrepareBda` runs before draws and dispatches that use buffer device addresses. To find CPU-written data it currently walks every mapped cached buffer and queries its tracked state, even though most buffers have nothing to upload.

## Change

Track a hint bit for each 4 MiB memory-tracker region that may contain CPU-dirty pages. The hint is published when pages become dirty, tracker regions are created, buffers are registered, or memory is mapped.

`PrepareBda` consumes those hints, reads the existing dirty bitmap and synchronizes only registered buffers that can contain dirty pages. The existing per-page dirty state remains authoritative; `SynchronizeBuffer`, page protection, uploads and Vulkan synchronization are unchanged.

The old walk remains available as the legacy/fallback path (`--bda-sync Legacy`), and `--bda-sync SelectiveChecked` adds an invariant check for debugging and validation.

## Performance

In a fixed Kena: Bridge of Spirits scene, using alternating legacy/selective 30-second blocks in the same process:

| | Legacy | Selective |
|---|---|---|
| FPS | 16.01 | 19.12 (+19.4%) |
| Mean frame time | 62.47 ms | 52.36 ms (-16.2%) |
| `PrepareBda` | 20.90 ms/frame | 11.26 ms/frame (-46.1%) |
| Buffer sync attempts | ~122k/frame | ~2k/frame (-98.3%) |

All four selective blocks were faster than all four legacy blocks. The improvement depends on workload and mapped-buffer count; no equivalent performance gain is claimed for other titles.

## Validation

Added deterministic coverage for dirty-hint publication, concurrent publication/consumption, partial and aliased mappings, buffer registration/replacement, mapping lifecycle, fault-driven creation and other BDA coherency cases. The GPU tests verify the bytes visible to the consumer against guest memory in both legacy and selective modes.

Full CTest: 39/40. The remaining `kernel_file_system` target has the same pre-existing link failure on current upstream.

Kena also completed a gameplay smoke test in `SelectiveChecked` mode without an invariant failure, crash or visible rendering issue.

AI assistance was used during investigation, implementation and testing. I reviewed the resulting change and validation before submitting it.