### PR TITLE
graphics: fix device rejection on GPUs lacking depthBounds/barycentric, add hardware-interpolation fallback and fix input-driven stutter

### DIFF
--- a/src/graphics/host_gpu/graphicContext.h
+++ b/src/graphics/host_gpu/graphicContext.h
@@ -32,6 +32,7 @@ struct GraphicContext {
 	bool                               depth_bounds_supported                = false;
 	bool                               attachment_feedback_loop_enabled      = false;
 	bool                               provoking_vertex_last_enabled         = false;
+	bool                               fragment_shader_barycentric_enabled   = false;
 	bool                               supports_block_texel_view              = false;
 	bool                                      mesh_shader_enabled                   = false;
 	vk::PhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties                = {};

--- a/src/graphics/host_gpu/graphicContext.h
+++ b/src/graphics/host_gpu/graphicContext.h
@@ -29,6 +29,7 @@ struct GraphicContext {
 	bool                               memory_budget_ext_enabled             = false;
 	bool                               compute_subgroup_size_control_enabled = false;
 	bool                               sample_rate_shading_enabled           = false;
+	bool                               depth_bounds_supported                = false;
 	bool                               attachment_feedback_loop_enabled      = false;
 	bool                               provoking_vertex_last_enabled         = false;
 	bool                               supports_block_texel_view              = false;

--- a/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/pipelineCache.cpp
@@ -338,6 +338,7 @@ struct PipelineCache::ProgramCache {
 		options.early_dump  = options.dump_ir;
 		options.dump_label  = label;
 		options.input_info  = stage_input;
+		options.barycentric_supported = barycentric_supported;
 
 		if constexpr (std::is_same_v<InputInfo, ShaderVertexInputInfo>) {
 			options.user_data_base = 8;
@@ -374,7 +375,8 @@ struct PipelineCache::ProgramCache {
 		return permutation.handle;
 	}
 
-	explicit ProgramCache(vk::Device device): device(device) {
+	explicit ProgramCache(vk::Device device, bool barycentric_supported)
+	    : device(device), barycentric_supported(barycentric_supported) {
 		lookup_key.static_state.reserve(MaxStaticKeyWords);
 	}
 	~ProgramCache() {
@@ -389,11 +391,14 @@ struct PipelineCache::ProgramCache {
 	std::unordered_map<ProgramKey, SourceEntry, ProgramKeyHash> programs;
 	ProgramKey                                                  lookup_key;
 	vk::Device                                                  device;
+	bool                                                        barycentric_supported = true;
 	uint64_t                                                    next_shader_id = 0;
 };
 
 PipelineCache::PipelineCache(GraphicContext& graphics)
-    : m_graphics(graphics), m_program_cache(std::make_unique<ProgramCache>(graphics.device)) {
+    : m_graphics(graphics),
+      m_program_cache(std::make_unique<ProgramCache>(graphics.device,
+                                                     graphics.fragment_shader_barycentric_enabled)) {
 	EXIT_NOT_IMPLEMENTED(!Common::Thread::IsMainThread());
 	InitializeDriverCache();
 }

--- a/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
+++ b/src/graphics/host_gpu/renderer/pipeline/shaders.cpp
@@ -467,12 +467,12 @@ void CreatePipelineInternal(
 	EXIT_NOT_IMPLEMENTED(pipeline.pipeline_layout == nullptr);
 
 	vk::PipelineDepthStencilStateCreateInfo depth_stencil_info {};
+	// Depth-bounds testing is an optional PM4-driven optimization (DB_DEPTH_CONTROL); when the
+	// device doesn't expose VkPhysicalDeviceFeatures::depthBounds (MoltenVK, some Mesa/Intel
+	// ICDs, etc.) we simply skip the test rather than refusing to run.
 	depth_stencil_info.depthBoundsTestEnable =
-#if defined(__APPLE__)
-	    VK_FALSE; // MoltenVK lacks the depthBounds feature; depth-bounds testing is disabled
-#else
-	    (static_params.depth_bounds_test_enable ? VK_TRUE : VK_FALSE);
-#endif
+	    (graphics.depth_bounds_supported && static_params.depth_bounds_test_enable) ? VK_TRUE
+	                                                                                 : VK_FALSE;
 	depth_stencil_info.stencilTestEnable = (static_params.stencil_test_enable ? VK_TRUE : VK_FALSE);
 	depth_stencil_info.front.failOp      = static_params.stencil_front.failOp;
 	depth_stencil_info.front.passOp      = static_params.stencil_front.passOp;

--- a/src/graphics/presentation/window/hostInput.cpp
+++ b/src/graphics/presentation/window/hostInput.cpp
@@ -71,6 +71,13 @@ struct Binding {
 };
 
 constexpr int              MOUSE_POLL_INTERVAL_MS = 33;
+// Upper bound on how long the main loop (WindowContext::Run()) can sit blocked in
+// HostInputWaitEvent() with no SDL event pending. Must be short enough that main-thread work
+// queued via RunOnMainThread() (window/graphics-thread cross-thread dispatch) is drained at a
+// steady cadence even when there's no real input activity; ~4ms keeps it well under a 240Hz
+// frame interval without meaningfully increasing idle CPU usage (SDL_WaitEventTimeout still
+// sleeps, it doesn't spin).
+constexpr int              MAIN_LOOP_IDLE_TIMEOUT_MS = 4;
 constexpr std::string_view MOUSE_SENSITIVITY      = "MouseSensitivity=";
 
 struct MouseJoystickState {
@@ -409,10 +416,25 @@ int PollMouse(uint64_t now_ms) {
 bool HostInputWaitEvent(SDL_Event* event) {
 	if (!g_mouse.enabled || SDL_GetKeyboardFocus() == nullptr) {
 		CenterMouseStick();
-		if (SDL_WaitEvent(event) == 0) {
+		// Previously an unbounded SDL_WaitEvent(): the main thread (WindowContext::Run()) would
+		// block indefinitely here whenever no SDL event was pending, and DrainMainThreadTasks()
+		// -- which processes work queued cross-thread via RunOnMainThread(), e.g. from the
+		// graphics/emulation thread -- only runs once per loop iteration, i.e. only after this
+		// call returns. With no real input activity (mouse stationary, no keys held), that main-
+		// thread work would sit queued until an incidental SDL event (window focus/expose, timer,
+		// etc.) happened to arrive, producing periodic stalls/stutter that vanished the moment
+		// continuous input (e.g. mouse motion) kept the loop waking every iteration.
+		//
+		// Bound the wait so the loop always comes back around at a steady interval regardless of
+		// input activity, matching the timeout already used in the mouse-to-joystick branch below.
+		SDL_ClearError();
+		if (SDL_WaitEventTimeout(event, MAIN_LOOP_IDLE_TIMEOUT_MS) != 0) {
+			return true;
+		}
+		if (SDL_GetError()[0] != '\0') {
 			EXIT("%s\n", SDL_GetError());
 		}
-		return true;
+		return false;
 	}
 
 	const int timeout_ms = PollMouse(SDL_GetTicks64());

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -339,10 +339,9 @@ static void VulkanFindPhysicalDevice(vk::Instance instance, vk::SurfaceKHR surfa
 			skip_device = true;
 		}
 		if (device_features2.features.depthBounds != VK_TRUE) {
-			LOGF("depthBounds is not supported\n");
-#if !defined(__APPLE__)
-			skip_device = true;
-#endif
+			// Not a hard requirement: depthBoundsTestEnable is simply forced off for this
+			// device below (see depth_bounds_supported), same as the existing MoltenVK path.
+			LOGF("depthBounds is not supported, depth-bounds testing will be disabled\n");
 		}
 		if (device_features2.features.shaderStorageImageWriteWithoutFormat != VK_TRUE) {
 			LOGF("shaderStorageImageWriteWithoutFormat is not supported\n");
@@ -610,8 +609,11 @@ static vk::Device VulkanCreateDevice(GraphicContext& graphics,
 	device_features.fragmentStoresAndAtomics = VK_TRUE;
 	device_features.samplerAnisotropy        = VK_TRUE;
 	device_features.robustBufferAccess       = VK_TRUE;
-#if !defined(__APPLE__)
-	device_features.depthBounds = VK_TRUE; // unsupported by MoltenVK
+#if defined(__APPLE__)
+	graphics.depth_bounds_supported = false; // unsupported by MoltenVK
+#else
+	graphics.depth_bounds_supported = supported_features2.features.depthBounds == VK_TRUE;
+	device_features.depthBounds     = graphics.depth_bounds_supported ? VK_TRUE : VK_FALSE;
 #endif
 	device_features.shaderStorageImageWriteWithoutFormat = VK_TRUE;
 	device_features.shaderImageGatherExtended            = VK_TRUE;

--- a/src/graphics/presentation/window/vulkanWindow.cpp
+++ b/src/graphics/presentation/window/vulkanWindow.cpp
@@ -152,6 +152,33 @@ static uint32_t VulkanFindQueueFamily(vk::PhysicalDevice device, vk::SurfaceKHR 
 	return static_cast<uint32_t>(-1);
 }
 
+static bool QueryFragmentBarycentricSupport(vk::PhysicalDevice device) {
+#if defined(__APPLE__)
+	return false;
+#else
+	// GTX 10-series (Pascal) and older GPUs lack
+	// VK_KHR_fragment_shader_barycentric. Treat it as optional so those
+	// devices can still be selected; the shader recompiler falls back to
+	// hardware interpolation when it is missing.
+	auto available_extensions = EnumerateVulkan<vk::ExtensionProperties>(
+	    "vkEnumerateDeviceExtensionProperties",
+	    [&](uint32_t* count, vk::ExtensionProperties* values) {
+		    return device.enumerateDeviceExtensionProperties(nullptr, count, values);
+	    });
+	if (!HasExtension(available_extensions, VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME)) {
+		return false;
+	}
+	vk::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR barycentric {};
+	barycentric.sType = vk::StructureType::ePhysicalDeviceFragmentShaderBarycentricFeaturesKHR;
+	barycentric.pNext = nullptr;
+	vk::PhysicalDeviceFeatures2 features2 {};
+	features2.sType = vk::StructureType::ePhysicalDeviceFeatures2;
+	features2.pNext = &barycentric;
+	device.getFeatures2(&features2);
+	return barycentric.fragmentShaderBarycentric == VK_TRUE;
+#endif
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void VulkanFindPhysicalDevice(vk::Instance instance, vk::SurfaceKHR surface,
                                      const std::vector<const char*>& device_extensions,
@@ -248,8 +275,8 @@ static void VulkanFindPhysicalDevice(vk::Instance instance, vk::SurfaceKHR surfa
 		}
 #if !defined(__APPLE__)
 		if (fragment_barycentric.fragmentShaderBarycentric != VK_TRUE) {
-			LOGF("fragmentShaderBarycentric is not supported\n");
-			skip_device = true;
+			LOGF("fragmentShaderBarycentric is not supported; falling back to hardware "
+			     "interpolation\n");
 		}
 #endif
 
@@ -630,14 +657,26 @@ static vk::Device VulkanCreateDevice(GraphicContext& graphics,
 	graphics.sample_rate_shading_enabled                 = true;
 	device_features.shaderInt64 = VK_TRUE;
 
+	if (!graphics.fragment_shader_barycentric_enabled) {
+		LOGF("Vulkan barycentric fallback active: fragment shaders use hardware "
+		     "interpolation\n");
+	}
+
 	vk::PhysicalDeviceRobustness2FeaturesEXT robustness2 {};
 #if defined(__APPLE__)
 	robustness2.pNext = &features12;
 #else
 	vk::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR fragment_barycentric {};
-	fragment_barycentric.pNext                     = &features12;
-	fragment_barycentric.fragmentShaderBarycentric = VK_TRUE;
-	robustness2.pNext                              = &fragment_barycentric;
+	fragment_barycentric.pNext = &features12;
+	// Only request the feature if it's actually supported; requesting VK_TRUE for an
+	// unsupported feature would make vkCreateDevice fail validation.
+	fragment_barycentric.fragmentShaderBarycentric =
+	    graphics.fragment_shader_barycentric_enabled ? VK_TRUE : VK_FALSE;
+	if (graphics.fragment_shader_barycentric_enabled) {
+		robustness2.pNext = &fragment_barycentric;
+	} else {
+		robustness2.pNext = &features12;
+	}
 #endif
 	if (robustness2_ext_enabled) {
 		robustness2.robustBufferAccess2 = supported_robustness2.robustBufferAccess2;
@@ -650,8 +689,13 @@ static vk::Device VulkanCreateDevice(GraphicContext& graphics,
 	features13.pNext = robustness2_ext_enabled ? static_cast<void*>(&robustness2)
 	                                           : static_cast<void*>(&features12);
 #else
-	features13.pNext = robustness2_ext_enabled ? static_cast<void*>(&robustness2)
-	                                           : static_cast<void*>(&fragment_barycentric);
+	if (robustness2_ext_enabled) {
+		features13.pNext = static_cast<void*>(&robustness2);
+	} else if (graphics.fragment_shader_barycentric_enabled) {
+		features13.pNext = static_cast<void*>(&fragment_barycentric);
+	} else {
+		features13.pNext = static_cast<void*>(&features12);
+	}
 #endif
 	features13.robustImageAccess   = supported_features13.robustImageAccess;
 	features13.subgroupSizeControl =
@@ -996,7 +1040,8 @@ void WindowContext::CreateVulkan() {
 #else
 	device_extensions.push_back(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
 	device_extensions.push_back(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
-	device_extensions.push_back(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
+	// VK_KHR_fragment_shader_barycentric is optional (missing on GTX 10-series).
+	// It is appended after physical-device selection only when supported.
 #endif
 
 #ifdef KYTY_ENABLE_DEBUG_PRINTF
@@ -1022,6 +1067,16 @@ void WindowContext::CreateVulkan() {
 	const auto& device_properties = graphic_ctx.GetPhysicalDeviceProperties();
 
 	LOGF("Select device: %s\n", device_properties.deviceName.data());
+
+	graphic_ctx.fragment_shader_barycentric_enabled =
+	    QueryFragmentBarycentricSupport(graphic_ctx.physical_device);
+	LOGF("fragmentShaderBarycentric support: %s\n",
+	     graphic_ctx.fragment_shader_barycentric_enabled ? "Yes" : "No (fallback)");
+#if !defined(__APPLE__)
+	if (graphic_ctx.fragment_shader_barycentric_enabled) {
+		device_extensions.push_back(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
+	}
+#endif
 
 	const vk::PhysicalDeviceImageFormatInfo2 block_texel_view_info {
 	    .format = vk::Format::eBc1RgbaUnormBlock,

--- a/src/graphics/shader/recompiler/ShaderRecompiler.cpp
+++ b/src/graphics/shader/recompiler/ShaderRecompiler.cpp
@@ -630,7 +630,7 @@ CompileResult CompileProgram(TranslateResult translated, const CompileOptions& o
 	IR::RemoveIdentities(ir.blocks);
 	IR::EliminateDeadCode(ir.blocks);
 
-	IR::CollectShaderInfo(ir, options.input_info);
+	IR::CollectShaderInfo(ir, options.input_info, options.barycentric_supported);
 	IR::AllocateBindings(ir, push_data_start_dword);
 	std::string ir_dump;
 	if (options.dump_ir) {

--- a/src/graphics/shader/recompiler/ShaderRecompiler.h
+++ b/src/graphics/shader/recompiler/ShaderRecompiler.h
@@ -16,6 +16,7 @@ struct CompileOptions {
 	uint32_t                    wave_size       = 64;
 	uint32_t                    user_data_base  = 0;
 	uint64_t                    shader_hash     = 0;
+	bool                        barycentric_supported = true;
 	bool                        dump_ir                    = true;
 	bool                        early_dump                 = false;
 	const char*                 dump_label                 = nullptr;

--- a/src/graphics/shader/recompiler/ir/passes/ShaderInfoCollection.cpp
+++ b/src/graphics/shader/recompiler/ir/passes/ShaderInfoCollection.cpp
@@ -195,7 +195,7 @@ void CollectVertexInputs(const Program& program, const ShaderVertexInputInfo* ve
 }
 
 void CollectPixelInputs(const Program& program, const ShaderPixelInputInfo* pixel,
-                        ShaderInfo& info) {
+                        ShaderInfo& info, bool barycentric_supported) {
 	if (pixel->HasPositionInput()) {
 		AddInput(info, StageInputKind::FragCoord, 0, 4, "gl_FragCoord");
 	}
@@ -217,8 +217,13 @@ void CollectPixelInputs(const Program& program, const ShaderPixelInputInfo* pixe
 		}
 	}
 	for (uint32_t input = 0; input < pixel->input_num; input++) {
+		// Without barycentric support there is no PerVertexKHR varying; all
+		// parameters use standard hardware interpolation.
 		AddInput(info, StageInputKind::Parameter, input, 4, fmt::format("in_param_{}", input),
-		         per_vertex[input]);
+		         barycentric_supported && per_vertex[input]);
+	}
+	if (!barycentric_supported) {
+		return;
 	}
 	for (uint32_t input = 0; input < pixel->input_num; input++) {
 		if (interpolated[input] && per_vertex[input]) {
@@ -246,7 +251,7 @@ void CollectComputeInputs(const ShaderComputeInputInfo* compute, ShaderInfo& inf
 	}
 }
 
-void CollectBuiltinInputs(const Program& program, ShaderInfo& info) {
+void CollectBuiltinInputs(const Program& program, ShaderInfo& info, bool barycentric_supported) {
 	for (const auto* block: program.blocks) {
 		for (const auto& inst: *block) {
 			if (inst.GetOpcode() != ValueOpcode::GetBuiltin) {
@@ -267,10 +272,14 @@ void CollectBuiltinInputs(const Program& program, ShaderInfo& info) {
 				case StageInputKind::Layer: AddInput(info, kind, 0, 1, "gl_Layer"); break;
 				case StageInputKind::SampleId: AddInput(info, kind, 0, 1, "gl_SampleID"); break;
 				case StageInputKind::BaryCoordSmooth:
-					AddInput(info, kind, 0, 3, "gl_BaryCoordKHR");
+					if (barycentric_supported) {
+						AddInput(info, kind, 0, 3, "gl_BaryCoordKHR");
+					}
 					break;
 				case StageInputKind::BaryCoordNoPerspective:
-					AddInput(info, kind, 0, 3, "gl_BaryCoordNoPerspKHR");
+					if (barycentric_supported) {
+						AddInput(info, kind, 0, 3, "gl_BaryCoordNoPerspKHR");
+					}
 					break;
 				case StageInputKind::WorkgroupId:
 					AddInput(info, kind, 0, 3, "gl_WorkGroupID");
@@ -362,7 +371,8 @@ void CollectOutputs(const Program& program, ShaderStageInputInfo input_info, Sha
 
 } // namespace
 
-void CollectShaderInfo(Program& program, ShaderStageInputInfo input_info) {
+void CollectShaderInfo(Program& program, ShaderStageInputInfo input_info,
+                       bool barycentric_supported) {
 	if (!program.resource_tracking_complete || program.shader_info_complete) {
 		return Fail(!program.resource_tracking_complete ? "shader resources were not tracked"
 		                                                : "shader info already collected");
@@ -382,11 +392,13 @@ void CollectShaderInfo(Program& program, ShaderStageInputInfo input_info) {
 	switch (program.stage) {
 		case ShaderType::Vertex: CollectVertexInputs(program, input_info.vertex, next); break;
 		case ShaderType::Mesh: break;
-		case ShaderType::Pixel: CollectPixelInputs(program, input_info.pixel, next); break;
+		case ShaderType::Pixel:
+			CollectPixelInputs(program, input_info.pixel, next, barycentric_supported);
+			break;
 		case ShaderType::Compute: CollectComputeInputs(input_info.compute, next); break;
 		default: return Fail("unsupported shader stage for info collection");
 	}
-	CollectBuiltinInputs(program, next);
+	CollectBuiltinInputs(program, next, barycentric_supported);
 	CollectOutputs(program, input_info, next);
 	program.info                 = std::move(next);
 	program.shader_info_complete = true;

--- a/src/graphics/shader/recompiler/ir/passes/ShaderInfoCollection.h
+++ b/src/graphics/shader/recompiler/ir/passes/ShaderInfoCollection.h
@@ -6,8 +6,11 @@
 namespace Libs::Graphics::ShaderRecompiler::IR {
 
 // Completes the immutable shader interface after resource tracking. On failure Program::info and
-// all completion state remain unchanged.
-void CollectShaderInfo(Program& program, ShaderStageInputInfo input_info);
+// all completion state remain unchanged. barycentric_supported is false on GPUs without
+// VK_KHR_fragment_shader_barycentric (e.g. GTX 10-series); pixel params are then compiled for
+// hardware interpolation instead of manual barycentric weighting.
+void CollectShaderInfo(Program& program, ShaderStageInputInfo input_info,
+                       bool barycentric_supported = true);
 
 } // namespace Libs::Graphics::ShaderRecompiler::IR
 


### PR DESCRIPTION
Combines the fixes from #551 and #559 into one PR, since they address
independent parts of the same underlying problem (GPUs being rejected
or misbehaving due to hard barycentric/depthBounds requirements) and
don't conflict with each other.

## Barycentric fallback (credit: @markl0101)
GPUs without VK_KHR_fragment_shader_barycentric (GTX 10-series/Pascal,
older hardware in general) couldn't run the emulator. This makes
barycentric support optional end-to-end: when unsupported, the SPIR-V
emitter falls back to standard hardware interpolation instead of
requiring PerVertexKHR/BaryCoordKHR. This is the correct fix -- #551's
original approach only touched device selection and relied on Mesa ANV
tolerating an unenforced capability declaration, which doesn't hold up
under NVIDIA's stricter validation.

Tested in-game (Lego Brawls) on GTX 1070 Ti -- previously failed to launch.

## depthBounds device requirement (from #551)
depthBounds was a hard device requirement, rejecting GPUs that lack it
with "Could not find suitable device" before any game could run.
depthBoundsTestEnable is now forced off per-pipeline when unsupported,
the same fallback already used for MoltenVK.

## Input-driven stutter fix (from #551)
The main loop's idle wait was an unbounded SDL_WaitEvent(), so
cross-thread work queued via RunOnMainThread() only got drained when an
SDL event happened to arrive. Bounded to a 4ms timeout so the loop
comes back around at a steady interval regardless of input activity.

## Testing
- Barycentric fallback: GTX 1070 Ti, Lego Brawls (previously crashed on launch)
- depthBounds + stutter: Intel UHD 620 (KBL, Mesa anv), Dreaming Sarah
  (previously rejected outright; now boots, runs, no stutter)

Both fixes were tested independently on their respective hardware; not
yet cross-tested on a single machine with both issues present.

Closes #551, closes #559.

Co-authored-by: Mark Laloo <marklaloo0101@gmail.com>
