### PR TITLE
tests: link the kernel filesystem test on Windows

### DIFF
--- a/tests/KernelFileSystemTests.cpp
+++ b/tests/KernelFileSystemTests.cpp
@@ -1,3 +1,5 @@
+#define SDL_MAIN_HANDLED
+
 #include "SDL.h"
 #include "common/emulatorConfig.h"
 #include "common/file.h"


### PR DESCRIPTION
SDL_main.h rewrites main() to SDL_main() on Windows, and nothing links SDL2main, so the test failed to link with "undefined symbol: main" and the executable was never produced. ctest then reported "Could not find executable" rather than a failure, which is how a red test went unnoticed on main.

Define SDL_MAIN_HANDLED ahead of the SDL include; the test drives SDL itself and does not want the rewrite. With the executable building again the failure reported in #505 reproduces: guest PEEK and WAITALL do not preserve the wake bytes, and the test exits 0xc0000409. That fix is not part of this change.

issue: #505 