### PR TITLE
vscode: point IntelliSense at clang instead of MSVC

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,11 @@
     "cmake.configureSettings": {
         "CMAKE_C_COMPILER": "clang-cl",
         "CMAKE_CXX_COMPILER": "clang-cl",
-        "CMAKE_PREFIX_PATH": "C:/Qt/6.11.0/msvc2022_64"
-    }
+        "CMAKE_PREFIX_PATH": "C:/Qt/6.11.0/msvc2022_64",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+    },
+    "C_Cpp.default.intelliSenseMode": "windows-clang-x64",
+    "C_Cpp.default.compilerPath": "${env:ProgramFiles}/Microsoft Visual Studio/18/Community/VC/Tools/Llvm/x64/bin/clang-cl.exe",
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/_Build/windows/compile_commands.json",
+    "C_Cpp.default.cppStandard": "c++20"
 }
-


### PR DESCRIPTION
KYTY_SYSV_ABI expands to __attribute__((sysv_abi)) with no MSVC fallback, which is correct for a project that rejects cl.exe at configure time. Nothing told the C/C++ extension that, so it fell back to windows-msvc-x64 and flagged every guest-facing function in the tree with "__attribute__ is not a type name".

Set the IntelliSense mode, compiler path and C++ standard to match the compiler the build actually uses, and export a compile database for it to read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Visual Studio development environment settings for CMake.
  - Added default C/C++ IntelliSense configuration for Windows Clang x64, including C++20 support and compile commands integration.
  - Simplified environment path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->