### PR TITLE
shader: support S_MUL_HI_I32 (SOP2 0x36)

### DIFF
--- a/src/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp
+++ b/src/graphics/shader/recompiler/frontend/decode/ScalarAluOps.cpp
@@ -33,6 +33,7 @@ constexpr OpcodeMap SOP2_OPCODE_LIST[] = {
     {0x31u, Opcode::S_LSHL4_ADD_U32},   {0x32u, Opcode::S_PACK_LL_B32_B16},
     {0x33u, Opcode::S_PACK_LH_B32_B16}, {0x34u, Opcode::S_PACK_HH_B32_B16},
     {0x35u, Opcode::S_MUL_HI_U32},
+    {0x36u, Opcode::S_MUL_HI_I32},
 };
 
 constexpr OpcodeMap SOP1_OPCODE_LIST[] = {

--- a/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.h
+++ b/src/graphics/shader/recompiler/frontend/decode/ShaderDecoder.h
@@ -108,6 +108,7 @@ enum class Opcode {
 	S_ASHR_I32,
 	S_MUL_I32,
 	S_MUL_HI_U32,
+	S_MUL_HI_I32,
 	S_MULK_I32,
 	S_BFE_U32,
 	S_BFE_I32,

--- a/src/graphics/shader/recompiler/frontend/translate/Scalar.cpp
+++ b/src/graphics/shader/recompiler/frontend/translate/Scalar.cpp
@@ -138,6 +138,8 @@ bool Translator::EmitScalar(const Decoder::Instruction& inst) {
 			return SimpleInteger(inst, IR::ValueOpcode::IMul32, IR::Type::U32, false, false, false);
 		case O::S_MUL_HI_U32:
 			return SimpleInteger(inst, IR::ValueOpcode::UMulHi, IR::Type::U32, false, false, false);
+		case O::S_MUL_HI_I32:
+			return SimpleInteger(inst, IR::ValueOpcode::SMulHi, IR::Type::U32, false, false, false);
 		case O::S_AND_B32:
 			return SimpleInteger(inst, IR::ValueOpcode::BitwiseAnd32, IR::Type::U32, false, false,
 			                     true);

--- a/tests/shaderCfgTests.cpp
+++ b/tests/shaderCfgTests.cpp
@@ -1796,6 +1796,7 @@ void TestNewShaderRecompilerScalarVectorAlu() {
       EncodeSop2(0x30, 11, 10, 1),     // s_lshl3_add_u32 s11, s10, s1
       EncodeSop2(0x31, 12, 11, 1),     // s_lshl4_add_u32 s12, s11, s1
       EncodeSop2(0x35, 13, 12, 1),     // s_mul_hi_u32 s13, s12, s1
+      EncodeSop2(0x36, 15, 12, 1),     // s_mul_hi_i32 s15, s12, s1
       EncodeSopc(0x08, 8, 1),          // s_cmp_gt_u32 s8, s1
       EncodeSop2(0x04, 14, 13, 129),   // s_addc_u32 s14, s13, 1
       EncodeVop2(0x03, 1, 242, 0),     // v_add_f32 v1, 1.0, v0
@@ -1832,6 +1833,8 @@ void TestNewShaderRecompilerScalarVectorAlu() {
       "new decoder did not decode old-backed S_LSHL4_ADD_U32");
   Check(Common::ContainsStr(result.decoded_dump, "s_mul_hi_u32 s13, s12, s1"),
         "new decoder did not decode old-backed S_MUL_HI_U32");
+  Check(Common::ContainsStr(result.decoded_dump, "s_mul_hi_i32 s15, s12, s1"),
+        "new decoder did not decode old-backed S_MUL_HI_I32");
   Check(Common::ContainsStr(result.decoded_dump, "v_add_f32 v1"),
         "new decoder did not decode VOP2 float add");
   Check(Common::ContainsStr(result.decoded_dump, "v_cndmask_b32 v5"),
@@ -1868,6 +1871,8 @@ void TestNewShaderRecompilerScalarVectorAlu() {
       "S_LSHL4_ADD_U32 did not lower through carry-writing shift-left-add IR");
   Check(Common::ContainsStr(result.ir_dump, "UMulHighU32 s13, s12, s1"),
         "S_MUL_HI_U32 did not lower to unsigned high-multiply IR");
+  Check(Common::ContainsStr(result.ir_dump, "SMulHighI32 s15, s12, s1"),
+        "S_MUL_HI_I32 did not lower to signed high-multiply IR");
   Check(Common::ContainsStr(result.ir_dump, "CompareGtU32"),
         "SOPC compare did not lower to IR");
   Check(Common::ContainsStr(result.ir_dump, "FAddF32 v1"),


### PR DESCRIPTION
Dakar Desert Rally (PPSA04477) fails shader recompilation on SOP2 opcode 0x36
— see #281, raw=[0x9b0cff6b], still current on 2e315a3.

Change. Decode and translate only. The signed high-multiply IR opcode already
exists and is fully wired: SMulHi (ValueOpcodes.inc), lowered through
EmitMulHigh(..., signed=true) in spirvEmitterAlu.cpp, already used by VOP1
V_MUL_HI_I32 and folded by ConstantPropagation. So this adds the table entry,
the enum value next to S_MUL_HI_U32, and the translate case — nothing
downstream.

Tests. shaderCfgTests gains a paired case: S_MUL_HI_U32 must lower to
UMulHighU32 and S_MUL_HI_I32 to SMulHighI32, so the signedness is asserted
rather than assumed.

Verification. Clean build on Windows, clang-cl 19.1.5, Ninja. 36/37 tests pass
— the only failure is kernel_file_system, which fails on clean main as well
(see #505; PR #565 is not merged here).

Not verified at runtime — I don't have the title.

References
 - AMD RDNA 2 ISA Reference Guide, SOP2: opcode 0x36 S_MUL_HI_I32
 - Captured instruction word: 0x9b0cff6b

AI assistance. Written with AI assistance; every change reviewed, built and
tested locally by me.